### PR TITLE
mc文档中redefine超链接跳转问题

### DIFF
--- a/site/src/site/sphinx/mc.md
+++ b/site/src/site/sphinx/mc.md
@@ -19,4 +19,4 @@ mc -c 327a647b /tmp/Test.java
 mc -d /tmp/output /tmp/ClassA.java /tmp/ClassB.java
 ```
 
-编译生成`.class`文件之后，可以结合[`redefine`](redefine.md)命令实现热更新代码。
+编译生成`.class`文件之后，可以结合[redefine](redefine.md)命令实现热更新代码。


### PR DESCRIPTION
https://alibaba.github.io/arthas/mc.html  中点击`redefine`跳转失败（404），跳转地址为：https://alibaba.github.io/arthas/redefine.md