### PR TITLE
 support prettify trace call stack

### DIFF
--- a/core/src/main/java/com/taobao/arthas/core/GlobalOptions.java
+++ b/core/src/main/java/com/taobao/arthas/core/GlobalOptions.java
@@ -99,4 +99,15 @@ public class GlobalOptions {
     )
     public static volatile String jobTimeout = "1d";
 
+    /**
+     * 是否美化Trace调用树（合并重复调用节点，动态Proxy类显示为接口类）
+     */
+    @Option(level = 2,
+            name = "prettify-trace-stack",
+            summary = "Option to prettify trace command output call stack",
+            description = "This option enables to prettify trace command output call stack, " +
+                    "merge two node of the same invoking, change the dynamic proxy classname to interface name."
+    )
+    public static volatile boolean isPrettifyTraceStack = true;
+
 }

--- a/core/src/main/java/com/taobao/arthas/core/command/monitor200/AbstractTraceAdviceListener.java
+++ b/core/src/main/java/com/taobao/arthas/core/command/monitor200/AbstractTraceAdviceListener.java
@@ -6,6 +6,7 @@ import com.taobao.arthas.core.advisor.ReflectAdviceListenerAdapter;
 import com.taobao.arthas.core.shell.command.CommandProcess;
 import com.taobao.arthas.core.util.LogUtil;
 import com.taobao.arthas.core.util.ThreadLocalWatch;
+import com.taobao.arthas.core.view.TreeView;
 
 /**
  * @author ralf0131 2017-01-06 16:02.
@@ -40,7 +41,7 @@ public class AbstractTraceAdviceListener extends ReflectAdviceListenerAdapter {
     @Override
     public void before(ClassLoader loader, Class<?> clazz, ArthasMethod method, Object target, Object[] args)
             throws Throwable {
-        threadBoundEntity.get().view.begin(clazz.getName() + ":" + method.getName() + "()");
+        threadBoundEntity.get().view.begin(clazz.getName() + ":" + method.getName() + "()", TreeView.INVOKE_ON_BEGIN);
         threadBoundEntity.get().deep++;
         // 开始计算本次方法调用耗时
         threadLocalWatch.start();
@@ -57,7 +58,7 @@ public class AbstractTraceAdviceListener extends ReflectAdviceListenerAdapter {
     @Override
     public void afterThrowing(ClassLoader loader, Class<?> clazz, ArthasMethod method, Object target, Object[] args,
                               Throwable throwable) throws Throwable {
-        threadBoundEntity.get().view.begin("throw:" + throwable.getClass().getName() + "()").end().end();
+        threadBoundEntity.get().view.begin("throw:" + throwable.getClass().getName() + "()", TreeView.INVOKE_AFTER_THROWING).end().end();
         final Advice advice = Advice.newForAfterThrowing(loader, clazz, method, target, args, throwable);
         finishing(advice);
     }

--- a/core/src/main/java/com/taobao/arthas/core/command/monitor200/TraceAdviceListener.java
+++ b/core/src/main/java/com/taobao/arthas/core/command/monitor200/TraceAdviceListener.java
@@ -3,6 +3,7 @@ package com.taobao.arthas.core.command.monitor200;
 import com.taobao.arthas.core.advisor.InvokeTraceable;
 import com.taobao.arthas.core.shell.command.CommandProcess;
 import com.taobao.arthas.core.util.StringUtils;
+import com.taobao.arthas.core.view.TreeView;
 
 /**
  * @author beiwei30 on 29/11/2016.
@@ -23,7 +24,7 @@ public class TraceAdviceListener extends AbstractTraceAdviceListener implements 
     public void invokeBeforeTracing(String tracingClassName, String tracingMethodName, String tracingMethodDesc)
             throws Throwable {
         threadBoundEntity.get().view.begin(
-                StringUtils.normalizeClassName(tracingClassName) + ":" + tracingMethodName + "()");
+                StringUtils.normalizeClassName(tracingClassName) + ":" + tracingMethodName + "()", TreeView.INVOKE_ON_INVOKE_BEFORE);
     }
 
     @Override

--- a/core/src/main/java/com/taobao/arthas/core/view/TreeView.java
+++ b/core/src/main/java/com/taobao/arthas/core/view/TreeView.java
@@ -13,6 +13,10 @@ import java.util.Map;
  */
 public class TreeView implements View {
 
+    public static final int INVOKE_ON_BEGIN = 1;
+    public static final int INVOKE_AFTER_THROWING = 2;
+    public static final int INVOKE_ON_INVOKE_BEFORE = 3;
+
     private static final String STEP_FIRST_CHAR = "`---";
     private static final String STEP_NORMAL_CHAR = "+---";
     private static final String STEP_HAS_BOARD = "|   ";
@@ -40,6 +44,8 @@ public class TreeView implements View {
 
     @Override
     public String draw() {
+
+        rebuildInvokeTree(root);
 
         findMaxCostNode(root);
 
@@ -70,6 +76,19 @@ public class TreeView implements View {
         });
 
         return treeSB.toString();
+    }
+
+    private Node rebuildInvokeTree(Node root) {
+        Node newRoot = new Node(root.data);
+        return null;
+    }
+
+    private boolean shouldMergeNodes(Node parent, Node node) {
+        //合并重复的结点： merge onBegin to last level onInvokeBefore
+        if(node.invokeType == INVOKE_ON_BEGIN && parent.invokeType == INVOKE_ON_INVOKE_BEFORE){
+
+        }
+        return false;
     }
 
     /**
@@ -119,12 +138,12 @@ public class TreeView implements View {
      * @param data 节点数据
      * @return this
      */
-    public TreeView begin(String data) {
+    public TreeView begin(String data, int invokeType) {
         Node n = current.find(data);
         if (n != null) {
             current = n;
         } else {
-            current = new Node(current, data);
+            current = new Node(current, data, invokeType);
         }
         current.markBegin();
         return this;
@@ -197,11 +216,17 @@ public class TreeView implements View {
         private String mark;
 
         /**
+         * 调用方式
+         */
+        private int invokeType;
+
+        /**
          * 构造树节点(根节点)
          */
         private Node(String data) {
             this.parent = null;
             this.data = data;
+            this.invokeType = INVOKE_ON_BEGIN;
         }
 
         /**
@@ -210,11 +235,26 @@ public class TreeView implements View {
          * @param parent 父节点
          * @param data   节点数据
          */
-        private Node(Node parent, String data) {
+        private Node(Node parent, String data, int invokeType) {
             this.parent = parent;
             this.data = data;
+            this.invokeType = invokeType;
             parent.children.add(this);
             parent.map.put(data, this);
+        }
+
+        Node copy() {
+            Node node = new Node(data);
+            node.invokeType = invokeType;
+            node.beginTimestamp = beginTimestamp;
+            node.endTimestamp = endTimestamp;
+            node.mark = mark;
+            node.marks = marks;
+            node.totalCost = totalCost;
+            node.maxCost = maxCost;
+            node.minCost = minCost;
+            node.times = times;
+            return node;
         }
 
         /**


### PR DESCRIPTION
美化trace命令输出的调用栈：
1、合并同一个方法调用的两个节点（onBeforceInvoke, onMethodBegin)
判断规则是： 
1）有且只有一个儿子节点
2）父节点调用方式是onBeforceInvoke， 子节点调用类型是onMethodBegin
3）父节点类名与子节点相同 或者 子节点类名是父节点类名的实现类 （这个暂未实现）

2、合并节点时将JDK 动态代理类名修改为其接口类名

美化后trace输出的调用栈精简了很多，看起来更加清晰。如果要看原始调用栈，可以关闭美化功能： options prettify-trace-stack false 。

