### PR TITLE
删除重复的Mac OS判断分支

### DIFF
--- a/common/src/main/java/com/taobao/arthas/common/OSUtils.java
+++ b/common/src/main/java/com/taobao/arthas/common/OSUtils.java
@@ -16,8 +16,6 @@ public class OSUtils {
             platform = PlatformEnum.LINUX;
         } else if (OPERATING_SYSTEM_NAME.startsWith("mac") || OPERATING_SYSTEM_NAME.startsWith("darwin")) {
             platform = PlatformEnum.MACOSX;
-        } else if (OPERATING_SYSTEM_NAME.startsWith("mac") || OPERATING_SYSTEM_NAME.startsWith("darwin")) {
-            platform = PlatformEnum.MACOSX;
         } else if (OPERATING_SYSTEM_NAME.startsWith("windows")) {
             platform = PlatformEnum.WINDOWS;
         } else {


### PR DESCRIPTION
OSUtils中有两个完全相同的Mac OS判断分支