### PR TITLE
fix method completion when class only has one method

### DIFF
--- a/core/src/main/java/com/taobao/arthas/core/shell/cli/CompletionUtils.java
+++ b/core/src/main/java/com/taobao/arthas/core/shell/cli/CompletionUtils.java
@@ -200,6 +200,10 @@ public class CompletionUtils {
         List<CliToken> tokens = completion.lineTokens();
         String lastToken = completion.lineTokens().get(tokens.size() - 1).value();
 
+        if (StringUtils.isBlank(lastToken)) {
+            lastToken = "";
+        }
+
         // retrieve the class name
         String className;
         if (StringUtils.isBlank(lastToken)) {


### PR DESCRIPTION
```
public class MathGame {
    private static Random random = new Random();

    public int illegalArgumentCount = 0;

    public static void main(String[] args) throws InterruptedException {
        while (true) {
            TimeUnit.SECONDS.sleep(1);
        }
    }
}
```

![image](https://user-images.githubusercontent.com/48389485/55637979-c596a180-57f8-11e9-9d7d-be5fe84a906c.png)
