### PR TITLE
More user-friendly prompts when selecting pid.

### DIFF
--- a/boot/src/main/java/com/taobao/arthas/boot/Bootstrap.java
+++ b/boot/src/main/java/com/taobao/arthas/boot/Bootstrap.java
@@ -12,6 +12,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.logging.Level;
+import java.util.InputMismatchException;
 
 import javax.xml.parsers.ParserConfigurationException;
 
@@ -249,7 +250,12 @@ public class Bootstrap {
         int pid = bootStrap.getPid();
         // select pid
         if (pid < 0) {
-            pid = ProcessUtils.select(bootStrap.isVerbose());
+            try {
+                pid = ProcessUtils.select(bootStrap.isVerbose());
+            } catch (InputMismatchException e) {
+                System.out.println("Please input an integer to select pid.");
+                System.exit(1);
+            }
             if (pid < 0) {
                 System.out.println("Please select an avaliable pid.");
                 System.exit(1);

--- a/boot/src/main/java/com/taobao/arthas/boot/ProcessUtils.java
+++ b/boot/src/main/java/com/taobao/arthas/boot/ProcessUtils.java
@@ -12,6 +12,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Scanner;
+import java.util.InputMismatchException;
 
 import com.taobao.arthas.common.AnsiLog;
 import com.taobao.arthas.common.ExecutingCommand;
@@ -44,7 +45,8 @@ public class ProcessUtils {
         return PID;
     }
 
-    public static int select(boolean v) {
+    @SuppressWarnings("resource")
+    public static int select(boolean v) throws InputMismatchException {
         Map<Integer, String> processMap = listProcessByJps(v);
 
         if (processMap.isEmpty()) {


### PR DESCRIPTION
When users accidentally enter a non-integer, prompt instead of printing
stack trace.

```
[INFO] Process 3027 already using port 3658
[INFO] Process 3027 already using port 8563
* [1]: 3027 jar
a
Exception in thread "main" java.util.InputMismatchException
	at java.util.Scanner.throwFor(Scanner.java:913)
	at java.util.Scanner.next(Scanner.java:1534)
	at java.util.Scanner.nextInt(Scanner.java:2164)
	at java.util.Scanner.nextInt(Scanner.java:2123)
	at com.taobao.arthas.boot.ProcessUtils.select(ProcessUtils.java:71)
	at com.taobao.arthas.boot.Bootstrap.main(Bootstrap.java:252)
```