### PR TITLE
support stack variable in time tunnel watch/search/condition

### DIFF
--- a/core/src/main/java/com/taobao/arthas/core/advisor/ReflectAdviceListenerAdapter.java
+++ b/core/src/main/java/com/taobao/arthas/core/advisor/ReflectAdviceListenerAdapter.java
@@ -201,8 +201,20 @@ public abstract class ReflectAdviceListenerAdapter implements AdviceListener {
      * @return true 如果条件表达式满足
      */
     protected boolean isConditionMet(String conditionExpress, Advice advice, double cost) throws ExpressException {
+        return isConditionMet(conditionExpress, advice, cost, null);
+    }
+
+    /**
+     * 判断条件是否满足，满足的情况下需要输出结果
+     * @param conditionExpress 条件表达式
+     * @param advice 当前的advice对象
+     * @param cost 本次执行的耗时
+     * @param stack 本次调用的调用栈
+     * @return true 如果条件表达式满足
+     */
+    protected boolean isConditionMet(String conditionExpress, Advice advice, double cost, String stack) throws ExpressException {
         return StringUtils.isEmpty(conditionExpress) ||
-                ExpressFactory.threadLocalExpress(advice).bind(Constants.COST_VARIABLE, cost).is(conditionExpress);
+                ExpressFactory.threadLocalExpress(advice).bind(Constants.COST_VARIABLE, cost).bind(Constants.STACK_VARIABLE, stack).is(conditionExpress);
     }
 
     protected Object getExpressionResult(String express, Advice advice, double cost) throws ExpressException {

--- a/core/src/main/java/com/taobao/arthas/core/command/monitor200/TimeFragment.java
+++ b/core/src/main/java/com/taobao/arthas/core/command/monitor200/TimeFragment.java
@@ -9,15 +9,17 @@ import java.util.Date;
  */
 class TimeFragment {
 
-    public TimeFragment(Advice advice, Date gmtCreate, double cost) {
+    public TimeFragment(Advice advice, Date gmtCreate, double cost, String stack) {
         this.advice = advice;
         this.gmtCreate = gmtCreate;
         this.cost = cost;
+        this.stack = stack;
     }
 
     private final Advice advice;
     private final Date gmtCreate;
     private final double cost;
+    private final String stack;
 
     public Advice getAdvice() {
         return advice;
@@ -29,5 +31,9 @@ class TimeFragment {
 
     public double getCost() {
         return cost;
+    }
+
+    public String getStack() {
+        return stack;
     }
 }

--- a/core/src/main/java/com/taobao/arthas/core/command/monitor200/TimeTunnelCommand.java
+++ b/core/src/main/java/com/taobao/arthas/core/command/monitor200/TimeTunnelCommand.java
@@ -27,6 +27,7 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import static com.taobao.arthas.core.util.Constants.STACK_VARIABLE;
 import static java.lang.Integer.toHexString;
 import static java.lang.String.format;
 
@@ -353,7 +354,7 @@ public class TimeTunnelCommand extends EnhancerCommand {
             }
 
             Advice advice = tf.getAdvice();
-            Object value = ExpressFactory.threadLocalExpress(advice).get(watchExpress);
+            Object value = ExpressFactory.threadLocalExpress(advice).bind(STACK_VARIABLE, tf.getStack()).get(watchExpress);
             if (isNeedExpand()) {
                 process.write(new ObjectView(value, expand, sizeLimit).draw()).write("\n");
             } else {
@@ -382,7 +383,7 @@ public class TimeTunnelCommand extends EnhancerCommand {
                 Advice advice = tf.getAdvice();
 
                 // 搜索出匹配的时间片段
-                if ((ExpressFactory.threadLocalExpress(advice)).is(searchExpress)) {
+                if ((ExpressFactory.threadLocalExpress(advice).bind(STACK_VARIABLE, tf.getStack())).is(searchExpress)) {
                     matchingTimeSegmentMap.put(index, tf);
                 }
             }

--- a/core/src/main/java/com/taobao/arthas/core/command/monitor200/TimeTunnelTable.java
+++ b/core/src/main/java/com/taobao/arthas/core/command/monitor200/TimeTunnelTable.java
@@ -17,6 +17,7 @@ import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.Map;
 
+import static com.taobao.arthas.core.util.Constants.STACK_VARIABLE;
 import static com.taobao.text.ui.Element.label;
 import static java.lang.Integer.toHexString;
 
@@ -162,7 +163,8 @@ public class TimeTunnelTable {
                                  String watchExpress, boolean isNeedExpand, int expandLevel, int sizeLimit)
             throws ExpressException {
         for (Map.Entry<Integer, TimeFragment> entry : matchingTimeSegmentMap.entrySet()) {
-            Object value = ExpressFactory.threadLocalExpress(entry.getValue().getAdvice()).get(watchExpress);
+            TimeFragment tf = entry.getValue();
+            Object value = ExpressFactory.threadLocalExpress(tf.getAdvice()).bind(STACK_VARIABLE, tf.getStack()).get(watchExpress);
             table.row("" + entry.getKey(), "" +
                     (isNeedExpand ? new ObjectView(value, expandLevel, sizeLimit).draw() : StringUtils.objectToString(value)));
         }

--- a/core/src/main/java/com/taobao/arthas/core/util/Constants.java
+++ b/core/src/main/java/com/taobao/arthas/core/util/Constants.java
@@ -40,6 +40,11 @@ public interface Constants {
      */
     String COST_VARIABLE = "cost";
 
+    /**
+     * 方法执行 stack
+     */
+    String STACK_VARIABLE = "stack";
+
     String CMD_HISTORY_FILE = System.getProperty("user.home") + File.separator + ".arthas" + File.separator + "history";
 
     /**


### PR DESCRIPTION
在我们的场景中，一个底层方法会出现大量已知的调用和少量位置的调用，因为调用时的参数、返回值没有明显区别，最快速的方法就是通过调用栈过滤，将已知的调用栈都过滤掉。

所以在 Time Tunnel 增加了 `stack` 这个变量，可以用于在 Time Tunnel 中使用 `conditionExpress`、`searchExpress` 过滤，以及通过 `watchExpress` 查看。

这样在某些场景需要将特殊参数和调用栈对应上时，也不用分别使用  Time Tunnel 和 Stack 两个命令了。