### PR TITLE
Improve get Java version

### DIFF
--- a/common/src/main/java/com/taobao/arthas/common/JavaVersionUtils.java
+++ b/common/src/main/java/com/taobao/arthas/common/JavaVersionUtils.java
@@ -1,16 +1,23 @@
 package com.taobao.arthas.common;
 
+import java.util.Properties;
+
 /**
  *
  * @author hengyunabc 2018-11-21
  *
  */
 public class JavaVersionUtils {
-    private static final String javaVersionStr = System.getProperty("java.specification.version");
+    private static final String versionPropName = "java.specification.version";
+    private static final String javaVersionStr = System.getProperty(versionPropName);
     private static final float javaVersion = Float.parseFloat(javaVersionStr);
 
     public static String javaVersionStr() {
         return javaVersionStr;
+    }
+
+    public static String javaVersionStr(Properties props) {
+        return (null != props) ? props.getProperty(versionPropName): null;
     }
 
     public static float javaVersion() {
@@ -18,19 +25,19 @@ public class JavaVersionUtils {
     }
 
     public static boolean isJava6() {
-        return Float.toString(javaVersion).equals("1.6");
+        return javaVersionStr.equals("1.6");
     }
 
     public static boolean isJava7() {
-        return Float.toString(javaVersion).equals("1.7");
+        return javaVersionStr.equals("1.7");
     }
 
     public static boolean isJava8() {
-        return Float.toString(javaVersion).equals("1.8");
+        return javaVersionStr.equals("1.8");
     }
 
     public static boolean isJava9() {
-        return Float.toString(javaVersion).equals("9");
+        return javaVersionStr.equals("9");
     }
 
     public static boolean isLessThanJava9() {

--- a/core/src/main/java/com/taobao/arthas/core/Arthas.java
+++ b/core/src/main/java/com/taobao/arthas/core/Arthas.java
@@ -3,6 +3,7 @@ package com.taobao.arthas.core;
 import com.sun.tools.attach.VirtualMachine;
 import com.sun.tools.attach.VirtualMachineDescriptor;
 import com.taobao.arthas.common.AnsiLog;
+import com.taobao.arthas.common.JavaVersionUtils;
 import com.taobao.arthas.core.config.Configure;
 import com.taobao.middleware.cli.CLI;
 import com.taobao.middleware.cli.CLIs;
@@ -73,8 +74,8 @@ public class Arthas {
             }
 
             Properties targetSystemProperties = virtualMachine.getSystemProperties();
-            String targetJavaVersion = targetSystemProperties.getProperty("java.specification.version");
-            String currentJavaVersion = System.getProperty("java.specification.version");
+            String targetJavaVersion = JavaVersionUtils.javaVersionStr(targetSystemProperties);
+            String currentJavaVersion = JavaVersionUtils.javaVersionStr();
             if (targetJavaVersion != null && currentJavaVersion != null) {
                 if (!targetJavaVersion.equals(currentJavaVersion)) {
                     AnsiLog.warn("Current VM java version: {} do not match target VM java version: {}, attach may fail.",


### PR DESCRIPTION
1. 我觉得既然有了`JavaVersionUtils`工具类，那么在获取Java版本时尽量要使用它

2. `java`和`jps`都是JAVA的二进制文件，是否能统一它们的查找过程？