### PR TITLE
Use uppercase L to declare variables

### DIFF
--- a/testcase/src/main/java/com/alibaba/arthas/Test.java
+++ b/testcase/src/main/java/com/alibaba/arthas/Test.java
@@ -43,7 +43,7 @@ public class Test {
             list.get(random).setName(null);
             test(list);
             list.get(random).setName(name);
-            Thread.sleep(1000l);
+            Thread.sleep(1000L);
         }
     }
 


### PR DESCRIPTION
long或者Long初始赋值时，必须使用大写的L，不能是小写的l，小写容易跟数字1混淆，造成误解。
