### PR TITLE
Double confirmation when enhance match too many class or method

### DIFF
--- a/core/src/main/java/com/taobao/arthas/core/command/monitor200/EnhancerCommand.java
+++ b/core/src/main/java/com/taobao/arthas/core/command/monitor200/EnhancerCommand.java
@@ -164,6 +164,13 @@ public abstract class EnhancerCommand extends AnnotatedCommand {
         }
     }
 
+    /**
+     * Predicted affect of the command matches. Prediction may be differences from real affect.
+     *
+     * @param process         the CommandProcess
+     * @param enhanceClassSet matched class
+     * @return Whether to continue
+     */
     private boolean safeEnhance(CommandProcess process, Set<Class<?>> enhanceClassSet) {
         try {
             if (enhanceClassSet.size() > WEARING_CLASS_SIZE) {

--- a/core/src/main/java/com/taobao/arthas/core/shell/command/CommandProcess.java
+++ b/core/src/main/java/com/taobao/arthas/core/shell/command/CommandProcess.java
@@ -41,6 +41,11 @@ public interface CommandProcess extends Tty {
      */
     boolean isForeground();
 
+    /**
+     *
+     */
+    boolean isRunning();
+
     CommandProcess stdinHandler(Handler<String> handler);
 
     /**
@@ -121,9 +126,9 @@ public interface CommandProcess extends Tty {
 
     /**
      * Register listener
-     * 
+     *
      * @param lock the lock for enhance class
-     * @param listener 
+     * @param listener
      */
     void register(int lock, AdviceListener listener);
 
@@ -134,7 +139,7 @@ public interface CommandProcess extends Tty {
 
     /**
      * Execution times
-     * 
+     *
      * @return execution times
      */
     AtomicInteger times();
@@ -150,8 +155,16 @@ public interface CommandProcess extends Tty {
     void suspend();
 
     /**
+     *
+     * @throws InterruptedException
+     */
+    void waitFor() throws InterruptedException;
+
+    void notice();
+
+    /**
      * echo tips
-     * 
+     *
      * @param tips process tips
      */
     void echoTips(String tips);

--- a/core/src/main/java/com/taobao/arthas/core/shell/handlers/shell/YContinueHandler.java
+++ b/core/src/main/java/com/taobao/arthas/core/shell/handlers/shell/YContinueHandler.java
@@ -1,0 +1,28 @@
+package com.taobao.arthas.core.shell.handlers.shell;
+
+import com.taobao.arthas.core.shell.command.CommandProcess;
+import com.taobao.arthas.core.shell.handlers.Handler;
+
+/**
+ * Date: 2019/4/2
+ *
+ * @author xuzhiyi
+ */
+public class YContinueHandler implements Handler<String> {
+
+    private final CommandProcess process;
+
+    public YContinueHandler(CommandProcess process) {
+        this.process = process;
+    }
+
+    @Override
+    public void handle(String event) {
+        process.write(event + "\n");
+        if ("y".equalsIgnoreCase(event)) {
+            process.notice();
+        } else {
+            process.end();
+        }
+    }
+}

--- a/core/src/main/java/com/taobao/arthas/core/shell/system/impl/ProcessImpl.java
+++ b/core/src/main/java/com/taobao/arthas/core/shell/system/impl/ProcessImpl.java
@@ -412,6 +412,11 @@ public class ProcessImpl implements Process {
         }
 
         @Override
+        public boolean isRunning() {
+            return processStatus == ExecStatus.RUNNING;
+        }
+
+        @Override
         public int width() {
             return tty.width();
         }
@@ -549,13 +554,24 @@ public class ProcessImpl implements Process {
         }
 
         @Override
+        public synchronized void waitFor() throws InterruptedException {
+            wait();
+        }
+
+        @Override
+        public synchronized void notice() {
+            notifyAll();
+        }
+
+        @Override
         public void end() {
             end(0);
         }
 
         @Override
-        public void end(int statusCode) {
+        public synchronized void end(int statusCode) {
             terminate(statusCode, null);
+            notifyAll();
         }
     }
 

--- a/core/src/main/java/com/taobao/arthas/core/util/SearchUtils.java
+++ b/core/src/main/java/com/taobao/arthas/core/util/SearchUtils.java
@@ -6,6 +6,7 @@ import com.taobao.arthas.core.util.matcher.RegexMatcher;
 import com.taobao.arthas.core.util.matcher.WildcardMatcher;
 
 import java.lang.instrument.Instrumentation;
+import java.lang.reflect.Method;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
@@ -131,6 +132,16 @@ public class SearchUtils {
                 if (clazz.getName().startsWith(c.getName())) {
                     matches.add(clazz);
                 }
+            }
+        }
+        return matches;
+    }
+
+    public static Set<Method> searchClassMethod(Class clazz, Matcher<String> methodNameMatcher) {
+        final Set<Method> matches = new HashSet<Method>();
+        for (Method method : clazz.getDeclaredMethods()) {
+            if (methodNameMatcher.matching(method.getName())) {
+                matches.add(method);
             }
         }
         return matches;


### PR DESCRIPTION
Arthas as a diagnostic tool for production system, should provide strong reliability.
Enhance is high cost operation.It's fatal in production system if your command match too many class or method.
Such as: 
`trace -E .* .*`
`watch -E .* .*`
Of course, you probably won't write like this. But misuse is inevitable. Once it happens, it will have a serious impact.
To avoid this case, double confirmation is necessary.

![image](https://user-images.githubusercontent.com/48389485/55483618-85e58380-5659-11e9-94f3-7360425b309b.png)