### PR TITLE
fix arthas-client windows cmd shortcuts support.

### DIFF
--- a/client/src/main/java/com/taobao/arthas/client/TelnetConsole.java
+++ b/client/src/main/java/com/taobao/arthas/client/TelnetConsole.java
@@ -273,7 +273,7 @@ public class TelnetConsole {
             }
 
             if (cmds.isEmpty()) {
-                IOUtil.readWrite(telnet.getInputStream(), telnet.getOutputStream(), System.in,
+                IOUtil.readWrite(telnet.getInputStream(), telnet.getOutputStream(), consoleReader.getInput(),
                                 consoleReader.getOutput());
             } else {
                 batchModeRun(telnet, cmds);


### PR DESCRIPTION
jline already wrapper stdin, processing up/down/left/right arrow keys, just use consoleReader.getInput() instead of System.in.