### PR TITLE
bug fix when cannot create directory

### DIFF
--- a/boot/src/main/java/com/taobao/arthas/boot/Bootstrap.java
+++ b/boot/src/main/java/com/taobao/arthas/boot/Bootstrap.java
@@ -325,7 +325,11 @@ public class Bootstrap {
 
         // try to download from remote server
         if (arthasHomeDir == null) {
-            ARTHAS_LIB_DIR.mkdirs();
+            boolean checkFile =  ARTHAS_LIB_DIR.exists() || ARTHAS_LIB_DIR.mkdirs();
+            if(!checkFile){
+                AnsiLog.error("cannot create directory {}: Permission denied", ARTHAS_LIB_DIR.getAbsolutePath());
+                System.exit(1);
+            }
 
             /**
              * <pre>


### PR DESCRIPTION
### env
My project is running in docker
*  `arthas-boot` version: 3.0.5.1
*   docker run with "--user nobody"

### 重现问题的步骤
java -jar arthas-boot.jar

### 实际运行的结果 
```
Exception in thread "main" java.lang.NullPointerException
	at com.taobao.arthas.boot.Bootstrap.listNames(Bootstrap.java:468)
	at com.taobao.arthas.boot.Bootstrap.main(Bootstrap.java:337)
``` 

