### PR TITLE
Create Dockerfile-No-Jdk

### DIFF
--- a/Dockerfile-No-Jdk
+++ b/Dockerfile-No-Jdk
@@ -4,19 +4,14 @@ ARG ARTHAS_VERSION="3.0.5"
 ARG MIRROR=false
 
 ENV MAVEN_HOST=https://repo1.maven.org/maven2 \
-    ALPINE_HOST=dl-cdn.alpinelinux.org \
-    MIRROR_MAVEN_HOST=http://maven.aliyun.com/repository/public \
-    MIRROR_ALPINE_HOST=mirrors.aliyun.com 
+  ALPINE_HOST=dl-cdn.alpinelinux.org \
+  MIRROR_MAVEN_HOST=http://maven.aliyun.com/repository/public \
+  MIRROR_ALPINE_HOST=mirrors.aliyun.com 
 
 # if use mirror change to aliyun mirror site
 RUN if $MIRROR; then MAVEN_HOST=${MIRROR_MAVEN_HOST} ;ALPINE_HOST=${MIRROR_ALPINE_HOST} ; sed -i "s/dl-cdn.alpinelinux.org/${ALPINE_HOST}/g" /etc/apk/repositories ; fi && \
-    # https://github.com/docker-library/openjdk/issues/76
-    apk add --no-cache tini && \ 
-    # download & install arthas
-    wget -qO /tmp/arthas.zip "${MAVEN_HOST}/com/taobao/arthas/arthas-packaging/${ARTHAS_VERSION}/arthas-packaging-${ARTHAS_VERSION}-bin.zip" && \
-    mkdir -p /opt/arthas && \
-    unzip /tmp/arthas.zip -d /opt/arthas && \
-    rm /tmp/arthas.zip
-
-# Tini is now available at /sbin/tini
-ENTRYPOINT ["/sbin/tini", "--"]
+  # download & install arthas
+  wget -qO /tmp/arthas.zip "${MAVEN_HOST}/com/taobao/arthas/arthas-packaging/${ARTHAS_VERSION}/arthas-packaging-${ARTHAS_VERSION}-bin.zip" && \
+  mkdir -p /opt/arthas && \
+  unzip /tmp/arthas.zip -d /opt/arthas && \
+  rm /tmp/arthas.zip

--- a/Dockerfile-No-Jdk
+++ b/Dockerfile-No-Jdk
@@ -1,0 +1,22 @@
+FROM alpine
+
+ARG ARTHAS_VERSION="3.0.5"
+ARG MIRROR=false
+
+ENV MAVEN_HOST=https://repo1.maven.org/maven2 \
+    ALPINE_HOST=dl-cdn.alpinelinux.org \
+    MIRROR_MAVEN_HOST=http://maven.aliyun.com/repository/public \
+    MIRROR_ALPINE_HOST=mirrors.aliyun.com 
+
+# if use mirror change to aliyun mirror site
+RUN if $MIRROR; then MAVEN_HOST=${MIRROR_MAVEN_HOST} ;ALPINE_HOST=${MIRROR_ALPINE_HOST} ; sed -i "s/dl-cdn.alpinelinux.org/${ALPINE_HOST}/g" /etc/apk/repositories ; fi && \
+    # https://github.com/docker-library/openjdk/issues/76
+    apk add --no-cache tini && \ 
+    # download & install arthas
+    wget -qO /tmp/arthas.zip "${MAVEN_HOST}/com/taobao/arthas/arthas-packaging/${ARTHAS_VERSION}/arthas-packaging-${ARTHAS_VERSION}-bin.zip" && \
+    mkdir -p /opt/arthas && \
+    unzip /tmp/arthas.zip -d /opt/arthas && \
+    rm /tmp/arthas.zip
+
+# Tini is now available at /sbin/tini
+ENTRYPOINT ["/sbin/tini", "--"]

--- a/Dockerfile-No-Jdk
+++ b/Dockerfile-No-Jdk
@@ -4,12 +4,10 @@ ARG ARTHAS_VERSION="3.0.5"
 ARG MIRROR=false
 
 ENV MAVEN_HOST=https://repo1.maven.org/maven2 \
-  ALPINE_HOST=dl-cdn.alpinelinux.org \
-  MIRROR_MAVEN_HOST=http://maven.aliyun.com/repository/public \
-  MIRROR_ALPINE_HOST=mirrors.aliyun.com 
+  MIRROR_MAVEN_HOST=http://maven.aliyun.com/repository/public
 
 # if use mirror change to aliyun mirror site
-RUN if $MIRROR; then MAVEN_HOST=${MIRROR_MAVEN_HOST} ;ALPINE_HOST=${MIRROR_ALPINE_HOST} ; sed -i "s/dl-cdn.alpinelinux.org/${ALPINE_HOST}/g" /etc/apk/repositories ; fi && \
+RUN if $MIRROR; then MAVEN_HOST=${MIRROR_MAVEN_HOST} ; fi && \
   # download & install arthas
   wget -qO /tmp/arthas.zip "${MAVEN_HOST}/com/taobao/arthas/arthas-packaging/${ARTHAS_VERSION}/arthas-packaging-${ARTHAS_VERSION}-bin.zip" && \
   mkdir -p /opt/arthas && \


### PR DESCRIPTION
ref doc https://alibaba.github.io/arthas/en/docker.html#install-arthas-into-the-base-docker-image

In this scenario
base on openjdk:8-alpine, the image size > 110MB
```
docker build --build-arg MIRROR=true . -t arthas:jdk
```
base on alpine only 15MB
```
docker build -f Dockerfile-No-Jdk --build-arg MIRROR=true . -t arthas:no-jdk
```
![image](https://user-images.githubusercontent.com/15098916/50277928-bcb7d500-0480-11e9-93f3-5280471a42b3.png)
