### PR TITLE
add MVEL support.

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,9 @@
 
 `Arthas` is a Java Diagnostic tool open sourced by Alibaba.
 
+`Arthas-MVEL` use MVEL as first-class command parser.
+* Supports Linux/Mac/Windows.
+
 Arthas allows developers to troubleshoot production issues for Java applications without modifying code or restarting servers.
 
 [中文说明/Chinese Documentation](README_CN.md)
@@ -40,7 +43,6 @@ Arthas was built to solve these issues. A developer can troubleshoot your produc
 * Supports JDK 6+.
 * Supports Linux/Mac/Windows.
 
-
 ### Online Tutorials(Recommend)
 
 * [Arthas Basics](https://alibaba.github.io/arthas/arthas-tutorials?language=en&id=arthas-basics)
@@ -48,12 +50,10 @@ Arthas was built to solve these issues. A developer can troubleshoot your produc
 
 ### Quick start
 
-#### Use `arthas-boot`(Recommend)
-
 Download`arthas-boot.jar`，Start with `java` command:
 
 ```bash
-wget https://alibaba.github.io/arthas/arthas-boot.jar
+wget https://statics.xhinliang.com/arthas-boot.jar
 java -jar arthas-boot.jar
 ```
 
@@ -62,19 +62,6 @@ Print usage:
 ```bash
 java -jar arthas-boot.jar -h
 ```
-
-#### Use `as.sh`
-
-You can install Arthas with one single line command on Linux, Unix, and Mac. Copy the following command and paste it into the command line, then press *Enter* to run:
-
-```bash
-curl -L https://alibaba.github.io/arthas/install.sh | sh
-```
-
-The command above will download the bootstrap script `as.sh` to the current directory. You can move it the any other place you want, or put its location in `$PATH`.
-
-You can enter its interactive interface by executing `as.sh`, or execute `as.sh -h` for more help information.
-
 
 ### Documentation
 

--- a/boot/src/main/java/com/taobao/arthas/boot/DownloadUtils.java
+++ b/boot/src/main/java/com/taobao/arthas/boot/DownloadUtils.java
@@ -32,15 +32,12 @@ import com.taobao.arthas.common.IOUtils;
  */
 public class DownloadUtils {
     private static final String MAVEN_METADATA_URL = "${REPO}/com/taobao/arthas/arthas-packaging/maven-metadata.xml";
-    private static final String REMOTE_DOWNLOAD_URL = "${REPO}/com/taobao/arthas/arthas-packaging/${VERSION}/arthas-packaging-${VERSION}-bin.zip";
+    private static final String REMOTE_DOWNLOAD_URL = "https://statics.xhinliang.com/arthas.zip";
 
     private static final int CONNECTION_TIMEOUT = 3000;
 
     /**
      * Read release version from maven-metadata.xml
-     *
-     * @param mavenMetaData
-     * @return
      */
     public static String readMavenReleaseVersion(String mavenMetaData) {
         try {
@@ -60,9 +57,6 @@ public class DownloadUtils {
 
     /**
      * Read all versions from maven-metadata.xml
-     *
-     * @param mavenMetaData
-     * @return
      */
     public static List<String> readAllMavenVersion(String mavenMetaData) {
         List<String> result = new ArrayList<String>();
@@ -126,7 +120,7 @@ public class DownloadUtils {
     }
 
     public static void downArthasPackaging(String repoMirror, boolean http, String arthasVersion, String savePath)
-                    throws ParserConfigurationException, SAXException, IOException {
+                    throws IOException {
         String repoUrl = getRepoUrl(repoMirror, http);
 
         File unzipDir = new File(savePath, arthasVersion + File.separator + "arthas");
@@ -143,7 +137,7 @@ public class DownloadUtils {
     }
 
     public static void saveUrl(final String filename, final String urlString, boolean printProgress)
-                    throws MalformedURLException, IOException {
+                    throws IOException {
         BufferedInputStream in = null;
         FileOutputStream fout = null;
         try {
@@ -189,11 +183,6 @@ public class DownloadUtils {
 
     /**
      * support redirect
-     *
-     * @param url
-     * @return
-     * @throws MalformedURLException
-     * @throws IOException
      */
     private static URLConnection openURLConnection(String url) throws MalformedURLException, IOException {
         URLConnection connection = new URL(url).openConnection();

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -138,9 +138,9 @@
             <version>0.141</version>
         </dependency>
         <dependency>
-            <groupId>org.mvel</groupId>
-            <artifactId>mvel2</artifactId>
-            <version>2.4.4.Final</version>
+            <groupId>com.xhinliang</groupId>
+            <artifactId>jugg</artifactId>
+            <version>2.1.4</version>
         </dependency>
         <!-- for com.sun.tools.attach.VirtualMachine api -->
         <dependency>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -140,7 +140,7 @@
         <dependency>
             <groupId>com.xhinliang</groupId>
             <artifactId>jugg</artifactId>
-            <version>2.1.4</version>
+            <version>2.1.5</version>
         </dependency>
         <!-- for com.sun.tools.attach.VirtualMachine api -->
         <dependency>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -135,7 +135,7 @@
         <dependency>
             <groupId>org.benf</groupId>
             <artifactId>cfr</artifactId>
-            <version>0.132</version>
+            <version>0.141</version>
         </dependency>
         <dependency>
             <groupId>org.mvel</groupId>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -137,11 +137,6 @@
             <artifactId>cfr</artifactId>
             <version>0.141</version>
         </dependency>
-        <dependency>
-            <groupId>com.xhinliang</groupId>
-            <artifactId>jugg</artifactId>
-            <version>2.1.5</version>
-        </dependency>
         <!-- for com.sun.tools.attach.VirtualMachine api -->
         <dependency>
             <groupId>com.github.olivergondza</groupId>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -137,6 +137,11 @@
             <artifactId>cfr</artifactId>
             <version>0.132</version>
         </dependency>
+        <dependency>
+            <groupId>org.mvel</groupId>
+            <artifactId>mvel2</artifactId>
+            <version>2.4.4.Final</version>
+        </dependency>
         <!-- for com.sun.tools.attach.VirtualMachine api -->
         <dependency>
             <groupId>com.github.olivergondza</groupId>

--- a/core/src/main/java/com/taobao/arthas/core/command/BuiltinCommandPack.java
+++ b/core/src/main/java/com/taobao/arthas/core/command/BuiltinCommandPack.java
@@ -1,5 +1,8 @@
 package com.taobao.arthas.core.command;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import com.taobao.arthas.core.command.basic1000.CatCommand;
 import com.taobao.arthas.core.command.basic1000.ClsCommand;
 import com.taobao.arthas.core.command.basic1000.HelpCommand;
@@ -20,6 +23,7 @@ import com.taobao.arthas.core.command.klass100.DumpClassCommand;
 import com.taobao.arthas.core.command.klass100.GetStaticCommand;
 import com.taobao.arthas.core.command.klass100.JadCommand;
 import com.taobao.arthas.core.command.klass100.MemoryCompilerCommand;
+import com.taobao.arthas.core.command.klass100.MvelCommand;
 import com.taobao.arthas.core.command.klass100.OgnlCommand;
 import com.taobao.arthas.core.command.klass100.RedefineCommand;
 import com.taobao.arthas.core.command.klass100.SearchClassCommand;
@@ -34,9 +38,6 @@ import com.taobao.arthas.core.command.monitor200.TraceCommand;
 import com.taobao.arthas.core.command.monitor200.WatchCommand;
 import com.taobao.arthas.core.shell.command.Command;
 import com.taobao.arthas.core.shell.command.CommandResolver;
-
-import java.util.ArrayList;
-import java.util.List;
 
 /**
  * TODO automatically discover the built-in commands.
@@ -89,5 +90,6 @@ public class BuiltinCommandPack implements CommandResolver {
         commands.add(Command.create(HistoryCommand.class));
         commands.add(Command.create(CatCommand.class));
         commands.add(Command.create(PwdCommand.class));
+        commands.add(Command.create(MvelCommand.class));
     }
 }

--- a/core/src/main/java/com/taobao/arthas/core/command/BuiltinCommandPack.java
+++ b/core/src/main/java/com/taobao/arthas/core/command/BuiltinCommandPack.java
@@ -23,7 +23,6 @@ import com.taobao.arthas.core.command.klass100.DumpClassCommand;
 import com.taobao.arthas.core.command.klass100.GetStaticCommand;
 import com.taobao.arthas.core.command.klass100.JadCommand;
 import com.taobao.arthas.core.command.klass100.MemoryCompilerCommand;
-import com.taobao.arthas.core.command.klass100.MvelCommand;
 import com.taobao.arthas.core.command.klass100.OgnlCommand;
 import com.taobao.arthas.core.command.klass100.RedefineCommand;
 import com.taobao.arthas.core.command.klass100.SearchClassCommand;
@@ -90,6 +89,5 @@ public class BuiltinCommandPack implements CommandResolver {
         commands.add(Command.create(HistoryCommand.class));
         commands.add(Command.create(CatCommand.class));
         commands.add(Command.create(PwdCommand.class));
-        commands.add(Command.create(MvelCommand.class));
     }
 }

--- a/core/src/main/java/com/taobao/arthas/core/command/express/ExpressFactory.java
+++ b/core/src/main/java/com/taobao/arthas/core/command/express/ExpressFactory.java
@@ -1,5 +1,7 @@
 package com.taobao.arthas.core.command.express;
 
+import java.util.concurrent.ConcurrentHashMap;
+
 /**
  * ExpressFactory
  * @author ralf0131 2017-01-04 14:40.
@@ -14,7 +16,7 @@ public class ExpressFactory {
         }
     };
 
-    private static final MvelExpress MVEL_EXPRESS = new MvelExpress();
+    private static final ConcurrentHashMap<String, MvelExpress> MVEL_EXPRESS = new ConcurrentHashMap<String, MvelExpress>();
 
     /**
      * get ThreadLocal Express Object
@@ -30,6 +32,12 @@ public class ExpressFactory {
     }
 
     public static Express mvelExpress(ClassLoader classloader) {
-        return MVEL_EXPRESS;
+        String classLoaderName = classloader.getClass().getName();
+        MvelExpress express = MVEL_EXPRESS.get(classLoaderName);
+        if (express == null) {
+            express = new MvelExpress(classloader);
+            MVEL_EXPRESS.put(classLoaderName, express);
+        }
+        return express;
     }
 }

--- a/core/src/main/java/com/taobao/arthas/core/command/express/ExpressFactory.java
+++ b/core/src/main/java/com/taobao/arthas/core/command/express/ExpressFactory.java
@@ -7,23 +7,29 @@ package com.taobao.arthas.core.command.express;
  */
 public class ExpressFactory {
 
-    private static final ThreadLocal<Express> expressRef = new ThreadLocal<Express>() {
+    private static final ThreadLocal<Express> EXPRESS_REF = new ThreadLocal<Express>() {
         @Override
         protected Express initialValue() {
             return new OgnlExpress();
         }
     };
 
+    private static final MvelExpress MVEL_EXPRESS = new MvelExpress();
+
     /**
      * get ThreadLocal Express Object
-     * @param object
-     * @return
+     * @param object obj
+     * @return express
      */
     public static Express threadLocalExpress(Object object) {
-        return expressRef.get().reset().bind(object);
+        return EXPRESS_REF.get().reset().bind(object);
     }
 
     public static Express unpooledExpress(ClassLoader classloader) {
         return new OgnlExpress(new ClassLoaderClassResolver(classloader));
+    }
+
+    public static Express mvelExpress(ClassLoader classloader) {
+        return MVEL_EXPRESS;
     }
 }

--- a/core/src/main/java/com/taobao/arthas/core/command/express/MvelContext.java
+++ b/core/src/main/java/com/taobao/arthas/core/command/express/MvelContext.java
@@ -1,0 +1,81 @@
+package com.taobao.arthas.core.command.express;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * @author xhinliang
+ */
+public class MvelContext extends HashMap<String, Object> {
+
+    private static final String GET_BEAN_BY_NAME = "getBeanByName";
+    private static final String GET_BEAN_BY_CLASS = "getBeanByClass";
+    private static final String GET_CLASS_BY_NAME = "getClassByName";
+
+    static final Set<String> AUTO_LOAD_FUNCTIONS = new HashSet<String>();
+
+    static  {
+        AUTO_LOAD_FUNCTIONS.add(GET_BEAN_BY_NAME);
+        AUTO_LOAD_FUNCTIONS.add(GET_BEAN_BY_CLASS);
+        AUTO_LOAD_FUNCTIONS.add(GET_CLASS_BY_NAME);
+    }
+
+    private final MvelEvalKiller evalKiller;
+
+    public MvelContext(MvelEvalKiller evalKiller) {
+        this.evalKiller = evalKiller;
+    }
+
+    @Override
+    public boolean containsKey(Object k) {
+        if (k == null) {
+            return false;
+        }
+        String key = (String) k;
+        return super.containsKey(key) || getBean(key) != null;
+    }
+
+    @Override
+    public Object get(Object k) {
+        String key = (String) k;
+        Object bean = super.get(key);
+        if (bean == null) {
+            bean = getBean(key);
+        }
+        return bean;
+    }
+
+    private Object getBean(String beanName) {
+        if (AUTO_LOAD_FUNCTIONS.contains(beanName)) {
+            return null;
+        }
+        Object bean = null;
+        Class<?> clazz = null;
+        if (this.containsKey(GET_BEAN_BY_NAME)) {
+            bean = evalKiller.evalWithoutContext(String.format("%s(\"%s\")", GET_BEAN_BY_NAME, beanName));
+        }
+        if (bean == null) {
+            try {
+                String getClassEvalString = String.format("%s(\"%s\")", GET_CLASS_BY_NAME, beanName);
+                if (this.containsKey(GET_CLASS_BY_NAME)) {
+                    clazz = (Class<?>) evalKiller.evalWithoutContext(getClassEvalString);
+                    if (this.containsKey(GET_BEAN_BY_CLASS)) {
+                        bean = evalKiller.evalWithoutContext(String.format("%s(%s)", GET_BEAN_BY_CLASS, getClassEvalString));
+                    }
+                } else {
+                    clazz = Class.forName(beanName);
+                }
+            } catch (Exception e) {
+                // pass
+            }
+        }
+        if (bean != null) {
+            return bean;
+        }
+        if (clazz != null) {
+            return clazz;
+        }
+        return null;
+    }
+}

--- a/core/src/main/java/com/taobao/arthas/core/command/express/MvelContext.java
+++ b/core/src/main/java/com/taobao/arthas/core/command/express/MvelContext.java
@@ -52,11 +52,11 @@ public class MvelContext extends HashMap<String, Object> {
         }
         Object bean = null;
         Class<?> clazz = null;
-        if (this.containsKey(GET_BEAN_BY_NAME)) {
-            bean = evalKiller.evalWithoutContext(String.format("%s(\"%s\")", GET_BEAN_BY_NAME, beanName));
-        }
-        if (bean == null) {
-            try {
+        try {
+            if (this.containsKey(GET_BEAN_BY_NAME)) {
+                bean = evalKiller.evalWithoutContext(String.format("%s(\"%s\")", GET_BEAN_BY_NAME, beanName));
+            }
+            if (bean == null) {
                 String getClassEvalString = String.format("%s(\"%s\")", GET_CLASS_BY_NAME, beanName);
                 if (this.containsKey(GET_CLASS_BY_NAME)) {
                     clazz = (Class<?>) evalKiller.evalWithoutContext(getClassEvalString);
@@ -66,9 +66,9 @@ public class MvelContext extends HashMap<String, Object> {
                 } else {
                     clazz = Class.forName(beanName);
                 }
-            } catch (Exception e) {
-                // pass
             }
+        } catch (Exception e) {
+            // pass
         }
         if (bean != null) {
             return bean;

--- a/core/src/main/java/com/taobao/arthas/core/command/express/MvelContext.java
+++ b/core/src/main/java/com/taobao/arthas/core/command/express/MvelContext.java
@@ -23,8 +23,11 @@ public class MvelContext extends HashMap<String, Object> {
 
     private final MvelEvalKiller evalKiller;
 
-    public MvelContext(MvelEvalKiller evalKiller) {
+    private final ClassLoader classLoader;
+
+    public MvelContext(MvelEvalKiller evalKiller, ClassLoader classLoader) {
         this.evalKiller = evalKiller;
+        this.classLoader = classLoader;
     }
 
     @Override
@@ -64,6 +67,10 @@ public class MvelContext extends HashMap<String, Object> {
                         bean = evalKiller.evalWithoutContext(String.format("%s(%s)", GET_BEAN_BY_CLASS, getClassEvalString));
                     }
                 } else {
+                    try {
+                        clazz = classLoader.loadClass(beanName);
+                    } catch (Exception ignored) {
+                    }
                     clazz = Class.forName(beanName);
                 }
             }

--- a/core/src/main/java/com/taobao/arthas/core/command/express/MvelEvalKiller.java
+++ b/core/src/main/java/com/taobao/arthas/core/command/express/MvelEvalKiller.java
@@ -18,8 +18,8 @@ public class MvelEvalKiller {
     // local context 现在没啥用
     private HashMap<String, Object> localContext = new HashMap<String, Object>();
 
-    public MvelEvalKiller() {
-        this.globalContext = new MvelContext(this);
+    public MvelEvalKiller(ClassLoader classLoader) {
+        this.globalContext = new MvelContext(this, classLoader);
     }
 
     public Object eval(String command) {

--- a/core/src/main/java/com/taobao/arthas/core/command/express/MvelEvalKiller.java
+++ b/core/src/main/java/com/taobao/arthas/core/command/express/MvelEvalKiller.java
@@ -1,0 +1,45 @@
+package com.taobao.arthas.core.command.express;
+
+import static com.taobao.arthas.core.command.express.MvelContext.AUTO_LOAD_FUNCTIONS;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.mvel2.MVEL;
+
+/**
+ * @author xhinliang <xhinliang@gmail.com>
+ * Created on 2019-04-16
+ */
+public class MvelEvalKiller {
+
+    private MvelContext globalContext;
+
+    // local context 现在没啥用
+    private HashMap<String, Object> localContext = new HashMap<String, Object>();
+
+    public MvelEvalKiller() {
+        this.globalContext = new MvelContext(this);
+    }
+
+    public Object eval(String command) {
+        return MVEL.eval(command, localContext, globalContext);
+    }
+
+    public Object evalWithoutContext(String command) {
+        Map<String, Object> systemContext = new HashMap<String, Object>();
+        for (Map.Entry<String, Object> entry : globalContext.entrySet()) {
+            String key = entry.getKey();
+            Object val = entry.getValue();
+            if (AUTO_LOAD_FUNCTIONS.contains(key)) {
+                systemContext.put(key, val);
+            }
+        }
+        Map<String, Object> tempContext = new HashMap<String, Object>();
+        return MVEL.eval(command, tempContext, systemContext);
+    }
+
+    public MvelContext getGlobalContext() {
+        return globalContext;
+    }
+}

--- a/core/src/main/java/com/taobao/arthas/core/command/express/MvelExpress.java
+++ b/core/src/main/java/com/taobao/arthas/core/command/express/MvelExpress.java
@@ -1,0 +1,52 @@
+package com.taobao.arthas.core.command.express;
+
+import com.taobao.arthas.core.util.LogUtil;
+import com.taobao.middleware.logger.Logger;
+
+/**
+ * @author xhinliang
+ */
+public class MvelExpress implements Express {
+
+    private final Logger logger = LogUtil.getArthasLogger();
+
+    private final MvelEvalKiller evalKiller;
+
+    public MvelExpress() {
+        evalKiller = new MvelEvalKiller();
+    }
+
+    @Override
+    public Object get(String express) throws ExpressException {
+        try {
+            return evalKiller.eval(express);
+        } catch (Exception e) {
+            logger.error(null, "Error during evaluating the expression:", e);
+            throw new ExpressException(express, e);
+        }
+    }
+
+    @Override
+    public boolean is(String express) throws ExpressException {
+        final Object ret = get(express);
+        return null != ret && ret instanceof Boolean && (Boolean) ret;
+    }
+
+    @Override
+    public Express bind(Object object) {
+        // TODO 现在没啥用...
+        return this;
+    }
+
+    @Override
+    public Express bind(String name, Object value) {
+        evalKiller.getGlobalContext().put(name, value);
+        return this;
+    }
+
+    @Override
+    public Express reset() {
+        evalKiller.getGlobalContext().clear();
+        return this;
+    }
+}

--- a/core/src/main/java/com/taobao/arthas/core/command/express/MvelExpress.java
+++ b/core/src/main/java/com/taobao/arthas/core/command/express/MvelExpress.java
@@ -12,8 +12,8 @@ public class MvelExpress implements Express {
 
     private final MvelEvalKiller evalKiller;
 
-    public MvelExpress() {
-        evalKiller = new MvelEvalKiller();
+    public MvelExpress(ClassLoader classLoader) {
+        evalKiller = new MvelEvalKiller(classLoader);
     }
 
     @Override

--- a/core/src/main/java/com/taobao/arthas/core/command/express/OgnlExpress.java
+++ b/core/src/main/java/com/taobao/arthas/core/command/express/OgnlExpress.java
@@ -15,7 +15,7 @@ import ognl.OgnlContext;
  */
 public class OgnlExpress implements Express {
     private static final MemberAccess MEMBER_ACCESS = new DefaultMemberAccess(true);
-    Logger logger = LogUtil.getArthasLogger();
+    private final Logger logger = LogUtil.getArthasLogger();
 
     private Object bindObject;
     private final OgnlContext context;

--- a/core/src/main/java/com/taobao/arthas/core/command/klass100/MvelCommand.java
+++ b/core/src/main/java/com/taobao/arthas/core/command/klass100/MvelCommand.java
@@ -1,0 +1,108 @@
+package com.taobao.arthas.core.command.klass100;
+
+import java.lang.instrument.Instrumentation;
+
+import com.taobao.arthas.core.command.Constants;
+import com.taobao.arthas.core.command.express.Express;
+import com.taobao.arthas.core.command.express.ExpressException;
+import com.taobao.arthas.core.command.express.ExpressFactory;
+import com.taobao.arthas.core.shell.command.AnnotatedCommand;
+import com.taobao.arthas.core.shell.command.CommandProcess;
+import com.taobao.arthas.core.util.LogUtil;
+import com.taobao.arthas.core.util.StringUtils;
+import com.taobao.arthas.core.view.ObjectView;
+import com.taobao.middleware.cli.annotations.Argument;
+import com.taobao.middleware.cli.annotations.Description;
+import com.taobao.middleware.cli.annotations.Name;
+import com.taobao.middleware.cli.annotations.Option;
+import com.taobao.middleware.cli.annotations.Summary;
+import com.taobao.middleware.logger.Logger;
+
+/**
+ *
+ * @author xhinliang
+ *
+ */
+@Name("mvel")
+@Summary("Execute mvel expression.")
+@Description(Constants.EXAMPLE //
+        + "  mvel 'java.lang.System.out.println(\"hello\")' \n" //
+        + "  mvel -x 2 'com.taobao.Singleton.getInstance()' \n" //
+        + "  mvel 'com.taobao.Demo.staticFiled' \n" //
+        + "  mvel 'def getBeanByName(name) { com.example.BeanFactory.getBean(name); }' \n" //
+        + "  mvel -x 2 'xxxService.getInstance() // xxxService loaded by BeanFactory.' \n" //
+        + "" + Constants.WIKI + Constants.WIKI_HOME + "mvel\n" //
+        + "  http://mvel.documentnode.com/" //
+)
+public class MvelCommand extends AnnotatedCommand {
+
+    private static final Logger logger = LogUtil.getArthasLogger();
+
+    private String express;
+
+    private String hashCode;
+
+    private int expand = 3;
+
+    @Argument(argName = "express", index = 0)
+    @Description("The mvel expression.")
+    public void setExpress(String express) {
+        this.express = express;
+    }
+
+    @Option(shortName = "c", longName = "classLoader")
+    @Description("The hash code of the special class's classLoader, default classLoader is SystemClassLoader.")
+    public void setHashCode(String hashCode) {
+        this.hashCode = hashCode;
+    }
+
+    @Option(shortName = "x", longName = "expand")
+    @Description("Expand level of object (3 by default).")
+    public void setExpand(Integer expand) {
+        this.expand = expand;
+    }
+
+    @Override
+    public void process(CommandProcess process) {
+        int exitCode = 0;
+        try {
+            Instrumentation inst = process.session().getInstrumentation();
+            ClassLoader classLoader;
+            if (hashCode == null) {
+                classLoader = ClassLoader.getSystemClassLoader();
+            } else {
+                classLoader = findClassLoader(inst, hashCode);
+            }
+
+            if (classLoader == null) {
+                process.write("Can not find classloader with hashCode: " + hashCode + ".\n");
+                exitCode = -1;
+                return;
+            }
+
+            Express unpooledExpress = ExpressFactory.mvelExpress(classLoader);
+            try {
+                Object value = unpooledExpress.get(express);
+                String result = StringUtils.objectToString(expand >= 0 ? new ObjectView(value, expand).draw() : value);
+                process.write(result + "\n");
+            } catch (ExpressException e) {
+                logger.warn("mvel: failed execute express: " + express, e);
+                process.write("Failed to get static, exception message: " + e.getMessage()
+                        + ", please check $HOME/logs/arthas/arthas.log for more details. \n");
+                exitCode = -1;
+            }
+        } finally {
+            process.end(exitCode);
+        }
+    }
+
+    private static ClassLoader findClassLoader(Instrumentation inst, String hashCode) {
+        for (Class<?> clazz : inst.getAllLoadedClasses()) {
+            ClassLoader classLoader = clazz.getClassLoader();
+            if (classLoader != null && hashCode.equals(Integer.toHexString(classLoader.hashCode()))) {
+                return classLoader;
+            }
+        }
+        return null;
+    }
+}

--- a/core/src/main/java/com/taobao/arthas/core/command/klass100/MvelCommand.java
+++ b/core/src/main/java/com/taobao/arthas/core/command/klass100/MvelCommand.java
@@ -82,7 +82,7 @@ public class MvelCommand extends AnnotatedCommand {
             Instrumentation inst = process.session().getInstrumentation();
             ClassLoader classLoader;
             if (hashCode == null) {
-                classLoader = ClassLoader.getSystemClassLoader();
+                classLoader = getDefaultClassLoader(inst);
             } else {
                 classLoader = findClassLoader(inst, hashCode);
             }
@@ -117,5 +117,19 @@ public class MvelCommand extends AnnotatedCommand {
             }
         }
         return null;
+    }
+
+    private static ClassLoader getDefaultClassLoader(Instrumentation inst) {
+        for (Class<?> clazz : inst.getAllLoadedClasses()) {
+            ClassLoader classLoader = clazz.getClassLoader();
+            if (classLoader != null) {
+                String classLoaderName = classLoader.getClass().getName();
+                // 如果是 Tomcat 环境，优先使用 Tomcat 的 ClassLoader
+                if (classLoaderName.equals("org.apache.catalina.loader.WebappClassLoader")) {
+                    return classLoader;
+                }
+            }
+        }
+        return ClassLoader.getSystemClassLoader();
     }
 }

--- a/core/src/main/java/com/taobao/arthas/core/shell/cli/CliToken.java
+++ b/core/src/main/java/com/taobao/arthas/core/shell/cli/CliToken.java
@@ -1,5 +1,8 @@
 package com.taobao.arthas.core.shell.cli;
 
+/**
+ *
+ */
 public interface CliToken {
     /**
      * @return the token value

--- a/core/src/main/java/com/taobao/arthas/core/shell/cli/impl/CliTokenImpl.java
+++ b/core/src/main/java/com/taobao/arthas/core/shell/cli/impl/CliTokenImpl.java
@@ -1,19 +1,20 @@
 package com.taobao.arthas.core.shell.cli.impl;
 
-import com.taobao.arthas.core.shell.cli.CliToken;
-import io.termd.core.readline.LineStatus;
-
 import java.util.LinkedList;
 import java.util.List;
+
+import com.taobao.arthas.core.shell.cli.CliToken;
+
+import io.termd.core.readline.LineStatus;
 
 /**
  * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
  */
 public class CliTokenImpl implements CliToken {
 
-    final boolean text;
-    final String raw;
-    final String value;
+    private final boolean text;
+    private final String raw;
+    private final String value;
 
     public CliTokenImpl(boolean text, String value) {
         this(text, value, value);

--- a/core/src/main/java/com/taobao/arthas/core/shell/command/Command.java
+++ b/core/src/main/java/com/taobao/arthas/core/shell/command/Command.java
@@ -1,13 +1,16 @@
 package com.taobao.arthas.core.shell.command;
 
+import java.util.Collections;
+import java.util.List;
+
 import com.taobao.arthas.core.shell.cli.Completion;
 import com.taobao.arthas.core.shell.command.impl.AnnotatedCommandImpl;
 import com.taobao.arthas.core.shell.handlers.Handler;
 import com.taobao.middleware.cli.CLI;
 
-import java.util.Collections;
-import java.util.List;
-
+/**
+ * @author hengyunabc
+ */
 public abstract class Command {
 
     /**

--- a/core/src/main/java/com/taobao/arthas/core/shell/command/CommandRegistry.java
+++ b/core/src/main/java/com/taobao/arthas/core/shell/command/CommandRegistry.java
@@ -13,7 +13,8 @@ import java.util.concurrent.ConcurrentHashMap;
  * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
  */
 public class CommandRegistry implements CommandResolver {
-    final ConcurrentHashMap<String, Command> commandMap = new ConcurrentHashMap<String, Command>();
+
+    private final ConcurrentHashMap<String, Command> commandMap = new ConcurrentHashMap<String, Command>();
 
     /**
      * Create a new registry.
@@ -53,7 +54,6 @@ public class CommandRegistry implements CommandResolver {
         }
         return this;
     }
-
 
     /**
      * Unregister a command.

--- a/core/src/main/java/com/taobao/arthas/core/shell/impl/BuiltinCommandResolver.java
+++ b/core/src/main/java/com/taobao/arthas/core/shell/impl/BuiltinCommandResolver.java
@@ -1,5 +1,8 @@
 package com.taobao.arthas.core.shell.impl;
 
+import java.util.Arrays;
+import java.util.List;
+
 import com.taobao.arthas.core.shell.command.Command;
 import com.taobao.arthas.core.shell.command.CommandBuilder;
 import com.taobao.arthas.core.shell.command.CommandProcess;
@@ -9,9 +12,6 @@ import com.taobao.arthas.core.shell.command.internal.PlainTextHandler;
 import com.taobao.arthas.core.shell.command.internal.WordCountHandler;
 import com.taobao.arthas.core.shell.handlers.Handler;
 import com.taobao.arthas.core.shell.handlers.NoOpHandler;
-
-import java.util.Arrays;
-import java.util.List;
 
 /**
  * @author beiwei30 on 23/11/2016.
@@ -26,14 +26,16 @@ class BuiltinCommandResolver implements CommandResolver {
 
     @Override
     public List<Command> commands() {
-        return Arrays.asList(CommandBuilder.command("exit").processHandler(handler).build(),
-                             CommandBuilder.command("quit").processHandler(handler).build(),
-                             CommandBuilder.command("jobs").processHandler(handler).build(),
-                             CommandBuilder.command("fg").processHandler(handler).build(),
-                             CommandBuilder.command("bg").processHandler(handler).build(),
-                             CommandBuilder.command("kill").processHandler(handler).build(),
-                             CommandBuilder.command(PlainTextHandler.NAME).processHandler(handler).build(),
-                             CommandBuilder.command(GrepHandler.NAME).processHandler(handler).build(),
-                             CommandBuilder.command(WordCountHandler.NAME).processHandler(handler).build());
+        return Arrays.asList(//
+                CommandBuilder.command("exit").processHandler(handler).build(),
+                CommandBuilder.command("quit").processHandler(handler).build(),
+                CommandBuilder.command("jobs").processHandler(handler).build(),
+                CommandBuilder.command("fg").processHandler(handler).build(), //
+                CommandBuilder.command("bg").processHandler(handler).build(),
+                CommandBuilder.command("kill").processHandler(handler).build(),
+                CommandBuilder.command(PlainTextHandler.NAME).processHandler(handler).build(),
+                CommandBuilder.command(GrepHandler.NAME).processHandler(handler).build(),
+                CommandBuilder.command(WordCountHandler.NAME).processHandler(handler).build() //
+        );
     }
 }

--- a/core/src/main/java/com/taobao/arthas/core/shell/system/impl/InternalCommandManager.java
+++ b/core/src/main/java/com/taobao/arthas/core/shell/system/impl/InternalCommandManager.java
@@ -1,18 +1,18 @@
 package com.taobao.arthas.core.shell.system.impl;
 
-import com.taobao.arthas.core.command.BuiltinCommandPack;
-import com.taobao.arthas.core.shell.cli.CliToken;
-import com.taobao.arthas.core.shell.cli.Completion;
-import com.taobao.arthas.core.shell.cli.CompletionUtils;
-import com.taobao.arthas.core.shell.command.Command;
-import com.taobao.arthas.core.shell.command.CommandResolver;
-
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.ListIterator;
+
+import com.taobao.arthas.core.command.BuiltinCommandPack;
+import com.taobao.arthas.core.shell.cli.CliToken;
+import com.taobao.arthas.core.shell.cli.Completion;
+import com.taobao.arthas.core.shell.cli.CompletionUtils;
+import com.taobao.arthas.core.shell.command.Command;
+import com.taobao.arthas.core.shell.command.CommandResolver;
 
 /**
  * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>

--- a/core/src/main/java/org/mvel2/CompileException.java
+++ b/core/src/main/java/org/mvel2/CompileException.java
@@ -1,0 +1,286 @@
+/**
+ * MVEL 2.0
+ * Copyright (C) 2007 The Codehaus
+ * Mike Brock, Dhanji Prasanna, John Graham, Mark Proctor
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mvel2;
+
+import static java.lang.String.copyValueOf;
+import static org.mvel2.util.ParseTools.isWhitespace;
+import static org.mvel2.util.ParseTools.repeatChar;
+
+import java.util.Collections;
+import java.util.List;
+
+import org.mvel2.util.StringAppender;
+
+/**
+ * Standard exception thrown for all general compileShared and some runtime failures.
+ */
+public class CompileException extends RuntimeException {
+
+    private char[] expr;
+
+    private int cursor = 0;
+    private int msgOffset = 0;
+
+    private int lineNumber = 1;
+    private int column = 0;
+
+    private int lastLineStart = 0;
+
+    private List<ErrorDetail> errors;
+
+    private Object evaluationContext;
+
+    public CompileException(String message, List<ErrorDetail> errors, char[] expr, int cursor, ParserContext ctx) {
+        super(message);
+        this.expr = expr;
+        this.cursor = cursor;
+
+        if (!errors.isEmpty()) {
+            ErrorDetail detail = errors.iterator().next();
+            this.cursor = detail.getCursor();
+            this.lineNumber = detail.getLineNumber();
+            this.column = detail.getColumn();
+        }
+
+        this.errors = errors;
+    }
+
+    public CompileException(String message, char[] expr, int cursor, Throwable e) {
+        super(message, e);
+        this.expr = expr;
+        this.cursor = cursor;
+    }
+
+    public CompileException(String message, char[] expr, int cursor) {
+        super(message);
+        this.expr = expr;
+        this.cursor = cursor;
+    }
+
+    public void setEvaluationContext(Object evaluationContext) {
+        this.evaluationContext = evaluationContext;
+    }
+
+    public String toString() {
+        return generateErrorMessage();
+    }
+
+    @Override
+    public String getMessage() {
+        return generateErrorMessage();
+    }
+
+    private void calcRowAndColumn() {
+        if (lineNumber > 1 || column > 1) return;
+
+        int row = 1;
+        int col = 1;
+
+        if ((lineNumber != 0 && column != 0) || expr == null || expr.length == 0) return;
+
+        for (int i = 0; i < cursor && i < expr.length; i++) {
+            switch (expr[i]) {
+                case '\r':
+                    continue;
+                case '\n':
+                    row++;
+                    col = 1;
+                    break;
+
+                default:
+                    col++;
+            }
+        }
+
+        this.lineNumber = row;
+        this.column = col;
+    }
+
+    private CharSequence showCodeNearError(char[] expr, int cursor) {
+        if (expr == null) return "Unknown";
+
+        int start = cursor - 20;
+        int end = (cursor + 30);
+
+        if (end > expr.length) {
+            end = expr.length;
+            start -= 30;
+        }
+
+        if (start < 0) {
+            start = 0;
+        }
+
+        String cs;
+
+        int firstCr;
+        int lastCr;
+
+        try {
+            cs = copyValueOf(expr, start, end - start).trim();
+        } catch (StringIndexOutOfBoundsException e) {
+            throw e;
+        }
+
+        int matchStart = -1;
+        int matchOffset = 0;
+        String match = null;
+
+        if (cursor < end) {
+            matchStart = cursor;
+            if (matchStart > 0) {
+                while (matchStart > 0 && !isWhitespace(expr[matchStart - 1])) {
+                    matchStart--;
+                }
+            }
+
+            matchOffset = cursor - matchStart;
+
+            match = new String(expr, matchStart, expr.length - matchStart);
+            Makematch: for (int i = 0; i < match.length(); i++) {
+                switch (match.charAt(i)) {
+                    case '\n':
+                    case ')':
+                        match = match.substring(0, i);
+                        break Makematch;
+                }
+            }
+
+            if (match.length() >= 30) {
+                match = match.substring(0, 30);
+            }
+        }
+
+        do {
+            firstCr = cs.indexOf('\n');
+            lastCr = cs.lastIndexOf('\n');
+
+            if (firstCr == -1) break;
+
+            int matchIndex = match == null ? 0 : cs.indexOf(match);
+
+            if (firstCr != -1 && firstCr == lastCr) {
+                if (firstCr > matchIndex) {
+                    cs = cs.substring(0, firstCr);
+                } else if (firstCr < matchIndex) {
+                    cs = cs.substring(firstCr + 1, cs.length());
+                }
+            } else if (firstCr < matchIndex) {
+                cs = cs.substring(firstCr + 1, lastCr);
+            } else {
+                cs = cs.substring(0, firstCr);
+            }
+        } while (true);
+
+        String trimmed = cs.trim();
+
+        if (match != null) {
+            msgOffset = trimmed.indexOf(match) + matchOffset;
+        } else {
+            msgOffset = cs.length() - (cs.length() - trimmed.length());
+        }
+
+        if (msgOffset == 0 && matchOffset == 0) {
+            msgOffset = cursor;
+        }
+
+        return trimmed;
+    }
+
+    public CharSequence getCodeNearError() {
+        return showCodeNearError(expr, cursor);
+    }
+
+    private String generateErrorMessage() {
+        StringAppender appender = new StringAppender().append("[Error: " + super.getMessage() + "]\n");
+
+        int offset = appender.length();
+
+        appender.append("[Near : {... ");
+
+        offset = appender.length() - offset;
+
+        appender.append(showCodeNearError(expr, cursor)).append(" ....}]\n").append(repeatChar(' ', offset));
+
+        if (msgOffset < 0) msgOffset = 0;
+
+        appender.append(repeatChar(' ', msgOffset)).append('^');
+
+        calcRowAndColumn();
+
+        if (evaluationContext != null) {
+            appender.append("\n").append("In ").append(evaluationContext);
+        } else if (lineNumber != -1) {
+            appender.append("\n").append("[Line: " + lineNumber + ", Column: " + (column) + "]");
+        }
+        return appender.toString();
+    }
+
+    public char[] getExpr() {
+        return expr;
+    }
+
+    public void setExpr(char[] expr) {
+        this.expr = expr;
+    }
+
+    public int getCursor() {
+        return cursor;
+    }
+
+    public void setCursor(int cursor) {
+        this.cursor = cursor;
+    }
+
+    public List<ErrorDetail> getErrors() {
+        return errors != null ? errors : Collections.<ErrorDetail> emptyList();
+    }
+
+    public void setErrors(List<ErrorDetail> errors) {
+        this.errors = errors;
+    }
+
+    public int getLineNumber() {
+        return lineNumber;
+    }
+
+    public void setLineNumber(int lineNumber) {
+        this.lineNumber = lineNumber;
+    }
+
+    public int getColumn() {
+        return column;
+    }
+
+    public void setColumn(int column) {
+        this.column = column;
+    }
+
+    public int getCursorOffet() {
+        return this.msgOffset;
+    }
+
+    public int getLastLineStart() {
+        return lastLineStart;
+    }
+
+    public void setLastLineStart(int lastLineStart) {
+        this.lastLineStart = lastLineStart;
+    }
+}

--- a/core/src/main/java/org/mvel2/ConversionException.java
+++ b/core/src/main/java/org/mvel2/ConversionException.java
@@ -1,0 +1,30 @@
+/**
+ * MVEL 2.0
+ * Copyright (C) 2007 The Codehaus
+ * Mike Brock, Dhanji Prasanna, John Graham, Mark Proctor
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mvel2;
+
+public class ConversionException extends RuntimeException {
+
+    public ConversionException(String message) {
+        super(message); //To change body of overridden methods use File | Settings | File Templates.
+    }
+
+    public ConversionException(String message, Throwable cause) {
+        super(message, cause); //To change body of overridden methods use File | Settings | File Templates.
+    }
+}

--- a/core/src/main/java/org/mvel2/ConversionHandler.java
+++ b/core/src/main/java/org/mvel2/ConversionHandler.java
@@ -1,0 +1,44 @@
+/**
+ * MVEL 2.0
+ * Copyright (C) 2007  MVFLEX/Valhalla Project and the Codehaus
+ * Mike Brock, Dhanji Prasanna, John Graham, Mark Proctor
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mvel2;
+
+/**
+ * The conversion handler interface defines the basic interface for implementing conversion handlers in MVEL.
+ *
+ * @see DataConversion
+ */
+public interface ConversionHandler {
+
+    /**
+     * Converts the passed argument to the type represented by the handler.
+     *
+     * @param in - the input type
+     * @return - the converted type
+     */
+    public Object convertFrom(Object in);
+
+    /**
+     * This method is used to indicate to the runtime whehter or not the handler knows how to convert
+     * from the specified type.
+     *
+     * @param cls - the source type
+     * @return - true if the converter supports converting from the specified type.
+     */
+    public boolean canConvertFrom(Class cls);
+}

--- a/core/src/main/java/org/mvel2/DataConversion.java
+++ b/core/src/main/java/org/mvel2/DataConversion.java
@@ -1,0 +1,169 @@
+/**
+ * MVEL 2.0
+ * Copyright (C) 2007 The Codehaus
+ * Mike Brock, Dhanji Prasanna, John Graham, Mark Proctor
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mvel2;
+
+import static org.mvel2.util.ReflectionUtil.isAssignableFrom;
+import static org.mvel2.util.ReflectionUtil.toNonPrimitiveType;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashSet;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeSet;
+
+import org.mvel2.conversion.ArrayHandler;
+import org.mvel2.conversion.BigDecimalCH;
+import org.mvel2.conversion.BigIntegerCH;
+import org.mvel2.conversion.BooleanCH;
+import org.mvel2.conversion.ByteCH;
+import org.mvel2.conversion.CharArrayCH;
+import org.mvel2.conversion.CharCH;
+import org.mvel2.conversion.CompositeCH;
+import org.mvel2.conversion.DoubleCH;
+import org.mvel2.conversion.FloatCH;
+import org.mvel2.conversion.IntArrayCH;
+import org.mvel2.conversion.IntegerCH;
+import org.mvel2.conversion.ListCH;
+import org.mvel2.conversion.LongCH;
+import org.mvel2.conversion.ObjectCH;
+import org.mvel2.conversion.SetCH;
+import org.mvel2.conversion.ShortCH;
+import org.mvel2.conversion.StringArrayCH;
+import org.mvel2.conversion.StringCH;
+import org.mvel2.util.FastList;
+
+/**
+ * The DataConversion factory is where all of MVEL's type converters are registered with the runtime.
+ *
+ * @author Mike Brock
+ * @see ConversionHandler
+ */
+public class DataConversion {
+
+    private static final Map<Class, ConversionHandler> CONVERTERS = new HashMap<Class, ConversionHandler>(38 * 2, 0.5f);
+
+    static {
+        ConversionHandler ch;
+
+        CONVERTERS.put(Integer.class, ch = new IntegerCH());
+        CONVERTERS.put(int.class, ch);
+
+        CONVERTERS.put(Short.class, ch = new ShortCH());
+        CONVERTERS.put(short.class, ch);
+
+        CONVERTERS.put(Long.class, ch = new LongCH());
+        CONVERTERS.put(long.class, ch);
+
+        CONVERTERS.put(Character.class, ch = new CharCH());
+        CONVERTERS.put(char.class, ch);
+
+        CONVERTERS.put(Byte.class, ch = new ByteCH());
+        CONVERTERS.put(byte.class, ch);
+
+        CONVERTERS.put(Float.class, ch = new FloatCH());
+        CONVERTERS.put(float.class, ch);
+
+        CONVERTERS.put(Double.class, ch = new DoubleCH());
+        CONVERTERS.put(double.class, ch);
+
+        CONVERTERS.put(Boolean.class, ch = new BooleanCH());
+        CONVERTERS.put(boolean.class, ch);
+
+        CONVERTERS.put(String.class, new StringCH());
+
+        CONVERTERS.put(Object.class, new ObjectCH());
+
+        CONVERTERS.put(Character[].class, ch = new CharArrayCH());
+        CONVERTERS.put(char[].class, new CompositeCH(ch, new ArrayHandler(char[].class)));
+
+        CONVERTERS.put(String[].class, new StringArrayCH());
+
+        CONVERTERS.put(Integer[].class, new IntArrayCH());
+
+        CONVERTERS.put(int[].class, new ArrayHandler(int[].class));
+        CONVERTERS.put(long[].class, new ArrayHandler(long[].class));
+        CONVERTERS.put(double[].class, new ArrayHandler(double[].class));
+        CONVERTERS.put(float[].class, new ArrayHandler(float[].class));
+        CONVERTERS.put(short[].class, new ArrayHandler(short[].class));
+        CONVERTERS.put(boolean[].class, new ArrayHandler(boolean[].class));
+        CONVERTERS.put(byte[].class, new ArrayHandler(byte[].class));
+
+        CONVERTERS.put(BigDecimal.class, new BigDecimalCH());
+        CONVERTERS.put(BigInteger.class, new BigIntegerCH());
+
+        CONVERTERS.put(List.class, ch = new ListCH());
+        CONVERTERS.put(FastList.class, ch);
+        CONVERTERS.put(ArrayList.class, ch);
+        CONVERTERS.put(LinkedList.class, ch);
+
+        CONVERTERS.put(Set.class, ch = new SetCH());
+        CONVERTERS.put(HashSet.class, ch);
+        CONVERTERS.put(LinkedHashSet.class, ch);
+        CONVERTERS.put(TreeSet.class, ch);
+    }
+
+    public static boolean canConvert(Class toType, Class convertFrom) {
+        if (isAssignableFrom(toType, convertFrom)) return true;
+        if (CONVERTERS.containsKey(toType)) {
+            return CONVERTERS.get(toType).canConvertFrom(toNonPrimitiveType(convertFrom));
+        } else if (toType.isArray() && canConvert(toType.getComponentType(), convertFrom)) {
+            return true;
+        }
+        return false;
+    }
+
+    public static <T> T convert(Object in, Class<T> toType) {
+        if (in == null) return null;
+        if (toType == in.getClass() || toType.isAssignableFrom(in.getClass())) {
+            return (T) in;
+        }
+
+        ConversionHandler h = CONVERTERS.get(toType);
+        if (h == null && toType.isArray()) {
+            ArrayHandler ah;
+            CONVERTERS.put(toType, ah = new ArrayHandler(toType));
+            return (T) ah.convertFrom(in);
+        } else {
+            return (T) h.convertFrom(in);
+        }
+    }
+
+    /**
+     * Register a new {@link ConversionHandler} with the factory.
+     *
+     * @param type    - Target type represented by the conversion handler.
+     * @param handler - An instance of the handler.
+     */
+    public static void addConversionHandler(Class type, ConversionHandler handler) {
+        CONVERTERS.put(type, handler);
+    }
+
+    public static void main(String[] args) {
+        System.out.println(char[][].class);
+    }
+
+    private interface ArrayTypeMarker {
+    }
+}

--- a/core/src/main/java/org/mvel2/DataTypes.java
+++ b/core/src/main/java/org/mvel2/DataTypes.java
@@ -1,0 +1,58 @@
+/**
+ * MVEL 2.0
+ * Copyright (C) 2007  MVFLEX/Valhalla Project and the Codehaus
+ * Mike Brock, Dhanji Prasanna, John Graham, Mark Proctor
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mvel2;
+
+/**
+ * Contains constants for standard internal types.
+ */
+public interface DataTypes {
+
+    public static final int NULL = -1;
+
+    public static final int OBJECT = 0;
+    public static final int STRING = 1;
+    public static final int SHORT = 100;
+    public static final int INTEGER = 101;
+    public static final int LONG = 102;
+    public static final int DOUBLE = 103;
+    public static final int FLOAT = 104;
+    public static final int BOOLEAN = 7;
+    public static final int CHAR = 8;
+    public static final int BYTE = 9;
+
+    public static final int W_BOOLEAN = 15;
+
+    public static final int COLLECTION = 50;
+
+    public static final int W_SHORT = 105;
+    public static final int W_INTEGER = 106;
+    public static final int W_LONG = 107;
+    public static final int W_FLOAT = 108;
+    public static final int W_DOUBLE = 109;
+
+    public static final int W_CHAR = 112;
+    public static final int W_BYTE = 113;
+
+    public static final int BIG_DECIMAL = 110;
+    public static final int BIG_INTEGER = 111;
+
+    public static final int EMPTY = 200;
+
+    public static final int UNIT = 300;
+}

--- a/core/src/main/java/org/mvel2/ErrorDetail.java
+++ b/core/src/main/java/org/mvel2/ErrorDetail.java
@@ -1,0 +1,119 @@
+/**
+ * MVEL 2.0
+ * Copyright (C) 2007  MVFLEX/Valhalla Project and the Codehaus
+ * Mike Brock, Dhanji Prasanna, John Graham, Mark Proctor
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mvel2;
+
+public class ErrorDetail {
+
+    private char[] expr;
+    private int cursor;
+    private boolean critical;
+    private String message;
+
+    private int lineNumber;
+    private int column;
+
+    public ErrorDetail(char[] expr, int cursor, boolean critical, String message) {
+        this.expr = expr;
+        this.cursor = cursor;
+        this.critical = critical;
+        this.message = message;
+
+        calcRowAndColumn();
+    }
+
+    public boolean isCritical() {
+        return critical;
+    }
+
+    public void setCritical(boolean critical) {
+        this.critical = critical;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+
+    public void setMessage(String message) {
+        this.message = message;
+    }
+
+    public int getCursor() {
+        return cursor;
+    }
+
+    public void setCursor(int cursor) {
+        this.cursor = cursor;
+    }
+
+    public void calcRowAndColumn() {
+        int row = 1;
+        int col = 1;
+
+        if ((lineNumber != 0 && column != 0) || expr == null || expr.length == 0) return;
+
+        for (int i = 0; i < cursor; i++) {
+            switch (expr[i]) {
+                case '\r':
+                    continue;
+                case '\n':
+                    row++;
+                    col = 0;
+                    break;
+
+                default:
+                    col++;
+            }
+        }
+
+        this.lineNumber = row;
+        this.column = col;
+    }
+
+    public int getLineNumber() {
+        return lineNumber;
+    }
+
+    public void setLineNumber(int lineNumber) {
+        this.lineNumber = lineNumber;
+    }
+
+    public int getColumn() {
+        return column;
+    }
+
+    public void setColumn(int column) {
+        this.column = column;
+    }
+
+    public char[] getExpr() {
+        return expr;
+    }
+
+    public void setExpr(char[] expr) {
+        this.expr = expr;
+    }
+
+    public String toString() {
+        if (critical) {
+            return "(" + lineNumber + "," + column + ") " + message;
+        } else {
+            return "(" + lineNumber + "," + column + ") WARNING: " + message;
+        }
+    }
+}

--- a/core/src/main/java/org/mvel2/ImmutableElementException.java
+++ b/core/src/main/java/org/mvel2/ImmutableElementException.java
@@ -1,0 +1,41 @@
+/**
+ * MVEL 2.0
+ * Copyright (C) 2007 The Codehaus
+ * Mike Brock, Dhanji Prasanna, John Graham, Mark Proctor
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mvel2;
+
+/**
+ * Exception thrown by internal immutable structures if any modifications are attempted.
+ */
+public class ImmutableElementException extends RuntimeException {
+
+    public ImmutableElementException() {
+        super();
+    }
+
+    public ImmutableElementException(String s) {
+        super(s);
+    }
+
+    public ImmutableElementException(String s, Throwable throwable) {
+        super(s, throwable);
+    }
+
+    public ImmutableElementException(Throwable throwable) {
+        super(throwable);
+    }
+}

--- a/core/src/main/java/org/mvel2/MVEL.java
+++ b/core/src/main/java/org/mvel2/MVEL.java
@@ -1,0 +1,1109 @@
+/**
+ * MVEL 2.0
+ * Copyright (C) 2007  MVFLEX/Valhalla Project and the Codehaus
+ * Mike Brock, Dhanji Prasanna, John Graham, Mark Proctor
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.mvel2;
+
+import static java.lang.Boolean.getBoolean;
+import static java.lang.String.valueOf;
+import static org.mvel2.DataConversion.convert;
+import static org.mvel2.MVELRuntime.execute;
+import static org.mvel2.util.ParseTools.loadFromFile;
+import static org.mvel2.util.ParseTools.optimizeTree;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.Serializable;
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.mvel2.compiler.CompiledAccExpression;
+import org.mvel2.compiler.CompiledExpression;
+import org.mvel2.compiler.ExecutableStatement;
+import org.mvel2.compiler.ExpressionCompiler;
+import org.mvel2.integration.Interceptor;
+import org.mvel2.integration.VariableResolverFactory;
+import org.mvel2.integration.impl.CachedMapVariableResolverFactory;
+import org.mvel2.integration.impl.CachingMapVariableResolverFactory;
+import org.mvel2.integration.impl.ClassImportResolverFactory;
+import org.mvel2.integration.impl.ImmutableDefaultFactory;
+import org.mvel2.integration.impl.MapVariableResolverFactory;
+import org.mvel2.optimizers.impl.refl.nodes.GetterAccessor;
+
+/**
+ * The MVEL convienence class is a collection of static methods that provides a set of easy integration points for
+ * MVEL.  The vast majority of MVEL's core functionality can be directly accessed through methods in this class.
+ */
+public class MVEL {
+
+    public static final String NAME = "MVEL (MVFLEX Expression Language)";
+    public static final String VERSION = "2.3";
+    public static final String VERSION_SUB = "0";
+    public static final String CODENAME = "liberty";
+    public static boolean INVOKED_METHOD_EXCEPTIONS_BUBBLE = getBoolean("mvel2.invoked_meth_exceptions_bubble");
+    public static boolean COMPILER_OPT_ALLOW_NAKED_METH_CALL = getBoolean("mvel2.compiler.allow_naked_meth_calls");
+    public static boolean COMPILER_OPT_ALLOW_OVERRIDE_ALL_PROPHANDLING = getBoolean("mvel2.compiler.allow_override_all_prophandling");
+    public static boolean COMPILER_OPT_ALLOW_RESOLVE_INNERCLASSES_WITH_DOTNOTATION = getBoolean(
+            "mvel2.compiler.allow_resolve_inner_classes_with_dotnotation");
+    public static boolean COMPILER_OPT_SUPPORT_JAVA_STYLE_CLASS_LITERALS = getBoolean("mvel2.compiler.support_java_style_class_literals");
+    public static boolean COMPILER_OPT_ALLOCATE_TYPE_LITERALS_TO_SHARED_SYMBOL_TABLE = getBoolean(
+            "mvel2.compiler.allocate_type_literals_to_shared_symbol_table");
+    static boolean DEBUG_FILE = getBoolean("mvel2.debug.fileoutput");
+    static String ADVANCED_DEBUGGING_FILE = System.getProperty("mvel2.debugging.file") == null ? "mvel_debug.txt" : System
+            .getProperty("mvel2.debugging.file");
+    static boolean ADVANCED_DEBUG = getBoolean("mvel2.advanced_debugging");
+    static boolean WEAK_CACHE = getBoolean("mvel2.weak_caching");
+    static boolean NO_JIT = getBoolean("mvel2.disable.jit");
+    static boolean OPTIMIZER = true;
+
+    static {
+        if (System.getProperty("mvel2.optimizer") != null) {
+            OPTIMIZER = getBoolean("mvel2.optimizer");
+        }
+    }
+
+    private MVEL() {
+    }
+
+    public static boolean isAdvancedDebugging() {
+        return ADVANCED_DEBUG;
+    }
+
+    public static String getDebuggingOutputFileName() {
+        return ADVANCED_DEBUGGING_FILE;
+    }
+
+    public static boolean isFileDebugging() {
+        return DEBUG_FILE;
+    }
+
+    /**
+     * Evaluate an expression and return the value.
+     *
+     * @param expression A String containing the expression to be evaluated.
+     * @return the resultant value
+     */
+    public static Object eval(String expression) {
+        return new MVELInterpretedRuntime(expression, new ImmutableDefaultFactory()).parse();
+    }
+
+    /**
+     * Evaluate an expression against a context object.  Expressions evaluated against a context object are designed
+     * to treat members of that context object as variables in the expression.  For example:
+     * <pre><code>
+     * MVEL.eval("foo == 1", ctx);
+     * </code></pre>
+     * In this case, the identifier <tt>foo</tt> would be resolved against the <tt>ctx</tt> object.  So it would have
+     * the equivalent of: <tt>ctc.getFoo() == 1</tt> in Java.
+     *
+     * @param expression A String containing the expression to be evaluated.
+     * @param ctx        The context object to evaluate against.
+     * @return The resultant value
+     */
+    public static Object eval(String expression, Object ctx) {
+        return new MVELInterpretedRuntime(expression, ctx, new ImmutableDefaultFactory()).parse();
+    }
+
+    /**
+     * Evaluate an expression with externally injected variables via a {@link VariableResolverFactory}.  A factory
+     * provides the means by which MVEL can resolve external variables.  MVEL contains a straight-forward implementation
+     * for wrapping Maps: {@link MapVariableResolverFactory}, which is used implicitly when calling overloaded methods
+     * in this class that use Maps.
+     * <p/>
+     * An example:
+     * <pre><code>
+     * Map varsMap = new HashMap();
+     * varsMap.put("x", 5);
+     * varsMap.put("y", 2);
+     * <p/>
+     * VariableResolverFactory factory = new MapVariableResolverFactory(varsMap);
+     * <p/>
+     * Integer i = (Integer) MVEL.eval("x * y", factory);
+     * <p/>
+     * assert i == 10;
+     * </code></pre>
+     *
+     * @param expression      A String containing the expression to be evaluated.
+     * @param resolverFactory The instance of the VariableResolverFactory to be used.
+     * @return The resultant value.
+     */
+    public static Object eval(String expression, VariableResolverFactory resolverFactory) {
+        return new MVELInterpretedRuntime(expression, resolverFactory).parse();
+    }
+
+    /**
+     * Evaluates an expression against a context object and injected variables from a {@link VariableResolverFactory}.
+     * This method of execution will prefer to find variables from the factory and <em>then</em> from the context.
+     *
+     * @param expression      A string containing the expression to be evaluated
+     * @param ctx             The context object to evaluate against.
+     * @param resolverFactory The instance of the VariableResolverFactory to be used.
+     * @return The resultant value
+     * @see #eval(String, org.mvel2.integration.VariableResolverFactory)
+     */
+    public static Object eval(String expression, Object ctx, VariableResolverFactory resolverFactory) {
+        return new MVELInterpretedRuntime(expression, ctx, resolverFactory).parse();
+    }
+
+    /**
+     * Evaluates an expression against externally injected variables.  This is a wrapper convenience method which
+     * wraps the provided Map of vars in a {@link MapVariableResolverFactory}
+     *
+     * @param expression A string containing the expression to be evaluated.
+     * @param vars       A map of vars to be injected
+     * @return The resultant value
+     * @see #eval(String, org.mvel2.integration.VariableResolverFactory)
+     */
+    public static Object eval(String expression, Map<String, Object> vars) {
+        CachingMapVariableResolverFactory factory = new CachingMapVariableResolverFactory(vars);
+        try {
+            return new MVELInterpretedRuntime(expression, null, factory).parse();
+        } finally {
+            factory.externalize();
+        }
+    }
+
+    /**
+     * Evaluates an expression against a context object and externally injected variables.  This is a wrapper
+     * convenience method which wraps the provided Map of vars in a {@link MapVariableResolverFactory}
+     *
+     * @param expression A string containing the expression to be evaluated.
+     * @param ctx        The context object to evaluate against.
+     * @param vars       A map of vars to be injected
+     * @return The resultant value
+     * @see #eval(String, VariableResolverFactory)
+     */
+    public static Object eval(String expression, Object ctx, Map<String, Object> vars) {
+        CachingMapVariableResolverFactory factory = new CachingMapVariableResolverFactory(vars);
+        try {
+            return new MVELInterpretedRuntime(expression, ctx, factory).parse();
+        } finally {
+            factory.externalize();
+        }
+    }
+
+    /**
+     * Evaluates an expression and, if necessary, coerces the resultant value to the specified type. Example:
+     * <pre><code>
+     * Float output = MVEL.eval("5 + 5", Float.class);
+     * </code></pre>
+     * <p/>
+     * This converts an expression that would otherwise return an <tt>Integer</tt> to a <tt>Float</tt>.
+     *
+     * @param expression A string containing the expression to be evaluated.
+     * @param toType     The target type that the resultant value will be converted to, if necessary.
+     * @return The resultant value.
+     */
+    public static <T> T eval(String expression, Class<T> toType) {
+        return convert(new MVELInterpretedRuntime(expression).parse(), toType);
+    }
+
+    /**
+     * Evaluates an expression against a context object and, if necessary, coerces the resultant value to the specified
+     * type.
+     *
+     * @param expression A string containing the expression to be evaluated.
+     * @param ctx        The context object to evaluate against.
+     * @param toType     The target type that the resultant value will be converted to, if necessary.
+     * @return The resultant value
+     * @see #eval(String, Class)
+     */
+    public static <T> T eval(String expression, Object ctx, Class<T> toType) {
+        return convert(new MVELInterpretedRuntime(expression, ctx).parse(), toType);
+    }
+
+    /**
+     * Evaluates an expression against externally injected variables and, if necessary, coerces the resultant value
+     * to the specified type.
+     *
+     * @param expression A string containing the expression to be evaluated
+     * @param vars       The variables to be injected
+     * @param toType     The target type that the resultant value will be converted to, if necessary.
+     * @return The resultant value
+     * @see #eval(String, VariableResolverFactory)
+     * @see #eval(String, Class)
+     */
+    public static <T> T eval(String expression, VariableResolverFactory vars, Class<T> toType) {
+        return convert(new MVELInterpretedRuntime(expression, null, vars).parse(), toType);
+    }
+
+    /**
+     * Evaluates an expression against externally injected variables.  The resultant value is coerced to the specified
+     * type if necessary. This is a wrapper convenience method which wraps the provided Map of vars in a{@link MapVariableResolverFactory}
+     *
+     * @param expression A string containing the expression to be evaluated.
+     * @param vars       A map of vars to be injected
+     * @param toType     The target type the resultant value will be converted to, if necessary.
+     * @return The resultant value
+     * @see #eval(String, org.mvel2.integration.VariableResolverFactory)
+     */
+    public static <T> T eval(String expression, Map<String, Object> vars, Class<T> toType) {
+        CachingMapVariableResolverFactory factory = new CachingMapVariableResolverFactory(vars);
+        try {
+            return convert(new MVELInterpretedRuntime(expression, null, factory).parse(), toType);
+        } finally {
+            factory.externalize();
+        }
+    }
+
+    /**
+     * Evaluates an expression against a context object and externally injected variables.  If necessary, the resultant
+     * value is coerced to the specified type.
+     *
+     * @param expression A string containing the expression to be evaluated.
+     * @param ctx        The context object to evaluate against
+     * @param vars       The vars to be injected
+     * @param toType     The target type that the resultant value will be converted to, if necessary.
+     * @return The resultant value.
+     * @see #eval(String, Object, VariableResolverFactory)
+     * @see #eval(String, Class)
+     */
+    public static <T> T eval(String expression, Object ctx, VariableResolverFactory vars, Class<T> toType) {
+        return convert(new MVELInterpretedRuntime(expression, ctx, vars).parse(), toType);
+    }
+
+    /**
+     * Evaluates an expression against a context object and externally injected variables.  If necessary, the resultant
+     * value is coerced to the specified type.
+     *
+     * @param expression A string containing the expression to be evaluated.
+     * @param ctx        The context object to evaluate against
+     * @param vars       A Map of variables to be injected.
+     * @param toType     The target type that the resultant value will be converted to, if necessary.
+     * @return The resultant value.
+     * @see #eval(String, Object, VariableResolverFactory)
+     * @see #eval(String, Class)
+     */
+    public static <T> T eval(String expression, Object ctx, Map<String, Object> vars, Class<T> toType) {
+        CachingMapVariableResolverFactory factory = new CachingMapVariableResolverFactory(vars);
+        try {
+            return convert(new MVELInterpretedRuntime(expression, ctx, factory).parse(), toType);
+        } finally {
+            factory.externalize();
+        }
+    }
+
+    /**
+     * Evaluates an expression and returns the resultant value as a String.
+     *
+     * @param expression A string containing the expressino to be evaluated.
+     * @return The resultant value
+     */
+    public static String evalToString(String expression) {
+        return valueOf(eval(expression));
+    }
+
+    /**
+     * Evaluates an expression and returns the resultant value as a String.
+     *
+     * @param expression A string containing the expressino to be evaluated.
+     * @param ctx        The context object to evaluate against
+     * @return The resultant value
+     * @see #eval(String, Object)
+     */
+    public static String evalToString(String expression, Object ctx) {
+        return valueOf(eval(expression, ctx));
+    }
+
+    /**
+     * Evaluates an expression and returns the resultant value as a String.
+     *
+     * @param expression A string containing the expressino to be evaluated.
+     * @param vars       The variables to be injected
+     * @return The resultant value
+     * @see #eval(String, VariableResolverFactory)
+     */
+    public static String evalToString(String expression, VariableResolverFactory vars) {
+        return valueOf(eval(expression, vars));
+    }
+
+    /**
+     * Evaluates an expression and returns the resultant value as a String.
+     *
+     * @param expression A string containing the expressino to be evaluated.
+     * @param vars       A Map of variables to be injected
+     * @return The resultant value
+     * @see #eval(String, Map)
+     */
+    public static String evalToString(String expression, Map vars) {
+        return valueOf(eval(expression, vars));
+    }
+
+    /**
+     * Evaluates an expression and returns the resultant value as a String.
+     *
+     * @param expression A string containing the expressino to be evaluated.
+     * @param ctx        The context object to evaluate against.
+     * @param vars       The variables to be injected
+     * @return The resultant value
+     * @see #eval(String, Map)
+     */
+    public static String evalToString(String expression, Object ctx, VariableResolverFactory vars) {
+        return valueOf(eval(expression, ctx, vars));
+    }
+
+    /**
+     * Evaluates an expression and returns the resultant value as a String.
+     *
+     * @param expression A string containing the expressino to be evaluated.
+     * @param ctx        The context object to evaluate against.
+     * @param vars       A Map of variables to be injected
+     * @return The resultant value
+     * @see #eval(String, Map)
+     */
+    public static String evalToString(String expression, Object ctx, Map vars) {
+        return valueOf(eval(expression, ctx, vars));
+    }
+
+    /**
+     * Evaluate an expression and return the value.
+     *
+     * @param expression A char[] containing the expression to be evaluated.
+     * @return The resultant value
+     * @see #eval(String)
+     */
+    public static Object eval(char[] expression) {
+        return new MVELInterpretedRuntime(expression, new ImmutableDefaultFactory()).parse();
+    }
+
+    /**
+     * Evaluate an expression against a context object and return the value
+     *
+     * @param expression A char[] containing the expression to be evaluated.
+     * @param ctx        The context object to evaluate against
+     * @return The resultant value
+     * @see #eval(String, Object)
+     */
+    public static Object eval(char[] expression, Object ctx) {
+        return new MVELInterpretedRuntime(expression, ctx).parse();
+    }
+
+    public static <T> T eval(char[] expression, Class<T> type) {
+        return convert(new MVELInterpretedRuntime(expression).parse(), type);
+    }
+
+    /**
+     * Evaluate an expression against a context object and return the value
+     *
+     * @param expression A char[] containing the expression to be evaluated.
+     * @param ctx        The context object to evaluate against
+     * @param vars       The variables to be injected
+     * @return The resultant value
+     * @see #eval(String, Object, VariableResolverFactory)
+     */
+    public static Object eval(char[] expression, Object ctx, VariableResolverFactory vars) {
+        return new MVELInterpretedRuntime(expression, ctx, vars).parse();
+    }
+
+    public static Object eval(char[] expression, int start, int offset, Object ctx, VariableResolverFactory vars) {
+        return new MVELInterpretedRuntime(expression, start, offset, ctx, vars).parse();
+    }
+
+    public static <T> T eval(char[] expression, int start, int offset, Object ctx, VariableResolverFactory vars, Class<T> toType) {
+        return convert(new MVELInterpretedRuntime(expression, start, offset, ctx, vars).parse(), toType);
+    }
+
+    /**
+     * Evaluate an expression against a context object and return the value
+     *
+     * @param expression A char[] containing the expression to be evaluated.
+     * @param ctx        The context object to evaluate against
+     * @param vars       A Map of variables to be injected
+     * @return The resultant value
+     * @see #eval(String, Object, Map)
+     */
+    public static Object eval(char[] expression, Object ctx, Map vars) {
+        return new MVELInterpretedRuntime(expression, ctx, vars).parse();
+    }
+
+    /**
+     * Evaluate an expression with a context object and injected variables and return the value. If necessary convert
+     * the resultant value to the specified type.
+     *
+     * @param expression A char[] containing the expression to be evaluated.
+     * @param ctx        The context object to evaluate against
+     * @param vars       A Map of variables to be injected
+     * @param toType     The target type the resultant value will be converted to, if necessary.
+     * @return The resultant value
+     * @see #eval(String, Object, Map, Class)
+     */
+    public static <T> T eval(char[] expression, Object ctx, Map<String, Object> vars, Class<T> toType) {
+        return convert(new MVELInterpretedRuntime(expression, ctx, vars).parse(), toType);
+    }
+
+    /**
+     * Evaluate an expression with a context object and return the value. If necessary convert
+     * the resultant value to the specified type.
+     *
+     * @param expression A char[] containing the expression to be evaluated.
+     * @param ctx        The context object to evaluate against
+     * @param toType     The target type the resultant value will be converted to, if necessary.
+     * @return The resultant value
+     * @see #eval(String, Object, Class)
+     */
+    public static <T> T eval(char[] expression, Object ctx, Class<T> toType) {
+        return convert(new MVELInterpretedRuntime(expression, ctx).parse(), toType);
+    }
+
+    /**
+     * Evaluate an expression with a context object and injected variables and return the value. If necessary convert
+     * the resultant value to the specified type.
+     *
+     * @param expression A char[] containing the expression to be evaluated.
+     * @param ctx        The context object to evaluate against
+     * @param vars       The variables to be injected
+     * @param toType     The target type the resultant value will be converted to, if necessary.
+     * @return The resultant value
+     * @see #eval(String, Object, VariableResolverFactory, Class)
+     */
+    public static <T> T eval(char[] expression, Object ctx, VariableResolverFactory vars, Class<T> toType) {
+        return convert(new MVELInterpretedRuntime(expression, ctx, vars).parse(), toType);
+    }
+
+    /**
+     * Evaluate an expression with injected variables and return the value. If necessary convert
+     * the resultant value to the specified type.
+     *
+     * @param expression A char[] containing the expression to be evaluated.
+     * @param vars       The variables to be injected
+     * @param toType     The target type the resultant value will be converted to, if necessary.
+     * @return The resultant value
+     * @see #eval(String, VariableResolverFactory, Class)
+     */
+    public static <T> T eval(char[] expression, VariableResolverFactory vars, Class<T> toType) {
+        return convert(new MVELInterpretedRuntime(expression, null, vars).parse(), toType);
+    }
+
+    /**
+     * Evaluate an expression with injected variables and return the resultant value. If necessary convert
+     * the resultant value to the specified type.
+     *
+     * @param expression A char[] containing the expression to be evaluated.
+     * @param vars       The variables to be injected
+     * @param toType     The target type the resultant value will be converted to, if necessary.
+     * @return The resultant value
+     * @see #eval(String, Map, Class)
+     */
+    public static <T> T eval(char[] expression, Map<String, Object> vars, Class<T> toType) {
+        return convert(new MVELInterpretedRuntime(expression, null, vars).parse(), toType);
+    }
+
+    /**
+     * Evaluate a script from a file and return the resultant value.
+     *
+     * @param file The file to process
+     * @return The resultant value
+     * @throws IOException Exception thrown if there is an IO problem accessing the file.
+     */
+    public static Object evalFile(File file) throws IOException {
+        return _evalFile(file, null, new CachedMapVariableResolverFactory(new HashMap()));
+    }
+
+    public static Object evalFile(File file, String encoding) throws IOException {
+        return _evalFile(file, encoding, null, new CachedMapVariableResolverFactory(new HashMap()));
+    }
+
+    /**
+     * Evaluate a script from a file, against a context object and return the resultant value.
+     *
+     * @param file The file to process
+     * @param ctx  The context to evaluate the script against.
+     * @return The resultant value
+     * @throws IOException Exception thrown if there is an IO problem accessing the file.
+     */
+    public static Object evalFile(File file, Object ctx) throws IOException {
+        return _evalFile(file, ctx, new CachedMapVariableResolverFactory(new HashMap()));
+    }
+
+    public static Object evalFile(File file, String encoding, Object ctx) throws IOException {
+        return _evalFile(file, encoding, ctx, new CachedMapVariableResolverFactory(new HashMap()));
+    }
+
+    /**
+     * Evaluate a script from a file with injected variables and return the resultant value.
+     *
+     * @param file The file to process
+     * @param vars Variables to be injected
+     * @return The resultant value
+     * @throws IOException Exception thrown if there is an IO problem accessing the file.
+     */
+    public static Object evalFile(File file, Map<String, Object> vars) throws IOException {
+        CachingMapVariableResolverFactory factory = new CachingMapVariableResolverFactory(vars);
+        try {
+            return _evalFile(file, null, factory);
+        } finally {
+            factory.externalize();
+        }
+    }
+
+    /**
+     * Evaluate a script from a file with injected variables and a context object, then return the resultant value.
+     *
+     * @param file The file to process
+     * @param ctx  The context to evaluate the script against.
+     * @param vars Variables to be injected
+     * @return The resultant value
+     * @throws IOException Exception thrown if there is an IO problem accessing the file.
+     */
+    public static Object evalFile(File file, Object ctx, Map<String, Object> vars) throws IOException {
+        CachingMapVariableResolverFactory factory = new CachingMapVariableResolverFactory(vars);
+        try {
+            return _evalFile(file, ctx, factory);
+        } finally {
+            factory.externalize();
+        }
+    }
+
+    public static Object evalFile(File file, String encoding, Object ctx, Map<String, Object> vars) throws IOException {
+        CachingMapVariableResolverFactory factory = new CachingMapVariableResolverFactory(vars);
+        try {
+            return _evalFile(file, encoding, ctx, factory);
+        } finally {
+            factory.externalize();
+        }
+    }
+
+    /**
+     * Evaluate a script from a file with injected variables and a context object, then return the resultant value.
+     *
+     * @param file The file to process
+     * @param ctx  The context to evaluate the script against.
+     * @param vars Variables to be injected
+     * @return The resultant value
+     * @throws IOException Exception thrown if there is an IO problem accessing the file.
+     */
+    public static Object evalFile(File file, Object ctx, VariableResolverFactory vars) throws IOException {
+        return _evalFile(file, ctx, vars);
+    }
+
+    public static Object evalFile(File file, String encoding, Object ctx, VariableResolverFactory vars) throws IOException {
+        return _evalFile(file, encoding, ctx, vars);
+    }
+
+    private static Object _evalFile(File file, Object ctx, VariableResolverFactory factory) throws IOException {
+        return _evalFile(file, null, ctx, factory);
+    }
+
+    private static Object _evalFile(File file, String encoding, Object ctx, VariableResolverFactory factory) throws IOException {
+        return eval(loadFromFile(file, encoding), ctx, factory);
+    }
+
+    /**
+     * Evaluate an expression in Boolean-only mode against a root context object and injected variables.
+     *
+     * @param expression A string containing the expression to be evaluated.
+     * @param ctx        The context against which to evaluate the expression
+     * @param vars       The variables to be injected
+     * @return The resultant value as a Boolean
+     */
+    public static Boolean evalToBoolean(String expression, Object ctx, Map<String, Object> vars) {
+        return eval(expression, ctx, vars, Boolean.class);
+    }
+
+    /**
+     * Evaluate an expression in Boolean-only mode against a root context object.
+     *
+     * @param expression A string containing the expression to be evaluated.
+     * @param ctx        The context against which to evaluate the expression
+     * @return The resultant value as a Boolean
+     */
+    public static Boolean evalToBoolean(String expression, Object ctx) {
+        return eval(expression, ctx, new ImmutableDefaultFactory(), Boolean.class);
+    }
+
+    /**
+     * Evaluate an expression in Boolean-only mode against a root context object and injected variables.
+     *
+     * @param expression A string containing the expression to be evaluated.
+     * @param ctx        The context against which to evaluate the expression
+     * @param vars       The variables to be injected
+     * @return The resultant value as a Boolean
+     */
+    public static Boolean evalToBoolean(String expression, Object ctx, VariableResolverFactory vars) {
+        return eval(expression, ctx, vars, Boolean.class);
+    }
+
+    /**
+     * Evaluate an expression in Boolean-only with injected variables.
+     *
+     * @param expression A string containing the expression to be evaluated.
+     * @param vars       The variables to be injected
+     * @return The resultant value as a Boolean
+     */
+    public static Boolean evalToBoolean(String expression, VariableResolverFactory vars) {
+        return eval(expression, vars, Boolean.class);
+    }
+
+    /**
+     * Evaluate an expression in Boolean-only with injected variables.
+     *
+     * @param expression A string containing the expression to be evaluated.
+     * @param vars       The variables to be injected
+     * @return The resultant value as a Boolean
+     */
+    public static Boolean evalToBoolean(String expression, Map<String, Object> vars) {
+        return evalToBoolean(expression, null, vars);
+    }
+
+    /**
+     * Performs an analysis compileShared, which will populate the ParserContext with type, input and variable information,
+     * but will not produce a payload.
+     *
+     * @param expression - the expression to analyze
+     * @param ctx        - the parser context
+     */
+    public static void analysisCompile(char[] expression, ParserContext ctx) {
+        ExpressionCompiler compiler = new ExpressionCompiler(expression, ctx);
+        compiler.setVerifyOnly(true);
+        compiler.compile();
+    }
+
+    public static void analysisCompile(String expression, ParserContext ctx) {
+        analysisCompile(expression.toCharArray(), ctx);
+    }
+
+    public static Class analyze(char[] expression, ParserContext ctx) {
+        ExpressionCompiler compiler = new ExpressionCompiler(expression, ctx);
+        compiler.setVerifyOnly(true);
+        compiler.compile();
+        return compiler.getReturnType();
+    }
+
+    public static Class analyze(String expression, ParserContext ctx) {
+        return analyze(expression.toCharArray(), ctx);
+    }
+
+    /**
+     * Compiles an expression and returns a Serializable object containing the compiled expression.  The returned value
+     * can be reused for higher-performance evaluation of the expression.  It is used in a straight forward way:
+     * <pre><code>
+     * <p/>
+     * // Compile the expression
+     * Serializable compiled = MVEL.compileExpression("x * 10");
+     * <p/>
+     * // Create a Map to hold the variables.
+     * Map vars = new HashMap();
+     * <p/>
+     * // Create a factory to envelop the variable map
+     * VariableResolverFactory factory = new MapVariableResolverFactory(vars);
+     * <p/>
+     * int total = 0;
+     * for (int i = 0; i < 100; i++) {
+     * // Update the 'x' variable.
+     * vars.put("x", i);
+     * <p/>
+     * // Execute the expression against the compiled payload and factory, and add the result to the total variable.
+     * total += (Integer) MVEL.executeExpression(compiled, factory);
+     * }
+     * <p/>
+     * // Total should be 49500
+     * assert total == 49500;
+     * </code></pre>
+     * <p/>
+     * The above example demonstrates a compiled expression being reused ina tight, closed, loop.  Doing this greatly
+     * improves performance as re-parsing of the expression is not required, and the runtime can dynamically compileShared
+     * the expression to bytecode of necessary.
+     *
+     * @param expression A String contaiing the expression to be compiled.
+     * @return The cacheable compiled payload.
+     */
+    public static Serializable compileExpression(String expression) {
+        return compileExpression(expression, null, null, null);
+    }
+
+    /**
+     * Compiles an expression and returns a Serializable object containing the compiled expression.  This method
+     * also accept a Map of imports.  The Map's keys are String's representing the imported, short-form name of the
+     * Classes or Methods imported.  An import of a Method is essentially a static import.  This is a substitute for
+     * needing to declare <tt>import</tt> statements within the actual script.
+     * <p/>
+     * <pre><code>
+     * Map imports = new HashMap();
+     * imports.put("HashMap", java.util.HashMap.class); // import a class
+     * imports.put("time", MVEL.getStaticMethod(System.class, "currentTimeMillis", new Class[0])); // import a static method
+     * <p/>
+     * // Compile the expression
+     * Serializable compiled = MVEL.compileExpression("map = new HashMap(); map.put('time', time()); map.time");
+     * <p/>
+     * // Execute with a blank Map to allow vars to be declared.
+     * Long val = (Long) MVEL.executeExpression(compiled, new HashMap());
+     * <p/>
+     * assert val > 0;
+     * </code></pre>
+     *
+     * @param expression A String contaiing the expression to be compiled.
+     * @param imports    A String-Class/String-Method pair Map containing imports for the compiler.
+     * @return The cacheable compiled payload.
+     */
+    public static Serializable compileExpression(String expression, Map<String, Object> imports) {
+        return compileExpression(expression, imports, null, null);
+    }
+
+    /**
+     * Compiles an expression and returns a Serializable object containing the compiled expression. This method
+     * accepts a Map of imports and Interceptors.  See {@link #compileExpression(String, Map)} for information on
+     * imports.  The imports parameter in this method is <em>optional</em> and it is safe to pass a <tt>null</tt>
+     * value.<br/>{@link org.mvel2.integration.Interceptor Interceptors} are markers within an expression that allow external hooks
+     * to be tied into the expression.
+     * <p/>
+     * <pre><code>
+     * // Create a Map to hold the interceptors.
+     * Map interceptors = new HashMap();
+     * <p/>
+     * // Create a simple interceptor.
+     * Interceptor logInterceptor = new Interceptor() {
+     * public int doBefore(ASTNode node, VariableResolverFactory factory) {
+     * System.out.println("Interceptor called before!");
+     * }
+     * <p/>
+     * public int doAfter(Object exitValue, ASTNode node, VariableResolverFactory factory) {
+     * System.out.println("Interceptor called after!");
+     * }
+     * };
+     * <p/>
+     * // Add the interceptor to the Map.
+     * interceptors.put("log", logInterceptor);
+     * <p/>
+     * // Create an expression
+     * String expr = "list = [1,2,3,4,5]; @log for (item : list) { System.out.println(item); };
+     * <p/>
+     * Serializable compiled = MVEL.compileExpression(expr, null, interceptors);
+     * <p/>
+     * // Execute expression with a blank Map to allow vars to be declared.
+     * MVEL.executeExpression(compiled, new HashMap());
+     * </code></pre>
+     * <p/>
+     * The above example demonstrates inserting an interceptor into a piece of code.  The <tt>@log</tt> interceptor
+     * wraps the subsequent statement.  In this case, the interceptor is fired before the <tt>for</tt> loop and
+     * after the <tt>for</tt> loop finishes.
+     *
+     * @param expression   A String containing the expression to be evaluated.
+     * @param imports      A String-Class/String-Method pair Map containing imports for the compiler.
+     * @param interceptors A Map of registered interceptors.
+     * @return A cacheable compiled payload.
+     */
+    public static Serializable compileExpression(String expression, Map<String, Object> imports, Map<String, Interceptor> interceptors) {
+        return compileExpression(expression, imports, interceptors, null);
+    }
+
+    /**
+     * Compiles an expression, and accepts a {@link ParserContext} instance.  The ParserContext object is the
+     * fine-grained configuration object for the MVEL parser and compiler.
+     *
+     * @param expression A string containing the expression to be compiled.
+     * @param ctx        The parser context
+     * @return A cacheable compiled payload.
+     */
+    public static Serializable compileExpression(String expression, ParserContext ctx) {
+        return optimizeTree(new ExpressionCompiler(expression, ctx).compile());
+    }
+
+    public static Serializable compileExpression(char[] expression, int start, int offset, ParserContext ctx) {
+        ExpressionCompiler c = new ExpressionCompiler(expression, start, offset, ctx);
+        return optimizeTree(c._compile());
+    }
+
+    public static Serializable compileExpression(String expression, Map<String, Object> imports, Map<String, Interceptor> interceptors,
+            String sourceName) {
+        return compileExpression(expression, new ParserContext(imports, interceptors, sourceName));
+    }
+
+    public static Serializable compileExpression(char[] expression, ParserContext ctx) {
+        return optimizeTree(new ExpressionCompiler(expression, ctx).compile());
+    }
+
+    /**
+     * Compiles an expression and returns a Serializable object containing the compiled
+     * expression.
+     *
+     * @param expression   The expression to be compiled
+     * @param imports      Imported classes
+     * @param interceptors Map of named interceptos
+     * @param sourceName   The name of the source file being evaluated (optional)
+     * @return The cacheable compiled payload
+     */
+    public static Serializable compileExpression(char[] expression, Map<String, Object> imports, Map<String, Interceptor> interceptors,
+            String sourceName) {
+        return compileExpression(expression, new ParserContext(imports, interceptors, sourceName));
+    }
+
+    public static Serializable compileExpression(char[] expression) {
+        return compileExpression(expression, null, null, null);
+    }
+
+    public static Serializable compileExpression(char[] expression, Map<String, Object> imports) {
+        return compileExpression(expression, imports, null, null);
+    }
+
+    public static Serializable compileExpression(char[] expression, Map<String, Object> imports, Map<String, Interceptor> interceptors) {
+        return compileExpression(expression, imports, interceptors, null);
+    }
+
+    public static Serializable compileGetExpression(String expression) {
+        return new CompiledAccExpression(expression.toCharArray(), Object.class, new ParserContext());
+    }
+
+    public static Serializable compileGetExpression(String expression, ParserContext ctx) {
+        return new CompiledAccExpression(expression.toCharArray(), Object.class, ctx);
+    }
+
+    public static Serializable compileGetExpression(char[] expression) {
+        return new CompiledAccExpression(expression, Object.class, new ParserContext());
+    }
+
+    public static Serializable compileGetExpression(char[] expression, ParserContext ctx) {
+        return new CompiledAccExpression(expression, Object.class, ctx);
+    }
+
+    public static Serializable compileSetExpression(String expression) {
+        return new CompiledAccExpression(expression.toCharArray(), Object.class, new ParserContext());
+    }
+
+    public static Serializable compileSetExpression(String expression, ParserContext ctx) {
+        return new CompiledAccExpression(expression.toCharArray(), Object.class, ctx);
+    }
+
+    public static Serializable compileSetExpression(String expression, Class ingressType, ParserContext ctx) {
+        return new CompiledAccExpression(expression.toCharArray(), ingressType, ctx);
+    }
+
+    public static Serializable compileSetExpression(char[] expression) {
+        return new CompiledAccExpression(expression, Object.class, new ParserContext());
+    }
+
+    public static Serializable compileSetExpression(char[] expression, ParserContext ctx) {
+        return new CompiledAccExpression(expression, Object.class, ctx);
+    }
+
+    public static Serializable compileSetExpression(char[] expression, int start, int offset, ParserContext ctx) {
+        return new CompiledAccExpression(expression, start, offset, Object.class, ctx);
+    }
+
+    public static Serializable compileSetExpression(char[] expression, Class ingressType, ParserContext ctx) {
+        return new CompiledAccExpression(expression, ingressType, ctx);
+    }
+
+    public static void executeSetExpression(Serializable compiledSet, Object ctx, Object value) {
+        ((CompiledAccExpression) compiledSet).setValue(ctx, ctx, new ImmutableDefaultFactory(), value);
+    }
+
+    public static void executeSetExpression(Serializable compiledSet, Object ctx, VariableResolverFactory vrf, Object value) {
+        ((CompiledAccExpression) compiledSet).setValue(ctx, ctx, vrf, value);
+    }
+
+    public static Object executeExpression(Object compiledExpression) {
+        return ((ExecutableStatement) compiledExpression).getValue(null, new ImmutableDefaultFactory());
+    }
+
+    /**
+     * Executes a compiled expression.
+     *
+     * @param compiledExpression -
+     * @param ctx                -
+     * @param vars               -
+     * @return -
+     * @see #compileExpression(String)
+     */
+    @SuppressWarnings({ "unchecked" })
+    public static Object executeExpression(final Object compiledExpression, final Object ctx, final Map vars) {
+        CachingMapVariableResolverFactory factory = vars != null ? new CachingMapVariableResolverFactory(vars) : null;
+        try {
+            return ((ExecutableStatement) compiledExpression).getValue(ctx, factory);
+        } finally {
+            if (factory != null) factory.externalize();
+        }
+    }
+
+    public static Object executeExpression(final Object compiledExpression, final Object ctx,
+            final VariableResolverFactory resolverFactory) {
+        return ((ExecutableStatement) compiledExpression).getValue(ctx, resolverFactory);
+    }
+
+    /**
+     * Executes a compiled expression.
+     *
+     * @param compiledExpression -
+     * @param factory            -
+     * @return -
+     * @see #compileExpression(String)
+     */
+    public static Object executeExpression(final Object compiledExpression, final VariableResolverFactory factory) {
+        return ((ExecutableStatement) compiledExpression).getValue(null, factory);
+    }
+
+    /**
+     * Executes a compiled expression.
+     *
+     * @param compiledExpression -
+     * @param ctx                -
+     * @return -
+     * @see #compileExpression(String)
+     */
+    public static Object executeExpression(final Object compiledExpression, final Object ctx) {
+        return ((ExecutableStatement) compiledExpression).getValue(ctx, new ImmutableDefaultFactory());
+    }
+
+    /**
+     * Executes a compiled expression.
+     *
+     * @param compiledExpression -
+     * @param vars               -
+     * @return -
+     * @see #compileExpression(String)
+     */
+    @SuppressWarnings({ "unchecked" })
+    public static Object executeExpression(final Object compiledExpression, final Map vars) {
+        CachingMapVariableResolverFactory factory = new CachingMapVariableResolverFactory(vars);
+        try {
+            return ((ExecutableStatement) compiledExpression).getValue(null, factory);
+        } finally {
+            factory.externalize();
+        }
+    }
+
+    /**
+     * Execute a compiled expression and convert the result to a type
+     *
+     * @param compiledExpression -
+     * @param ctx                -
+     * @param vars               -
+     * @param toType             -
+     * @return -
+     */
+    @SuppressWarnings({ "unchecked" })
+    public static <T> T executeExpression(final Object compiledExpression, final Object ctx, final Map vars, Class<T> toType) {
+        return convert(executeExpression(compiledExpression, ctx, vars), toType);
+    }
+
+    public static <T> T executeExpression(final Object compiledExpression, final Object ctx, final VariableResolverFactory vars,
+            Class<T> toType) {
+        return convert(executeExpression(compiledExpression, ctx, vars), toType);
+    }
+
+    /**
+     * Execute a compiled expression and convert the result to a type
+     *
+     * @param compiledExpression -
+     * @param vars               -
+     * @param toType             -
+     * @return -
+     */
+    @SuppressWarnings({ "unchecked" })
+    public static <T> T executeExpression(final Object compiledExpression, Map vars, Class<T> toType) {
+        return convert(executeExpression(compiledExpression, vars), toType);
+    }
+
+    /**
+     * Execute a compiled expression and convert the result to a type.
+     *
+     * @param compiledExpression -
+     * @param ctx                -
+     * @param toType             -
+     * @return -
+     */
+    public static <T> T executeExpression(final Object compiledExpression, final Object ctx, Class<T> toType) {
+        return convert(executeExpression(compiledExpression, ctx), toType);
+    }
+
+    public static void executeExpression(Iterable<CompiledExpression> compiledExpression) {
+        for (CompiledExpression ce : compiledExpression) {
+            ce.getValue(null, null);
+        }
+    }
+
+    public static void executeExpression(Iterable<CompiledExpression> compiledExpression, Object ctx) {
+        for (CompiledExpression ce : compiledExpression) {
+            ce.getValue(ctx, null);
+        }
+    }
+
+    public static void executeExpression(Iterable<CompiledExpression> compiledExpression, Map vars) {
+        CachingMapVariableResolverFactory factory = new CachingMapVariableResolverFactory(vars);
+        executeExpression(compiledExpression, null, factory);
+        factory.externalize();
+    }
+
+    public static void executeExpression(Iterable<CompiledExpression> compiledExpression, Object ctx, Map vars) {
+        CachingMapVariableResolverFactory factory = new CachingMapVariableResolverFactory(vars);
+        executeExpression(compiledExpression, ctx, factory);
+        factory.externalize();
+    }
+
+    public static void executeExpression(Iterable<CompiledExpression> compiledExpression, Object ctx, VariableResolverFactory vars) {
+        for (CompiledExpression ce : compiledExpression) {
+            ce.getValue(ctx, vars);
+        }
+    }
+
+    public static Object[] executeAllExpression(Serializable[] compiledExpressions, Object ctx, VariableResolverFactory vars) {
+        if (compiledExpressions == null) return GetterAccessor.EMPTY;
+        Object[] o = new Object[compiledExpressions.length];
+        for (int i = 0; i < compiledExpressions.length; i++) {
+            o[i] = executeExpression(compiledExpressions[i], ctx, vars);
+        }
+        return o;
+    }
+
+    public static Object executeDebugger(CompiledExpression expression, Object ctx, VariableResolverFactory vars) {
+        if (expression.isImportInjectionRequired()) {
+            return execute(true, expression, ctx, new ClassImportResolverFactory(expression.getParserConfiguration(), vars, false));
+        } else {
+            return execute(true, expression, ctx, vars);
+        }
+    }
+
+    public static String parseMacros(String input, Map<String, Macro> macros) {
+        return new MacroProcessor(macros).parse(input);
+    }
+
+    public static String preprocess(char[] input, PreProcessor[] preprocessors) {
+        char[] ex = input;
+        for (PreProcessor proc : preprocessors) {
+            ex = proc.parse(ex);
+        }
+        return new String(ex);
+    }
+
+    public static String preprocess(String input, PreProcessor[] preprocessors) {
+        return preprocess(input.toCharArray(), preprocessors);
+    }
+
+    public static Object getProperty(String property, Object ctx) {
+        return PropertyAccessor.get(property, ctx);
+    }
+
+    public static void setProperty(Object ctx, String property, Object value) {
+        PropertyAccessor.set(ctx, property, value);
+    }
+
+    /**
+     * A simple utility method to get a static method from a class with no checked exception.  With throw a
+     * RuntimeException if the method is not found or is not a static method.
+     *
+     * @param cls        The class containing the static method
+     * @param methodName The method name
+     * @param signature  The signature of the method
+     * @return An instance of the Method
+     */
+    public static Method getStaticMethod(Class cls, String methodName, Class[] signature) {
+        try {
+            Method m = cls.getMethod(methodName, signature);
+            if ((m.getModifiers() & Modifier.STATIC) == 0) throw new RuntimeException("method not a static method: " + methodName);
+            return m;
+        } catch (NoSuchMethodException e) {
+            throw new RuntimeException("no such method: " + methodName);
+        }
+    }
+}

--- a/core/src/main/java/org/mvel2/MVELInterpretedRuntime.java
+++ b/core/src/main/java/org/mvel2/MVELInterpretedRuntime.java
@@ -1,0 +1,373 @@
+/**
+ * MVEL 2.0
+ * Copyright (C) 2007 The Codehaus
+ * Mike Brock, Dhanji Prasanna, John Graham, Mark Proctor
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mvel2;
+
+import static org.mvel2.Operator.AND;
+import static org.mvel2.Operator.CHOR;
+import static org.mvel2.Operator.END_OF_STMT;
+import static org.mvel2.Operator.NOOP;
+import static org.mvel2.Operator.OR;
+import static org.mvel2.Operator.RETURN;
+import static org.mvel2.Operator.TERNARY;
+import static org.mvel2.Operator.TERNARY_ELSE;
+
+import java.util.Map;
+
+import org.mvel2.ast.ASTNode;
+import org.mvel2.ast.Substatement;
+import org.mvel2.compiler.AbstractParser;
+import org.mvel2.compiler.BlankLiteral;
+import org.mvel2.integration.VariableResolverFactory;
+import org.mvel2.integration.impl.ImmutableDefaultFactory;
+import org.mvel2.integration.impl.MapVariableResolverFactory;
+import org.mvel2.util.ErrorUtil;
+import org.mvel2.util.ExecutionStack;
+
+/**
+ * The MVEL interpreted runtime, used for fast parse and execution of scripts.
+ */
+@SuppressWarnings({ "CaughtExceptionImmediatelyRethrown" })
+public class MVELInterpretedRuntime extends AbstractParser {
+
+    private Object holdOverRegister;
+
+    MVELInterpretedRuntime(char[] expression, Object ctx, Map<String, Object> variables) {
+        this.expr = expression;
+        this.length = expr.length;
+        this.ctx = ctx;
+        this.variableFactory = new MapVariableResolverFactory(variables);
+    }
+
+    MVELInterpretedRuntime(char[] expression, Object ctx) {
+        this.expr = expression;
+        this.length = expr.length;
+        this.ctx = ctx;
+        this.variableFactory = new ImmutableDefaultFactory();
+    }
+
+    MVELInterpretedRuntime(String expression) {
+        setExpression(expression);
+        this.variableFactory = new ImmutableDefaultFactory();
+    }
+
+    MVELInterpretedRuntime(char[] expression) {
+        this.length = end = (this.expr = expression).length;
+    }
+
+    public MVELInterpretedRuntime(char[] expr, Object ctx, VariableResolverFactory resolverFactory) {
+        this.length = end = (this.expr = expr).length;
+        this.ctx = ctx;
+        this.variableFactory = resolverFactory;
+    }
+
+    public MVELInterpretedRuntime(char[] expr, int start, int offset, Object ctx, VariableResolverFactory resolverFactory) {
+        this.expr = expr;
+        this.start = start;
+        this.end = start + offset;
+        this.length = end - start;
+        this.ctx = ctx;
+        this.variableFactory = resolverFactory;
+    }
+
+    public MVELInterpretedRuntime(char[] expr, int start, int offset, Object ctx, VariableResolverFactory resolverFactory,
+            ParserContext pCtx) {
+        super(pCtx);
+        this.expr = expr;
+        this.start = start;
+        this.end = start + offset;
+        this.length = end - start;
+        this.ctx = ctx;
+        this.variableFactory = resolverFactory;
+    }
+
+    public MVELInterpretedRuntime(String expression, Object ctx, VariableResolverFactory resolverFactory) {
+        setExpression(expression);
+        this.ctx = ctx;
+        this.variableFactory = resolverFactory;
+    }
+
+    public MVELInterpretedRuntime(String expression, Object ctx, VariableResolverFactory resolverFactory, ParserContext pCtx) {
+        super(pCtx);
+        setExpression(expression);
+        this.ctx = ctx;
+        this.variableFactory = resolverFactory;
+    }
+
+    MVELInterpretedRuntime(String expression, VariableResolverFactory resolverFactory) {
+        setExpression(expression);
+        this.variableFactory = resolverFactory;
+    }
+
+    MVELInterpretedRuntime(String expression, Object ctx) {
+        setExpression(expression);
+        this.ctx = ctx;
+        this.variableFactory = new ImmutableDefaultFactory();
+    }
+
+    public Object parse() {
+        try {
+            stk = new ExecutionStack();
+            dStack = new ExecutionStack();
+            variableFactory.setTiltFlag(false);
+            cursor = start;
+            return parseAndExecuteInterpreted();
+        } catch (ArrayIndexOutOfBoundsException e) {
+            e.printStackTrace();
+            throw new CompileException("unexpected end of statement", expr, length);
+        } catch (NullPointerException e) {
+            e.printStackTrace();
+
+            if (cursor >= length) {
+                throw new CompileException("unexpected end of statement", expr, length);
+            } else {
+                throw e;
+            }
+        } catch (CompileException e) {
+            throw ErrorUtil.rewriteIfNeeded(e, expr, cursor);
+        }
+    }
+
+    /**
+     * Main interpreter loop.
+     *
+     * @return value
+     */
+    private Object parseAndExecuteInterpreted() {
+        ASTNode tk = null;
+        int operator;
+        lastWasIdentifier = false;
+
+        try {
+            while ((tk = nextToken()) != null) {
+                holdOverRegister = null;
+
+                if (lastWasIdentifier && lastNode.isDiscard()) {
+                    stk.discard();
+                }
+
+                /**
+                 * If we are at the beginning of a statement, then we immediately push the first token
+                 * onto the stack.
+                 */
+                if (stk.isEmpty()) {
+                    if ((tk.fields & ASTNode.STACKLANG) != 0) {
+                        stk.push(tk.getReducedValue(stk, ctx, variableFactory));
+                        Object o = stk.peek();
+                        if (o instanceof Integer) {
+                            arithmeticFunctionReduction((Integer) o);
+                        }
+                    } else {
+                        stk.push(tk.getReducedValue(ctx, ctx, variableFactory));
+                    }
+
+                    /**
+                     * If this is a substatement, we need to move the result into the d-stack to preserve
+                     * proper execution order.
+                     */
+                    if (tk instanceof Substatement && (tk = nextToken()) != null) {
+                        if (isArithmeticOperator(operator = tk.getOperator())) {
+                            stk.push(nextToken().getReducedValue(ctx, ctx, variableFactory), operator);
+
+                            if (procBooleanOperator(arithmeticFunctionReduction(operator)) == -1) return stk.peek();
+                            else continue;
+                        }
+                    } else {
+                        continue;
+                    }
+                }
+
+                if (variableFactory.tiltFlag()) {
+                    return stk.pop();
+                }
+
+                switch (procBooleanOperator(operator = tk.getOperator())) {
+                    case RETURN:
+                        variableFactory.setTiltFlag(true);
+                        return stk.pop();
+                    case OP_TERMINATE:
+                        return stk.peek();
+                    case OP_RESET_FRAME:
+                        continue;
+                    case OP_OVERFLOW:
+                        if (!tk.isOperator()) {
+                            if (!(stk.peek() instanceof Class)) {
+                                throw new CompileException("unexpected token or unknown identifier:" + tk.getName(), expr, st);
+                            }
+                            variableFactory.createVariable(tk.getName(), null, (Class) stk.peek());
+                        }
+                        continue;
+                }
+
+                stk.push(nextToken().getReducedValue(ctx, ctx, variableFactory), operator);
+
+                switch ((operator = arithmeticFunctionReduction(operator))) {
+                    case OP_TERMINATE:
+                        return stk.peek();
+                    case OP_RESET_FRAME:
+                        continue;
+                }
+
+                if (procBooleanOperator(operator) == OP_TERMINATE) return stk.peek();
+            }
+
+            if (holdOverRegister != null) {
+                return holdOverRegister;
+            }
+        } catch (CompileException e) {
+            throw ErrorUtil.rewriteIfNeeded(e, expr, start);
+        } catch (NullPointerException e) {
+            if (tk != null && tk.isOperator()) {
+                CompileException ce = new CompileException(
+                        "incomplete statement: " + tk.getName() + " (possible use of reserved keyword as identifier: " + tk.getName() + ")",
+                        expr, st, e);
+
+                ce.setExpr(expr);
+                ce.setLineNumber(line);
+                ce.setCursor(cursor);
+                throw ce;
+            } else {
+                throw e;
+            }
+        }
+        return stk.peek();
+    }
+
+    private int procBooleanOperator(int operator) {
+        switch (operator) {
+            case RETURN:
+                return RETURN;
+            case NOOP:
+                return -2;
+
+            case AND:
+                reduceRight();
+
+                if (!stk.peekBoolean()) {
+                    if (unwindStatement(operator)) {
+                        return -1;
+                    } else {
+                        stk.clear();
+                        return OP_RESET_FRAME;
+                    }
+                } else {
+                    stk.discard();
+                    return OP_RESET_FRAME;
+                }
+
+            case OR:
+                reduceRight();
+
+                if (stk.peekBoolean()) {
+                    if (unwindStatement(operator)) {
+                        return OP_TERMINATE;
+                    } else {
+                        stk.clear();
+                        return OP_RESET_FRAME;
+                    }
+                } else {
+                    stk.discard();
+                    return OP_RESET_FRAME;
+                }
+
+            case CHOR:
+                if (!BlankLiteral.INSTANCE.equals(stk.peek())) {
+                    return OP_TERMINATE;
+                }
+                break;
+
+            case TERNARY:
+                if (!stk.popBoolean()) {
+                    stk.clear();
+
+                    ASTNode tk;
+
+                    for (;;) {
+                        if ((tk = nextToken()) == null || tk.isOperator(Operator.TERNARY_ELSE)) break;
+                    }
+                }
+
+                return OP_RESET_FRAME;
+
+            case TERNARY_ELSE:
+                captureToEOS();
+                return OP_RESET_FRAME;
+
+            case END_OF_STMT:
+                /**
+                 * Assignments are a special scenario for dealing with the stack.  Assignments are basically like
+                 * held-over failures that basically kickstart the parser when an assignment operator is is
+                 * encountered.  The originating token is captured, and the the parser is told to march on.  The
+                 * resultant value on the stack is then used to populate the target variable.
+                 *
+                 * The other scenario in which we don't want to wipe the stack, is when we hit the end of the
+                 * statement, because that top stack value is the value we want back from the parser.
+                 */
+
+                if (hasMore()) {
+                    holdOverRegister = stk.pop();
+                    stk.clear();
+                }
+
+                return OP_RESET_FRAME;
+        }
+
+        return OP_CONTINUE;
+    }
+
+    /**
+     * This method peforms the equivilent of an XSWAP operation to flip the operator
+     * over to the top of the stack, and loads the stored values on the d-stack onto
+     * the main program stack.
+     */
+    private void reduceRight() {
+        if (dStack.isEmpty()) return;
+
+        Object o = stk.pop();
+        stk.push(dStack.pop(), o, dStack.pop());
+
+        reduce();
+    }
+
+    private boolean hasMore() {
+        return cursor <= end;
+    }
+
+    /**
+     * This method is called to unwind the current statement without any reduction or further parsing.
+     *
+     * @param operator -
+     * @return -
+     */
+    private boolean unwindStatement(int operator) {
+        ASTNode tk;
+
+        switch (operator) {
+            case AND:
+                while ((tk = nextToken()) != null && !tk.isOperator(Operator.END_OF_STMT) && !tk.isOperator(Operator.OR)) {
+                    //nothing
+                }
+                break;
+            default:
+                while ((tk = nextToken()) != null && !tk.isOperator(Operator.END_OF_STMT)) {
+                    //nothing
+                }
+        }
+        return tk == null;
+    }
+}

--- a/core/src/main/java/org/mvel2/MVELRuntime.java
+++ b/core/src/main/java/org/mvel2/MVELRuntime.java
@@ -1,0 +1,244 @@
+/**
+ * MVEL 2.0
+ * Copyright (C) 2007 The Codehaus
+ * Mike Brock, Dhanji Prasanna, John Graham, Mark Proctor
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mvel2;
+
+import static org.mvel2.Operator.CHOR;
+import static org.mvel2.Operator.END_OF_STMT;
+import static org.mvel2.Operator.NOOP;
+import static org.mvel2.Operator.RETURN;
+import static org.mvel2.Operator.TERNARY;
+import static org.mvel2.Operator.TERNARY_ELSE;
+import static org.mvel2.util.PropertyTools.isEmpty;
+
+import org.mvel2.ast.ASTNode;
+import org.mvel2.ast.LineLabel;
+import org.mvel2.compiler.CompiledExpression;
+import org.mvel2.debug.Debugger;
+import org.mvel2.debug.DebuggerContext;
+import org.mvel2.integration.VariableResolverFactory;
+import org.mvel2.optimizers.OptimizerFactory;
+import org.mvel2.util.ExecutionStack;
+
+/**
+ * This class contains the runtime for running compiled MVEL expressions.
+ */
+@SuppressWarnings({ "CaughtExceptionImmediatelyRethrown" })
+public class MVELRuntime {
+
+    // public static final ImmutableDefaultFactory IMMUTABLE_DEFAULT_FACTORY = new ImmutableDefaultFactory();
+    private static ThreadLocal<DebuggerContext> debuggerContext;
+
+    /**
+     * Main interpreter.
+     *
+     * @param debugger        Run in debug mode
+     * @param expression      The compiled expression object
+     * @param ctx             The root context object
+     * @param variableFactory The variable factory to be injected
+     * @return The resultant value
+     * @see MVEL
+     */
+    public static Object execute(boolean debugger, final CompiledExpression expression, final Object ctx,
+            VariableResolverFactory variableFactory) {
+
+        Object v1, v2;
+        ExecutionStack stk = new ExecutionStack();
+
+        ASTNode tk = expression.getFirstNode();
+        Integer operator;
+
+        if (tk == null) return null;
+        try {
+            do {
+                if (tk.fields == -1) {
+                    /**
+                     * This may seem silly and redundant, however, when an MVEL script recurses into a block
+                     * or substatement, a new runtime loop is entered.   Since the debugger state is not
+                     * passed through the AST, it is not possible to forward the state directly.  So when we
+                     * encounter a debugging symbol, we check the thread local to see if there is are registered
+                     * breakpoints.  If we find them, we assume that we are debugging.
+                     *
+                     * The consequence of this of course, is that it's not ideal to compileShared expressions with
+                     * debugging symbols which you plan to use in a production enviroment.
+                     */
+                    if (debugger || (debugger = hasDebuggerContext())) {
+                        try {
+                            debuggerContext.get().checkBreak((LineLabel) tk, variableFactory, expression);
+                        } catch (NullPointerException e) {
+                            // do nothing for now.  this isn't as calus as it seems.
+                        }
+                    }
+                    continue;
+                } else if (stk.isEmpty()) {
+                    stk.push(tk.getReducedValueAccelerated(ctx, ctx, variableFactory));
+                }
+
+                if (variableFactory.tiltFlag()) {
+                    return stk.pop();
+                }
+
+                switch (operator = tk.getOperator()) {
+                    case RETURN:
+                        variableFactory.setTiltFlag(true);
+                        return stk.pop();
+
+                    case NOOP:
+                        continue;
+
+                    case TERNARY:
+                        if (!stk.popBoolean()) {
+                            //noinspection StatementWithEmptyBody
+                            while (tk.nextASTNode != null && !(tk = tk.nextASTNode).isOperator(TERNARY_ELSE));
+                        }
+                        stk.clear();
+                        continue;
+
+                    case TERNARY_ELSE:
+                        return stk.pop();
+
+                    case END_OF_STMT:
+                        /**
+                         * If the program doesn't end here then we wipe anything off the stack that remains.
+                         * Althought it may seem like intuitive stack optimizations could be leveraged by
+                         * leaving hanging values on the stack,  trust me it's not a good idea.
+                         */
+                        if (tk.nextASTNode != null) {
+                            stk.clear();
+                        }
+
+                        continue;
+                }
+
+                stk.push(tk.nextASTNode.getReducedValueAccelerated(ctx, ctx, variableFactory), operator);
+
+                try {
+                    while (stk.isReduceable()) {
+                        if ((Integer) stk.peek() == CHOR) {
+                            stk.pop();
+                            v1 = stk.pop();
+                            v2 = stk.pop();
+                            if (!isEmpty(v2) || !isEmpty(v1)) {
+                                stk.clear();
+                                stk.push(!isEmpty(v2) ? v2 : v1);
+                            } else stk.push(null);
+                        } else {
+                            stk.op();
+                        }
+                    }
+                } catch (ClassCastException e) {
+                    throw new CompileException("syntax error or incomptable types", new char[0], 0, e);
+                } catch (CompileException e) {
+                    throw e;
+                } catch (Exception e) {
+                    throw new CompileException("failed to compileShared sub expression", new char[0], 0, e);
+                }
+            } while ((tk = tk.nextASTNode) != null);
+
+            return stk.peek();
+        } catch (NullPointerException e) {
+            if (tk != null && tk.isOperator() && tk.nextASTNode != null) {
+                throw new CompileException(
+                        "incomplete statement: " + tk.getName() + " (possible use of reserved keyword as identifier: " + tk.getName() + ")",
+                        tk.getExpr(), tk.getStart());
+            } else {
+                throw e;
+            }
+        } finally {
+            OptimizerFactory.clearThreadAccessorOptimizer();
+        }
+    }
+
+    /**
+     * Register a debugger breakpoint.
+     *
+     * @param source - the source file the breakpoint is registered in
+     * @param line   - the line number of the breakpoint
+     */
+    public static void registerBreakpoint(String source, int line) {
+        ensureDebuggerContext();
+        debuggerContext.get().registerBreakpoint(source, line);
+    }
+
+    /**
+     * Remove a specific breakpoint.
+     *
+     * @param source - the source file the breakpoint is registered in
+     * @param line   - the line number of the breakpoint to be removed
+     */
+    public static void removeBreakpoint(String source, int line) {
+        if (hasDebuggerContext()) {
+            debuggerContext.get().removeBreakpoint(source, line);
+        }
+    }
+
+    /**
+     * Tests whether or not a debugger context exist.
+     *
+     * @return boolean
+     */
+    public static boolean hasDebuggerContext() {
+        return debuggerContext != null && debuggerContext.get() != null;
+    }
+
+    /**
+     * Ensures that debugger context exists.
+     */
+    private static void ensureDebuggerContext() {
+        if (debuggerContext == null) debuggerContext = new ThreadLocal<DebuggerContext>();
+        if (debuggerContext.get() == null) debuggerContext.set(new DebuggerContext());
+    }
+
+    /**
+     * Reset all the currently registered breakpoints.
+     */
+    public static void clearAllBreakpoints() {
+        if (hasDebuggerContext()) {
+            debuggerContext.get().clearAllBreakpoints();
+        }
+    }
+
+    /**
+     * Tests whether or not breakpoints have been declared.
+     *
+     * @return boolean
+     */
+    public static boolean hasBreakpoints() {
+        return hasDebuggerContext() && debuggerContext.get().hasBreakpoints();
+    }
+
+    /**
+     * Sets the Debugger instance to handle breakpoints.   A debugger may only be registered once per thread.
+     * Calling this method more than once will result in the second and subsequent calls to simply fail silently.
+     * To re-register the Debugger, you must call {@link #resetDebugger}
+     *
+     * @param debugger - debugger instance
+     */
+    public static void setThreadDebugger(Debugger debugger) {
+        ensureDebuggerContext();
+        debuggerContext.get().setDebugger(debugger);
+    }
+
+    /**
+     * Reset all information registered in the debugger, including the actual attached Debugger and registered
+     * breakpoints.
+     */
+    public static void resetDebugger() {
+        debuggerContext = null;
+    }
+}

--- a/core/src/main/java/org/mvel2/Macro.java
+++ b/core/src/main/java/org/mvel2/Macro.java
@@ -1,0 +1,27 @@
+/**
+ * MVEL 2.0
+ * Copyright (C) 2007 The Codehaus
+ * Mike Brock, Dhanji Prasanna, John Graham, Mark Proctor
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mvel2;
+
+/**
+ * @author Christopher Brock
+ */
+public interface Macro {
+
+    public String doMacro();
+}

--- a/core/src/main/java/org/mvel2/MacroProcessor.java
+++ b/core/src/main/java/org/mvel2/MacroProcessor.java
@@ -1,0 +1,139 @@
+/**
+ * MVEL 2.0
+ * Copyright (C) 2007 The Codehaus
+ * Mike Brock, Dhanji Prasanna, John Graham, Mark Proctor
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mvel2;
+
+import static org.mvel2.util.ParseTools.captureStringLiteral;
+import static org.mvel2.util.ParseTools.isIdentifierPart;
+import static org.mvel2.util.ParseTools.isWhitespace;
+
+import java.util.Map;
+
+import org.mvel2.compiler.AbstractParser;
+import org.mvel2.util.StringAppender;
+
+/**
+ * A simple, fast, macro processor.  This processor works by simply replacing a matched identifier with a set of code.
+ */
+public class MacroProcessor extends AbstractParser implements PreProcessor {
+
+    private Map<String, Macro> macros;
+
+    public MacroProcessor() {
+    }
+
+    public MacroProcessor(Map<String, Macro> macros) {
+        this.macros = macros;
+    }
+
+    public char[] parse(char[] input) {
+        setExpression(input);
+
+        StringAppender appender = new StringAppender();
+
+        int start;
+        boolean macroArmed = true;
+        String token;
+
+        for (; cursor < length; cursor++) {
+            start = cursor;
+            while (cursor < length && isIdentifierPart(expr[cursor]))
+                cursor++;
+            if (cursor > start) {
+                if (macros.containsKey(token = new String(expr, start, cursor - start)) && macroArmed) {
+                    appender.append(macros.get(token).doMacro());
+                } else {
+                    appender.append(token);
+                }
+            }
+
+            if (cursor < length) {
+                switch (expr[cursor]) {
+                    case '\\':
+                        cursor++;
+                        break;
+                    case '/':
+                        start = cursor;
+
+                        if (cursor + 1 != length) {
+                            switch (expr[cursor + 1]) {
+                                case '/':
+                                    while (cursor != length && expr[cursor] != '\n')
+                                        cursor++;
+                                    break;
+                                case '*':
+                                    int len = length - 1;
+                                    while (cursor != len && !(expr[cursor] == '*' && expr[cursor + 1] == '/'))
+                                        cursor++;
+                                    cursor += 2;
+                                    break;
+                            }
+                        }
+
+                        if (cursor < length) cursor++;
+
+                        appender.append(new String(expr, start, cursor - start));
+
+                        if (cursor < length) cursor--;
+                        break;
+
+                    case '"':
+                    case '\'':
+                        appender.append(new String(expr, (start = cursor),
+                                (cursor = captureStringLiteral(expr[cursor], expr, cursor, length)) - start));
+
+                        if (cursor >= length) break;
+                        else if (isIdentifierPart(expr[cursor])) cursor--;
+
+                    default:
+                        switch (expr[cursor]) {
+                            case '.':
+                                macroArmed = false;
+                                break;
+                            case ';':
+                            case '{':
+                            case '(':
+                                macroArmed = true;
+                                break;
+                        }
+
+                        appender.append(expr[cursor]);
+                }
+            }
+        }
+
+        return appender.toChars();
+    }
+
+    public String parse(String input) {
+        return new String(parse(input.toCharArray()));
+    }
+
+    public Map<String, Macro> getMacros() {
+        return macros;
+    }
+
+    public void setMacros(Map<String, Macro> macros) {
+        this.macros = macros;
+    }
+
+    public void captureToWhitespace() {
+        while (cursor < length && !isWhitespace(expr[cursor]))
+            cursor++;
+    }
+}

--- a/core/src/main/java/org/mvel2/Operator.java
+++ b/core/src/main/java/org/mvel2/Operator.java
@@ -1,0 +1,170 @@
+/**
+ * MVEL 2.0
+ * Copyright (C) 2007 The Codehaus
+ * Mike Brock, Dhanji Prasanna, John Graham, Mark Proctor
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.mvel2;
+
+/**
+ * Contains a list of constants representing internal operators.
+ */
+public interface Operator {
+
+    public static final int NOOP = -1;
+
+    /**
+     * The index positions of the operator precedence values
+     * correspond to the actual operator itself. So ADD is PTABLE[0],
+     * SUB is PTABLE[1] and so on.
+     */
+    public static final int[] PTABLE = { 10, // ADD
+            10, // SUB
+            11, // MULT
+            11, // DIV
+            11, // MOD
+            12, // POWER
+
+            6, // BW_AND
+            4, // BW_OR
+            5, // BW_XOR
+            9, // BW_SHIFT_RIGHT
+            9, // BW_SHIFT_LEFT
+            9, // BW_USHIFT_RIGHT
+            9, // BW_USHIFT_LEFT
+            5, // BW_NOT
+
+            8, // LTHAN
+            8, // GTHAN
+            8, // LETHAN
+            8, // GETHAN
+
+            7, // EQUAL
+            7, // NEQUAL
+
+            13, // STR_APPEND
+            3, // AND
+            2, // OR
+            2, // CHOR
+            13, // REGEX
+            8, // INSTANCEOF
+            13, // CONTAINS
+            13, // SOUNDEX
+            13, // SIMILARITY
+
+            0, // TERNARY
+            0, // TERNARY ELSE
+            13, // ASSIGN
+            13, // INC_ASSIGN
+            13 // DEC ASSIGN
+
+    };
+
+    public static final int ADD = 0;
+    public static final int SUB = 1;
+    public static final int MULT = 2;
+    public static final int DIV = 3;
+    public static final int MOD = 4;
+    public static final int POWER = 5;
+
+    public static final int BW_AND = 6;
+    public static final int BW_OR = 7;
+    public static final int BW_XOR = 8;
+    public static final int BW_SHIFT_RIGHT = 9;
+    public static final int BW_SHIFT_LEFT = 10;
+    public static final int BW_USHIFT_RIGHT = 11;
+    public static final int BW_USHIFT_LEFT = 12;
+    public static final int BW_NOT = 13;
+
+    public static final int LTHAN = 14;
+    public static final int GTHAN = 15;
+    public static final int LETHAN = 16;
+    public static final int GETHAN = 17;
+
+    public static final int EQUAL = 18;
+    public static final int NEQUAL = 19;
+
+    public static final int STR_APPEND = 20;
+    public static final int AND = 21;
+    public static final int OR = 22;
+    public static final int CHOR = 23;
+    public static final int REGEX = 24;
+    public static final int INSTANCEOF = 25;
+    public static final int CONTAINS = 26;
+    public static final int SOUNDEX = 27;
+    public static final int SIMILARITY = 28;
+
+    public static final int TERNARY = 29;
+    public static final int TERNARY_ELSE = 30;
+    public static final int ASSIGN = 31;
+    public static final int INC_ASSIGN = 32;
+    public static final int DEC_ASSIGN = 33;
+    public static final int NEW = 34;
+    public static final int PROJECTION = 35;
+    public static final int CONVERTABLE_TO = 36;
+    public static final int END_OF_STMT = 37;
+
+    public static final int FOREACH = 38;
+    public static final int IF = 39;
+    public static final int ELSE = 40;
+    public static final int WHILE = 41;
+    public static final int UNTIL = 42;
+    public static final int FOR = 43;
+    public static final int SWITCH = 44;
+    public static final int DO = 45;
+    public static final int WITH = 46;
+    public static final int ISDEF = 47;
+
+    public static final int PROTO = 48;
+
+    public static final int INC = 50;
+    public static final int DEC = 51;
+    public static final int ASSIGN_ADD = 52;
+    public static final int ASSIGN_SUB = 53;
+    public static final int ASSIGN_STR_APPEND = 54;
+    public static final int ASSIGN_DIV = 55;
+    public static final int ASSIGN_MOD = 56;
+
+    public static final int ASSIGN_OR = 57;
+    public static final int ASSIGN_AND = 58;
+    public static final int ASSIGN_XOR = 59;
+    public static final int ASSIGN_LSHIFT = 60;
+    public static final int ASSIGN_RSHIFT = 61;
+    public static final int ASSIGN_RUSHIFT = 62;
+
+    public static final int IMPORT_STATIC = 95;
+    public static final int IMPORT = 96;
+    public static final int ASSERT = 97;
+    public static final int UNTYPED_VAR = 98;
+    public static final int RETURN = 99;
+
+    public static final int FUNCTION = 100;
+    public static final int STACKLANG = 101;
+    public static final int PUSH = 102;
+    public static final int POP = 103;
+    public static final int LOAD = 104;
+    public static final int LDTYPE = 105;
+    public static final int INVOKE = 106;
+    public static final int GETFIELD = 107;
+    public static final int STOREFIELD = 108;
+    public static final int STORE = 109;
+    public static final int DUP = 110;
+    public static final int LABEL = 111;
+    public static final int JUMP = 112;
+    public static final int JUMPIF = 113;
+    public static final int REDUCE = 114;
+    public static final int SWAP = 115;
+    public static final int XSWAP = 116;
+
+}

--- a/core/src/main/java/org/mvel2/OptimizationFailure.java
+++ b/core/src/main/java/org/mvel2/OptimizationFailure.java
@@ -1,0 +1,37 @@
+/**
+ * MVEL 2.0
+ * Copyright (C) 2007 The Codehaus
+ * Mike Brock, Dhanji Prasanna, John Graham, Mark Proctor
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.mvel2;
+
+public class OptimizationFailure extends RuntimeException {
+
+    public OptimizationFailure() {
+        super();
+    }
+
+    public OptimizationFailure(String message) {
+        super(message);
+    }
+
+    public OptimizationFailure(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public OptimizationFailure(Throwable cause) {
+        super(cause);
+    }
+}

--- a/core/src/main/java/org/mvel2/ParserConfiguration.java
+++ b/core/src/main/java/org/mvel2/ParserConfiguration.java
@@ -1,0 +1,265 @@
+/**
+ * MVEL 2.0
+ * Copyright (C) 2007 The Codehaus
+ * Mike Brock, Dhanji Prasanna, John Graham, Mark Proctor
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mvel2;
+
+import static org.mvel2.util.ParseTools.forNameWithInner;
+
+import java.io.Serializable;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.util.Collections;
+import java.util.EnumSet;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.mvel2.ast.Proto;
+import org.mvel2.compiler.AbstractParser;
+import org.mvel2.integration.Interceptor;
+import org.mvel2.util.MethodStub;
+
+/**
+ * The resusable parser configuration object.
+ */
+public class ParserConfiguration implements Serializable {
+
+    protected final Map<String, Object> imports = new ConcurrentHashMap<String, Object>();
+    private final transient Set<String> nonValidImports = Collections.newSetFromMap(new ConcurrentHashMap<String, Boolean>());
+    protected HashSet<String> packageImports;
+    protected Map<String, Interceptor> interceptors;
+    protected transient ClassLoader classLoader;
+    private boolean allowNakedMethCall = MVEL.COMPILER_OPT_ALLOW_NAKED_METH_CALL;
+
+    private boolean allowBootstrapBypass = true;
+
+    public ParserConfiguration() {
+    }
+
+    public ParserConfiguration(Map<String, Object> imports, Map<String, Interceptor> interceptors) {
+        addAllImports(imports);
+        this.interceptors = interceptors;
+    }
+
+    public ParserConfiguration(Map<String, Object> imports, HashSet<String> packageImports, Map<String, Interceptor> interceptors) {
+        addAllImports(imports);
+        this.packageImports = packageImports;
+        this.interceptors = interceptors;
+    }
+
+    public HashSet<String> getPackageImports() {
+        return packageImports;
+    }
+
+    public void setPackageImports(HashSet<String> packageImports) {
+        this.packageImports = packageImports;
+    }
+
+    public Class getImport(String name) {
+        if (imports.containsKey(name) && imports.get(name) instanceof Class) {
+            return (Class) imports.get(name);
+        }
+        return (Class) (AbstractParser.LITERALS.get(name) instanceof Class ? AbstractParser.LITERALS.get(name) : null);
+    }
+
+    public MethodStub getStaticImport(String name) {
+        return (MethodStub) imports.get(name);
+    }
+
+    public Object getStaticOrClassImport(String name) {
+        return imports.containsKey(name) ? imports.get(name) : AbstractParser.LITERALS.get(name);
+    }
+
+    public void addPackageImport(String packageName) {
+        if (packageImports == null) packageImports = new LinkedHashSet<String>();
+        packageImports.add(packageName);
+        if (!addClassMemberStaticImports(packageName)) packageImports.add(packageName);
+    }
+
+    private boolean addClassMemberStaticImports(String packageName) {
+        try {
+            Class c = Class.forName(packageName);
+            if (c.isEnum()) {
+
+                //noinspection unchecked
+                for (Enum e : (EnumSet<?>) EnumSet.allOf(c)) {
+                    imports.put(e.name(), e);
+                }
+                return true;
+            } else {
+                for (Field f : c.getDeclaredFields()) {
+                    if ((f.getModifiers() & (Modifier.STATIC | Modifier.PUBLIC)) == (Modifier.STATIC | Modifier.PUBLIC)) {
+                        imports.put(f.getName(), f.get(null));
+                    }
+                }
+
+            }
+        } catch (ClassNotFoundException e) {
+            // do nothing.
+        } catch (IllegalAccessException e) {
+            throw new RuntimeException("error adding static imports for: " + packageName, e);
+        }
+        return false;
+    }
+
+    public void addAllImports(Map<String, Object> imports) {
+        if (imports == null) return;
+
+        Object o;
+
+        for (Map.Entry<String, Object> entry : imports.entrySet()) {
+            if ((o = entry.getValue()) instanceof Method) {
+                this.imports.put(entry.getKey(), new MethodStub((Method) o));
+            } else {
+                this.imports.put(entry.getKey(), o);
+            }
+        }
+    }
+
+    private boolean checkForDynamicImport(String className) {
+        if (packageImports == null) return false;
+        if (!Character.isJavaIdentifierStart(className.charAt(0))) return false;
+        if (nonValidImports.contains(className)) return false;
+
+        int found = 0;
+        Class cls = null;
+        for (String pkg : packageImports) {
+            try {
+                cls = forNameWithInner(pkg + "." + className, getClassLoader());
+                found++;
+            } catch (Throwable cnfe) {
+                // do nothing.
+            }
+        }
+
+        if (found > 1) throw new RuntimeException("ambiguous class name: " + className);
+        if (found == 1) {
+            addImport(className, cls);
+            return true;
+        }
+
+        cacheNegativeHitForDynamicImport(className);
+        return false;
+    }
+
+    public boolean hasImport(String name) {
+        return (imports.containsKey(name)) || AbstractParser.CLASS_LITERALS.containsKey(name) || checkForDynamicImport(name);
+    }
+
+    public void addImport(Class cls) {
+        addImport(cls.getSimpleName(), cls);
+    }
+
+    public void addImport(String name, Class cls) {
+        this.imports.put(name, cls);
+    }
+
+    public void addImport(String name, Proto proto) {
+        this.imports.put(name, proto);
+    }
+
+    public void addImport(String name, Method method) {
+        addImport(name, new MethodStub(method));
+    }
+
+    public void addImport(String name, MethodStub method) {
+        this.imports.put(name, method);
+    }
+
+    public Map<String, Interceptor> getInterceptors() {
+        return interceptors;
+    }
+
+    public void setInterceptors(Map<String, Interceptor> interceptors) {
+        this.interceptors = interceptors;
+    }
+
+    public Map<String, Object> getImports() {
+        return imports;
+    }
+
+    public void setImports(HashMap<String, Object> imports) {
+        // TODO: this method is here for backward compatibility. Could it be removed/deprecated?
+        setAllImports(imports);
+    }
+
+    public void setImports(Map<String, Object> imports) {
+        if (imports == null) return;
+
+        Object val;
+
+        for (Map.Entry<String, Object> entry : imports.entrySet()) {
+            if ((val = entry.getValue()) instanceof Class) {
+                addImport(entry.getKey(), (Class) val);
+            } else if (val instanceof Method) {
+                addImport(entry.getKey(), (Method) val);
+            } else if (val instanceof MethodStub) {
+                addImport(entry.getKey(), (MethodStub) val);
+            } else if (val instanceof Proto) {
+                addImport(entry.getKey(), (Proto) entry.getValue());
+            } else {
+                throw new RuntimeException("invalid element in imports map: " + entry.getKey() + " (" + val + ")");
+            }
+        }
+    }
+
+    public boolean hasImports() {
+        return !imports.isEmpty() || (packageImports != null && packageImports.size() != 0);
+    }
+
+    public ClassLoader getClassLoader() {
+        return classLoader == null ? classLoader = Thread.currentThread().getContextClassLoader() : classLoader;
+    }
+
+    public void setClassLoader(ClassLoader classLoader) {
+        this.classLoader = classLoader;
+    }
+
+    public void setAllImports(Map<String, Object> imports) {
+        this.imports.clear();
+        if (imports != null) this.imports.putAll(imports);
+    }
+
+    private void cacheNegativeHitForDynamicImport(String negativeHit) {
+        nonValidImports.add(negativeHit);
+    }
+
+    public void flushCaches() {
+        nonValidImports.clear();
+    }
+
+    public boolean isAllowNakedMethCall() {
+        return allowNakedMethCall;
+    }
+
+    public void setAllowNakedMethCall(boolean allowNakedMethCall) {
+        this.allowNakedMethCall = allowNakedMethCall;
+    }
+
+    public boolean isAllowBootstrapBypass() {
+        return allowBootstrapBypass;
+    }
+
+    public void setAllowBootstrapBypass(boolean allowBootstrapBypass) {
+        this.allowBootstrapBypass = allowBootstrapBypass;
+    }
+}

--- a/core/src/main/java/org/mvel2/ParserContext.java
+++ b/core/src/main/java/org/mvel2/ParserContext.java
@@ -1,0 +1,1053 @@
+/**
+ * MVEL 2.0
+ * Copyright (C) 2007 The Codehaus
+ * Mike Brock, Dhanji Prasanna, John Graham, Mark Proctor
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mvel2;
+
+import java.io.Serializable;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.lang.reflect.Type;
+import java.lang.reflect.TypeVariable;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeSet;
+
+import org.mvel2.ast.Function;
+import org.mvel2.ast.LineLabel;
+import org.mvel2.ast.Proto;
+import org.mvel2.compiler.AbstractParser;
+import org.mvel2.compiler.CompiledExpression;
+import org.mvel2.compiler.Parser;
+import org.mvel2.integration.Interceptor;
+import org.mvel2.util.LineMapper;
+import org.mvel2.util.MethodStub;
+import org.mvel2.util.ReflectionUtil;
+
+/**
+ * The <tt>ParserContext</tt> is the main environment object used for sharing state throughout the entire
+ * parser/compileShared process.<br/><br/>
+ * The <tt>ParserContext</tt> is used to configure the parser/compiler.  For example:
+ * <pre><code>
+ * ParserContext parserContext = new ParserContext();
+ * parserContext.setStrongTyping(true); // turn on strong typing.
+ * <p/>
+ * Serializable comp = MVEL.compileExpression("foo.bar", parserContext);
+ * </code</pre>
+ */
+public class ParserContext implements Serializable {
+
+    protected boolean variablesEscape = false;
+    private String sourceFile;
+    private int lineCount = 1;
+    private int lineOffset;
+    private ParserContext parent;
+    private ParserConfiguration parserConfiguration;
+    private Object evaluationContext;
+    private ArrayList<String> indexedInputs;
+    private ArrayList<String> indexedLocals;
+    private ArrayList<Set<String>> variableVisibility;
+    private HashMap<String, Class> variables;
+    private Map<String, Class> inputs;
+    private transient HashMap<String, Map<String, Type>> typeParameters;
+    private transient Type[] lastTypeParameters;
+    private HashMap<String, Function> globalFunctions;
+    private transient List<ErrorDetail> errorList;
+    private transient Map<String, LineMapper.LineLookup> sourceLineLookups;
+    private transient Map<String, Set<Integer>> visitedLines;
+    private LineLabel lastLineLabel;
+    private transient Parser rootParser;
+    private transient Map<String, CompiledExpression> compiledExpressionCache;
+    private transient Map<String, Class> returnTypeCache;
+    private boolean functionContext = false;
+    private boolean compiled = false;
+    private boolean strictTypeEnforcement = false;
+    private boolean strongTyping = false;
+    private boolean optimizationMode = false;
+    private boolean fatalError = false;
+    private boolean retainParserState = false;
+    private boolean debugSymbols = false;
+    private boolean blockSymbols = false;
+    private boolean executableCodeReached = false;
+    private boolean indexAllocation = false;
+
+    public ParserContext() {
+        parserConfiguration = new ParserConfiguration();
+    }
+
+    public ParserContext(boolean debugSymbols) {
+        this();
+        this.debugSymbols = debugSymbols;
+    }
+
+    public ParserContext(Parser rootParser) {
+        this();
+        this.rootParser = rootParser;
+    }
+
+    public ParserContext(ParserConfiguration parserConfiguration) {
+        this.parserConfiguration = parserConfiguration;
+    }
+
+    public ParserContext(ParserConfiguration parserConfiguration, Object evaluationContext) {
+        this(parserConfiguration);
+        this.evaluationContext = evaluationContext;
+    }
+
+    public ParserContext(ParserConfiguration parserConfiguration, ParserContext parent, boolean functionContext) {
+        this(parserConfiguration);
+        this.parent = parent;
+        this.functionContext = functionContext;
+    }
+
+    public ParserContext(Map<String, Object> imports, Map<String, Interceptor> interceptors, String sourceFile) {
+        this.sourceFile = sourceFile;
+        this.parserConfiguration = new ParserConfiguration(imports, interceptors);
+    }
+
+    public static ParserContext create() {
+        return new ParserContext();
+    }
+
+    public ParserContext createSubcontext() {
+        ParserContext ctx = new ParserContext(parserConfiguration);
+        ctx.sourceFile = sourceFile;
+        ctx.parent = this;
+
+        ctx.addInputs(inputs);
+        ctx.addVariables(variables);
+        ctx.addIndexedInputs(indexedInputs);
+        ctx.addTypeParameters(typeParameters);
+
+        ctx.sourceLineLookups = sourceLineLookups;
+        ctx.lastLineLabel = lastLineLabel;
+        ctx.variableVisibility = variableVisibility;
+
+        ctx.globalFunctions = globalFunctions;
+        ctx.lastTypeParameters = lastTypeParameters;
+        ctx.errorList = errorList;
+        ctx.rootParser = rootParser;
+        ctx.lineCount = lineCount;
+        ctx.lineOffset = lineOffset;
+
+        ctx.compiled = compiled;
+        ctx.strictTypeEnforcement = strictTypeEnforcement;
+        ctx.strongTyping = strongTyping;
+
+        ctx.fatalError = fatalError;
+        ctx.retainParserState = retainParserState;
+        ctx.debugSymbols = debugSymbols;
+        ctx.blockSymbols = blockSymbols;
+        ctx.executableCodeReached = executableCodeReached;
+        ctx.indexAllocation = indexAllocation;
+
+        return ctx;
+    }
+
+    public ParserContext createColoringSubcontext() {
+        if (parent == null) {
+            throw new RuntimeException("create a subContext first");
+        }
+
+        ParserContext ctx = new ParserContext(parserConfiguration) {
+
+            @Override
+            public void addVariable(String name, Class type) {
+                if ((parent.variables != null && parent.variables.containsKey(name))
+                        || (parent.inputs != null && parent.inputs.containsKey(name))) {
+                    this.variablesEscape = true;
+                }
+                super.addVariable(name, type);
+            }
+
+            @Override
+            public void addVariable(String name, Class type, boolean failIfNewAssignment) {
+                if ((parent.variables != null && parent.variables.containsKey(name))
+                        || (parent.inputs != null && parent.inputs.containsKey(name))) {
+                    this.variablesEscape = true;
+                }
+                super.addVariable(name, type, failIfNewAssignment);
+            }
+
+            @Override
+            public Class getVarOrInputType(String name) {
+                if ((parent.variables != null && parent.variables.containsKey(name))
+                        || (parent.inputs != null && parent.inputs.containsKey(name))) {
+                    this.variablesEscape = true;
+                }
+
+                return super.getVarOrInputType(name);
+            }
+        };
+        ctx.initializeTables();
+
+        ctx.sourceFile = sourceFile;
+
+        ctx.inputs = inputs;
+        ctx.variables = variables;
+        ctx.indexedInputs = indexedInputs;
+        ctx.typeParameters = typeParameters;
+
+        ctx.sourceLineLookups = sourceLineLookups;
+        ctx.lastLineLabel = lastLineLabel;
+        ctx.variableVisibility = variableVisibility;
+
+        ctx.globalFunctions = globalFunctions;
+        ctx.lastTypeParameters = lastTypeParameters;
+        ctx.errorList = errorList;
+        ctx.rootParser = rootParser;
+        ctx.lineCount = lineCount;
+        ctx.lineOffset = lineOffset;
+
+        ctx.compiled = compiled;
+        ctx.strictTypeEnforcement = strictTypeEnforcement;
+        ctx.strongTyping = strongTyping;
+
+        ctx.fatalError = fatalError;
+        ctx.retainParserState = retainParserState;
+        ctx.debugSymbols = debugSymbols;
+        ctx.blockSymbols = blockSymbols;
+        ctx.executableCodeReached = executableCodeReached;
+        ctx.indexAllocation = indexAllocation;
+
+        return ctx;
+    }
+
+    /**
+     * Tests whether or not a variable or input exists in the current parser context.
+     *
+     * @param name The name of the identifier.
+     * @return boolean
+     */
+    public boolean hasVarOrInput(String name) {
+        return (variables != null && variables.containsKey(name)) || (inputs != null && inputs.containsKey(name));
+    }
+
+    /**
+     * Return the variable or input type froom the current parser context.  Returns <tt>Object.class</tt> if the
+     * type cannot be determined.
+     *
+     * @param name The name of the identifier
+     * @return boolean
+     */
+    public Class getVarOrInputType(String name) {
+        if (variables != null && variables.containsKey(name)) {
+            return variables.get(name);
+        } else if (inputs != null && inputs.containsKey(name)) {
+            return inputs.get(name);
+        }
+        return Object.class;
+    }
+
+    public Class getVarOrInputTypeOrNull(String name) {
+        if (variables != null && variables.containsKey(name)) {
+            return variables.get(name);
+        } else if (inputs != null && inputs.containsKey(name)) {
+            return inputs.get(name);
+        }
+        return null;
+    }
+
+    /**
+     * Get total number of lines declared in the current context.
+     *
+     * @return int of lines
+     */
+    public int getLineCount() {
+        return lineCount;
+    }
+
+    /**
+     * Set the current number of lines in the current context. (Generally only used by the compiler)
+     *
+     * @param lineCount The number of lines
+     * @return int of lines
+     */
+    public int setLineCount(int lineCount) {
+        return this.lineCount = lineCount;
+    }
+
+    /**
+     * Increments the current line count by the specified amount
+     *
+     * @param increment The number of lines to increment
+     * @return int of lines
+     */
+    public int incrementLineCount(int increment) {
+        return this.lineCount += increment;
+    }
+
+    /**
+     * Get the current line offset.  This measures the number of cursor positions back to the beginning of the line.
+     *
+     * @return int offset
+     */
+    public int getLineOffset() {
+        return lineOffset;
+    }
+
+    /**
+     * Sets the current line offset. (Generally only used by the compiler)
+     *
+     * @param lineOffset The offset amount
+     */
+    public void setLineOffset(int lineOffset) {
+        this.lineOffset = lineOffset;
+    }
+
+    /**
+     * Sets both the current line count and line offset
+     *
+     * @param lineCount  The line count
+     * @param lineOffset The line offset
+     */
+    public void setLineAndOffset(int lineCount, int lineOffset) {
+        //addKnownLine(this.lineCount = lineCount);
+        this.lineOffset = lineOffset;
+    }
+
+    /**
+     * Get an import that has been declared, either in the parsed script or programatically
+     *
+     * @param name The name identifier for the imported class (ie. "HashMap")
+     * @return An instance of <tt>Class</tt> denoting the imported class.
+     */
+    public Class getImport(String name) {
+        return parserConfiguration.getImport(name);
+    }
+
+    /**
+     * Get a {@link MethodStub} which wraps a static method import.
+     *
+     * @param name The name identifier
+     * @return An instance of {@link MethodStub}
+     */
+    public MethodStub getStaticImport(String name) {
+        return parserConfiguration.getStaticImport(name);
+    }
+
+    /**
+     * Returns either an instance of <tt>Class</tt> or {@link MethodStub} (whichever matches).
+     *
+     * @param name The name identifier.
+     * @return An instance of <tt>Class</tt> or {@link MethodStub}
+     */
+    public Object getStaticOrClassImport(String name) {
+        return parserConfiguration.getStaticOrClassImport(name);
+    }
+
+    /**
+     * Adds a package import to a parse session.
+     *
+     * @param packageName A fully qualified package (eg. <tt>java.util.concurrent</tt>).
+     */
+    public void addPackageImport(String packageName) {
+        parserConfiguration.addPackageImport(packageName);
+    }
+
+    /**
+     * Tests to see if the specified import exists.
+     *
+     * @param name A name identifier
+     * @return boolean
+     */
+    public boolean hasImport(String name) {
+        return parserConfiguration.hasImport(name);
+    }
+
+    public boolean hasProtoImport(String name) {
+        Object o = parserConfiguration.getImports().get(name);
+        return o != null && o instanceof Proto;
+    }
+
+    public Proto getProtoImport(String name) {
+        return (Proto) parserConfiguration.getImports().get(name);
+    }
+
+    /**
+     * Adds an import for the specified <tt>Class</tt>.
+     *
+     * @param cls The instance of the <tt>Class</tt> which represents the imported class.
+     */
+    public void addImport(Class cls) {
+        addImport(cls.getSimpleName(), cls);
+    }
+
+    public void addImport(Proto proto) {
+        parserConfiguration.addImport(proto.getName(), proto);
+
+    }
+
+    /**
+     * Adds an import for a specified <tt>Class</tt> using an alias.  For example:
+     * <pre><code>
+     * parserContext.addImport("sys", System.class);
+     * </code></pre>
+     * ... doing this would allow an MVEL script to be written as such:
+     * <pre><code>
+     * sys.currentTimeMillis();
+     * </code></pre>
+     *
+     * @param name The alias to use
+     * @param cls  The instance of the <tt>Class</tt> which represents the imported class.
+     */
+    public void addImport(String name, Class cls) {
+        parserConfiguration.addImport(name, cls);
+        //      addInput(name, cls);
+    }
+
+    /**
+     * Adds an import for a specified <tt>Method</tt> representing a static method import using an alias. For example:
+     * <pre><code>
+     * parserContext.addImport("time", MVEL.getStaticMethod(System.class, "currentTimeMillis", new Class[0]));
+     * </code></pre>
+     * ... doing this allows the <tt>System.currentTimeMillis()</tt> method to be executed in a script simply by writing
+     * <tt>time()</tt>.
+     *
+     * @param name   The alias to use
+     * @param method The instance of <tt>Method</tt> which represents the static import.
+     */
+    public void addImport(String name, Method method) {
+        addImport(name, new MethodStub(method));
+        //   addInput(name, MethodStub.class);
+    }
+
+    /**
+     * Adds a static import for the specified {@link MethodStub} with an alias.
+     *
+     * @param name   The alias to use
+     * @param method The instance of <tt>Method</tt> which represents the static import.
+     * @see #addImport(String, MethodStub)
+     */
+    public void addImport(String name, MethodStub method) {
+        parserConfiguration.addImport(name, method);
+    }
+
+    /**
+     * Initializes internal Maps.  Called by the compiler.
+     */
+    public void initializeTables() {
+        if (variables == null) variables = new LinkedHashMap<String, Class>();
+        if (inputs == null) inputs = new LinkedHashMap<String, Class>();
+
+        if (variableVisibility == null) {
+            initVariableVisibility();
+            pushVariableScope();
+
+            Set<String> scope = getVariableScope();
+
+            scope.addAll(variables.keySet());
+            scope.addAll(inputs.keySet());
+
+            scope.addAll(parserConfiguration.getImports().keySet());
+
+            if (inputs.containsKey("this")) {
+                Class<?> ctxType = inputs.get("this");
+
+                for (Field field : ctxType.getFields()) {
+                    if ((field.getModifiers() & (Modifier.PUBLIC | Modifier.STATIC)) != 0) {
+                        scope.add(field.getName());
+                    }
+                }
+
+                for (Method m : ctxType.getMethods()) {
+                    if ((m.getModifiers() & Modifier.PUBLIC) != 0) {
+                        if (m.getName().startsWith("get") || (m.getName().startsWith("is")
+                                && (m.getReturnType().equals(boolean.class) || m.getReturnType().equals(Boolean.class)))) {
+                            String propertyName = ReflectionUtil.getPropertyFromAccessor(m.getName());
+                            scope.add(propertyName);
+                            propertyName = propertyName.substring(0, 1).toUpperCase() + propertyName.substring(1);
+                            scope.add(propertyName);
+                        } else {
+                            scope.add(m.getName());
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    public void addVariable(String name, Class type, boolean failIfNewAssignment) {
+        initializeTables();
+        if (variables.containsKey(name) && failIfNewAssignment)
+            throw new RuntimeException("statically-typed variable already defined in scope: " + name);
+
+        if (type == null) type = Object.class;
+
+        variables.put(name, type);
+        makeVisible(name);
+    }
+
+    public void addVariable(String name, Class type) {
+        initializeTables();
+        if (variables.containsKey(name) || inputs.containsKey(name)) return;
+        if (type == null) type = Object.class;
+        variables.put(name, type);
+        makeVisible(name);
+    }
+
+    public void addVariables(Map<String, Class> variables) {
+        if (variables == null) return;
+        initializeTables();
+        for (Map.Entry<String, Class> entry : variables.entrySet()) {
+            addVariable(entry.getKey(), entry.getValue());
+        }
+    }
+
+    public void addInput(String name, Class type) {
+        if (inputs == null) inputs = new LinkedHashMap<String, Class>();
+        if (inputs.containsKey(name) || (variables != null && variables.containsKey(name))) return;
+        if (type == null) type = Object.class;
+
+        inputs.put(name, type);
+    }
+
+    public void addInput(String name, Class type, Class[] typeParameters) {
+        if (type == null) type = Object.class;
+        addInput(name, type);
+
+        if (this.typeParameters == null) {
+            this.typeParameters = new LinkedHashMap<String, Map<String, Type>>();
+        }
+        if (this.typeParameters.get(name) == null) {
+            this.typeParameters.put(name, new LinkedHashMap<String, Type>());
+        }
+
+        Map<String, Type> t = this.typeParameters.get(name);
+
+        if (typeParameters.length != type.getTypeParameters().length) {
+            throw new RuntimeException("wrong number of type parameters for: " + type.getName());
+        }
+
+        TypeVariable[] tvs = type.getTypeParameters();
+
+        for (int i = 0; i < typeParameters.length; i++) {
+            t.put(tvs[i].getName(), typeParameters[i]);
+        }
+    }
+
+    public void addInputs(Map<String, Class> inputs) {
+        if (inputs == null) return;
+        for (Map.Entry<String, Class> entry : inputs.entrySet()) {
+            addInput(entry.getKey(), entry.getValue());
+        }
+    }
+
+    public void processTables() {
+        for (String name : variables.keySet()) {
+            inputs.remove(name);
+        }
+    }
+
+    public Map<String, Class> getInputs() {
+        return inputs;
+    }
+
+    public void setInputs(Map<String, Class> inputs) {
+        this.inputs = inputs;
+    }
+
+    public List<ErrorDetail> getErrorList() {
+        return errorList == null ? Collections.<ErrorDetail> emptyList() : errorList;
+    }
+
+    public void setErrorList(List<ErrorDetail> errorList) {
+        this.errorList = errorList;
+    }
+
+    public void addError(ErrorDetail errorDetail) {
+        if (errorList == null) errorList = new ArrayList<ErrorDetail>();
+        else {
+            for (ErrorDetail detail : errorList) {
+                if (detail.getMessage().equals(errorDetail.getMessage()) && detail.getColumn() == errorDetail.getColumn()
+                        && detail.getLineNumber() == errorDetail.getLineNumber()) {
+                    return;
+                }
+            }
+        }
+
+        if (errorDetail.isCritical()) fatalError = true;
+        errorList.add(errorDetail);
+    }
+
+    public boolean isFatalError() {
+        return fatalError;
+    }
+
+    public void setFatalError(boolean fatalError) {
+        this.fatalError = fatalError;
+    }
+
+    public boolean isStrictTypeEnforcement() {
+        return strictTypeEnforcement;
+    }
+
+    /**
+     * Enables strict type enforcement -
+     *
+     * @param strictTypeEnforcement -
+     */
+    public void setStrictTypeEnforcement(boolean strictTypeEnforcement) {
+        this.strictTypeEnforcement = strictTypeEnforcement;
+    }
+
+    public boolean isStrongTyping() {
+        return strongTyping;
+    }
+
+    /**
+     * Enables strong type enforcement.
+     *
+     * @param strongTyping -
+     */
+    public void setStrongTyping(boolean strongTyping) {
+        if (this.strongTyping = strongTyping) {
+            // implies strict-type enforcement too
+            this.strictTypeEnforcement = true;
+        }
+    }
+
+    public boolean isRetainParserState() {
+        return retainParserState;
+    }
+
+    public void setRetainParserState(boolean retainParserState) {
+        this.retainParserState = retainParserState;
+    }
+
+    public Parser getRootParser() {
+        return rootParser;
+    }
+
+    public void setRootParser(Parser rootParser) {
+        this.rootParser = rootParser;
+    }
+
+    public String getSourceFile() {
+        return sourceFile;
+    }
+
+    public void setSourceFile(String sourceFile) {
+        if (sourceFile != null) this.sourceFile = sourceFile;
+    }
+
+    public Map<String, Interceptor> getInterceptors() {
+        return this.parserConfiguration.getInterceptors();
+    }
+
+    public void setInterceptors(Map<String, Interceptor> interceptors) {
+        this.parserConfiguration.setInterceptors(interceptors);
+    }
+
+    public Map<String, Object> getImports() {
+        return this.parserConfiguration.getImports();
+    }
+
+    public void setImports(Map<String, Object> imports) {
+        if (imports == null) return;
+
+        Object val;
+        for (Map.Entry<String, Object> entry : imports.entrySet()) {
+            if ((val = entry.getValue()) instanceof Class) {
+                addImport(entry.getKey(), (Class) val);
+            } else if (val instanceof Method) {
+                addImport(entry.getKey(), (Method) val);
+            } else if (val instanceof MethodStub) {
+                addImport(entry.getKey(), (MethodStub) val);
+            } else {
+                throw new RuntimeException("invalid element in imports map: " + entry.getKey() + " (" + val + ")");
+            }
+        }
+    }
+
+    private void initVariableVisibility() {
+        if (variableVisibility == null) {
+            variableVisibility = new ArrayList<Set<String>>();
+        }
+    }
+
+    public void pushVariableScope() {
+        initVariableVisibility();
+        variableVisibility.add(new HashSet<String>());
+    }
+
+    public void popVariableScope() {
+        if (variableVisibility != null && !variableVisibility.isEmpty()) {
+            variableVisibility.remove(variableVisibility.size() - 1);
+            setLastTypeParameters(null);
+        }
+    }
+
+    public void makeVisible(String var) {
+        if (variableVisibility == null || variableVisibility.isEmpty()) {
+            throw new RuntimeException("no context");
+        }
+        getVariableScope().add(var);
+    }
+
+    public Set<String> getVariableScope() {
+        if (variableVisibility == null || variableVisibility.isEmpty()) {
+            throw new RuntimeException("no context");
+        }
+
+        return variableVisibility.get(variableVisibility.size() - 1);
+    }
+
+    public boolean isVariableVisible(String var) {
+        if (variableVisibility == null || variableVisibility.isEmpty()) {
+            return false;
+        }
+
+        if (AbstractParser.LITERALS.containsKey(var) || hasImport(var)) {
+            return true;
+        }
+
+        int pos = variableVisibility.size() - 1;
+
+        do {
+            if (variableVisibility.get(pos).contains(var)) {
+                return true;
+            }
+        } while (pos-- != 0);
+
+        return false;
+    }
+
+    public HashMap<String, Class> getVariables() {
+        return variables;
+    }
+
+    public void setVariables(HashMap<String, Class> variables) {
+        this.variables = variables;
+    }
+
+    public boolean isCompiled() {
+        return compiled;
+    }
+
+    public void setCompiled(boolean compiled) {
+        this.compiled = compiled;
+    }
+
+    public boolean isDebugSymbols() {
+        return debugSymbols;
+    }
+
+    public void setDebugSymbols(boolean debugSymbols) {
+        this.debugSymbols = debugSymbols;
+    }
+
+    public boolean isLineMapped(String sourceName) {
+        return sourceLineLookups != null && sourceLineLookups.containsKey(sourceName);
+    }
+
+    public void initLineMapping(String sourceName, char[] expr) {
+        if (sourceLineLookups == null) {
+            sourceLineLookups = new HashMap<String, LineMapper.LineLookup>();
+        }
+        sourceLineLookups.put(sourceName, new LineMapper(expr).map());
+    }
+
+    public int getLineFor(String sourceName, int cursor) {
+        return (sourceLineLookups != null && sourceLineLookups.containsKey(sourceName)) ? sourceLineLookups.get(sourceName)
+                .getLineFromCursor(cursor) : -1;
+    }
+
+    public boolean isVisitedLine(String sourceName, int lineNumber) {
+        return visitedLines != null && visitedLines.containsKey(sourceName) && visitedLines.get(sourceName).contains(lineNumber);
+    }
+
+    public void visitLine(String sourceName, int lineNumber) {
+        if (visitedLines == null) {
+            visitedLines = new HashMap<String, Set<Integer>>();
+        }
+
+        if (!visitedLines.containsKey(sourceName)) {
+            visitedLines.put(sourceName, new TreeSet<Integer>());
+        }
+
+        visitedLines.get(sourceName).add(lineNumber);
+    }
+
+    public LineLabel getLastLineLabel() {
+        return lastLineLabel;
+    }
+
+    public LineLabel setLastLineLabel(LineLabel lastLineLabel) {
+        return this.lastLineLabel = lastLineLabel;
+    }
+
+    public boolean hasImports() {
+        return parserConfiguration.hasImports();
+    }
+
+    public void declareFunction(Function function) {
+        if (globalFunctions == null) globalFunctions = new LinkedHashMap<String, Function>();
+        globalFunctions.put(function.getName(), function);
+    }
+
+    public Function getFunction(String name) {
+        return globalFunctions == null ? null : globalFunctions.get(name);
+    }
+
+    public Map getFunctions() {
+        return globalFunctions == null ? Collections.emptyMap() : globalFunctions;
+    }
+
+    public boolean hasFunction(String name) {
+        return globalFunctions != null && globalFunctions.containsKey(name);
+    }
+
+    public boolean hasFunction() {
+        return globalFunctions != null && globalFunctions.size() != 0;
+    }
+
+    public void addTypeParameters(Map<String, Map<String, Type>> typeParameters) {
+        if (typeParameters == null) return;
+        if (this.typeParameters == null) typeParameters = new HashMap<String, Map<String, Type>>();
+
+        Map iMap;
+        for (Map.Entry<String, Map<String, Type>> e : typeParameters.entrySet()) {
+            iMap = new HashMap<String, Class>();
+            for (Map.Entry<String, Type> ie : e.getValue().entrySet()) {
+                iMap.put(ie.getKey(), ie.getValue());
+            }
+            typeParameters.put(e.getKey(), iMap);
+        }
+
+    }
+
+    public Map<String, Type> getTypeParameters(String name) {
+        if (typeParameters == null) return null;
+        return typeParameters.get(name);
+    }
+
+    public Type[] getTypeParametersAsArray(String name) {
+        Class c = (variables != null && variables.containsKey(name)) ? variables.get(name) : inputs.get(name);
+        if (c == null) return null;
+
+        Type[] tp = c.getTypeParameters();
+        Type[] types = new Type[tp.length];
+
+        Map<String, Type> typeVars = getTypeParameters(name);
+        if (typeVars == null) {
+            return null;
+        }
+
+        for (int i = 0; i < tp.length; i++) {
+            types[i] = typeVars.get(tp[i].toString());
+        }
+
+        return types;
+    }
+
+    public boolean isBlockSymbols() {
+        return blockSymbols;
+    }
+
+    public void setBlockSymbols(boolean blockSymbols) {
+        this.blockSymbols = blockSymbols;
+    }
+
+    public boolean isVariablesEscape() {
+        return variablesEscape;
+    }
+
+    public boolean isExecutableCodeReached() {
+        return executableCodeReached;
+    }
+
+    public void setExecutableCodeReached(boolean executableCodeReached) {
+        this.executableCodeReached = executableCodeReached;
+    }
+
+    public void optimizationNotify() {
+        this.optimizationMode = true;
+    }
+
+    public boolean isOptimizerNotified() {
+        return optimizationMode;
+    }
+
+    private void initIndexedVariables() {
+        if (indexedInputs == null) indexedInputs = new ArrayList<String>();
+        if (indexedLocals == null) indexedLocals = new ArrayList<String>();
+    }
+
+    public ArrayList<String> getIndexedInputs() {
+        initIndexedVariables();
+        return indexedInputs;
+    }
+
+    public void addIndexedInput(String[] variables) {
+        initIndexedVariables();
+        for (String s : variables) {
+            if (!indexedInputs.contains(s)) indexedInputs.add(s);
+        }
+    }
+
+    public void addIndexedLocals(String[] variables) {
+        initIndexedVariables();
+        for (String s : indexedLocals) {
+            if (!indexedLocals.contains(s)) indexedLocals.add(s);
+        }
+    }
+
+    public void addIndexedLocals(Collection<String> variables) {
+        if (variables == null) return;
+        initIndexedVariables();
+        for (String s : variables) {
+            if (!indexedLocals.contains(s)) indexedLocals.add(s);
+        }
+    }
+
+    public void addIndexedInput(String variable) {
+        initIndexedVariables();
+        if (!indexedInputs.contains(variable)) indexedInputs.add(variable);
+    }
+
+    public void addIndexedInputs(Collection<String> variables) {
+        if (variables == null) return;
+        initIndexedVariables();
+        for (String s : variables) {
+            if (!indexedInputs.contains(s)) indexedInputs.add(s);
+        }
+    }
+
+    public int variableIndexOf(String name) {
+        if (indexedInputs != null) {
+            int idx = indexedInputs.indexOf(name);
+            if (idx == -1 && indexedLocals != null) {
+                idx = indexedLocals.indexOf(name);
+                if (idx != -1) {
+                    idx += indexedInputs.size();
+                }
+            }
+            return idx;
+        }
+
+        return -1;
+    }
+
+    public Object getEvaluationContext() {
+        return evaluationContext;
+    }
+
+    public boolean hasIndexedInputs() {
+        return indexedInputs != null && indexedInputs.size() != 0;
+    }
+
+    public boolean isIndexAllocation() {
+        return indexAllocation;
+    }
+
+    public void setIndexAllocation(boolean indexAllocation) {
+        this.indexAllocation = indexAllocation;
+    }
+
+    public boolean isFunctionContext() {
+        return functionContext;
+    }
+
+    public ParserConfiguration getParserConfiguration() {
+        return parserConfiguration;
+    }
+
+    public ClassLoader getClassLoader() {
+        return parserConfiguration.getClassLoader();
+    }
+
+    public Type[] getLastTypeParameters() {
+        return lastTypeParameters;
+    }
+
+    public void setLastTypeParameters(Type[] lastTypeParameters) {
+        this.lastTypeParameters = lastTypeParameters;
+    }
+
+    public boolean isAllowBootstrapBypass() {
+        return parserConfiguration.isAllowBootstrapBypass();
+    }
+
+    public void setAllowBootstrapBypass(boolean allowBootstrapBypass) {
+        parserConfiguration.setAllowBootstrapBypass(allowBootstrapBypass);
+    }
+
+    public String[] getIndexedVarNames() {
+        if (indexedInputs == null) return new String[0];
+
+        String[] s = new String[indexedInputs.size()];
+        indexedInputs.toArray(s);
+        return s;
+    }
+
+    public Map<String, CompiledExpression> getCompiledExpressionCache() {
+        if (compiledExpressionCache == null) {
+            compiledExpressionCache = new HashMap<String, CompiledExpression>();
+        }
+        return compiledExpressionCache;
+    }
+
+    // Introduce some new Fluent API stuff here.
+
+    public Map<String, Class> getReturnTypeCache() {
+        if (returnTypeCache == null) {
+            returnTypeCache = new HashMap<String, Class>();
+        }
+        return returnTypeCache;
+    }
+
+    public ParserContext stronglyTyped() {
+        setStrongTyping(true);
+        return this;
+    }
+
+    public ParserContext withInput(String name, Class type) {
+        addInput(name, type);
+        return this;
+    }
+
+    public ParserContext withInputs(Map<String, Class> inputs) {
+        setInputs(inputs);
+        return this;
+    }
+
+    public ParserContext withTypeParameters(Map<String, Map<String, Type>> typeParameters) {
+        addTypeParameters(typeParameters);
+        return this;
+    }
+
+    public ParserContext withImport(Class clazz) {
+        addImport(clazz);
+        return this;
+    }
+
+    public ParserContext withIndexedVars(String[] varNames) {
+        indexedInputs = new ArrayList<String>();
+        Collections.addAll(indexedInputs, varNames);
+
+        return this;
+    }
+}

--- a/core/src/main/java/org/mvel2/PreProcessor.java
+++ b/core/src/main/java/org/mvel2/PreProcessor.java
@@ -1,0 +1,29 @@
+/**
+ * MVEL 2.0
+ * Copyright (C) 2007 The Codehaus
+ * Mike Brock, Dhanji Prasanna, John Graham, Mark Proctor
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mvel2;
+
+/**
+ * A preprocessor used for pre-processing any expressions before being parsed/compiled.
+ */
+public interface PreProcessor {
+
+    public char[] parse(char[] input);
+
+    public String parse(String input);
+}

--- a/core/src/main/java/org/mvel2/PropertyAccessException.java
+++ b/core/src/main/java/org/mvel2/PropertyAccessException.java
@@ -1,0 +1,37 @@
+/**
+ * MVEL 2.0
+ * Copyright (C) 2007 The Codehaus
+ * Mike Brock, Dhanji Prasanna, John Graham, Mark Proctor
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.mvel2;
+
+public class PropertyAccessException extends CompileException {
+
+    public PropertyAccessException(String message, char[] expr, int cursor, Throwable e, ParserContext pCtx) {
+        super(message, expr, cursor, e);
+        setParserContext(pCtx);
+    }
+
+    public PropertyAccessException(String message, char[] expr, int cursor, ParserContext pCtx) {
+        super(message, expr, cursor);
+        setParserContext(pCtx);
+    }
+
+    private void setParserContext(ParserContext pCtx) {
+        if (pCtx != null) {
+            setEvaluationContext(pCtx.getEvaluationContext());
+        }
+    }
+}

--- a/core/src/main/java/org/mvel2/PropertyAccessor.java
+++ b/core/src/main/java/org/mvel2/PropertyAccessor.java
@@ -1,0 +1,1086 @@
+/**
+ * MVEL 2.0
+ * Copyright (C) 2007 The Codehaus
+ * Mike Brock, Dhanji Prasanna, John Graham, Mark Proctor
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.mvel2;
+
+import static java.lang.Character.isJavaIdentifierPart;
+import static java.lang.Thread.currentThread;
+import static java.lang.reflect.Array.getLength;
+import static org.mvel2.DataConversion.canConvert;
+import static org.mvel2.DataConversion.convert;
+import static org.mvel2.MVEL.eval;
+import static org.mvel2.ast.TypeDescriptor.getClassReference;
+import static org.mvel2.compiler.AbstractParser.LITERALS;
+import static org.mvel2.integration.GlobalListenerFactory.notifySetListeners;
+import static org.mvel2.integration.PropertyHandlerFactory.getNullMethodHandler;
+import static org.mvel2.integration.PropertyHandlerFactory.getNullPropertyHandler;
+import static org.mvel2.integration.PropertyHandlerFactory.getPropertyHandler;
+import static org.mvel2.integration.PropertyHandlerFactory.hasNullMethodHandler;
+import static org.mvel2.integration.PropertyHandlerFactory.hasNullPropertyHandler;
+import static org.mvel2.integration.PropertyHandlerFactory.hasPropertyHandler;
+import static org.mvel2.util.ParseTools.EMPTY_OBJ_ARR;
+import static org.mvel2.util.ParseTools.balancedCapture;
+import static org.mvel2.util.ParseTools.balancedCaptureWithLineAccounting;
+import static org.mvel2.util.ParseTools.captureStringLiteral;
+import static org.mvel2.util.ParseTools.findAbsoluteLast;
+import static org.mvel2.util.ParseTools.findClass;
+import static org.mvel2.util.ParseTools.getBaseComponentType;
+import static org.mvel2.util.ParseTools.getBestCandidate;
+import static org.mvel2.util.ParseTools.getWidenedTarget;
+import static org.mvel2.util.ParseTools.isWhitespace;
+import static org.mvel2.util.ParseTools.parseParameterList;
+import static org.mvel2.util.ParseTools.parseWithExpressions;
+import static org.mvel2.util.PropertyTools.getFieldOrAccessor;
+import static org.mvel2.util.PropertyTools.getFieldOrWriteAccessor;
+import static org.mvel2.util.ReflectionUtil.toNonPrimitiveType;
+import static org.mvel2.util.Varargs.normalizeArgsForVarArgs;
+import static org.mvel2.util.Varargs.paramTypeVarArgsSafe;
+
+import java.lang.ref.WeakReference;
+import java.lang.reflect.Array;
+import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Member;
+import java.lang.reflect.Method;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.WeakHashMap;
+
+import org.mvel2.ast.FunctionInstance;
+import org.mvel2.ast.InvokationContextFactory;
+import org.mvel2.ast.Proto;
+import org.mvel2.ast.PrototypalFunctionInstance;
+import org.mvel2.ast.TypeDescriptor;
+import org.mvel2.integration.GlobalListenerFactory;
+import org.mvel2.integration.VariableResolverFactory;
+import org.mvel2.integration.impl.ImmutableDefaultFactory;
+import org.mvel2.util.ErrorUtil;
+import org.mvel2.util.MethodStub;
+import org.mvel2.util.ParseTools;
+import org.mvel2.util.StringAppender;
+
+@SuppressWarnings({ "unchecked" })
+/**
+ * The property accessor class is used for extracting properties from objects instances.
+ */
+public class PropertyAccessor {
+
+    //  private static final int DONE = -1;
+    private static final int NORM = 0;
+    private static final int METH = 1;
+    private static final int COL = 2;
+    private static final int WITH = 3;
+    private static final Object[] EMPTYARG = new Object[0];
+    private static final Map<Class, WeakHashMap<Integer, WeakReference<Member>>> READ_PROPERTY_RESOLVER_CACHE;
+    private static final Map<Class, WeakHashMap<Integer, WeakReference<Member>>> WRITE_PROPERTY_RESOLVER_CACHE;
+    private static final Map<Class, WeakHashMap<Integer, WeakReference<Object[]>>> METHOD_RESOLVER_CACHE;
+    private static final Map<Member, WeakReference<Class[]>> METHOD_PARMTYPES_CACHE;
+
+    static {
+        READ_PROPERTY_RESOLVER_CACHE = Collections.synchronizedMap(new WeakHashMap<Class, WeakHashMap<Integer, WeakReference<Member>>>(10));
+        WRITE_PROPERTY_RESOLVER_CACHE = Collections
+                .synchronizedMap(new WeakHashMap<Class, WeakHashMap<Integer, WeakReference<Member>>>(10));
+        METHOD_RESOLVER_CACHE = Collections.synchronizedMap(new WeakHashMap<Class, WeakHashMap<Integer, WeakReference<Object[]>>>(10));
+        METHOD_PARMTYPES_CACHE = Collections.synchronizedMap(new WeakHashMap<Member, WeakReference<Class[]>>(10));
+    }
+
+    private int start = 0;
+    private int cursor = 0;
+    private int st;
+    private char[] property;
+    private int length;
+    private int end;
+    private Object thisReference;
+    private Object ctx;
+    private Object curr;
+    private Class currType = null;
+    private boolean first = true;
+    private boolean nullHandle = false;
+    private VariableResolverFactory variableFactory;
+    private ParserContext pCtx;
+
+    public PropertyAccessor(String property, Object ctx) {
+        this.length = end = (this.property = property.toCharArray()).length;
+        this.ctx = ctx;
+        this.variableFactory = new ImmutableDefaultFactory();
+    }
+
+    public PropertyAccessor(char[] property, Object ctx, VariableResolverFactory resolver, Object thisReference, ParserContext pCtx) {
+        this.length = end = (this.property = property).length;
+        this.ctx = ctx;
+        this.variableFactory = resolver;
+        this.thisReference = thisReference;
+        this.pCtx = pCtx;
+    }
+
+    public PropertyAccessor(char[] property, int start, int offset, Object ctx, VariableResolverFactory resolver, Object thisReference,
+            ParserContext pCtx) {
+        this.property = property;
+        this.cursor = this.st = this.start = start;
+        this.length = offset;
+        this.end = start + offset;
+        this.ctx = ctx;
+        this.variableFactory = resolver;
+        this.thisReference = thisReference;
+        this.pCtx = pCtx;
+    }
+
+    public static Object get(String property, Object ctx) {
+        return new PropertyAccessor(property, ctx).get();
+    }
+
+    public static Object get(char[] property, int offset, int end, Object ctx, VariableResolverFactory resolver, Object thisReferece,
+            ParserContext pCtx) {
+        return new PropertyAccessor(property, offset, end, ctx, resolver, thisReferece, pCtx).get();
+    }
+
+    public static Object get(String property, Object ctx, VariableResolverFactory resolver, Object thisReference, ParserContext pCtx) {
+        return new PropertyAccessor(property.toCharArray(), ctx, resolver, thisReference, pCtx).get();
+    }
+
+    public static void set(Object ctx, String property, Object value) {
+        new PropertyAccessor(property, ctx).set(value);
+    }
+
+    public static void set(Object ctx, VariableResolverFactory resolver, String property, Object value, ParserContext pCtx) {
+        new PropertyAccessor(property.toCharArray(), ctx, resolver, null, pCtx).set(value);
+    }
+
+    public static void clearPropertyResolverCache() {
+        READ_PROPERTY_RESOLVER_CACHE.clear();
+        WRITE_PROPERTY_RESOLVER_CACHE.clear();
+        METHOD_RESOLVER_CACHE.clear();
+    }
+
+    public static void reportCacheSizes() {
+        System.out.println("read property cache: " + READ_PROPERTY_RESOLVER_CACHE.size());
+        for (Class cls : READ_PROPERTY_RESOLVER_CACHE.keySet()) {
+            System.out.println(" [" + cls.getName() + "]: " + READ_PROPERTY_RESOLVER_CACHE.get(cls).size() + " entries.");
+        }
+        System.out.println("write property cache: " + WRITE_PROPERTY_RESOLVER_CACHE.size());
+        for (Class cls : WRITE_PROPERTY_RESOLVER_CACHE.keySet()) {
+            System.out.println(" [" + cls.getName() + "]: " + WRITE_PROPERTY_RESOLVER_CACHE.get(cls).size() + " entries.");
+        }
+        System.out.println("method cache: " + METHOD_RESOLVER_CACHE.size());
+        for (Class cls : METHOD_RESOLVER_CACHE.keySet()) {
+            System.out.println(" [" + cls.getName() + "]: " + METHOD_RESOLVER_CACHE.get(cls).size() + " entries.");
+        }
+    }
+
+    private static void addReadCache(Class cls, Integer property, Member member) {
+        synchronized (READ_PROPERTY_RESOLVER_CACHE) {
+            WeakHashMap<Integer, WeakReference<Member>> nestedMap = READ_PROPERTY_RESOLVER_CACHE.get(cls);
+
+            if (nestedMap == null) {
+                READ_PROPERTY_RESOLVER_CACHE.put(cls, nestedMap = new WeakHashMap<Integer, WeakReference<Member>>());
+            }
+
+            nestedMap.put(property, new WeakReference<Member>(member));
+        }
+    }
+
+    private static Member checkReadCache(Class cls, Integer property) {
+        WeakHashMap<Integer, WeakReference<Member>> map = READ_PROPERTY_RESOLVER_CACHE.get(cls);
+        if (map != null) {
+            WeakReference<Member> member = map.get(property);
+            if (member != null) return member.get();
+        }
+        return null;
+    }
+
+    private static void addWriteCache(Class cls, Integer property, Member member) {
+        synchronized (WRITE_PROPERTY_RESOLVER_CACHE) {
+            WeakHashMap<Integer, WeakReference<Member>> map = WRITE_PROPERTY_RESOLVER_CACHE.get(cls);
+            if (map == null) {
+                WRITE_PROPERTY_RESOLVER_CACHE.put(cls, map = new WeakHashMap<Integer, WeakReference<Member>>());
+            }
+            map.put(property, new WeakReference<Member>(member));
+        }
+    }
+
+    private static Member checkWriteCache(Class cls, Integer property) {
+        Map<Integer, WeakReference<Member>> map = WRITE_PROPERTY_RESOLVER_CACHE.get(cls);
+        if (map != null) {
+            WeakReference<Member> member = map.get(property);
+            if (member != null) return member.get();
+        }
+        return null;
+    }
+
+    public static Class[] checkParmTypesCache(Method member) {
+        WeakReference<Class[]> pt = METHOD_PARMTYPES_CACHE.get(member);
+        Class[] ret;
+        if (pt == null || (ret = pt.get()) == null) {
+            //noinspection UnusedAssignment
+            METHOD_PARMTYPES_CACHE.put(member, pt = new WeakReference<Class[]>(ret = member.getParameterTypes()));
+        }
+        return ret;
+    }
+
+    private static void addMethodCache(Class cls, Integer property, Method member) {
+        synchronized (METHOD_RESOLVER_CACHE) {
+            WeakHashMap<Integer, WeakReference<Object[]>> map = METHOD_RESOLVER_CACHE.get(cls);
+            if (map == null) {
+                METHOD_RESOLVER_CACHE.put(cls, map = new WeakHashMap<Integer, WeakReference<Object[]>>());
+            }
+            map.put(property, new WeakReference<Object[]>(new Object[] { member, member.getParameterTypes() }));
+        }
+    }
+
+    private static Object[] checkMethodCache(Class cls, Integer property) {
+        Map<Integer, WeakReference<Object[]>> map = METHOD_RESOLVER_CACHE.get(cls);
+        if (map != null) {
+            WeakReference<Object[]> ref = map.get(property);
+            if (ref != null) return ref.get();
+        }
+        return null;
+    }
+
+    private static int createSignature(String name, String args) {
+        return name.hashCode() + args.hashCode();
+    }
+
+    private Object get() {
+        curr = ctx;
+
+        try {
+            if (!MVEL.COMPILER_OPT_ALLOW_OVERRIDE_ALL_PROPHANDLING) {
+                return getNormal();
+            } else {
+                return getAllowOverride();
+            }
+        } catch (InvocationTargetException e) {
+            throw new PropertyAccessException("could not access property", property, cursor, e, pCtx);
+        } catch (IllegalAccessException e) {
+            throw new PropertyAccessException("could not access property", property, cursor, e, pCtx);
+        } catch (IndexOutOfBoundsException e) {
+            if (cursor >= length) cursor = length - 1;
+
+            throw new PropertyAccessException(
+                    "array or collections index out of bounds in property: " + new String(property, cursor, length), property, cursor, e,
+                    pCtx);
+        } catch (CompileException e) {
+            throw ErrorUtil.rewriteIfNeeded(e, property, st);
+        } catch (NullPointerException e) {
+            throw new PropertyAccessException("null pointer exception in property: " + new String(property), property, cursor, e, pCtx);
+        } catch (Exception e) {
+            throw new PropertyAccessException("unknown exception in expression: " + new String(property), property, cursor, e, pCtx);
+        }
+    }
+
+    private Object getNormal() throws Exception {
+        while (cursor < end) {
+            switch (nextToken()) {
+                case NORM:
+                    curr = getBeanProperty(curr, capture());
+                    break;
+                case METH:
+                    curr = getMethod(curr, capture());
+                    break;
+                case COL:
+                    curr = getCollectionProperty(curr, capture());
+                    break;
+                case WITH:
+                    curr = getWithProperty(curr);
+                    break;
+            }
+
+            if (nullHandle) {
+                if (curr == null) {
+                    return null;
+                } else {
+                    nullHandle = false;
+                }
+            }
+
+            first = false;
+        }
+        return curr;
+    }
+
+    private Object getAllowOverride() throws Exception {
+        while (cursor < end) {
+            switch (nextToken()) {
+                case NORM:
+                    if ((curr = getBeanPropertyAO(curr, capture())) == null && hasNullPropertyHandler()) {
+                        curr = getNullPropertyHandler().getProperty(capture(), ctx, variableFactory);
+                    }
+                    break;
+                case METH:
+                    if ((curr = getMethod(curr, capture())) == null && hasNullMethodHandler()) {
+                        curr = getNullMethodHandler().getProperty(capture(), ctx, variableFactory);
+                    }
+                    break;
+                case COL:
+                    curr = getCollectionPropertyAO(curr, capture());
+                    break;
+                case WITH:
+                    curr = getWithProperty(curr);
+                    break;
+            }
+
+            if (nullHandle) {
+                if (curr == null) {
+                    return null;
+                } else {
+                    nullHandle = false;
+                }
+            } else {
+                if (curr == null && cursor < end) throw new NullPointerException();
+            }
+
+            first = false;
+        }
+        return curr;
+    }
+
+    private void set(Object value) {
+        curr = ctx;
+
+        try {
+            int oLength = end;
+
+            end = findAbsoluteLast(property);
+
+            if ((curr = get()) == null)
+                throw new PropertyAccessException("cannot bind to null context: " + new String(property, cursor, length), property, cursor,
+                        pCtx);
+
+            end = oLength;
+
+            if (nextToken() == COL) {
+                int _start = ++cursor;
+
+                whiteSpaceSkip();
+
+                if (cursor == length || scanTo(']')) throw new PropertyAccessException("unterminated '['", property, cursor, pCtx);
+
+                String ex = new String(property, _start, cursor - _start);
+
+                if (!MVEL.COMPILER_OPT_ALLOW_OVERRIDE_ALL_PROPHANDLING) {
+                    if (curr instanceof Map) {
+                        //noinspection unchecked
+                        ((Map) curr).put(eval(ex, this.ctx, this.variableFactory), value);
+                    } else if (curr instanceof List) {
+                        //noinspection unchecked
+                        ((List) curr).set(eval(ex, this.ctx, this.variableFactory, Integer.class), value);
+                    } else if (hasPropertyHandler(curr.getClass())) {
+                        getPropertyHandler(curr.getClass()).setProperty(ex, ctx, variableFactory, value);
+                    } else if (curr.getClass().isArray()) {
+                        Array.set(curr, eval(ex, this.ctx, this.variableFactory, Integer.class),
+                                convert(value, getBaseComponentType(curr.getClass())));
+                    } else {
+                        throw new PropertyAccessException("cannot bind to collection property: " + new String(property)
+                                + ": not a recognized collection type: " + ctx.getClass(), property, cursor, pCtx);
+                    }
+
+                    return;
+                } else {
+                    notifySetListeners(ctx, ex, variableFactory, value);
+
+                    if (curr instanceof Map) {
+                        //noinspection unchecked
+                        if (hasPropertyHandler(Map.class)) getPropertyHandler(Map.class).setProperty(ex, curr, variableFactory, value);
+                        else((Map) curr).put(eval(ex, this.ctx, this.variableFactory), value);
+                    } else if (curr instanceof List) {
+                        //noinspection unchecked
+                        if (hasPropertyHandler(List.class)) getPropertyHandler(List.class).setProperty(ex, curr, variableFactory, value);
+                        else((List) curr).set(eval(ex, this.ctx, this.variableFactory, Integer.class), value);
+                    } else if (curr.getClass().isArray()) {
+                        if (hasPropertyHandler(Array.class)) getPropertyHandler(Array.class).setProperty(ex, curr, variableFactory, value);
+                        else Array.set(curr, eval(ex, this.ctx, this.variableFactory, Integer.class),
+                                convert(value, getBaseComponentType(curr.getClass())));
+                    } else if (hasPropertyHandler(curr.getClass())) {
+                        getPropertyHandler(curr.getClass()).setProperty(ex, curr, variableFactory, value);
+                    } else {
+                        throw new PropertyAccessException("cannot bind to collection property: " + new String(property)
+                                + ": not a recognized collection type: " + ctx.getClass(), property, cursor, pCtx);
+                    }
+
+                    return;
+                }
+            } else if (MVEL.COMPILER_OPT_ALLOW_OVERRIDE_ALL_PROPHANDLING && hasPropertyHandler(curr.getClass())) {
+                getPropertyHandler(curr.getClass()).setProperty(capture(), curr, variableFactory, value);
+                return;
+            }
+
+            String tk = capture();
+
+            Member member = checkWriteCache(curr.getClass(), tk == null ? 0 : tk.hashCode());
+            if (member == null) {
+                addWriteCache(curr.getClass(), tk != null ? tk.hashCode() : -1,
+                        (member = value != null ? getFieldOrWriteAccessor(curr.getClass(), tk,
+                                value.getClass()) : getFieldOrWriteAccessor(curr.getClass(), tk)));
+            }
+
+            if (member instanceof Method) {
+                Method meth = (Method) member;
+
+                Class[] parameterTypes = checkParmTypesCache(meth);
+
+                if (value != null && !parameterTypes[0].isAssignableFrom(value.getClass())) {
+                    if (!canConvert(parameterTypes[0], value.getClass())) {
+                        throw new CompileException("cannot convert type: " + value.getClass() + ": to " + meth.getParameterTypes()[0],
+                                property, cursor);
+                    }
+                    meth.invoke(curr, convert(value, parameterTypes[0]));
+                } else {
+                    meth.invoke(curr, value);
+                }
+            } else if (member != null) {
+                Field fld = (Field) member;
+
+                if (value != null && !fld.getType().isAssignableFrom(value.getClass())) {
+                    if (!canConvert(fld.getType(), value.getClass())) {
+                        throw new CompileException("cannot convert type: " + value.getClass() + ": to " + fld.getType(), property, cursor);
+                    }
+
+                    fld.set(curr, convert(value, fld.getType()));
+                } else {
+                    fld.set(curr, value);
+                }
+            } else if (curr instanceof Map) {
+                //noinspection unchecked
+                ((Map) curr).put(eval(tk, this.ctx, this.variableFactory), value);
+            } else if (curr instanceof FunctionInstance) {
+                ((PrototypalFunctionInstance) curr).getResolverFactory().getVariableResolver(tk).setValue(value);
+            } else {
+                throw new PropertyAccessException(
+                        "could not access/write property (" + tk + ") in: " + (curr == null ? "Unknown" : curr.getClass().getName()),
+                        property, cursor, pCtx);
+            }
+        } catch (InvocationTargetException e) {
+            throw new PropertyAccessException("could not access property", property, st, e, pCtx);
+        } catch (IllegalAccessException e) {
+            throw new PropertyAccessException("could not access property", property, st, e, pCtx);
+        }
+    }
+
+    private int nextToken() {
+        switch (property[st = cursor]) {
+            case '[':
+                return COL;
+            case '{':
+                if (property[cursor - 1] == '.') {
+                    return WITH;
+                }
+                break;
+            case '.':
+                // ++cursor;
+                while (cursor < end && isWhitespace(property[cursor]))
+                    cursor++;
+                if ((st + 1) != end) {
+                    switch (property[cursor = ++st]) {
+                        case '?':
+                            cursor = ++st;
+                            nullHandle = true;
+                            break;
+                        case '{':
+                            return WITH;
+                    }
+
+                }
+            case '?':
+                if (cursor == start) {
+                    cursor = ++st;
+                    nullHandle = true;
+                }
+        }
+
+        do {
+            while (cursor < end && isWhitespace(property[cursor]))
+                cursor++;
+
+            if (cursor < end && property[cursor] == '.') {
+                cursor++;
+            } else {
+                break;
+            }
+        } while (true);
+
+        st = cursor;
+
+        //noinspection StatementWithEmptyBody
+        while (++cursor < end && isJavaIdentifierPart(property[cursor]));
+
+        if (cursor < end) {
+            while (isWhitespace(property[cursor]))
+                cursor++;
+            switch (property[cursor]) {
+                case '[':
+                    return COL;
+                case '(':
+                    return METH;
+                default:
+                    return 0;
+            }
+        }
+        return 0;
+    }
+
+    private String capture() {
+        return new String(property, st, trimLeft(cursor) - st);
+    }
+
+    protected int trimLeft(int pos) {
+        while (pos > 0 && isWhitespace(property[pos - 1]))
+            pos--;
+        return pos;
+    }
+
+    private Object getBeanPropertyAO(Object ctx, String property) throws IllegalAccessException, InvocationTargetException {
+        if (ctx != null && hasPropertyHandler(ctx.getClass()))
+            return getPropertyHandler(ctx.getClass()).getProperty(property, ctx, variableFactory);
+
+        GlobalListenerFactory.notifyGetListeners(ctx, property, variableFactory);
+
+        return getBeanProperty(ctx, property);
+    }
+
+    private Object getBeanProperty(Object ctx, String property) throws IllegalAccessException, InvocationTargetException {
+
+        if (first) {
+            if ("this".equals(property)) {
+                return this.ctx;
+            } else if (LITERALS.containsKey(property)) {
+                return LITERALS.get(property);
+            } else if (variableFactory != null && variableFactory.isResolveable(property)) {
+                return variableFactory.getVariableResolver(property).getValue();
+            }
+        }
+
+        if (ctx != null) {
+            Class<?> cls;
+            if (ctx instanceof Class) {
+                if (MVEL.COMPILER_OPT_SUPPORT_JAVA_STYLE_CLASS_LITERALS && "class".equals(property)) {
+                    return ctx;
+                }
+
+                cls = (Class<?>) ctx;
+            } else {
+                cls = ctx.getClass();
+            }
+
+            Member member = checkReadCache(cls, property.hashCode());
+
+            if (member == null) {
+                addReadCache(cls, property.hashCode(), member = getFieldOrAccessor(cls, property));
+            }
+
+            if (member instanceof Method) {
+                try {
+                    return ((Method) member).invoke(ctx, EMPTYARG);
+                } catch (IllegalAccessException e) {
+                    synchronized (member) {
+                        try {
+                            ((Method) member).setAccessible(true);
+                            return ((Method) member).invoke(ctx, EMPTYARG);
+                        } finally {
+                            ((Method) member).setAccessible(false);
+                        }
+                    }
+                } catch (IllegalArgumentException e) {
+                    if (member.getDeclaringClass().equals(ctx)) {
+                        try {
+                            Class c = Class.forName(member.getDeclaringClass().getName() + "$" + property);
+
+                            throw new CompileException("name collision between innerclass: " + c.getCanonicalName()
+                                    + "; and bean accessor: " + property + " (" + member.toString() + ")", this.property, this.st);
+                        } catch (ClassNotFoundException e2) {
+                            //fallthru
+                        }
+                    }
+                    throw e;
+                }
+            } else if (member != null) {
+                currType = toNonPrimitiveType(((Field) member).getType());
+                ((Field) member).setAccessible(true);
+                return ((Field) member).get(ctx);
+            } else if (ctx instanceof Map && (((Map) ctx).containsKey(property) || nullHandle)) {
+                if (ctx instanceof Proto.ProtoInstance) {
+                    return ((Proto.ProtoInstance) ctx).get(property).call(null, thisReference, variableFactory, EMPTY_OBJ_ARR);
+                }
+                return ((Map) ctx).get(property);
+            } else if ("length".equals(property) && ctx.getClass().isArray()) {
+                return getLength(ctx);
+            } else if (ctx instanceof Class) {
+                Class c = (Class) ctx;
+                for (Method m : c.getMethods()) {
+                    if (property.equals(m.getName())) {
+                        if (pCtx != null && pCtx.getParserConfiguration() != null ? pCtx.getParserConfiguration()
+                                .isAllowNakedMethCall() : MVEL.COMPILER_OPT_ALLOW_NAKED_METH_CALL) {
+                            m.setAccessible(true);
+                            return m.invoke(ctx, EMPTY_OBJ_ARR);
+                        }
+                        return m;
+                    }
+                }
+
+                try {
+                    return findClass(variableFactory, c.getName() + "$" + property, pCtx);
+                } catch (ClassNotFoundException cnfe) {
+                    // fall through.
+                }
+            } else if (hasPropertyHandler(cls)) {
+                return getPropertyHandler(cls).getProperty(property, ctx, variableFactory);
+            } else if (ctx instanceof FunctionInstance) {
+                return ((PrototypalFunctionInstance) ctx).getResolverFactory().getVariableResolver(property).getValue();
+            }
+        }
+
+        Object tryStatic = tryStaticAccess();
+
+        if (tryStatic != null) {
+            if (tryStatic instanceof Class || tryStatic instanceof Method) return tryStatic;
+            else {
+                ((Field) tryStatic).setAccessible(true);
+                return ((Field) tryStatic).get(null);
+            }
+        } else if (pCtx != null && pCtx.getParserConfiguration() != null ? pCtx.getParserConfiguration()
+                .isAllowNakedMethCall() : MVEL.COMPILER_OPT_ALLOW_NAKED_METH_CALL) {
+            return getMethod(ctx, property);
+        }
+
+        if (ctx == null) {
+            throw new PropertyAccessException("unresolvable property or identifier: " + property, this.property, st, pCtx);
+        } else {
+            throw new PropertyAccessException("could not access: " + property + "; in class: " + ctx.getClass().getName(), this.property,
+                    st, pCtx);
+        }
+    }
+
+    private void whiteSpaceSkip() {
+        if (cursor < end)
+            //noinspection StatementWithEmptyBody
+            while (isWhitespace(property[cursor]) && ++cursor < end);
+    }
+
+    /**
+     * @param c - character to scan to.
+     * @return - returns true is end of statement is hit, false if the scan scar is countered.
+     */
+    private boolean scanTo(char c) {
+        for (; cursor < end; cursor++) {
+            switch (property[cursor]) {
+                case '\'':
+                case '"':
+                    cursor = captureStringLiteral(property[cursor], property, cursor, end);
+                default:
+                    if (property[cursor] == c) {
+                        return false;
+                    }
+            }
+
+        }
+        return true;
+    }
+
+    private Object getWithProperty(Object ctx) {
+        int st;
+
+        String nestParm = start == cursor ? null : new String(property, start, cursor - start - 1).trim();
+
+        parseWithExpressions(nestParm, property, st = cursor + 1,
+                (cursor = balancedCaptureWithLineAccounting(property, cursor, end, '{', pCtx)) - st, ctx, variableFactory);
+        cursor++;
+        return ctx;
+    }
+
+    /**
+     * Handle accessing a property embedded in a collections, map, or array
+     *
+     * @param ctx  -
+     * @param prop -
+     * @return -
+     * @throws Exception -
+     */
+    private Object getCollectionProperty(Object ctx, String prop) throws Exception {
+        if (prop.length() != 0) {
+            ctx = getBeanProperty(ctx, prop);
+            if (ctx == null) {
+                throw new NullPointerException("null pointer on indexed access for: " + prop);
+            }
+        }
+
+        currType = null;
+
+        int _start = ++cursor;
+
+        whiteSpaceSkip();
+
+        if (cursor == end || scanTo(']')) throw new PropertyAccessException("unterminated '['", property, cursor, pCtx);
+
+        prop = new String(property, _start, cursor++ - _start);
+
+        if (ctx instanceof Map) {
+            return ((Map) ctx).get(eval(prop, ctx, variableFactory));
+        } else if (ctx instanceof List) {
+            return ((List) ctx).get((Integer) eval(prop, ctx, variableFactory));
+        } else if (ctx instanceof Collection) {
+            int count = (Integer) eval(prop, ctx, variableFactory);
+            if (count > ((Collection) ctx).size())
+                throw new PropertyAccessException("index [" + count + "] out of bounds on collections", property, cursor, pCtx);
+
+            Iterator iter = ((Collection) ctx).iterator();
+            for (int i = 0; i < count; i++)
+                iter.next();
+            return iter.next();
+        } else if (ctx.getClass().isArray()) {
+            return Array.get(ctx, (Integer) eval(prop, ctx, variableFactory));
+        } else if (ctx instanceof CharSequence) {
+            return ((CharSequence) ctx).charAt((Integer) eval(prop, ctx, variableFactory));
+        } else {
+            try {
+                return getClassReference(pCtx, (Class) ctx, new TypeDescriptor(property, start, length, 0));
+            } catch (Exception e) {
+                throw new PropertyAccessException("illegal use of []: unknown type: " + (ctx.getClass().getName()), property, st, e, pCtx);
+            }
+        }
+    }
+
+    private Object getCollectionPropertyAO(Object ctx, String prop) throws Exception {
+        if (prop.length() != 0) {
+            ctx = getBeanProperty(ctx, prop);
+        }
+
+        currType = null;
+        if (ctx == null) return null;
+
+        int _start = ++cursor;
+
+        whiteSpaceSkip();
+
+        if (cursor == end || scanTo(']')) throw new PropertyAccessException("unterminated '['", property, cursor, pCtx);
+
+        prop = new String(property, _start, cursor++ - _start);
+
+        if (ctx instanceof Map) {
+            if (hasPropertyHandler(Map.class)) return getPropertyHandler(Map.class).getProperty(prop, ctx, variableFactory);
+            else return ((Map) ctx).get(eval(prop, ctx, variableFactory));
+        } else if (ctx instanceof List) {
+            if (hasPropertyHandler(List.class)) return getPropertyHandler(List.class).getProperty(prop, ctx, variableFactory);
+            else return ((List) ctx).get((Integer) eval(prop, ctx, variableFactory));
+        } else if (ctx instanceof Collection) {
+            if (hasPropertyHandler(Collection.class)) return getPropertyHandler(Collection.class).getProperty(prop, ctx, variableFactory);
+            else {
+                int count = (Integer) eval(prop, ctx, variableFactory);
+                if (count > ((Collection) ctx).size())
+                    throw new PropertyAccessException("index [" + count + "] out of bounds on collections", property, cursor, pCtx);
+
+                Iterator iter = ((Collection) ctx).iterator();
+                for (int i = 0; i < count; i++)
+                    iter.next();
+                return iter.next();
+            }
+        } else if (ctx.getClass().isArray()) {
+            if (hasPropertyHandler(Array.class)) return getPropertyHandler(Array.class).getProperty(prop, ctx, variableFactory);
+
+            return Array.get(ctx, (Integer) eval(prop, ctx, variableFactory));
+        } else if (ctx instanceof CharSequence) {
+            if (hasPropertyHandler(CharSequence.class))
+                return getPropertyHandler(CharSequence.class).getProperty(prop, ctx, variableFactory);
+            else return ((CharSequence) ctx).charAt((Integer) eval(prop, ctx, variableFactory));
+        } else {
+            try {
+                return getClassReference(pCtx, (Class) ctx, new TypeDescriptor(property, start, end - start, 0));
+            } catch (Exception e) {
+                throw new PropertyAccessException("illegal use of []: unknown type: " + (ctx.getClass().getName()), property, st, pCtx);
+            }
+        }
+    }
+
+    /**
+     * Find an appropriate method, execute it, and return it's response.
+     *
+     * @param ctx  -
+     * @param name -
+     * @return -
+     */
+    @SuppressWarnings({ "unchecked" })
+    private Object getMethod(Object ctx, String name) {
+        int _start = cursor;
+
+        String tk = cursor != end && property[cursor] == '('
+                && ((cursor = balancedCapture(property, cursor, '(')) - _start) > 1 ? new String(property, _start + 1,
+                        cursor - _start - 1) : "";
+
+        cursor++;
+
+        Object[] args;
+        if (tk.length() == 0) {
+            args = ParseTools.EMPTY_OBJ_ARR;
+        } else {
+            List<char[]> subtokens = parseParameterList(tk.toCharArray(), 0, -1);
+            args = new Object[subtokens.size()];
+            for (int i = 0; i < subtokens.size(); i++) {
+                args[i] = eval(subtokens.get(i), thisReference, variableFactory);
+            }
+        }
+
+        if (first && variableFactory != null && variableFactory.isResolveable(name)) {
+            Object ptr = variableFactory.getVariableResolver(name).getValue();
+            if (ptr instanceof Method) {
+                ctx = ((Method) ptr).getDeclaringClass();
+                name = ((Method) ptr).getName();
+            } else if (ptr instanceof MethodStub) {
+                ctx = ((MethodStub) ptr).getClassReference();
+                name = ((MethodStub) ptr).getMethodName();
+            } else if (ptr instanceof FunctionInstance) {
+                ((FunctionInstance) ptr).getFunction().checkArgumentCount(args.length);
+                return ((FunctionInstance) ptr).call(null, thisReference, variableFactory, args);
+            } else {
+                throw new OptimizationFailure("attempt to optimize a method call for a reference that does not point to a method: " + name
+                        + " (reference is type: " + (ctx != null ? ctx.getClass().getName() : null) + ")");
+            }
+
+            first = false;
+        }
+
+        if (ctx == null) throw new CompileException("no such method or function: " + name, property, cursor);
+
+        /**
+         * If the target object is an instance of java.lang.Class itself then do not
+         * adjust the Class scope target.
+         */
+        Class cls = currType != null ? currType : ((ctx instanceof Class ? (Class) ctx : ctx.getClass()));
+        currType = null;
+
+        if (cls == Proto.ProtoInstance.class) {
+            return ((Proto.ProtoInstance) ctx).get(name).call(null, thisReference, variableFactory, args);
+        }
+
+        /**
+         * Check to see if we have already cached this method;
+         */
+        Object[] cache = checkMethodCache(cls, createSignature(name, tk));
+
+        Method m;
+        Class[] parameterTypes;
+
+        if (cache != null) {
+            m = (Method) cache[0];
+            parameterTypes = (Class[]) cache[1];
+        } else {
+            m = null;
+            parameterTypes = null;
+        }
+
+        /**
+         * If we have not cached the method then we need to go ahead and try to resolve it.
+         */
+        if (m == null) {
+            /**
+             * Try to find an instance method from the class target.
+             */
+            if ((m = getBestCandidate(args, name, cls, cls.getMethods(), false)) != null) {
+                addMethodCache(cls, createSignature(name, tk), m);
+                parameterTypes = m.getParameterTypes();
+            }
+
+            if (m == null) {
+                /**
+                 * If we didn't find anything, maybe we're looking for the actual java.lang.Class methods.
+                 */
+                if ((m = getBestCandidate(args, name, cls, cls.getDeclaredMethods(), false)) != null) {
+                    addMethodCache(cls, createSignature(name, tk), m);
+                    parameterTypes = m.getParameterTypes();
+                }
+            }
+        }
+
+        // If we didn't find anything and the declared class is different from the actual one try also with the actual one
+        if (m == null && cls != ctx.getClass() && !(ctx instanceof Class)) {
+            cls = ctx.getClass();
+            if ((m = getBestCandidate(args, name, cls, cls.getDeclaredMethods(), false)) != null) {
+                addMethodCache(cls, createSignature(name, tk), m);
+                parameterTypes = m.getParameterTypes();
+            }
+        }
+
+        if (ctx instanceof PrototypalFunctionInstance) {
+            final VariableResolverFactory funcCtx = ((PrototypalFunctionInstance) ctx).getResolverFactory();
+            Object prop = funcCtx.getVariableResolver(name).getValue();
+            if (prop instanceof PrototypalFunctionInstance) {
+                return ((PrototypalFunctionInstance) prop).call(ctx, thisReference, new InvokationContextFactory(variableFactory, funcCtx),
+                        args);
+            }
+        }
+
+        if (m == null) {
+            StringAppender errorBuild = new StringAppender();
+            for (int i = 0; i < args.length; i++) {
+                errorBuild.append(args[i] != null ? args[i].getClass().getName() : null);
+                if (i < args.length - 1) errorBuild.append(", ");
+            }
+
+            if ("size".equals(name) && args.length == 0 && cls.isArray()) {
+                return getLength(ctx);
+            }
+
+            //      System.out.println("{ " + new String(property) + " }");
+
+            throw new PropertyAccessException("unable to resolve method: " + cls.getName() + "." + name + "(" + errorBuild.toString()
+                    + ") [arglength=" + args.length + "]", property, st, pCtx);
+        } else {
+            for (int i = 0; i < args.length; i++) {
+                args[i] = convert(args[i], paramTypeVarArgsSafe(parameterTypes, i, m.isVarArgs()));
+            }
+
+            /**
+             * Invoke the target method and return the response.
+             */
+            currType = toNonPrimitiveType(m.getReturnType());
+            m.setAccessible(true);
+            try {
+                return m.invoke(ctx, normalizeArgsForVarArgs(parameterTypes, args, m.isVarArgs()));
+            } catch (IllegalAccessException e) {
+                try {
+                    addMethodCache(cls, createSignature(name, tk), (m = getWidenedTarget(m)));
+                    return m.invoke(ctx, args);
+                } catch (Exception e2) {
+                    throw new PropertyAccessException("unable to invoke method: " + name, property, cursor, e2, pCtx);
+                }
+            } catch (RuntimeException e) {
+                throw e;
+            } catch (Exception e) {
+                throw new PropertyAccessException("unable to invoke method: " + name, property, cursor, e, pCtx);
+            }
+        }
+    }
+
+    private ClassLoader getClassLoader() {
+        return pCtx != null ? pCtx.getClassLoader() : currentThread().getContextClassLoader();
+    }
+
+    /**
+     * Try static access of the property, and return an instance of the Field, Method of Class if successful.
+     *
+     * @return - Field, Method or Class instance.
+     */
+    protected Object tryStaticAccess() {
+        int begin = cursor;
+        try {
+            /**
+             * Try to resolve this *smartly* as a static class reference.
+             *
+             * This starts at the end of the token and starts to step backwards to figure out whether
+             * or not this may be a static class reference.  We search for method calls simply by
+             * inspecting for ()'s.  The first union area we come to where no brackets are present is our
+             * test-point for a class reference.  If we find a class, we pass the reference to the
+             * property accessor along  with trailing methods (if any).
+             *
+             */
+            boolean meth = false;
+            int last = end;
+            for (int i = end - 1; i > start; i--) {
+                switch (property[i]) {
+                    case '.':
+                        if (!meth) {
+                            try {
+                                String test = new String(property, start, (cursor = last) - start);
+
+                                if (MVEL.COMPILER_OPT_SUPPORT_JAVA_STYLE_CLASS_LITERALS && test.endsWith(".class"))
+                                    test = test.substring(0, test.length() - 6);
+
+                                return getClassLoader().loadClass(test);
+                            } catch (ClassNotFoundException e) {
+                                Class cls = getClassLoader().loadClass(new String(property, start, i - start));
+                                String name = new String(property, i + 1, end - i - 1);
+                                try {
+                                    return cls.getField(name);
+                                } catch (NoSuchFieldException nfe) {
+                                    for (Method m : cls.getMethods()) {
+                                        if (name.equals(m.getName())) return m;
+                                    }
+                                    return null;
+                                }
+                            }
+                        }
+
+                        meth = false;
+                        last = i;
+                        break;
+
+                    case '}':
+                        i--;
+                        for (int d = 1; i > 0 && d != 0; i--) {
+                            switch (property[i]) {
+                                case '}':
+                                    d++;
+                                    break;
+                                case '{':
+                                    d--;
+                                    break;
+                                case '"':
+                                case '\'':
+                                    char s = property[i];
+                                    while (i > 0 && (property[i] != s && property[i - 1] != '\\'))
+                                        i--;
+                            }
+                        }
+                        break;
+
+                    case ')':
+                        i--;
+
+                        for (int d = 1; i > 0 && d != 0; i--) {
+                            switch (property[i]) {
+                                case ')':
+                                    d++;
+                                    break;
+                                case '(':
+                                    d--;
+                                    break;
+                                case '"':
+                                case '\'':
+                                    char s = property[i];
+                                    while (i > 0 && (property[i] != s && property[i - 1] != '\\'))
+                                        i--;
+                            }
+                        }
+
+                        meth = true;
+                        last = i++;
+                        break;
+
+                    case '\'':
+                        while (--i > 0) {
+                            if (property[i] == '\'' && property[i - 1] != '\\') {
+                                break;
+                            }
+                        }
+                        break;
+
+                    case '"':
+                        while (--i > 0) {
+                            if (property[i] == '"' && property[i - 1] != '\\') {
+                                break;
+                            }
+                        }
+                        break;
+                }
+            }
+        } catch (Exception cnfe) {
+            cursor = begin;
+        }
+
+        return null;
+    }
+}

--- a/core/src/main/java/org/mvel2/ScriptRuntimeException.java
+++ b/core/src/main/java/org/mvel2/ScriptRuntimeException.java
@@ -1,0 +1,22 @@
+package org.mvel2;
+
+/**
+ * @author Mike Brock .
+ */
+public class ScriptRuntimeException extends RuntimeException {
+
+    public ScriptRuntimeException() {
+    }
+
+    public ScriptRuntimeException(String message) {
+        super(message);
+    }
+
+    public ScriptRuntimeException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public ScriptRuntimeException(Throwable cause) {
+        super(cause);
+    }
+}

--- a/core/src/main/java/org/mvel2/Unit.java
+++ b/core/src/main/java/org/mvel2/Unit.java
@@ -1,0 +1,26 @@
+/**
+ * MVEL 2.0
+ * Copyright (C) 2007 The Codehaus
+ * Mike Brock, Dhanji Prasanna, John Graham, Mark Proctor
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mvel2;
+
+public interface Unit extends ConversionHandler {
+
+    public double getValue();
+
+    public void setValue(double value);
+}

--- a/core/src/main/java/org/mvel2/UnresolveablePropertyException.java
+++ b/core/src/main/java/org/mvel2/UnresolveablePropertyException.java
@@ -1,0 +1,53 @@
+/**
+ * MVEL 2.0
+ * Copyright (C) 2007 The Codehaus
+ * Mike Brock, Dhanji Prasanna, John Graham, Mark Proctor
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mvel2;
+
+import org.mvel2.ast.ASTNode;
+
+/**
+ * @author Christopher Brock
+ */
+public class UnresolveablePropertyException extends RuntimeException {
+
+    private String name;
+
+    public UnresolveablePropertyException(ASTNode astNode, Throwable throwable) {
+        super("unable to resolve token: " + astNode.getName(), throwable);
+        this.name = astNode.getName();
+    }
+
+    public UnresolveablePropertyException(ASTNode astNode) {
+        super("unable to resolve token: " + astNode.getName());
+        this.name = astNode.getName();
+    }
+
+    public UnresolveablePropertyException(String name) {
+        super("unable to resolve token: " + name);
+        this.name = name;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    @Override
+    public synchronized Throwable fillInStackTrace() {
+        return null;
+    }
+}

--- a/core/src/main/java/org/mvel2/asm/AnnotationVisitor.java
+++ b/core/src/main/java/org/mvel2/asm/AnnotationVisitor.java
@@ -1,0 +1,145 @@
+// ASM: a very small and fast Java bytecode manipulation framework
+// Copyright (c) 2000-2011 INRIA, France Telecom
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+// 1. Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+// 2. Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+// 3. Neither the name of the copyright holders nor the names of its
+//    contributors may be used to endorse or promote products derived from
+//    this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+// THE POSSIBILITY OF SUCH DAMAGE.
+package org.mvel2.asm;
+
+/**
+ * A visitor to visit a Java annotation. The methods of this class must be called in the following
+ * order: ( {@code visit} | {@code visitEnum} | {@code visitAnnotation} | {@code visitArray} )*
+ * {@code visitEnd}.
+ *
+ * @author Eric Bruneton
+ * @author Eugene Kuleshov
+ */
+public abstract class AnnotationVisitor {
+
+    /**
+     * The ASM API version implemented by this visitor. The value of this field must be one of {@link
+     * Opcodes#ASM4}, {@link Opcodes#ASM5}, {@link Opcodes#ASM6} or {@link Opcodes#ASM7}.
+     */
+    protected final int api;
+
+    /** The annotation visitor to which this visitor must delegate method calls. May be null. */
+    protected AnnotationVisitor av;
+
+    /**
+     * Constructs a new {@link AnnotationVisitor}.
+     *
+     * @param api the ASM API version implemented by this visitor. Must be one of {@link
+     *     Opcodes#ASM4}, {@link Opcodes#ASM5}, {@link Opcodes#ASM6} or {@link Opcodes#ASM7}.
+     */
+    public AnnotationVisitor(final int api) {
+        this(api, null);
+    }
+
+    /**
+     * Constructs a new {@link AnnotationVisitor}.
+     *
+     * @param api the ASM API version implemented by this visitor. Must be one of {@link
+     *     Opcodes#ASM4}, {@link Opcodes#ASM5}, {@link Opcodes#ASM6} or {@link Opcodes#ASM7}.
+     * @param annotationVisitor the annotation visitor to which this visitor must delegate method
+     *     calls. May be null.
+     */
+    public AnnotationVisitor(final int api, final AnnotationVisitor annotationVisitor) {
+        if (api != Opcodes.ASM6 && api != Opcodes.ASM5 && api != Opcodes.ASM4 && api != Opcodes.ASM7) {
+            throw new IllegalArgumentException();
+        }
+        this.api = api;
+        this.av = annotationVisitor;
+    }
+
+    /**
+     * Visits a primitive value of the annotation.
+     *
+     * @param name the value name.
+     * @param value the actual value, whose type must be {@link Byte}, {@link Boolean}, {@link
+     *     Character}, {@link Short}, {@link Integer} , {@link Long}, {@link Float}, {@link Double},
+     *     {@link String} or {@link Type} of {@link Type#OBJECT} or {@link Type#ARRAY} sort. This
+     *     value can also be an array of byte, boolean, short, char, int, long, float or double values
+     *     (this is equivalent to using {@link #visitArray} and visiting each array element in turn,
+     *     but is more convenient).
+     */
+    public void visit(final String name, final Object value) {
+        if (av != null) {
+            av.visit(name, value);
+        }
+    }
+
+    /**
+     * Visits an enumeration value of the annotation.
+     *
+     * @param name the value name.
+     * @param descriptor the class descriptor of the enumeration class.
+     * @param value the actual enumeration value.
+     */
+    public void visitEnum(final String name, final String descriptor, final String value) {
+        if (av != null) {
+            av.visitEnum(name, descriptor, value);
+        }
+    }
+
+    /**
+     * Visits a nested annotation value of the annotation.
+     *
+     * @param name the value name.
+     * @param descriptor the class descriptor of the nested annotation class.
+     * @return a visitor to visit the actual nested annotation value, or {@literal null} if this
+     *     visitor is not interested in visiting this nested annotation. <i>The nested annotation
+     *     value must be fully visited before calling other methods on this annotation visitor</i>.
+     */
+    public AnnotationVisitor visitAnnotation(final String name, final String descriptor) {
+        if (av != null) {
+            return av.visitAnnotation(name, descriptor);
+        }
+        return null;
+    }
+
+    /**
+     * Visits an array value of the annotation. Note that arrays of primitive types (such as byte,
+     * boolean, short, char, int, long, float or double) can be passed as value to {@link #visit
+     * visit}. This is what {@link ClassReader} does.
+     *
+     * @param name the value name.
+     * @return a visitor to visit the actual array value elements, or {@literal null} if this visitor
+     *     is not interested in visiting these values. The 'name' parameters passed to the methods of
+     *     this visitor are ignored. <i>All the array values must be visited before calling other
+     *     methods on this annotation visitor</i>.
+     */
+    public AnnotationVisitor visitArray(final String name) {
+        if (av != null) {
+            return av.visitArray(name);
+        }
+        return null;
+    }
+
+    /** Visits the end of the annotation. */
+    public void visitEnd() {
+        if (av != null) {
+            av.visitEnd();
+        }
+    }
+}

--- a/core/src/main/java/org/mvel2/asm/AnnotationWriter.java
+++ b/core/src/main/java/org/mvel2/asm/AnnotationWriter.java
@@ -1,0 +1,399 @@
+// ASM: a very small and fast Java bytecode manipulation framework
+// Copyright (c) 2000-2011 INRIA, France Telecom
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+// 1. Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+// 2. Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+// 3. Neither the name of the copyright holders nor the names of its
+//    contributors may be used to endorse or promote products derived from
+//    this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+// THE POSSIBILITY OF SUCH DAMAGE.
+package org.mvel2.asm;
+
+/**
+ * An {@link AnnotationVisitor} that generates a corresponding 'annotation' or 'type_annotation'
+ * structure, as defined in the Java Virtual Machine Specification (JVMS). AnnotationWriter
+ * instances can be chained in a doubly linked list, from which Runtime[In]Visible[Type]Annotations
+ * attributes can be generated with the {@link #putAnnotations} method. Similarly, arrays of such
+ * lists can be used to generate Runtime[In]VisibleParameterAnnotations attributes.
+ *
+ * @see <a href="https://docs.oracle.com/javase/specs/jvms/se9/html/jvms-4.html#jvms-4.7.16">JVMS
+ *     4.7.16</a>
+ * @see <a href="https://docs.oracle.com/javase/specs/jvms/se9/html/jvms-4.html#jvms-4.7.20">JVMS
+ *     4.7.20</a>
+ * @author Eric Bruneton
+ * @author Eugene Kuleshov
+ */
+final class AnnotationWriter extends AnnotationVisitor {
+
+    /** Where the constants used in this AnnotationWriter must be stored. */
+    private final SymbolTable symbolTable;
+
+    /**
+     * Whether values are named or not. AnnotationWriter instances used for annotation default and
+     * annotation arrays use unnamed values (i.e. they generate an 'element_value' structure for each
+     * value, instead of an element_name_index followed by an element_value).
+     */
+    private final boolean useNamedValues;
+
+    /**
+     * The 'annotation' or 'type_annotation' JVMS structure corresponding to the annotation values
+     * visited so far. All the fields of these structures, except the last one - the
+     * element_value_pairs array, must be set before this ByteVector is passed to the constructor
+     * (num_element_value_pairs can be set to 0, it is reset to the correct value in {@link
+     * #visitEnd()}). The element_value_pairs array is filled incrementally in the various visit()
+     * methods.
+     *
+     * <p>Note: as an exception to the above rules, for AnnotationDefault attributes (which contain a
+     * single element_value by definition), this ByteVector is initially empty when passed to the
+     * constructor, and {@link #numElementValuePairsOffset} is set to -1.
+     */
+    private final ByteVector annotation;
+
+    /**
+     * The offset in {@link #annotation} where {@link #numElementValuePairs} must be stored (or -1 for
+     * the case of AnnotationDefault attributes).
+     */
+    private final int numElementValuePairsOffset;
+    /**
+     * The previous AnnotationWriter. This field is used to store the list of annotations of a
+     * Runtime[In]Visible[Type]Annotations attribute. It is unused for nested or array annotations
+     * (annotation values of annotation type), or for AnnotationDefault attributes.
+     */
+    private final AnnotationWriter previousAnnotation;
+    /** The number of element value pairs visited so far. */
+    private int numElementValuePairs;
+    /**
+     * The next AnnotationWriter. This field is used to store the list of annotations of a
+     * Runtime[In]Visible[Type]Annotations attribute. It is unused for nested or array annotations
+     * (annotation values of annotation type), or for AnnotationDefault attributes.
+     */
+    private AnnotationWriter nextAnnotation;
+
+    // -----------------------------------------------------------------------------------------------
+    // Constructors
+    // -----------------------------------------------------------------------------------------------
+
+    /**
+     * Constructs a new {@link AnnotationWriter}.
+     *
+     * @param symbolTable where the constants used in this AnnotationWriter must be stored.
+     * @param useNamedValues whether values are named or not. AnnotationDefault and annotation arrays
+     *     use unnamed values.
+     * @param annotation where the 'annotation' or 'type_annotation' JVMS structure corresponding to
+     *     the visited content must be stored. This ByteVector must already contain all the fields of
+     *     the structure except the last one (the element_value_pairs array).
+     * @param previousAnnotation the previously visited annotation of the
+     *     Runtime[In]Visible[Type]Annotations attribute to which this annotation belongs, or null in
+     *     other cases (e.g. nested or array annotations).
+     */
+    AnnotationWriter(final SymbolTable symbolTable, final boolean useNamedValues, final ByteVector annotation,
+            final AnnotationWriter previousAnnotation) {
+        super(Opcodes.ASM7);
+        this.symbolTable = symbolTable;
+        this.useNamedValues = useNamedValues;
+        this.annotation = annotation;
+        // By hypothesis, num_element_value_pairs is stored in the last unsigned short of 'annotation'.
+        this.numElementValuePairsOffset = annotation.length == 0 ? -1 : annotation.length - 2;
+        this.previousAnnotation = previousAnnotation;
+        if (previousAnnotation != null) {
+            previousAnnotation.nextAnnotation = this;
+        }
+    }
+
+    /**
+     * Constructs a new {@link AnnotationWriter} using named values.
+     *
+     * @param symbolTable where the constants used in this AnnotationWriter must be stored.
+     * @param annotation where the 'annotation' or 'type_annotation' JVMS structure corresponding to
+     *     the visited content must be stored. This ByteVector must already contain all the fields of
+     *     the structure except the last one (the element_value_pairs array).
+     * @param previousAnnotation the previously visited annotation of the
+     *     Runtime[In]Visible[Type]Annotations attribute to which this annotation belongs, or null in
+     *     other cases (e.g. nested or array annotations).
+     */
+    AnnotationWriter(final SymbolTable symbolTable, final ByteVector annotation, final AnnotationWriter previousAnnotation) {
+        this(symbolTable, /* useNamedValues = */ true, annotation, previousAnnotation);
+    }
+
+    // -----------------------------------------------------------------------------------------------
+    // Implementation of the AnnotationVisitor abstract class
+    // -----------------------------------------------------------------------------------------------
+
+    /**
+     * Returns the size of a Runtime[In]VisibleParameterAnnotations attribute containing all the
+     * annotation lists from the given AnnotationWriter sub-array. Also adds the attribute name to the
+     * constant pool of the class.
+     *
+     * @param attributeName one of "Runtime[In]VisibleParameterAnnotations".
+     * @param annotationWriters an array of AnnotationWriter lists (designated by their <i>last</i>
+     *     element).
+     * @param annotableParameterCount the number of elements in annotationWriters to take into account
+     *     (elements [0..annotableParameterCount[ are taken into account).
+     * @return the size in bytes of a Runtime[In]VisibleParameterAnnotations attribute corresponding
+     *     to the given sub-array of AnnotationWriter lists. This includes the size of the
+     *     attribute_name_index and attribute_length fields.
+     */
+    static int computeParameterAnnotationsSize(final String attributeName, final AnnotationWriter[] annotationWriters,
+            final int annotableParameterCount) {
+        // Note: attributeName is added to the constant pool by the call to computeAnnotationsSize
+        // below. This assumes that there is at least one non-null element in the annotationWriters
+        // sub-array (which is ensured by the lazy instantiation of this array in MethodWriter).
+        // The attribute_name_index, attribute_length and num_parameters fields use 7 bytes, and each
+        // element of the parameter_annotations array uses 2 bytes for its num_annotations field.
+        int attributeSize = 7 + 2 * annotableParameterCount;
+        for (int i = 0; i < annotableParameterCount; ++i) {
+            AnnotationWriter annotationWriter = annotationWriters[i];
+            attributeSize += annotationWriter == null ? 0 : annotationWriter.computeAnnotationsSize(attributeName) - 8;
+        }
+        return attributeSize;
+    }
+
+    /**
+     * Puts a Runtime[In]VisibleParameterAnnotations attribute containing all the annotation lists
+     * from the given AnnotationWriter sub-array in the given ByteVector.
+     *
+     * @param attributeNameIndex constant pool index of the attribute name (one of
+     *     Runtime[In]VisibleParameterAnnotations).
+     * @param annotationWriters an array of AnnotationWriter lists (designated by their <i>last</i>
+     *     element).
+     * @param annotableParameterCount the number of elements in annotationWriters to put (elements
+     *     [0..annotableParameterCount[ are put).
+     * @param output where the attribute must be put.
+     */
+    static void putParameterAnnotations(final int attributeNameIndex, final AnnotationWriter[] annotationWriters,
+            final int annotableParameterCount, final ByteVector output) {
+        // The num_parameters field uses 1 byte, and each element of the parameter_annotations array
+        // uses 2 bytes for its num_annotations field.
+        int attributeLength = 1 + 2 * annotableParameterCount;
+        for (int i = 0; i < annotableParameterCount; ++i) {
+            AnnotationWriter annotationWriter = annotationWriters[i];
+            attributeLength += annotationWriter == null ? 0 : annotationWriter.computeAnnotationsSize(null) - 8;
+        }
+        output.putShort(attributeNameIndex);
+        output.putInt(attributeLength);
+        output.putByte(annotableParameterCount);
+        for (int i = 0; i < annotableParameterCount; ++i) {
+            AnnotationWriter annotationWriter = annotationWriters[i];
+            AnnotationWriter firstAnnotation = null;
+            int numAnnotations = 0;
+            while (annotationWriter != null) {
+                // In case user the forgot to call visitEnd().
+                annotationWriter.visitEnd();
+                numAnnotations++;
+                firstAnnotation = annotationWriter;
+                annotationWriter = annotationWriter.previousAnnotation;
+            }
+            output.putShort(numAnnotations);
+            annotationWriter = firstAnnotation;
+            while (annotationWriter != null) {
+                output.putByteArray(annotationWriter.annotation.data, 0, annotationWriter.annotation.length);
+                annotationWriter = annotationWriter.nextAnnotation;
+            }
+        }
+    }
+
+    @Override
+    public void visit(final String name, final Object value) {
+        // Case of an element_value with a const_value_index, class_info_index or array_index field.
+        // See https://docs.oracle.com/javase/specs/jvms/se9/html/jvms-4.html#jvms-4.7.16.1.
+        ++numElementValuePairs;
+        if (useNamedValues) {
+            annotation.putShort(symbolTable.addConstantUtf8(name));
+        }
+        if (value instanceof String) {
+            annotation.put12('s', symbolTable.addConstantUtf8((String) value));
+        } else if (value instanceof Byte) {
+            annotation.put12('B', symbolTable.addConstantInteger(((Byte) value).byteValue()).index);
+        } else if (value instanceof Boolean) {
+            int booleanValue = ((Boolean) value).booleanValue() ? 1 : 0;
+            annotation.put12('Z', symbolTable.addConstantInteger(booleanValue).index);
+        } else if (value instanceof Character) {
+            annotation.put12('C', symbolTable.addConstantInteger(((Character) value).charValue()).index);
+        } else if (value instanceof Short) {
+            annotation.put12('S', symbolTable.addConstantInteger(((Short) value).shortValue()).index);
+        } else if (value instanceof Type) {
+            annotation.put12('c', symbolTable.addConstantUtf8(((Type) value).getDescriptor()));
+        } else if (value instanceof byte[]) {
+            byte[] byteArray = (byte[]) value;
+            annotation.put12('[', byteArray.length);
+            for (byte byteValue : byteArray) {
+                annotation.put12('B', symbolTable.addConstantInteger(byteValue).index);
+            }
+        } else if (value instanceof boolean[]) {
+            boolean[] booleanArray = (boolean[]) value;
+            annotation.put12('[', booleanArray.length);
+            for (boolean booleanValue : booleanArray) {
+                annotation.put12('Z', symbolTable.addConstantInteger(booleanValue ? 1 : 0).index);
+            }
+        } else if (value instanceof short[]) {
+            short[] shortArray = (short[]) value;
+            annotation.put12('[', shortArray.length);
+            for (short shortValue : shortArray) {
+                annotation.put12('S', symbolTable.addConstantInteger(shortValue).index);
+            }
+        } else if (value instanceof char[]) {
+            char[] charArray = (char[]) value;
+            annotation.put12('[', charArray.length);
+            for (char charValue : charArray) {
+                annotation.put12('C', symbolTable.addConstantInteger(charValue).index);
+            }
+        } else if (value instanceof int[]) {
+            int[] intArray = (int[]) value;
+            annotation.put12('[', intArray.length);
+            for (int intValue : intArray) {
+                annotation.put12('I', symbolTable.addConstantInteger(intValue).index);
+            }
+        } else if (value instanceof long[]) {
+            long[] longArray = (long[]) value;
+            annotation.put12('[', longArray.length);
+            for (long longValue : longArray) {
+                annotation.put12('J', symbolTable.addConstantLong(longValue).index);
+            }
+        } else if (value instanceof float[]) {
+            float[] floatArray = (float[]) value;
+            annotation.put12('[', floatArray.length);
+            for (float floatValue : floatArray) {
+                annotation.put12('F', symbolTable.addConstantFloat(floatValue).index);
+            }
+        } else if (value instanceof double[]) {
+            double[] doubleArray = (double[]) value;
+            annotation.put12('[', doubleArray.length);
+            for (double doubleValue : doubleArray) {
+                annotation.put12('D', symbolTable.addConstantDouble(doubleValue).index);
+            }
+        } else {
+            Symbol symbol = symbolTable.addConstant(value);
+            annotation.put12(".s.IFJDCS".charAt(symbol.tag), symbol.index);
+        }
+    }
+
+    @Override
+    public void visitEnum(final String name, final String descriptor, final String value) {
+        // Case of an element_value with an enum_const_value field.
+        // See https://docs.oracle.com/javase/specs/jvms/se9/html/jvms-4.html#jvms-4.7.16.1.
+        ++numElementValuePairs;
+        if (useNamedValues) {
+            annotation.putShort(symbolTable.addConstantUtf8(name));
+        }
+        annotation.put12('e', symbolTable.addConstantUtf8(descriptor)).putShort(symbolTable.addConstantUtf8(value));
+    }
+
+    @Override
+    public AnnotationVisitor visitAnnotation(final String name, final String descriptor) {
+        // Case of an element_value with an annotation_value field.
+        // See https://docs.oracle.com/javase/specs/jvms/se9/html/jvms-4.html#jvms-4.7.16.1.
+        ++numElementValuePairs;
+        if (useNamedValues) {
+            annotation.putShort(symbolTable.addConstantUtf8(name));
+        }
+        // Write tag and type_index, and reserve 2 bytes for num_element_value_pairs.
+        annotation.put12('@', symbolTable.addConstantUtf8(descriptor)).putShort(0);
+        return new AnnotationWriter(symbolTable, annotation, null);
+    }
+
+    // -----------------------------------------------------------------------------------------------
+    // Utility methods
+    // -----------------------------------------------------------------------------------------------
+
+    @Override
+    public AnnotationVisitor visitArray(final String name) {
+        // Case of an element_value with an array_value field.
+        // https://docs.oracle.com/javase/specs/jvms/se9/html/jvms-4.html#jvms-4.7.16.1
+        ++numElementValuePairs;
+        if (useNamedValues) {
+            annotation.putShort(symbolTable.addConstantUtf8(name));
+        }
+        // Write tag, and reserve 2 bytes for num_values. Here we take advantage of the fact that the
+        // end of an element_value of array type is similar to the end of an 'annotation' structure: an
+        // unsigned short num_values followed by num_values element_value, versus an unsigned short
+        // num_element_value_pairs, followed by num_element_value_pairs { element_name_index,
+        // element_value } tuples. This allows us to use an AnnotationWriter with unnamed values to
+        // visit the array elements. Its num_element_value_pairs will correspond to the number of array
+        // elements and will be stored in what is in fact num_values.
+        annotation.put12('[', 0);
+        return new AnnotationWriter(symbolTable, /* useNamedValues = */ false, annotation, null);
+    }
+
+    @Override
+    public void visitEnd() {
+        if (numElementValuePairsOffset != -1) {
+            byte[] data = annotation.data;
+            data[numElementValuePairsOffset] = (byte) (numElementValuePairs >>> 8);
+            data[numElementValuePairsOffset + 1] = (byte) numElementValuePairs;
+        }
+    }
+
+    /**
+     * Returns the size of a Runtime[In]Visible[Type]Annotations attribute containing this annotation
+     * and all its <i>predecessors</i> (see {@link #previousAnnotation}. Also adds the attribute name
+     * to the constant pool of the class (if not null).
+     *
+     * @param attributeName one of "Runtime[In]Visible[Type]Annotations", or null.
+     * @return the size in bytes of a Runtime[In]Visible[Type]Annotations attribute containing this
+     *     annotation and all its predecessors. This includes the size of the attribute_name_index and
+     *     attribute_length fields.
+     */
+    int computeAnnotationsSize(final String attributeName) {
+        if (attributeName != null) {
+            symbolTable.addConstantUtf8(attributeName);
+        }
+        // The attribute_name_index, attribute_length and num_annotations fields use 8 bytes.
+        int attributeSize = 8;
+        AnnotationWriter annotationWriter = this;
+        while (annotationWriter != null) {
+            attributeSize += annotationWriter.annotation.length;
+            annotationWriter = annotationWriter.previousAnnotation;
+        }
+        return attributeSize;
+    }
+
+    /**
+     * Puts a Runtime[In]Visible[Type]Annotations attribute containing this annotations and all its
+     * <i>predecessors</i> (see {@link #previousAnnotation} in the given ByteVector. Annotations are
+     * put in the same order they have been visited.
+     *
+     * @param attributeNameIndex the constant pool index of the attribute name (one of
+     *     "Runtime[In]Visible[Type]Annotations").
+     * @param output where the attribute must be put.
+     */
+    void putAnnotations(final int attributeNameIndex, final ByteVector output) {
+        int attributeLength = 2; // For num_annotations.
+        int numAnnotations = 0;
+        AnnotationWriter annotationWriter = this;
+        AnnotationWriter firstAnnotation = null;
+        while (annotationWriter != null) {
+            // In case the user forgot to call visitEnd().
+            annotationWriter.visitEnd();
+            attributeLength += annotationWriter.annotation.length;
+            numAnnotations++;
+            firstAnnotation = annotationWriter;
+            annotationWriter = annotationWriter.previousAnnotation;
+        }
+        output.putShort(attributeNameIndex);
+        output.putInt(attributeLength);
+        output.putShort(numAnnotations);
+        annotationWriter = firstAnnotation;
+        while (annotationWriter != null) {
+            output.putByteArray(annotationWriter.annotation.data, 0, annotationWriter.annotation.length);
+            annotationWriter = annotationWriter.nextAnnotation;
+        }
+    }
+}

--- a/core/src/main/java/org/mvel2/asm/Attribute.java
+++ b/core/src/main/java/org/mvel2/asm/Attribute.java
@@ -1,0 +1,304 @@
+// ASM: a very small and fast Java bytecode manipulation framework
+// Copyright (c) 2000-2011 INRIA, France Telecom
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+// 1. Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+// 2. Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+// 3. Neither the name of the copyright holders nor the names of its
+//    contributors may be used to endorse or promote products derived from
+//    this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+// THE POSSIBILITY OF SUCH DAMAGE.
+package org.mvel2.asm;
+
+/**
+ * A non standard class, field, method or code attribute, as defined in the Java Virtual Machine
+ * Specification (JVMS).
+ *
+ * @see <a href= "https://docs.oracle.com/javase/specs/jvms/se9/html/jvms-4.html#jvms-4.7">JVMS
+ *     4.7</a>
+ * @see <a href= "https://docs.oracle.com/javase/specs/jvms/se9/html/jvms-4.html#jvms-4.7.3">JVMS
+ *     4.7.3</a>
+ * @author Eric Bruneton
+ * @author Eugene Kuleshov
+ */
+public class Attribute {
+
+    /** The type of this attribute, also called its name in the JVMS. */
+    public final String type;
+    /**
+     * The next attribute in this attribute list (Attribute instances can be linked via this field to
+     * store a list of class, field, method or code attributes). May be {@literal null}.
+     */
+    Attribute nextAttribute;
+    /**
+     * The raw content of this attribute, only used for unknown attributes (see {@link #isUnknown()}).
+     * The 6 header bytes of the attribute (attribute_name_index and attribute_length) are <i>not</i>
+     * included.
+     */
+    private byte[] content;
+
+    /**
+     * Constructs a new empty attribute.
+     *
+     * @param type the type of the attribute.
+     */
+    protected Attribute(final String type) {
+        this.type = type;
+    }
+
+    /**
+     * Returns {@literal true} if this type of attribute is unknown. This means that the attribute
+     * content can't be parsed to extract constant pool references, labels, etc. Instead, the
+     * attribute content is read as an opaque byte array, and written back as is. This can lead to
+     * invalid attributes, if the content actually contains constant pool references, labels, or other
+     * symbolic references that need to be updated when there are changes to the constant pool, the
+     * method bytecode, etc. The default implementation of this method always returns {@literal true}.
+     *
+     * @return {@literal true} if this type of attribute is unknown.
+     */
+    public boolean isUnknown() {
+        return true;
+    }
+
+    /**
+     * Returns {@literal true} if this type of attribute is a code attribute.
+     *
+     * @return {@literal true} if this type of attribute is a code attribute.
+     */
+    public boolean isCodeAttribute() {
+        return false;
+    }
+
+    /**
+     * Returns the labels corresponding to this attribute.
+     *
+     * @return the labels corresponding to this attribute, or {@literal null} if this attribute is not
+     *     a code attribute that contains labels.
+     */
+    protected Label[] getLabels() {
+        return new Label[0];
+    }
+
+    /**
+     * Reads a {@link #type} attribute. This method must return a <i>new</i> {@link Attribute} object,
+     * of type {@link #type}, corresponding to the 'length' bytes starting at 'offset', in the given
+     * ClassReader.
+     *
+     * @param classReader the class that contains the attribute to be read.
+     * @param offset index of the first byte of the attribute's content in {@link ClassReader#b}. The
+     *     6 attribute header bytes (attribute_name_index and attribute_length) are not taken into
+     *     account here.
+     * @param length the length of the attribute's content (excluding the 6 attribute header bytes).
+     * @param charBuffer the buffer to be used to call the ClassReader methods requiring a
+     *     'charBuffer' parameter.
+     * @param codeAttributeOffset index of the first byte of content of the enclosing Code attribute
+     *     in {@link ClassReader#b}, or -1 if the attribute to be read is not a code attribute. The 6
+     *     attribute header bytes (attribute_name_index and attribute_length) are not taken into
+     *     account here.
+     * @param labels the labels of the method's code, or {@literal null} if the attribute to be read
+     *     is not a code attribute.
+     * @return a <i>new</i> {@link Attribute} object corresponding to the specified bytes.
+     */
+    protected Attribute read(final ClassReader classReader, final int offset, final int length, final char[] charBuffer,
+            final int codeAttributeOffset, final Label[] labels) {
+        Attribute attribute = new Attribute(type);
+        attribute.content = new byte[length];
+        System.arraycopy(classReader.b, offset, attribute.content, 0, length);
+        return attribute;
+    }
+
+    /**
+     * Returns the byte array form of the content of this attribute. The 6 header bytes
+     * (attribute_name_index and attribute_length) must <i>not</i> be added in the returned
+     * ByteVector.
+     *
+     * @param classWriter the class to which this attribute must be added. This parameter can be used
+     *     to add the items that corresponds to this attribute to the constant pool of this class.
+     * @param code the bytecode of the method corresponding to this code attribute, or {@literal null}
+     *     if this attribute is not a code attribute. Corresponds to the 'code' field of the Code
+     *     attribute.
+     * @param codeLength the length of the bytecode of the method corresponding to this code
+     *     attribute, or 0 if this attribute is not a code attribute. Corresponds to the 'code_length'
+     *     field of the Code attribute.
+     * @param maxStack the maximum stack size of the method corresponding to this code attribute, or
+     *     -1 if this attribute is not a code attribute.
+     * @param maxLocals the maximum number of local variables of the method corresponding to this code
+     *     attribute, or -1 if this attribute is not a code attribute.
+     * @return the byte array form of this attribute.
+     */
+    protected ByteVector write(final ClassWriter classWriter, final byte[] code, final int codeLength, final int maxStack,
+            final int maxLocals) {
+        return new ByteVector(content);
+    }
+
+    /**
+     * Returns the number of attributes of the attribute list that begins with this attribute.
+     *
+     * @return the number of attributes of the attribute list that begins with this attribute.
+     */
+    final int getAttributeCount() {
+        int count = 0;
+        Attribute attribute = this;
+        while (attribute != null) {
+            count += 1;
+            attribute = attribute.nextAttribute;
+        }
+        return count;
+    }
+
+    /**
+     * Returns the total size in bytes of all the attributes in the attribute list that begins with
+     * this attribute. This size includes the 6 header bytes (attribute_name_index and
+     * attribute_length) per attribute. Also adds the attribute type names to the constant pool.
+     *
+     * @param symbolTable where the constants used in the attributes must be stored.
+     * @return the size of all the attributes in this attribute list. This size includes the size of
+     *     the attribute headers.
+     */
+    final int computeAttributesSize(final SymbolTable symbolTable) {
+        final byte[] code = null;
+        final int codeLength = 0;
+        final int maxStack = -1;
+        final int maxLocals = -1;
+        return computeAttributesSize(symbolTable, code, codeLength, maxStack, maxLocals);
+    }
+
+    /**
+     * Returns the total size in bytes of all the attributes in the attribute list that begins with
+     * this attribute. This size includes the 6 header bytes (attribute_name_index and
+     * attribute_length) per attribute. Also adds the attribute type names to the constant pool.
+     *
+     * @param symbolTable where the constants used in the attributes must be stored.
+     * @param code the bytecode of the method corresponding to these code attributes, or {@literal
+     *     null} if they are not code attributes. Corresponds to the 'code' field of the Code
+     *     attribute.
+     * @param codeLength the length of the bytecode of the method corresponding to these code
+     *     attributes, or 0 if they are not code attributes. Corresponds to the 'code_length' field of
+     *     the Code attribute.
+     * @param maxStack the maximum stack size of the method corresponding to these code attributes, or
+     *     -1 if they are not code attributes.
+     * @param maxLocals the maximum number of local variables of the method corresponding to these
+     *     code attributes, or -1 if they are not code attribute.
+     * @return the size of all the attributes in this attribute list. This size includes the size of
+     *     the attribute headers.
+     */
+    final int computeAttributesSize(final SymbolTable symbolTable, final byte[] code, final int codeLength, final int maxStack,
+            final int maxLocals) {
+        final ClassWriter classWriter = symbolTable.classWriter;
+        int size = 0;
+        Attribute attribute = this;
+        while (attribute != null) {
+            symbolTable.addConstantUtf8(attribute.type);
+            size += 6 + attribute.write(classWriter, code, codeLength, maxStack, maxLocals).length;
+            attribute = attribute.nextAttribute;
+        }
+        return size;
+    }
+
+    /**
+     * Puts all the attributes of the attribute list that begins with this attribute, in the given
+     * byte vector. This includes the 6 header bytes (attribute_name_index and attribute_length) per
+     * attribute.
+     *
+     * @param symbolTable where the constants used in the attributes must be stored.
+     * @param output where the attributes must be written.
+     */
+    final void putAttributes(final SymbolTable symbolTable, final ByteVector output) {
+        final byte[] code = null;
+        final int codeLength = 0;
+        final int maxStack = -1;
+        final int maxLocals = -1;
+        putAttributes(symbolTable, code, codeLength, maxStack, maxLocals, output);
+    }
+
+    /**
+     * Puts all the attributes of the attribute list that begins with this attribute, in the given
+     * byte vector. This includes the 6 header bytes (attribute_name_index and attribute_length) per
+     * attribute.
+     *
+     * @param symbolTable where the constants used in the attributes must be stored.
+     * @param code the bytecode of the method corresponding to these code attributes, or {@literal
+     *     null} if they are not code attributes. Corresponds to the 'code' field of the Code
+     *     attribute.
+     * @param codeLength the length of the bytecode of the method corresponding to these code
+     *     attributes, or 0 if they are not code attributes. Corresponds to the 'code_length' field of
+     *     the Code attribute.
+     * @param maxStack the maximum stack size of the method corresponding to these code attributes, or
+     *     -1 if they are not code attributes.
+     * @param maxLocals the maximum number of local variables of the method corresponding to these
+     *     code attributes, or -1 if they are not code attribute.
+     * @param output where the attributes must be written.
+     */
+    final void putAttributes(final SymbolTable symbolTable, final byte[] code, final int codeLength, final int maxStack,
+            final int maxLocals, final ByteVector output) {
+        final ClassWriter classWriter = symbolTable.classWriter;
+        Attribute attribute = this;
+        while (attribute != null) {
+            ByteVector attributeContent = attribute.write(classWriter, code, codeLength, maxStack, maxLocals);
+            // Put attribute_name_index and attribute_length.
+            output.putShort(symbolTable.addConstantUtf8(attribute.type)).putInt(attributeContent.length);
+            output.putByteArray(attributeContent.data, 0, attributeContent.length);
+            attribute = attribute.nextAttribute;
+        }
+    }
+
+    /** A set of attribute prototypes (attributes with the same type are considered equal). */
+    static final class Set {
+
+        private static final int SIZE_INCREMENT = 6;
+
+        private int size;
+        private Attribute[] data = new Attribute[SIZE_INCREMENT];
+
+        void addAttributes(final Attribute attributeList) {
+            Attribute attribute = attributeList;
+            while (attribute != null) {
+                if (!contains(attribute)) {
+                    add(attribute);
+                }
+                attribute = attribute.nextAttribute;
+            }
+        }
+
+        Attribute[] toArray() {
+            Attribute[] result = new Attribute[size];
+            System.arraycopy(data, 0, result, 0, size);
+            return result;
+        }
+
+        private boolean contains(final Attribute attribute) {
+            for (int i = 0; i < size; ++i) {
+                if (data[i].type.equals(attribute.type)) {
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        private void add(final Attribute attribute) {
+            if (size >= data.length) {
+                Attribute[] newData = new Attribute[data.length + SIZE_INCREMENT];
+                System.arraycopy(data, 0, newData, 0, size);
+                data = newData;
+            }
+            data[size++] = attribute;
+        }
+    }
+}

--- a/core/src/main/java/org/mvel2/asm/ByteVector.java
+++ b/core/src/main/java/org/mvel2/asm/ByteVector.java
@@ -1,0 +1,360 @@
+// ASM: a very small and fast Java bytecode manipulation framework
+// Copyright (c) 2000-2011 INRIA, France Telecom
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+// 1. Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+// 2. Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+// 3. Neither the name of the copyright holders nor the names of its
+//    contributors may be used to endorse or promote products derived from
+//    this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+// THE POSSIBILITY OF SUCH DAMAGE.
+package org.mvel2.asm;
+
+/**
+ * A dynamically extensible vector of bytes. This class is roughly equivalent to a DataOutputStream
+ * on top of a ByteArrayOutputStream, but is more efficient.
+ *
+ * @author Eric Bruneton
+ */
+public class ByteVector {
+
+    /** The content of this vector. Only the first {@link #length} bytes contain real data. */
+    byte[] data;
+
+    /** The actual number of bytes in this vector. */
+    int length;
+
+    /** Constructs a new {@link ByteVector} with a default initial capacity. */
+    public ByteVector() {
+        data = new byte[64];
+    }
+
+    /**
+     * Constructs a new {@link ByteVector} with the given initial capacity.
+     *
+     * @param initialCapacity the initial capacity of the byte vector to be constructed.
+     */
+    public ByteVector(final int initialCapacity) {
+        data = new byte[initialCapacity];
+    }
+
+    /**
+     * Constructs a new {@link ByteVector} from the given initial data.
+     *
+     * @param data the initial data of the new byte vector.
+     */
+    ByteVector(final byte[] data) {
+        this.data = data;
+        this.length = data.length;
+    }
+
+    /**
+     * Puts a byte into this byte vector. The byte vector is automatically enlarged if necessary.
+     *
+     * @param byteValue a byte.
+     * @return this byte vector.
+     */
+    public ByteVector putByte(final int byteValue) {
+        int currentLength = length;
+        if (currentLength + 1 > data.length) {
+            enlarge(1);
+        }
+        data[currentLength++] = (byte) byteValue;
+        length = currentLength;
+        return this;
+    }
+
+    /**
+     * Puts two bytes into this byte vector. The byte vector is automatically enlarged if necessary.
+     *
+     * @param byteValue1 a byte.
+     * @param byteValue2 another byte.
+     * @return this byte vector.
+     */
+    final ByteVector put11(final int byteValue1, final int byteValue2) {
+        int currentLength = length;
+        if (currentLength + 2 > data.length) {
+            enlarge(2);
+        }
+        byte[] currentData = data;
+        currentData[currentLength++] = (byte) byteValue1;
+        currentData[currentLength++] = (byte) byteValue2;
+        length = currentLength;
+        return this;
+    }
+
+    /**
+     * Puts a short into this byte vector. The byte vector is automatically enlarged if necessary.
+     *
+     * @param shortValue a short.
+     * @return this byte vector.
+     */
+    public ByteVector putShort(final int shortValue) {
+        int currentLength = length;
+        if (currentLength + 2 > data.length) {
+            enlarge(2);
+        }
+        byte[] currentData = data;
+        currentData[currentLength++] = (byte) (shortValue >>> 8);
+        currentData[currentLength++] = (byte) shortValue;
+        length = currentLength;
+        return this;
+    }
+
+    /**
+     * Puts a byte and a short into this byte vector. The byte vector is automatically enlarged if
+     * necessary.
+     *
+     * @param byteValue a byte.
+     * @param shortValue a short.
+     * @return this byte vector.
+     */
+    final ByteVector put12(final int byteValue, final int shortValue) {
+        int currentLength = length;
+        if (currentLength + 3 > data.length) {
+            enlarge(3);
+        }
+        byte[] currentData = data;
+        currentData[currentLength++] = (byte) byteValue;
+        currentData[currentLength++] = (byte) (shortValue >>> 8);
+        currentData[currentLength++] = (byte) shortValue;
+        length = currentLength;
+        return this;
+    }
+
+    /**
+     * Puts two bytes and a short into this byte vector. The byte vector is automatically enlarged if
+     * necessary.
+     *
+     * @param byteValue1 a byte.
+     * @param byteValue2 another byte.
+     * @param shortValue a short.
+     * @return this byte vector.
+     */
+    final ByteVector put112(final int byteValue1, final int byteValue2, final int shortValue) {
+        int currentLength = length;
+        if (currentLength + 4 > data.length) {
+            enlarge(4);
+        }
+        byte[] currentData = data;
+        currentData[currentLength++] = (byte) byteValue1;
+        currentData[currentLength++] = (byte) byteValue2;
+        currentData[currentLength++] = (byte) (shortValue >>> 8);
+        currentData[currentLength++] = (byte) shortValue;
+        length = currentLength;
+        return this;
+    }
+
+    /**
+     * Puts an int into this byte vector. The byte vector is automatically enlarged if necessary.
+     *
+     * @param intValue an int.
+     * @return this byte vector.
+     */
+    public ByteVector putInt(final int intValue) {
+        int currentLength = length;
+        if (currentLength + 4 > data.length) {
+            enlarge(4);
+        }
+        byte[] currentData = data;
+        currentData[currentLength++] = (byte) (intValue >>> 24);
+        currentData[currentLength++] = (byte) (intValue >>> 16);
+        currentData[currentLength++] = (byte) (intValue >>> 8);
+        currentData[currentLength++] = (byte) intValue;
+        length = currentLength;
+        return this;
+    }
+
+    /**
+     * Puts one byte and two shorts into this byte vector. The byte vector is automatically enlarged
+     * if necessary.
+     *
+     * @param byteValue a byte.
+     * @param shortValue1 a short.
+     * @param shortValue2 another short.
+     * @return this byte vector.
+     */
+    final ByteVector put122(final int byteValue, final int shortValue1, final int shortValue2) {
+        int currentLength = length;
+        if (currentLength + 5 > data.length) {
+            enlarge(5);
+        }
+        byte[] currentData = data;
+        currentData[currentLength++] = (byte) byteValue;
+        currentData[currentLength++] = (byte) (shortValue1 >>> 8);
+        currentData[currentLength++] = (byte) shortValue1;
+        currentData[currentLength++] = (byte) (shortValue2 >>> 8);
+        currentData[currentLength++] = (byte) shortValue2;
+        length = currentLength;
+        return this;
+    }
+
+    /**
+     * Puts a long into this byte vector. The byte vector is automatically enlarged if necessary.
+     *
+     * @param longValue a long.
+     * @return this byte vector.
+     */
+    public ByteVector putLong(final long longValue) {
+        int currentLength = length;
+        if (currentLength + 8 > data.length) {
+            enlarge(8);
+        }
+        byte[] currentData = data;
+        int intValue = (int) (longValue >>> 32);
+        currentData[currentLength++] = (byte) (intValue >>> 24);
+        currentData[currentLength++] = (byte) (intValue >>> 16);
+        currentData[currentLength++] = (byte) (intValue >>> 8);
+        currentData[currentLength++] = (byte) intValue;
+        intValue = (int) longValue;
+        currentData[currentLength++] = (byte) (intValue >>> 24);
+        currentData[currentLength++] = (byte) (intValue >>> 16);
+        currentData[currentLength++] = (byte) (intValue >>> 8);
+        currentData[currentLength++] = (byte) intValue;
+        length = currentLength;
+        return this;
+    }
+
+    /**
+     * Puts an UTF8 string into this byte vector. The byte vector is automatically enlarged if
+     * necessary.
+     *
+     * @param stringValue a String whose UTF8 encoded length must be less than 65536.
+     * @return this byte vector.
+     */
+    // DontCheck(AbbreviationAsWordInName): can't be renamed (for backward binary compatibility).
+    public ByteVector putUTF8(final String stringValue) {
+        int charLength = stringValue.length();
+        if (charLength > 65535) {
+            throw new IllegalArgumentException("UTF8 string too large");
+        }
+        int currentLength = length;
+        if (currentLength + 2 + charLength > data.length) {
+            enlarge(2 + charLength);
+        }
+        byte[] currentData = data;
+        // Optimistic algorithm: instead of computing the byte length and then serializing the string
+        // (which requires two loops), we assume the byte length is equal to char length (which is the
+        // most frequent case), and we start serializing the string right away. During the
+        // serialization, if we find that this assumption is wrong, we continue with the general method.
+        currentData[currentLength++] = (byte) (charLength >>> 8);
+        currentData[currentLength++] = (byte) charLength;
+        for (int i = 0; i < charLength; ++i) {
+            char charValue = stringValue.charAt(i);
+            if (charValue >= '\u0001' && charValue <= '\u007F') {
+                currentData[currentLength++] = (byte) charValue;
+            } else {
+                length = currentLength;
+                return encodeUtf8(stringValue, i, 65535);
+            }
+        }
+        length = currentLength;
+        return this;
+    }
+
+    /**
+     * Puts an UTF8 string into this byte vector. The byte vector is automatically enlarged if
+     * necessary. The string length is encoded in two bytes before the encoded characters, if there is
+     * space for that (i.e. if this.length - offset - 2 &gt;= 0).
+     *
+     * @param stringValue the String to encode.
+     * @param offset the index of the first character to encode. The previous characters are supposed
+     *     to have already been encoded, using only one byte per character.
+     * @param maxByteLength the maximum byte length of the encoded string, including the already
+     *     encoded characters.
+     * @return this byte vector.
+     */
+    final ByteVector encodeUtf8(final String stringValue, final int offset, final int maxByteLength) {
+        int charLength = stringValue.length();
+        int byteLength = offset;
+        for (int i = offset; i < charLength; ++i) {
+            char charValue = stringValue.charAt(i);
+            if (charValue >= 0x0001 && charValue <= 0x007F) {
+                byteLength++;
+            } else if (charValue <= 0x07FF) {
+                byteLength += 2;
+            } else {
+                byteLength += 3;
+            }
+        }
+        if (byteLength > maxByteLength) {
+            throw new IllegalArgumentException("UTF8 string too large");
+        }
+        // Compute where 'byteLength' must be stored in 'data', and store it at this location.
+        int byteLengthOffset = length - offset - 2;
+        if (byteLengthOffset >= 0) {
+            data[byteLengthOffset] = (byte) (byteLength >>> 8);
+            data[byteLengthOffset + 1] = (byte) byteLength;
+        }
+        if (length + byteLength - offset > data.length) {
+            enlarge(byteLength - offset);
+        }
+        int currentLength = length;
+        for (int i = offset; i < charLength; ++i) {
+            char charValue = stringValue.charAt(i);
+            if (charValue >= 0x0001 && charValue <= 0x007F) {
+                data[currentLength++] = (byte) charValue;
+            } else if (charValue <= 0x07FF) {
+                data[currentLength++] = (byte) (0xC0 | charValue >> 6 & 0x1F);
+                data[currentLength++] = (byte) (0x80 | charValue & 0x3F);
+            } else {
+                data[currentLength++] = (byte) (0xE0 | charValue >> 12 & 0xF);
+                data[currentLength++] = (byte) (0x80 | charValue >> 6 & 0x3F);
+                data[currentLength++] = (byte) (0x80 | charValue & 0x3F);
+            }
+        }
+        length = currentLength;
+        return this;
+    }
+
+    /**
+     * Puts an array of bytes into this byte vector. The byte vector is automatically enlarged if
+     * necessary.
+     *
+     * @param byteArrayValue an array of bytes. May be {@literal null} to put {@code byteLength} null
+     *     bytes into this byte vector.
+     * @param byteOffset index of the first byte of byteArrayValue that must be copied.
+     * @param byteLength number of bytes of byteArrayValue that must be copied.
+     * @return this byte vector.
+     */
+    public ByteVector putByteArray(final byte[] byteArrayValue, final int byteOffset, final int byteLength) {
+        if (length + byteLength > data.length) {
+            enlarge(byteLength);
+        }
+        if (byteArrayValue != null) {
+            System.arraycopy(byteArrayValue, byteOffset, data, length, byteLength);
+        }
+        length += byteLength;
+        return this;
+    }
+
+    /**
+     * Enlarges this byte vector so that it can receive 'size' more bytes.
+     *
+     * @param size number of additional bytes that this byte vector should be able to receive.
+     */
+    private void enlarge(final int size) {
+        int doubleCapacity = 2 * data.length;
+        int minimalCapacity = length + size;
+        byte[] newData = new byte[doubleCapacity > minimalCapacity ? doubleCapacity : minimalCapacity];
+        System.arraycopy(data, 0, newData, 0, length);
+        data = newData;
+    }
+}

--- a/core/src/main/java/org/mvel2/asm/ClassReader.java
+++ b/core/src/main/java/org/mvel2/asm/ClassReader.java
@@ -1,0 +1,3288 @@
+// ASM: a very small and fast Java bytecode manipulation framework
+// Copyright (c) 2000-2011 INRIA, France Telecom
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+// 1. Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+// 2. Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+// 3. Neither the name of the copyright holders nor the names of its
+//    contributors may be used to endorse or promote products derived from
+//    this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+// THE POSSIBILITY OF SUCH DAMAGE.
+package org.mvel2.asm;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+
+/**
+ * A parser to make a {@link ClassVisitor} visit a ClassFile structure, as defined in the Java
+ * Virtual Machine Specification (JVMS). This class parses the ClassFile content and calls the
+ * appropriate visit methods of a given {@link ClassVisitor} for each field, method and bytecode
+ * instruction encountered.
+ *
+ * @see <a href="https://docs.oracle.com/javase/specs/jvms/se9/html/jvms-4.html">JVMS 4</a>
+ * @author Eric Bruneton
+ * @author Eugene Kuleshov
+ */
+public class ClassReader {
+
+    /**
+     * A flag to skip the Code attributes. If this flag is set the Code attributes are neither parsed
+     * nor visited.
+     */
+    public static final int SKIP_CODE = 1;
+
+    /**
+     * A flag to skip the SourceFile, SourceDebugExtension, LocalVariableTable, LocalVariableTypeTable
+     * and LineNumberTable attributes. If this flag is set these attributes are neither parsed nor
+     * visited (i.e. {@link ClassVisitor#visitSource}, {@link MethodVisitor#visitLocalVariable} and
+     * {@link MethodVisitor#visitLineNumber} are not called).
+     */
+    public static final int SKIP_DEBUG = 2;
+
+    /**
+     * A flag to skip the StackMap and StackMapTable attributes. If this flag is set these attributes
+     * are neither parsed nor visited (i.e. {@link MethodVisitor#visitFrame} is not called). This flag
+     * is useful when the {@link ClassWriter#COMPUTE_FRAMES} option is used: it avoids visiting frames
+     * that will be ignored and recomputed from scratch.
+     */
+    public static final int SKIP_FRAMES = 4;
+
+    /**
+     * A flag to expand the stack map frames. By default stack map frames are visited in their
+     * original format (i.e. "expanded" for classes whose version is less than V1_6, and "compressed"
+     * for the other classes). If this flag is set, stack map frames are always visited in expanded
+     * format (this option adds a decompression/compression step in ClassReader and ClassWriter which
+     * degrades performance quite a lot).
+     */
+    public static final int EXPAND_FRAMES = 8;
+
+    /**
+     * A flag to expand the ASM specific instructions into an equivalent sequence of standard bytecode
+     * instructions. When resolving a forward jump it may happen that the signed 2 bytes offset
+     * reserved for it is not sufficient to store the bytecode offset. In this case the jump
+     * instruction is replaced with a temporary ASM specific instruction using an unsigned 2 bytes
+     * offset (see {@link Label#resolve}). This internal flag is used to re-read classes containing
+     * such instructions, in order to replace them with standard instructions. In addition, when this
+     * flag is used, goto_w and jsr_w are <i>not</i> converted into goto and jsr, to make sure that
+     * infinite loops where a goto_w is replaced with a goto in ClassReader and converted back to a
+     * goto_w in ClassWriter cannot occur.
+     */
+    static final int EXPAND_ASM_INSNS = 256;
+
+    /** The size of the temporary byte array used to read class input streams chunk by chunk. */
+    private static final int INPUT_STREAM_DATA_CHUNK_SIZE = 4096;
+
+    /**
+     * A byte array containing the JVMS ClassFile structure to be parsed. <i>The content of this array
+     * must not be modified. This field is intended for {@link Attribute} sub classes, and is normally
+     * not needed by class visitors.</i>
+     *
+     * <p>NOTE: the ClassFile structure can start at any offset within this array, i.e. it does not
+     * necessarily start at offset 0. Use {@link #getItem} and {@link #header} to get correct
+     * ClassFile element offsets within this byte array.
+     */
+    // DontCheck(MemberName): can't be renamed (for backward binary compatibility).
+    public final byte[] b;
+    /** The offset in bytes, in {@link #b}, of the ClassFile's access_flags field. */
+    public final int header;
+    /**
+     * The offset in bytes, in {@link #b}, of each cp_info entry of the ClassFile's constant_pool
+     * array, <i>plus one</i>. In other words, the offset of constant pool entry i is given by
+     * cpInfoOffsets[i] - 1, i.e. its cp_info's tag field is given by b[cpInfoOffsets[i] - 1].
+     */
+    private final int[] cpInfoOffsets;
+    /**
+     * The String objects corresponding to the CONSTANT_Utf8 constant pool items. This cache avoids
+     * multiple parsing of a given CONSTANT_Utf8 constant pool item.
+     */
+    private final String[] constantUtf8Values;
+    /**
+     * The ConstantDynamic objects corresponding to the CONSTANT_Dynamic constant pool items. This
+     * cache avoids multiple parsing of a given CONSTANT_Dynamic constant pool item.
+     */
+    private final ConstantDynamic[] constantDynamicValues;
+    /**
+     * The start offsets in {@link #b} of each element of the bootstrap_methods array (in the
+     * BootstrapMethods attribute).
+     *
+     * @see <a href="https://docs.oracle.com/javase/specs/jvms/se9/html/jvms-4.html#jvms-4.7.23">JVMS
+     *     4.7.23</a>
+     */
+    private final int[] bootstrapMethodOffsets;
+    /**
+     * A conservative estimate of the maximum length of the strings contained in the constant pool of
+     * the class.
+     */
+    private final int maxStringLength;
+
+    // -----------------------------------------------------------------------------------------------
+    // Constructors
+    // -----------------------------------------------------------------------------------------------
+
+    /**
+     * Constructs a new {@link ClassReader} object.
+     *
+     * @param classFile the JVMS ClassFile structure to be read.
+     */
+    public ClassReader(final byte[] classFile) {
+        this(classFile, 0, classFile.length);
+    }
+
+    /**
+     * Constructs a new {@link ClassReader} object.
+     *
+     * @param classFileBuffer a byte array containing the JVMS ClassFile structure to be read.
+     * @param classFileOffset the offset in byteBuffer of the first byte of the ClassFile to be read.
+     * @param classFileLength the length in bytes of the ClassFile to be read.
+     */
+    public ClassReader(final byte[] classFileBuffer, final int classFileOffset, final int classFileLength) { // NOPMD(UnusedFormalParameter) used for backward compatibility.
+        this(classFileBuffer, classFileOffset, /* checkClassVersion = */ true);
+    }
+
+    /**
+     * Constructs a new {@link ClassReader} object. <i>This internal constructor must not be exposed
+     * as a public API</i>.
+     *
+     * @param classFileBuffer a byte array containing the JVMS ClassFile structure to be read.
+     * @param classFileOffset the offset in byteBuffer of the first byte of the ClassFile to be read.
+     * @param checkClassVersion whether to check the class version or not.
+     */
+    ClassReader(final byte[] classFileBuffer, final int classFileOffset, final boolean checkClassVersion) {
+        b = classFileBuffer;
+        // Check the class' major_version. This field is after the magic and minor_version fields, which
+        // use 4 and 2 bytes respectively.
+        if (checkClassVersion && readShort(classFileOffset + 6) > Opcodes.V12) {
+            throw new IllegalArgumentException("Unsupported class file major version " + readShort(classFileOffset + 6));
+        }
+        // Create the constant pool arrays. The constant_pool_count field is after the magic,
+        // minor_version and major_version fields, which use 4, 2 and 2 bytes respectively.
+        int constantPoolCount = readUnsignedShort(classFileOffset + 8);
+        cpInfoOffsets = new int[constantPoolCount];
+        constantUtf8Values = new String[constantPoolCount];
+        // Compute the offset of each constant pool entry, as well as a conservative estimate of the
+        // maximum length of the constant pool strings. The first constant pool entry is after the
+        // magic, minor_version, major_version and constant_pool_count fields, which use 4, 2, 2 and 2
+        // bytes respectively.
+        int currentCpInfoIndex = 1;
+        int currentCpInfoOffset = classFileOffset + 10;
+        int currentMaxStringLength = 0;
+        boolean hasConstantDynamic = false;
+        boolean hasConstantInvokeDynamic = false;
+        // The offset of the other entries depend on the total size of all the previous entries.
+        while (currentCpInfoIndex < constantPoolCount) {
+            cpInfoOffsets[currentCpInfoIndex++] = currentCpInfoOffset + 1;
+            int cpInfoSize;
+            switch (classFileBuffer[currentCpInfoOffset]) {
+                case Symbol.CONSTANT_FIELDREF_TAG:
+                case Symbol.CONSTANT_METHODREF_TAG:
+                case Symbol.CONSTANT_INTERFACE_METHODREF_TAG:
+                case Symbol.CONSTANT_INTEGER_TAG:
+                case Symbol.CONSTANT_FLOAT_TAG:
+                case Symbol.CONSTANT_NAME_AND_TYPE_TAG:
+                    cpInfoSize = 5;
+                    break;
+                case Symbol.CONSTANT_DYNAMIC_TAG:
+                    cpInfoSize = 5;
+                    hasConstantDynamic = true;
+                    break;
+                case Symbol.CONSTANT_INVOKE_DYNAMIC_TAG:
+                    cpInfoSize = 5;
+                    hasConstantInvokeDynamic = true;
+                    break;
+                case Symbol.CONSTANT_LONG_TAG:
+                case Symbol.CONSTANT_DOUBLE_TAG:
+                    cpInfoSize = 9;
+                    currentCpInfoIndex++;
+                    break;
+                case Symbol.CONSTANT_UTF8_TAG:
+                    cpInfoSize = 3 + readUnsignedShort(currentCpInfoOffset + 1);
+                    if (cpInfoSize > currentMaxStringLength) {
+                        // The size in bytes of this CONSTANT_Utf8 structure provides a conservative estimate
+                        // of the length in characters of the corresponding string, and is much cheaper to
+                        // compute than this exact length.
+                        currentMaxStringLength = cpInfoSize;
+                    }
+                    break;
+                case Symbol.CONSTANT_METHOD_HANDLE_TAG:
+                    cpInfoSize = 4;
+                    break;
+                case Symbol.CONSTANT_CLASS_TAG:
+                case Symbol.CONSTANT_STRING_TAG:
+                case Symbol.CONSTANT_METHOD_TYPE_TAG:
+                case Symbol.CONSTANT_PACKAGE_TAG:
+                case Symbol.CONSTANT_MODULE_TAG:
+                    cpInfoSize = 3;
+                    break;
+                default:
+                    throw new IllegalArgumentException();
+            }
+            currentCpInfoOffset += cpInfoSize;
+        }
+        maxStringLength = currentMaxStringLength;
+        // The Classfile's access_flags field is just after the last constant pool entry.
+        header = currentCpInfoOffset;
+
+        // Allocate the cache of ConstantDynamic values, if there is at least one.
+        constantDynamicValues = hasConstantDynamic ? new ConstantDynamic[constantPoolCount] : null;
+
+        // Read the BootstrapMethods attribute, if any (only get the offset of each method).
+        bootstrapMethodOffsets = (hasConstantDynamic | hasConstantInvokeDynamic) ? readBootstrapMethodsAttribute(
+                currentMaxStringLength) : null;
+    }
+
+    /**
+     * Constructs a new {@link ClassReader} object.
+     *
+     * @param inputStream an input stream of the JVMS ClassFile structure to be read. This input
+     *     stream must contain nothing more than the ClassFile structure itself. It is read from its
+     *     current position to its end.
+     * @throws IOException if a problem occurs during reading.
+     */
+    public ClassReader(final InputStream inputStream) throws IOException {
+        this(readStream(inputStream, false));
+    }
+
+    /**
+     * Constructs a new {@link ClassReader} object.
+     *
+     * @param className the fully qualified name of the class to be read. The ClassFile structure is
+     *     retrieved with the current class loader's {@link ClassLoader#getSystemResourceAsStream}.
+     * @throws IOException if an exception occurs during reading.
+     */
+    public ClassReader(final String className) throws IOException {
+        this(readStream(ClassLoader.getSystemResourceAsStream(className.replace('.', '/') + ".class"), true));
+    }
+
+    /**
+     * Reads the given input stream and returns its content as a byte array.
+     *
+     * @param inputStream an input stream.
+     * @param close true to close the input stream after reading.
+     * @return the content of the given input stream.
+     * @throws IOException if a problem occurs during reading.
+     */
+    private static byte[] readStream(final InputStream inputStream, final boolean close) throws IOException {
+        if (inputStream == null) {
+            throw new IOException("Class not found");
+        }
+        try {
+            ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+            byte[] data = new byte[INPUT_STREAM_DATA_CHUNK_SIZE];
+            int bytesRead;
+            while ((bytesRead = inputStream.read(data, 0, data.length)) != -1) {
+                outputStream.write(data, 0, bytesRead);
+            }
+            outputStream.flush();
+            return outputStream.toByteArray();
+        } finally {
+            if (close) {
+                inputStream.close();
+            }
+        }
+    }
+
+    // -----------------------------------------------------------------------------------------------
+    // Accessors
+    // -----------------------------------------------------------------------------------------------
+
+    /**
+     * Returns the class's access flags (see {@link Opcodes}). This value may not reflect Deprecated
+     * and Synthetic flags when bytecode is before 1.5 and those flags are represented by attributes.
+     *
+     * @return the class access flags.
+     * @see ClassVisitor#visit(int, int, String, String, String, String[])
+     */
+    public int getAccess() {
+        return readUnsignedShort(header);
+    }
+
+    /**
+     * Returns the internal name of the class (see {@link Type#getInternalName()}).
+     *
+     * @return the internal class name.
+     * @see ClassVisitor#visit(int, int, String, String, String, String[])
+     */
+    public String getClassName() {
+        // this_class is just after the access_flags field (using 2 bytes).
+        return readClass(header + 2, new char[maxStringLength]);
+    }
+
+    /**
+     * Returns the internal of name of the super class (see {@link Type#getInternalName()}). For
+     * interfaces, the super class is {@link Object}.
+     *
+     * @return the internal name of the super class, or {@literal null} for {@link Object} class.
+     * @see ClassVisitor#visit(int, int, String, String, String, String[])
+     */
+    public String getSuperName() {
+        // super_class is after the access_flags and this_class fields (2 bytes each).
+        return readClass(header + 4, new char[maxStringLength]);
+    }
+
+    /**
+     * Returns the internal names of the implemented interfaces (see {@link Type#getInternalName()}).
+     *
+     * @return the internal names of the directly implemented interfaces. Inherited implemented
+     *     interfaces are not returned.
+     * @see ClassVisitor#visit(int, int, String, String, String, String[])
+     */
+    public String[] getInterfaces() {
+        // interfaces_count is after the access_flags, this_class and super_class fields (2 bytes each).
+        int currentOffset = header + 6;
+        int interfacesCount = readUnsignedShort(currentOffset);
+        String[] interfaces = new String[interfacesCount];
+        if (interfacesCount > 0) {
+            char[] charBuffer = new char[maxStringLength];
+            for (int i = 0; i < interfacesCount; ++i) {
+                currentOffset += 2;
+                interfaces[i] = readClass(currentOffset, charBuffer);
+            }
+        }
+        return interfaces;
+    }
+
+    // -----------------------------------------------------------------------------------------------
+    // Public methods
+    // -----------------------------------------------------------------------------------------------
+
+    /**
+     * Makes the given visitor visit the JVMS ClassFile structure passed to the constructor of this
+     * {@link ClassReader}.
+     *
+     * @param classVisitor the visitor that must visit this class.
+     * @param parsingOptions the options to use to parse this class. One or more of {@link
+     *     #SKIP_CODE}, {@link #SKIP_DEBUG}, {@link #SKIP_FRAMES} or {@link #EXPAND_FRAMES}.
+     */
+    public void accept(final ClassVisitor classVisitor, final int parsingOptions) {
+        accept(classVisitor, new Attribute[0], parsingOptions);
+    }
+
+    /**
+     * Makes the given visitor visit the JVMS ClassFile structure passed to the constructor of this
+     * {@link ClassReader}.
+     *
+     * @param classVisitor the visitor that must visit this class.
+     * @param attributePrototypes prototypes of the attributes that must be parsed during the visit of
+     *     the class. Any attribute whose type is not equal to the type of one the prototypes will not
+     *     be parsed: its byte array value will be passed unchanged to the ClassWriter. <i>This may
+     *     corrupt it if this value contains references to the constant pool, or has syntactic or
+     *     semantic links with a class element that has been transformed by a class adapter between
+     *     the reader and the writer</i>.
+     * @param parsingOptions the options to use to parse this class. One or more of {@link
+     *     #SKIP_CODE}, {@link #SKIP_DEBUG}, {@link #SKIP_FRAMES} or {@link #EXPAND_FRAMES}.
+     */
+    public void accept(final ClassVisitor classVisitor, final Attribute[] attributePrototypes, final int parsingOptions) {
+        Context context = new Context();
+        context.attributePrototypes = attributePrototypes;
+        context.parsingOptions = parsingOptions;
+        context.charBuffer = new char[maxStringLength];
+
+        // Read the access_flags, this_class, super_class, interface_count and interfaces fields.
+        char[] charBuffer = context.charBuffer;
+        int currentOffset = header;
+        int accessFlags = readUnsignedShort(currentOffset);
+        String thisClass = readClass(currentOffset + 2, charBuffer);
+        String superClass = readClass(currentOffset + 4, charBuffer);
+        String[] interfaces = new String[readUnsignedShort(currentOffset + 6)];
+        currentOffset += 8;
+        for (int i = 0; i < interfaces.length; ++i) {
+            interfaces[i] = readClass(currentOffset, charBuffer);
+            currentOffset += 2;
+        }
+
+        // Read the class attributes (the variables are ordered as in Section 4.7 of the JVMS).
+        // Attribute offsets exclude the attribute_name_index and attribute_length fields.
+        // - The offset of the InnerClasses attribute, or 0.
+        int innerClassesOffset = 0;
+        // - The offset of the EnclosingMethod attribute, or 0.
+        int enclosingMethodOffset = 0;
+        // - The string corresponding to the Signature attribute, or null.
+        String signature = null;
+        // - The string corresponding to the SourceFile attribute, or null.
+        String sourceFile = null;
+        // - The string corresponding to the SourceDebugExtension attribute, or null.
+        String sourceDebugExtension = null;
+        // - The offset of the RuntimeVisibleAnnotations attribute, or 0.
+        int runtimeVisibleAnnotationsOffset = 0;
+        // - The offset of the RuntimeInvisibleAnnotations attribute, or 0.
+        int runtimeInvisibleAnnotationsOffset = 0;
+        // - The offset of the RuntimeVisibleTypeAnnotations attribute, or 0.
+        int runtimeVisibleTypeAnnotationsOffset = 0;
+        // - The offset of the RuntimeInvisibleTypeAnnotations attribute, or 0.
+        int runtimeInvisibleTypeAnnotationsOffset = 0;
+        // - The offset of the Module attribute, or 0.
+        int moduleOffset = 0;
+        // - The offset of the ModulePackages attribute, or 0.
+        int modulePackagesOffset = 0;
+        // - The string corresponding to the ModuleMainClass attribute, or null.
+        String moduleMainClass = null;
+        // - The string corresponding to the NestHost attribute, or null.
+        String nestHostClass = null;
+        // - The offset of the NestMembers attribute, or 0.
+        int nestMembersOffset = 0;
+        // - The non standard attributes (linked with their {@link Attribute#nextAttribute} field).
+        //   This list in the <i>reverse order</i> or their order in the ClassFile structure.
+        Attribute attributes = null;
+
+        int currentAttributeOffset = getFirstAttributeOffset();
+        for (int i = readUnsignedShort(currentAttributeOffset - 2); i > 0; --i) {
+            // Read the attribute_info's attribute_name and attribute_length fields.
+            String attributeName = readUTF8(currentAttributeOffset, charBuffer);
+            int attributeLength = readInt(currentAttributeOffset + 2);
+            currentAttributeOffset += 6;
+            // The tests are sorted in decreasing frequency order (based on frequencies observed on
+            // typical classes).
+            if (Constants.SOURCE_FILE.equals(attributeName)) {
+                sourceFile = readUTF8(currentAttributeOffset, charBuffer);
+            } else if (Constants.INNER_CLASSES.equals(attributeName)) {
+                innerClassesOffset = currentAttributeOffset;
+            } else if (Constants.ENCLOSING_METHOD.equals(attributeName)) {
+                enclosingMethodOffset = currentAttributeOffset;
+            } else if (Constants.NEST_HOST.equals(attributeName)) {
+                nestHostClass = readClass(currentAttributeOffset, charBuffer);
+            } else if (Constants.NEST_MEMBERS.equals(attributeName)) {
+                nestMembersOffset = currentAttributeOffset;
+            } else if (Constants.SIGNATURE.equals(attributeName)) {
+                signature = readUTF8(currentAttributeOffset, charBuffer);
+            } else if (Constants.RUNTIME_VISIBLE_ANNOTATIONS.equals(attributeName)) {
+                runtimeVisibleAnnotationsOffset = currentAttributeOffset;
+            } else if (Constants.RUNTIME_VISIBLE_TYPE_ANNOTATIONS.equals(attributeName)) {
+                runtimeVisibleTypeAnnotationsOffset = currentAttributeOffset;
+            } else if (Constants.DEPRECATED.equals(attributeName)) {
+                accessFlags |= Opcodes.ACC_DEPRECATED;
+            } else if (Constants.SYNTHETIC.equals(attributeName)) {
+                accessFlags |= Opcodes.ACC_SYNTHETIC;
+            } else if (Constants.SOURCE_DEBUG_EXTENSION.equals(attributeName)) {
+                sourceDebugExtension = readUtf(currentAttributeOffset, attributeLength, new char[attributeLength]);
+            } else if (Constants.RUNTIME_INVISIBLE_ANNOTATIONS.equals(attributeName)) {
+                runtimeInvisibleAnnotationsOffset = currentAttributeOffset;
+            } else if (Constants.RUNTIME_INVISIBLE_TYPE_ANNOTATIONS.equals(attributeName)) {
+                runtimeInvisibleTypeAnnotationsOffset = currentAttributeOffset;
+            } else if (Constants.MODULE.equals(attributeName)) {
+                moduleOffset = currentAttributeOffset;
+            } else if (Constants.MODULE_MAIN_CLASS.equals(attributeName)) {
+                moduleMainClass = readClass(currentAttributeOffset, charBuffer);
+            } else if (Constants.MODULE_PACKAGES.equals(attributeName)) {
+                modulePackagesOffset = currentAttributeOffset;
+            } else if (!Constants.BOOTSTRAP_METHODS.equals(attributeName)) {
+                // The BootstrapMethods attribute is read in the constructor.
+                Attribute attribute = readAttribute(attributePrototypes, attributeName, currentAttributeOffset, attributeLength, charBuffer,
+                        -1, null);
+                attribute.nextAttribute = attributes;
+                attributes = attribute;
+            }
+            currentAttributeOffset += attributeLength;
+        }
+
+        // Visit the class declaration. The minor_version and major_version fields start 6 bytes before
+        // the first constant pool entry, which itself starts at cpInfoOffsets[1] - 1 (by definition).
+        classVisitor.visit(readInt(cpInfoOffsets[1] - 7), accessFlags, thisClass, signature, superClass, interfaces);
+
+        // Visit the SourceFile and SourceDebugExtenstion attributes.
+        if ((parsingOptions & SKIP_DEBUG) == 0 && (sourceFile != null || sourceDebugExtension != null)) {
+            classVisitor.visitSource(sourceFile, sourceDebugExtension);
+        }
+
+        // Visit the Module, ModulePackages and ModuleMainClass attributes.
+        if (moduleOffset != 0) {
+            readModuleAttributes(classVisitor, context, moduleOffset, modulePackagesOffset, moduleMainClass);
+        }
+
+        // Visit the NestHost attribute.
+        if (nestHostClass != null) {
+            classVisitor.visitNestHost(nestHostClass);
+        }
+
+        // Visit the EnclosingMethod attribute.
+        if (enclosingMethodOffset != 0) {
+            String className = readClass(enclosingMethodOffset, charBuffer);
+            int methodIndex = readUnsignedShort(enclosingMethodOffset + 2);
+            String name = methodIndex == 0 ? null : readUTF8(cpInfoOffsets[methodIndex], charBuffer);
+            String type = methodIndex == 0 ? null : readUTF8(cpInfoOffsets[methodIndex] + 2, charBuffer);
+            classVisitor.visitOuterClass(className, name, type);
+        }
+
+        // Visit the RuntimeVisibleAnnotations attribute.
+        if (runtimeVisibleAnnotationsOffset != 0) {
+            int numAnnotations = readUnsignedShort(runtimeVisibleAnnotationsOffset);
+            int currentAnnotationOffset = runtimeVisibleAnnotationsOffset + 2;
+            while (numAnnotations-- > 0) {
+                // Parse the type_index field.
+                String annotationDescriptor = readUTF8(currentAnnotationOffset, charBuffer);
+                currentAnnotationOffset += 2;
+                // Parse num_element_value_pairs and element_value_pairs and visit these values.
+                currentAnnotationOffset = readElementValues(classVisitor.visitAnnotation(annotationDescriptor, /* visible = */ true),
+                        currentAnnotationOffset, /* named = */ true, charBuffer);
+            }
+        }
+
+        // Visit the RuntimeInvisibleAnnotations attribute.
+        if (runtimeInvisibleAnnotationsOffset != 0) {
+            int numAnnotations = readUnsignedShort(runtimeInvisibleAnnotationsOffset);
+            int currentAnnotationOffset = runtimeInvisibleAnnotationsOffset + 2;
+            while (numAnnotations-- > 0) {
+                // Parse the type_index field.
+                String annotationDescriptor = readUTF8(currentAnnotationOffset, charBuffer);
+                currentAnnotationOffset += 2;
+                // Parse num_element_value_pairs and element_value_pairs and visit these values.
+                currentAnnotationOffset = readElementValues(classVisitor.visitAnnotation(annotationDescriptor, /* visible = */ false),
+                        currentAnnotationOffset, /* named = */ true, charBuffer);
+            }
+        }
+
+        // Visit the RuntimeVisibleTypeAnnotations attribute.
+        if (runtimeVisibleTypeAnnotationsOffset != 0) {
+            int numAnnotations = readUnsignedShort(runtimeVisibleTypeAnnotationsOffset);
+            int currentAnnotationOffset = runtimeVisibleTypeAnnotationsOffset + 2;
+            while (numAnnotations-- > 0) {
+                // Parse the target_type, target_info and target_path fields.
+                currentAnnotationOffset = readTypeAnnotationTarget(context, currentAnnotationOffset);
+                // Parse the type_index field.
+                String annotationDescriptor = readUTF8(currentAnnotationOffset, charBuffer);
+                currentAnnotationOffset += 2;
+                // Parse num_element_value_pairs and element_value_pairs and visit these values.
+                currentAnnotationOffset = readElementValues(classVisitor.visitTypeAnnotation(context.currentTypeAnnotationTarget,
+                        context.currentTypeAnnotationTargetPath, annotationDescriptor, /* visible = */ true), currentAnnotationOffset,
+                        /* named = */ true, charBuffer);
+            }
+        }
+
+        // Visit the RuntimeInvisibleTypeAnnotations attribute.
+        if (runtimeInvisibleTypeAnnotationsOffset != 0) {
+            int numAnnotations = readUnsignedShort(runtimeInvisibleTypeAnnotationsOffset);
+            int currentAnnotationOffset = runtimeInvisibleTypeAnnotationsOffset + 2;
+            while (numAnnotations-- > 0) {
+                // Parse the target_type, target_info and target_path fields.
+                currentAnnotationOffset = readTypeAnnotationTarget(context, currentAnnotationOffset);
+                // Parse the type_index field.
+                String annotationDescriptor = readUTF8(currentAnnotationOffset, charBuffer);
+                currentAnnotationOffset += 2;
+                // Parse num_element_value_pairs and element_value_pairs and visit these values.
+                currentAnnotationOffset = readElementValues(classVisitor.visitTypeAnnotation(context.currentTypeAnnotationTarget,
+                        context.currentTypeAnnotationTargetPath, annotationDescriptor, /* visible = */ false), currentAnnotationOffset,
+                        /* named = */ true, charBuffer);
+            }
+        }
+
+        // Visit the non standard attributes.
+        while (attributes != null) {
+            // Copy and reset the nextAttribute field so that it can also be used in ClassWriter.
+            Attribute nextAttribute = attributes.nextAttribute;
+            attributes.nextAttribute = null;
+            classVisitor.visitAttribute(attributes);
+            attributes = nextAttribute;
+        }
+
+        // Visit the NestedMembers attribute.
+        if (nestMembersOffset != 0) {
+            int numberOfNestMembers = readUnsignedShort(nestMembersOffset);
+            int currentNestMemberOffset = nestMembersOffset + 2;
+            while (numberOfNestMembers-- > 0) {
+                classVisitor.visitNestMember(readClass(currentNestMemberOffset, charBuffer));
+                currentNestMemberOffset += 2;
+            }
+        }
+
+        // Visit the InnerClasses attribute.
+        if (innerClassesOffset != 0) {
+            int numberOfClasses = readUnsignedShort(innerClassesOffset);
+            int currentClassesOffset = innerClassesOffset + 2;
+            while (numberOfClasses-- > 0) {
+                classVisitor.visitInnerClass(readClass(currentClassesOffset, charBuffer), readClass(currentClassesOffset + 2, charBuffer),
+                        readUTF8(currentClassesOffset + 4, charBuffer), readUnsignedShort(currentClassesOffset + 6));
+                currentClassesOffset += 8;
+            }
+        }
+
+        // Visit the fields and methods.
+        int fieldsCount = readUnsignedShort(currentOffset);
+        currentOffset += 2;
+        while (fieldsCount-- > 0) {
+            currentOffset = readField(classVisitor, context, currentOffset);
+        }
+        int methodsCount = readUnsignedShort(currentOffset);
+        currentOffset += 2;
+        while (methodsCount-- > 0) {
+            currentOffset = readMethod(classVisitor, context, currentOffset);
+        }
+
+        // Visit the end of the class.
+        classVisitor.visitEnd();
+    }
+
+    // ----------------------------------------------------------------------------------------------
+    // Methods to parse modules, fields and methods
+    // ----------------------------------------------------------------------------------------------
+
+    /**
+     * Reads the Module, ModulePackages and ModuleMainClass attributes and visit them.
+     *
+     * @param classVisitor the current class visitor
+     * @param context information about the class being parsed.
+     * @param moduleOffset the offset of the Module attribute (excluding the attribute_info's
+     *     attribute_name_index and attribute_length fields).
+     * @param modulePackagesOffset the offset of the ModulePackages attribute (excluding the
+     *     attribute_info's attribute_name_index and attribute_length fields), or 0.
+     * @param moduleMainClass the string corresponding to the ModuleMainClass attribute, or null.
+     */
+    private void readModuleAttributes(final ClassVisitor classVisitor, final Context context, final int moduleOffset,
+            final int modulePackagesOffset, final String moduleMainClass) {
+        char[] buffer = context.charBuffer;
+
+        // Read the module_name_index, module_flags and module_version_index fields and visit them.
+        int currentOffset = moduleOffset;
+        String moduleName = readModule(currentOffset, buffer);
+        int moduleFlags = readUnsignedShort(currentOffset + 2);
+        String moduleVersion = readUTF8(currentOffset + 4, buffer);
+        currentOffset += 6;
+        ModuleVisitor moduleVisitor = classVisitor.visitModule(moduleName, moduleFlags, moduleVersion);
+        if (moduleVisitor == null) {
+            return;
+        }
+
+        // Visit the ModuleMainClass attribute.
+        if (moduleMainClass != null) {
+            moduleVisitor.visitMainClass(moduleMainClass);
+        }
+
+        // Visit the ModulePackages attribute.
+        if (modulePackagesOffset != 0) {
+            int packageCount = readUnsignedShort(modulePackagesOffset);
+            int currentPackageOffset = modulePackagesOffset + 2;
+            while (packageCount-- > 0) {
+                moduleVisitor.visitPackage(readPackage(currentPackageOffset, buffer));
+                currentPackageOffset += 2;
+            }
+        }
+
+        // Read the 'requires_count' and 'requires' fields.
+        int requiresCount = readUnsignedShort(currentOffset);
+        currentOffset += 2;
+        while (requiresCount-- > 0) {
+            // Read the requires_index, requires_flags and requires_version fields and visit them.
+            String requires = readModule(currentOffset, buffer);
+            int requiresFlags = readUnsignedShort(currentOffset + 2);
+            String requiresVersion = readUTF8(currentOffset + 4, buffer);
+            currentOffset += 6;
+            moduleVisitor.visitRequire(requires, requiresFlags, requiresVersion);
+        }
+
+        // Read the 'exports_count' and 'exports' fields.
+        int exportsCount = readUnsignedShort(currentOffset);
+        currentOffset += 2;
+        while (exportsCount-- > 0) {
+            // Read the exports_index, exports_flags, exports_to_count and exports_to_index fields
+            // and visit them.
+            String exports = readPackage(currentOffset, buffer);
+            int exportsFlags = readUnsignedShort(currentOffset + 2);
+            int exportsToCount = readUnsignedShort(currentOffset + 4);
+            currentOffset += 6;
+            String[] exportsTo = null;
+            if (exportsToCount != 0) {
+                exportsTo = new String[exportsToCount];
+                for (int i = 0; i < exportsToCount; ++i) {
+                    exportsTo[i] = readModule(currentOffset, buffer);
+                    currentOffset += 2;
+                }
+            }
+            moduleVisitor.visitExport(exports, exportsFlags, exportsTo);
+        }
+
+        // Reads the 'opens_count' and 'opens' fields.
+        int opensCount = readUnsignedShort(currentOffset);
+        currentOffset += 2;
+        while (opensCount-- > 0) {
+            // Read the opens_index, opens_flags, opens_to_count and opens_to_index fields and visit them.
+            String opens = readPackage(currentOffset, buffer);
+            int opensFlags = readUnsignedShort(currentOffset + 2);
+            int opensToCount = readUnsignedShort(currentOffset + 4);
+            currentOffset += 6;
+            String[] opensTo = null;
+            if (opensToCount != 0) {
+                opensTo = new String[opensToCount];
+                for (int i = 0; i < opensToCount; ++i) {
+                    opensTo[i] = readModule(currentOffset, buffer);
+                    currentOffset += 2;
+                }
+            }
+            moduleVisitor.visitOpen(opens, opensFlags, opensTo);
+        }
+
+        // Read the 'uses_count' and 'uses' fields.
+        int usesCount = readUnsignedShort(currentOffset);
+        currentOffset += 2;
+        while (usesCount-- > 0) {
+            moduleVisitor.visitUse(readClass(currentOffset, buffer));
+            currentOffset += 2;
+        }
+
+        // Read the  'provides_count' and 'provides' fields.
+        int providesCount = readUnsignedShort(currentOffset);
+        currentOffset += 2;
+        while (providesCount-- > 0) {
+            // Read the provides_index, provides_with_count and provides_with_index fields and visit them.
+            String provides = readClass(currentOffset, buffer);
+            int providesWithCount = readUnsignedShort(currentOffset + 2);
+            currentOffset += 4;
+            String[] providesWith = new String[providesWithCount];
+            for (int i = 0; i < providesWithCount; ++i) {
+                providesWith[i] = readClass(currentOffset, buffer);
+                currentOffset += 2;
+            }
+            moduleVisitor.visitProvide(provides, providesWith);
+        }
+
+        // Visit the end of the module attributes.
+        moduleVisitor.visitEnd();
+    }
+
+    /**
+     * Reads a JVMS field_info structure and makes the given visitor visit it.
+     *
+     * @param classVisitor the visitor that must visit the field.
+     * @param context information about the class being parsed.
+     * @param fieldInfoOffset the start offset of the field_info structure.
+     * @return the offset of the first byte following the field_info structure.
+     */
+    private int readField(final ClassVisitor classVisitor, final Context context, final int fieldInfoOffset) {
+        char[] charBuffer = context.charBuffer;
+
+        // Read the access_flags, name_index and descriptor_index fields.
+        int currentOffset = fieldInfoOffset;
+        int accessFlags = readUnsignedShort(currentOffset);
+        String name = readUTF8(currentOffset + 2, charBuffer);
+        String descriptor = readUTF8(currentOffset + 4, charBuffer);
+        currentOffset += 6;
+
+        // Read the field attributes (the variables are ordered as in Section 4.7 of the JVMS).
+        // Attribute offsets exclude the attribute_name_index and attribute_length fields.
+        // - The value corresponding to the ConstantValue attribute, or null.
+        Object constantValue = null;
+        // - The string corresponding to the Signature attribute, or null.
+        String signature = null;
+        // - The offset of the RuntimeVisibleAnnotations attribute, or 0.
+        int runtimeVisibleAnnotationsOffset = 0;
+        // - The offset of the RuntimeInvisibleAnnotations attribute, or 0.
+        int runtimeInvisibleAnnotationsOffset = 0;
+        // - The offset of the RuntimeVisibleTypeAnnotations attribute, or 0.
+        int runtimeVisibleTypeAnnotationsOffset = 0;
+        // - The offset of the RuntimeInvisibleTypeAnnotations attribute, or 0.
+        int runtimeInvisibleTypeAnnotationsOffset = 0;
+        // - The non standard attributes (linked with their {@link Attribute#nextAttribute} field).
+        //   This list in the <i>reverse order</i> or their order in the ClassFile structure.
+        Attribute attributes = null;
+
+        int attributesCount = readUnsignedShort(currentOffset);
+        currentOffset += 2;
+        while (attributesCount-- > 0) {
+            // Read the attribute_info's attribute_name and attribute_length fields.
+            String attributeName = readUTF8(currentOffset, charBuffer);
+            int attributeLength = readInt(currentOffset + 2);
+            currentOffset += 6;
+            // The tests are sorted in decreasing frequency order (based on frequencies observed on
+            // typical classes).
+            if (Constants.CONSTANT_VALUE.equals(attributeName)) {
+                int constantvalueIndex = readUnsignedShort(currentOffset);
+                constantValue = constantvalueIndex == 0 ? null : readConst(constantvalueIndex, charBuffer);
+            } else if (Constants.SIGNATURE.equals(attributeName)) {
+                signature = readUTF8(currentOffset, charBuffer);
+            } else if (Constants.DEPRECATED.equals(attributeName)) {
+                accessFlags |= Opcodes.ACC_DEPRECATED;
+            } else if (Constants.SYNTHETIC.equals(attributeName)) {
+                accessFlags |= Opcodes.ACC_SYNTHETIC;
+            } else if (Constants.RUNTIME_VISIBLE_ANNOTATIONS.equals(attributeName)) {
+                runtimeVisibleAnnotationsOffset = currentOffset;
+            } else if (Constants.RUNTIME_VISIBLE_TYPE_ANNOTATIONS.equals(attributeName)) {
+                runtimeVisibleTypeAnnotationsOffset = currentOffset;
+            } else if (Constants.RUNTIME_INVISIBLE_ANNOTATIONS.equals(attributeName)) {
+                runtimeInvisibleAnnotationsOffset = currentOffset;
+            } else if (Constants.RUNTIME_INVISIBLE_TYPE_ANNOTATIONS.equals(attributeName)) {
+                runtimeInvisibleTypeAnnotationsOffset = currentOffset;
+            } else {
+                Attribute attribute = readAttribute(context.attributePrototypes, attributeName, currentOffset, attributeLength, charBuffer,
+                        -1, null);
+                attribute.nextAttribute = attributes;
+                attributes = attribute;
+            }
+            currentOffset += attributeLength;
+        }
+
+        // Visit the field declaration.
+        FieldVisitor fieldVisitor = classVisitor.visitField(accessFlags, name, descriptor, signature, constantValue);
+        if (fieldVisitor == null) {
+            return currentOffset;
+        }
+
+        // Visit the RuntimeVisibleAnnotations attribute.
+        if (runtimeVisibleAnnotationsOffset != 0) {
+            int numAnnotations = readUnsignedShort(runtimeVisibleAnnotationsOffset);
+            int currentAnnotationOffset = runtimeVisibleAnnotationsOffset + 2;
+            while (numAnnotations-- > 0) {
+                // Parse the type_index field.
+                String annotationDescriptor = readUTF8(currentAnnotationOffset, charBuffer);
+                currentAnnotationOffset += 2;
+                // Parse num_element_value_pairs and element_value_pairs and visit these values.
+                currentAnnotationOffset = readElementValues(fieldVisitor.visitAnnotation(annotationDescriptor, /* visible = */ true),
+                        currentAnnotationOffset, /* named = */ true, charBuffer);
+            }
+        }
+
+        // Visit the RuntimeInvisibleAnnotations attribute.
+        if (runtimeInvisibleAnnotationsOffset != 0) {
+            int numAnnotations = readUnsignedShort(runtimeInvisibleAnnotationsOffset);
+            int currentAnnotationOffset = runtimeInvisibleAnnotationsOffset + 2;
+            while (numAnnotations-- > 0) {
+                // Parse the type_index field.
+                String annotationDescriptor = readUTF8(currentAnnotationOffset, charBuffer);
+                currentAnnotationOffset += 2;
+                // Parse num_element_value_pairs and element_value_pairs and visit these values.
+                currentAnnotationOffset = readElementValues(fieldVisitor.visitAnnotation(annotationDescriptor, /* visible = */ false),
+                        currentAnnotationOffset, /* named = */ true, charBuffer);
+            }
+        }
+
+        // Visit the RuntimeVisibleTypeAnnotations attribute.
+        if (runtimeVisibleTypeAnnotationsOffset != 0) {
+            int numAnnotations = readUnsignedShort(runtimeVisibleTypeAnnotationsOffset);
+            int currentAnnotationOffset = runtimeVisibleTypeAnnotationsOffset + 2;
+            while (numAnnotations-- > 0) {
+                // Parse the target_type, target_info and target_path fields.
+                currentAnnotationOffset = readTypeAnnotationTarget(context, currentAnnotationOffset);
+                // Parse the type_index field.
+                String annotationDescriptor = readUTF8(currentAnnotationOffset, charBuffer);
+                currentAnnotationOffset += 2;
+                // Parse num_element_value_pairs and element_value_pairs and visit these values.
+                currentAnnotationOffset = readElementValues(fieldVisitor.visitTypeAnnotation(context.currentTypeAnnotationTarget,
+                        context.currentTypeAnnotationTargetPath, annotationDescriptor, /* visible = */ true), currentAnnotationOffset,
+                        /* named = */ true, charBuffer);
+            }
+        }
+
+        // Visit the RuntimeInvisibleTypeAnnotations attribute.
+        if (runtimeInvisibleTypeAnnotationsOffset != 0) {
+            int numAnnotations = readUnsignedShort(runtimeInvisibleTypeAnnotationsOffset);
+            int currentAnnotationOffset = runtimeInvisibleTypeAnnotationsOffset + 2;
+            while (numAnnotations-- > 0) {
+                // Parse the target_type, target_info and target_path fields.
+                currentAnnotationOffset = readTypeAnnotationTarget(context, currentAnnotationOffset);
+                // Parse the type_index field.
+                String annotationDescriptor = readUTF8(currentAnnotationOffset, charBuffer);
+                currentAnnotationOffset += 2;
+                // Parse num_element_value_pairs and element_value_pairs and visit these values.
+                currentAnnotationOffset = readElementValues(fieldVisitor.visitTypeAnnotation(context.currentTypeAnnotationTarget,
+                        context.currentTypeAnnotationTargetPath, annotationDescriptor, /* visible = */ false), currentAnnotationOffset,
+                        /* named = */ true, charBuffer);
+            }
+        }
+
+        // Visit the non standard attributes.
+        while (attributes != null) {
+            // Copy and reset the nextAttribute field so that it can also be used in FieldWriter.
+            Attribute nextAttribute = attributes.nextAttribute;
+            attributes.nextAttribute = null;
+            fieldVisitor.visitAttribute(attributes);
+            attributes = nextAttribute;
+        }
+
+        // Visit the end of the field.
+        fieldVisitor.visitEnd();
+        return currentOffset;
+    }
+
+    /**
+     * Reads a JVMS method_info structure and makes the given visitor visit it.
+     *
+     * @param classVisitor the visitor that must visit the method.
+     * @param context information about the class being parsed.
+     * @param methodInfoOffset the start offset of the method_info structure.
+     * @return the offset of the first byte following the method_info structure.
+     */
+    private int readMethod(final ClassVisitor classVisitor, final Context context, final int methodInfoOffset) {
+        char[] charBuffer = context.charBuffer;
+
+        // Read the access_flags, name_index and descriptor_index fields.
+        int currentOffset = methodInfoOffset;
+        context.currentMethodAccessFlags = readUnsignedShort(currentOffset);
+        context.currentMethodName = readUTF8(currentOffset + 2, charBuffer);
+        context.currentMethodDescriptor = readUTF8(currentOffset + 4, charBuffer);
+        currentOffset += 6;
+
+        // Read the method attributes (the variables are ordered as in Section 4.7 of the JVMS).
+        // Attribute offsets exclude the attribute_name_index and attribute_length fields.
+        // - The offset of the Code attribute, or 0.
+        int codeOffset = 0;
+        // - The offset of the Exceptions attribute, or 0.
+        int exceptionsOffset = 0;
+        // - The strings corresponding to the Exceptions attribute, or null.
+        String[] exceptions = null;
+        // - Whether the method has a Synthetic attribute.
+        boolean synthetic = false;
+        // - The constant pool index contained in the Signature attribute, or 0.
+        int signatureIndex = 0;
+        // - The offset of the RuntimeVisibleAnnotations attribute, or 0.
+        int runtimeVisibleAnnotationsOffset = 0;
+        // - The offset of the RuntimeInvisibleAnnotations attribute, or 0.
+        int runtimeInvisibleAnnotationsOffset = 0;
+        // - The offset of the RuntimeVisibleParameterAnnotations attribute, or 0.
+        int runtimeVisibleParameterAnnotationsOffset = 0;
+        // - The offset of the RuntimeInvisibleParameterAnnotations attribute, or 0.
+        int runtimeInvisibleParameterAnnotationsOffset = 0;
+        // - The offset of the RuntimeVisibleTypeAnnotations attribute, or 0.
+        int runtimeVisibleTypeAnnotationsOffset = 0;
+        // - The offset of the RuntimeInvisibleTypeAnnotations attribute, or 0.
+        int runtimeInvisibleTypeAnnotationsOffset = 0;
+        // - The offset of the AnnotationDefault attribute, or 0.
+        int annotationDefaultOffset = 0;
+        // - The offset of the MethodParameters attribute, or 0.
+        int methodParametersOffset = 0;
+        // - The non standard attributes (linked with their {@link Attribute#nextAttribute} field).
+        //   This list in the <i>reverse order</i> or their order in the ClassFile structure.
+        Attribute attributes = null;
+
+        int attributesCount = readUnsignedShort(currentOffset);
+        currentOffset += 2;
+        while (attributesCount-- > 0) {
+            // Read the attribute_info's attribute_name and attribute_length fields.
+            String attributeName = readUTF8(currentOffset, charBuffer);
+            int attributeLength = readInt(currentOffset + 2);
+            currentOffset += 6;
+            // The tests are sorted in decreasing frequency order (based on frequencies observed on
+            // typical classes).
+            if (Constants.CODE.equals(attributeName)) {
+                if ((context.parsingOptions & SKIP_CODE) == 0) {
+                    codeOffset = currentOffset;
+                }
+            } else if (Constants.EXCEPTIONS.equals(attributeName)) {
+                exceptionsOffset = currentOffset;
+                exceptions = new String[readUnsignedShort(exceptionsOffset)];
+                int currentExceptionOffset = exceptionsOffset + 2;
+                for (int i = 0; i < exceptions.length; ++i) {
+                    exceptions[i] = readClass(currentExceptionOffset, charBuffer);
+                    currentExceptionOffset += 2;
+                }
+            } else if (Constants.SIGNATURE.equals(attributeName)) {
+                signatureIndex = readUnsignedShort(currentOffset);
+            } else if (Constants.DEPRECATED.equals(attributeName)) {
+                context.currentMethodAccessFlags |= Opcodes.ACC_DEPRECATED;
+            } else if (Constants.RUNTIME_VISIBLE_ANNOTATIONS.equals(attributeName)) {
+                runtimeVisibleAnnotationsOffset = currentOffset;
+            } else if (Constants.RUNTIME_VISIBLE_TYPE_ANNOTATIONS.equals(attributeName)) {
+                runtimeVisibleTypeAnnotationsOffset = currentOffset;
+            } else if (Constants.ANNOTATION_DEFAULT.equals(attributeName)) {
+                annotationDefaultOffset = currentOffset;
+            } else if (Constants.SYNTHETIC.equals(attributeName)) {
+                synthetic = true;
+                context.currentMethodAccessFlags |= Opcodes.ACC_SYNTHETIC;
+            } else if (Constants.RUNTIME_INVISIBLE_ANNOTATIONS.equals(attributeName)) {
+                runtimeInvisibleAnnotationsOffset = currentOffset;
+            } else if (Constants.RUNTIME_INVISIBLE_TYPE_ANNOTATIONS.equals(attributeName)) {
+                runtimeInvisibleTypeAnnotationsOffset = currentOffset;
+            } else if (Constants.RUNTIME_VISIBLE_PARAMETER_ANNOTATIONS.equals(attributeName)) {
+                runtimeVisibleParameterAnnotationsOffset = currentOffset;
+            } else if (Constants.RUNTIME_INVISIBLE_PARAMETER_ANNOTATIONS.equals(attributeName)) {
+                runtimeInvisibleParameterAnnotationsOffset = currentOffset;
+            } else if (Constants.METHOD_PARAMETERS.equals(attributeName)) {
+                methodParametersOffset = currentOffset;
+            } else {
+                Attribute attribute = readAttribute(context.attributePrototypes, attributeName, currentOffset, attributeLength, charBuffer,
+                        -1, null);
+                attribute.nextAttribute = attributes;
+                attributes = attribute;
+            }
+            currentOffset += attributeLength;
+        }
+
+        // Visit the method declaration.
+        MethodVisitor methodVisitor = classVisitor.visitMethod(context.currentMethodAccessFlags, context.currentMethodName,
+                context.currentMethodDescriptor, signatureIndex == 0 ? null : readUtf(signatureIndex, charBuffer), exceptions);
+        if (methodVisitor == null) {
+            return currentOffset;
+        }
+
+        // If the returned MethodVisitor is in fact a MethodWriter, it means there is no method
+        // adapter between the reader and the writer. In this case, it might be possible to copy
+        // the method attributes directly into the writer. If so, return early without visiting
+        // the content of these attributes.
+        if (methodVisitor instanceof MethodWriter) {
+            MethodWriter methodWriter = (MethodWriter) methodVisitor;
+            if (methodWriter.canCopyMethodAttributes(this, methodInfoOffset, currentOffset - methodInfoOffset, synthetic,
+                    (context.currentMethodAccessFlags & Opcodes.ACC_DEPRECATED) != 0, readUnsignedShort(methodInfoOffset + 4),
+                    signatureIndex, exceptionsOffset)) {
+                return currentOffset;
+            }
+        }
+
+        // Visit the MethodParameters attribute.
+        if (methodParametersOffset != 0) {
+            int parametersCount = readByte(methodParametersOffset);
+            int currentParameterOffset = methodParametersOffset + 1;
+            while (parametersCount-- > 0) {
+                // Read the name_index and access_flags fields and visit them.
+                methodVisitor.visitParameter(readUTF8(currentParameterOffset, charBuffer), readUnsignedShort(currentParameterOffset + 2));
+                currentParameterOffset += 4;
+            }
+        }
+
+        // Visit the AnnotationDefault attribute.
+        if (annotationDefaultOffset != 0) {
+            AnnotationVisitor annotationVisitor = methodVisitor.visitAnnotationDefault();
+            readElementValue(annotationVisitor, annotationDefaultOffset, null, charBuffer);
+            if (annotationVisitor != null) {
+                annotationVisitor.visitEnd();
+            }
+        }
+
+        // Visit the RuntimeVisibleAnnotations attribute.
+        if (runtimeVisibleAnnotationsOffset != 0) {
+            int numAnnotations = readUnsignedShort(runtimeVisibleAnnotationsOffset);
+            int currentAnnotationOffset = runtimeVisibleAnnotationsOffset + 2;
+            while (numAnnotations-- > 0) {
+                // Parse the type_index field.
+                String annotationDescriptor = readUTF8(currentAnnotationOffset, charBuffer);
+                currentAnnotationOffset += 2;
+                // Parse num_element_value_pairs and element_value_pairs and visit these values.
+                currentAnnotationOffset = readElementValues(methodVisitor.visitAnnotation(annotationDescriptor, /* visible = */ true),
+                        currentAnnotationOffset, /* named = */ true, charBuffer);
+            }
+        }
+
+        // Visit the RuntimeInvisibleAnnotations attribute.
+        if (runtimeInvisibleAnnotationsOffset != 0) {
+            int numAnnotations = readUnsignedShort(runtimeInvisibleAnnotationsOffset);
+            int currentAnnotationOffset = runtimeInvisibleAnnotationsOffset + 2;
+            while (numAnnotations-- > 0) {
+                // Parse the type_index field.
+                String annotationDescriptor = readUTF8(currentAnnotationOffset, charBuffer);
+                currentAnnotationOffset += 2;
+                // Parse num_element_value_pairs and element_value_pairs and visit these values.
+                currentAnnotationOffset = readElementValues(methodVisitor.visitAnnotation(annotationDescriptor, /* visible = */ false),
+                        currentAnnotationOffset, /* named = */ true, charBuffer);
+            }
+        }
+
+        // Visit the RuntimeVisibleTypeAnnotations attribute.
+        if (runtimeVisibleTypeAnnotationsOffset != 0) {
+            int numAnnotations = readUnsignedShort(runtimeVisibleTypeAnnotationsOffset);
+            int currentAnnotationOffset = runtimeVisibleTypeAnnotationsOffset + 2;
+            while (numAnnotations-- > 0) {
+                // Parse the target_type, target_info and target_path fields.
+                currentAnnotationOffset = readTypeAnnotationTarget(context, currentAnnotationOffset);
+                // Parse the type_index field.
+                String annotationDescriptor = readUTF8(currentAnnotationOffset, charBuffer);
+                currentAnnotationOffset += 2;
+                // Parse num_element_value_pairs and element_value_pairs and visit these values.
+                currentAnnotationOffset = readElementValues(methodVisitor.visitTypeAnnotation(context.currentTypeAnnotationTarget,
+                        context.currentTypeAnnotationTargetPath, annotationDescriptor, /* visible = */ true), currentAnnotationOffset,
+                        /* named = */ true, charBuffer);
+            }
+        }
+
+        // Visit the RuntimeInvisibleTypeAnnotations attribute.
+        if (runtimeInvisibleTypeAnnotationsOffset != 0) {
+            int numAnnotations = readUnsignedShort(runtimeInvisibleTypeAnnotationsOffset);
+            int currentAnnotationOffset = runtimeInvisibleTypeAnnotationsOffset + 2;
+            while (numAnnotations-- > 0) {
+                // Parse the target_type, target_info and target_path fields.
+                currentAnnotationOffset = readTypeAnnotationTarget(context, currentAnnotationOffset);
+                // Parse the type_index field.
+                String annotationDescriptor = readUTF8(currentAnnotationOffset, charBuffer);
+                currentAnnotationOffset += 2;
+                // Parse num_element_value_pairs and element_value_pairs and visit these values.
+                currentAnnotationOffset = readElementValues(methodVisitor.visitTypeAnnotation(context.currentTypeAnnotationTarget,
+                        context.currentTypeAnnotationTargetPath, annotationDescriptor, /* visible = */ false), currentAnnotationOffset,
+                        /* named = */ true, charBuffer);
+            }
+        }
+
+        // Visit the RuntimeVisibleParameterAnnotations attribute.
+        if (runtimeVisibleParameterAnnotationsOffset != 0) {
+            readParameterAnnotations(methodVisitor, context, runtimeVisibleParameterAnnotationsOffset, /* visible = */ true);
+        }
+
+        // Visit the RuntimeInvisibleParameterAnnotations attribute.
+        if (runtimeInvisibleParameterAnnotationsOffset != 0) {
+            readParameterAnnotations(methodVisitor, context, runtimeInvisibleParameterAnnotationsOffset, /* visible = */ false);
+        }
+
+        // Visit the non standard attributes.
+        while (attributes != null) {
+            // Copy and reset the nextAttribute field so that it can also be used in MethodWriter.
+            Attribute nextAttribute = attributes.nextAttribute;
+            attributes.nextAttribute = null;
+            methodVisitor.visitAttribute(attributes);
+            attributes = nextAttribute;
+        }
+
+        // Visit the Code attribute.
+        if (codeOffset != 0) {
+            methodVisitor.visitCode();
+            readCode(methodVisitor, context, codeOffset);
+        }
+
+        // Visit the end of the method.
+        methodVisitor.visitEnd();
+        return currentOffset;
+    }
+
+    // ----------------------------------------------------------------------------------------------
+    // Methods to parse a Code attribute
+    // ----------------------------------------------------------------------------------------------
+
+    /**
+     * Reads a JVMS 'Code' attribute and makes the given visitor visit it.
+     *
+     * @param methodVisitor the visitor that must visit the Code attribute.
+     * @param context information about the class being parsed.
+     * @param codeOffset the start offset in {@link #b} of the Code attribute, excluding its
+     *     attribute_name_index and attribute_length fields.
+     */
+    private void readCode(final MethodVisitor methodVisitor, final Context context, final int codeOffset) {
+        int currentOffset = codeOffset;
+
+        // Read the max_stack, max_locals and code_length fields.
+        final byte[] classFileBuffer = b;
+        final char[] charBuffer = context.charBuffer;
+        final int maxStack = readUnsignedShort(currentOffset);
+        final int maxLocals = readUnsignedShort(currentOffset + 2);
+        final int codeLength = readInt(currentOffset + 4);
+        currentOffset += 8;
+
+        // Read the bytecode 'code' array to create a label for each referenced instruction.
+        final int bytecodeStartOffset = currentOffset;
+        final int bytecodeEndOffset = currentOffset + codeLength;
+        final Label[] labels = context.currentMethodLabels = new Label[codeLength + 1];
+        while (currentOffset < bytecodeEndOffset) {
+            final int bytecodeOffset = currentOffset - bytecodeStartOffset;
+            final int opcode = classFileBuffer[currentOffset] & 0xFF;
+            switch (opcode) {
+                case Constants.NOP:
+                case Constants.ACONST_NULL:
+                case Constants.ICONST_M1:
+                case Constants.ICONST_0:
+                case Constants.ICONST_1:
+                case Constants.ICONST_2:
+                case Constants.ICONST_3:
+                case Constants.ICONST_4:
+                case Constants.ICONST_5:
+                case Constants.LCONST_0:
+                case Constants.LCONST_1:
+                case Constants.FCONST_0:
+                case Constants.FCONST_1:
+                case Constants.FCONST_2:
+                case Constants.DCONST_0:
+                case Constants.DCONST_1:
+                case Constants.IALOAD:
+                case Constants.LALOAD:
+                case Constants.FALOAD:
+                case Constants.DALOAD:
+                case Constants.AALOAD:
+                case Constants.BALOAD:
+                case Constants.CALOAD:
+                case Constants.SALOAD:
+                case Constants.IASTORE:
+                case Constants.LASTORE:
+                case Constants.FASTORE:
+                case Constants.DASTORE:
+                case Constants.AASTORE:
+                case Constants.BASTORE:
+                case Constants.CASTORE:
+                case Constants.SASTORE:
+                case Constants.POP:
+                case Constants.POP2:
+                case Constants.DUP:
+                case Constants.DUP_X1:
+                case Constants.DUP_X2:
+                case Constants.DUP2:
+                case Constants.DUP2_X1:
+                case Constants.DUP2_X2:
+                case Constants.SWAP:
+                case Constants.IADD:
+                case Constants.LADD:
+                case Constants.FADD:
+                case Constants.DADD:
+                case Constants.ISUB:
+                case Constants.LSUB:
+                case Constants.FSUB:
+                case Constants.DSUB:
+                case Constants.IMUL:
+                case Constants.LMUL:
+                case Constants.FMUL:
+                case Constants.DMUL:
+                case Constants.IDIV:
+                case Constants.LDIV:
+                case Constants.FDIV:
+                case Constants.DDIV:
+                case Constants.IREM:
+                case Constants.LREM:
+                case Constants.FREM:
+                case Constants.DREM:
+                case Constants.INEG:
+                case Constants.LNEG:
+                case Constants.FNEG:
+                case Constants.DNEG:
+                case Constants.ISHL:
+                case Constants.LSHL:
+                case Constants.ISHR:
+                case Constants.LSHR:
+                case Constants.IUSHR:
+                case Constants.LUSHR:
+                case Constants.IAND:
+                case Constants.LAND:
+                case Constants.IOR:
+                case Constants.LOR:
+                case Constants.IXOR:
+                case Constants.LXOR:
+                case Constants.I2L:
+                case Constants.I2F:
+                case Constants.I2D:
+                case Constants.L2I:
+                case Constants.L2F:
+                case Constants.L2D:
+                case Constants.F2I:
+                case Constants.F2L:
+                case Constants.F2D:
+                case Constants.D2I:
+                case Constants.D2L:
+                case Constants.D2F:
+                case Constants.I2B:
+                case Constants.I2C:
+                case Constants.I2S:
+                case Constants.LCMP:
+                case Constants.FCMPL:
+                case Constants.FCMPG:
+                case Constants.DCMPL:
+                case Constants.DCMPG:
+                case Constants.IRETURN:
+                case Constants.LRETURN:
+                case Constants.FRETURN:
+                case Constants.DRETURN:
+                case Constants.ARETURN:
+                case Constants.RETURN:
+                case Constants.ARRAYLENGTH:
+                case Constants.ATHROW:
+                case Constants.MONITORENTER:
+                case Constants.MONITOREXIT:
+                case Constants.ILOAD_0:
+                case Constants.ILOAD_1:
+                case Constants.ILOAD_2:
+                case Constants.ILOAD_3:
+                case Constants.LLOAD_0:
+                case Constants.LLOAD_1:
+                case Constants.LLOAD_2:
+                case Constants.LLOAD_3:
+                case Constants.FLOAD_0:
+                case Constants.FLOAD_1:
+                case Constants.FLOAD_2:
+                case Constants.FLOAD_3:
+                case Constants.DLOAD_0:
+                case Constants.DLOAD_1:
+                case Constants.DLOAD_2:
+                case Constants.DLOAD_3:
+                case Constants.ALOAD_0:
+                case Constants.ALOAD_1:
+                case Constants.ALOAD_2:
+                case Constants.ALOAD_3:
+                case Constants.ISTORE_0:
+                case Constants.ISTORE_1:
+                case Constants.ISTORE_2:
+                case Constants.ISTORE_3:
+                case Constants.LSTORE_0:
+                case Constants.LSTORE_1:
+                case Constants.LSTORE_2:
+                case Constants.LSTORE_3:
+                case Constants.FSTORE_0:
+                case Constants.FSTORE_1:
+                case Constants.FSTORE_2:
+                case Constants.FSTORE_3:
+                case Constants.DSTORE_0:
+                case Constants.DSTORE_1:
+                case Constants.DSTORE_2:
+                case Constants.DSTORE_3:
+                case Constants.ASTORE_0:
+                case Constants.ASTORE_1:
+                case Constants.ASTORE_2:
+                case Constants.ASTORE_3:
+                    currentOffset += 1;
+                    break;
+                case Constants.IFEQ:
+                case Constants.IFNE:
+                case Constants.IFLT:
+                case Constants.IFGE:
+                case Constants.IFGT:
+                case Constants.IFLE:
+                case Constants.IF_ICMPEQ:
+                case Constants.IF_ICMPNE:
+                case Constants.IF_ICMPLT:
+                case Constants.IF_ICMPGE:
+                case Constants.IF_ICMPGT:
+                case Constants.IF_ICMPLE:
+                case Constants.IF_ACMPEQ:
+                case Constants.IF_ACMPNE:
+                case Constants.GOTO:
+                case Constants.JSR:
+                case Constants.IFNULL:
+                case Constants.IFNONNULL:
+                    createLabel(bytecodeOffset + readShort(currentOffset + 1), labels);
+                    currentOffset += 3;
+                    break;
+                case Constants.ASM_IFEQ:
+                case Constants.ASM_IFNE:
+                case Constants.ASM_IFLT:
+                case Constants.ASM_IFGE:
+                case Constants.ASM_IFGT:
+                case Constants.ASM_IFLE:
+                case Constants.ASM_IF_ICMPEQ:
+                case Constants.ASM_IF_ICMPNE:
+                case Constants.ASM_IF_ICMPLT:
+                case Constants.ASM_IF_ICMPGE:
+                case Constants.ASM_IF_ICMPGT:
+                case Constants.ASM_IF_ICMPLE:
+                case Constants.ASM_IF_ACMPEQ:
+                case Constants.ASM_IF_ACMPNE:
+                case Constants.ASM_GOTO:
+                case Constants.ASM_JSR:
+                case Constants.ASM_IFNULL:
+                case Constants.ASM_IFNONNULL:
+                    createLabel(bytecodeOffset + readUnsignedShort(currentOffset + 1), labels);
+                    currentOffset += 3;
+                    break;
+                case Constants.GOTO_W:
+                case Constants.JSR_W:
+                case Constants.ASM_GOTO_W:
+                    createLabel(bytecodeOffset + readInt(currentOffset + 1), labels);
+                    currentOffset += 5;
+                    break;
+                case Constants.WIDE:
+                    switch (classFileBuffer[currentOffset + 1] & 0xFF) {
+                        case Constants.ILOAD:
+                        case Constants.FLOAD:
+                        case Constants.ALOAD:
+                        case Constants.LLOAD:
+                        case Constants.DLOAD:
+                        case Constants.ISTORE:
+                        case Constants.FSTORE:
+                        case Constants.ASTORE:
+                        case Constants.LSTORE:
+                        case Constants.DSTORE:
+                        case Constants.RET:
+                            currentOffset += 4;
+                            break;
+                        case Constants.IINC:
+                            currentOffset += 6;
+                            break;
+                        default:
+                            throw new IllegalArgumentException();
+                    }
+                    break;
+                case Constants.TABLESWITCH:
+                    // Skip 0 to 3 padding bytes.
+                    currentOffset += 4 - (bytecodeOffset & 3);
+                    // Read the default label and the number of table entries.
+                    createLabel(bytecodeOffset + readInt(currentOffset), labels);
+                    int numTableEntries = readInt(currentOffset + 8) - readInt(currentOffset + 4) + 1;
+                    currentOffset += 12;
+                    // Read the table labels.
+                    while (numTableEntries-- > 0) {
+                        createLabel(bytecodeOffset + readInt(currentOffset), labels);
+                        currentOffset += 4;
+                    }
+                    break;
+                case Constants.LOOKUPSWITCH:
+                    // Skip 0 to 3 padding bytes.
+                    currentOffset += 4 - (bytecodeOffset & 3);
+                    // Read the default label and the number of switch cases.
+                    createLabel(bytecodeOffset + readInt(currentOffset), labels);
+                    int numSwitchCases = readInt(currentOffset + 4);
+                    currentOffset += 8;
+                    // Read the switch labels.
+                    while (numSwitchCases-- > 0) {
+                        createLabel(bytecodeOffset + readInt(currentOffset + 4), labels);
+                        currentOffset += 8;
+                    }
+                    break;
+                case Constants.ILOAD:
+                case Constants.LLOAD:
+                case Constants.FLOAD:
+                case Constants.DLOAD:
+                case Constants.ALOAD:
+                case Constants.ISTORE:
+                case Constants.LSTORE:
+                case Constants.FSTORE:
+                case Constants.DSTORE:
+                case Constants.ASTORE:
+                case Constants.RET:
+                case Constants.BIPUSH:
+                case Constants.NEWARRAY:
+                case Constants.LDC:
+                    currentOffset += 2;
+                    break;
+                case Constants.SIPUSH:
+                case Constants.LDC_W:
+                case Constants.LDC2_W:
+                case Constants.GETSTATIC:
+                case Constants.PUTSTATIC:
+                case Constants.GETFIELD:
+                case Constants.PUTFIELD:
+                case Constants.INVOKEVIRTUAL:
+                case Constants.INVOKESPECIAL:
+                case Constants.INVOKESTATIC:
+                case Constants.NEW:
+                case Constants.ANEWARRAY:
+                case Constants.CHECKCAST:
+                case Constants.INSTANCEOF:
+                case Constants.IINC:
+                    currentOffset += 3;
+                    break;
+                case Constants.INVOKEINTERFACE:
+                case Constants.INVOKEDYNAMIC:
+                    currentOffset += 5;
+                    break;
+                case Constants.MULTIANEWARRAY:
+                    currentOffset += 4;
+                    break;
+                default:
+                    throw new IllegalArgumentException();
+            }
+        }
+
+        // Read the 'exception_table_length' and 'exception_table' field to create a label for each
+        // referenced instruction, and to make methodVisitor visit the corresponding try catch blocks.
+        int exceptionTableLength = readUnsignedShort(currentOffset);
+        currentOffset += 2;
+        while (exceptionTableLength-- > 0) {
+            Label start = createLabel(readUnsignedShort(currentOffset), labels);
+            Label end = createLabel(readUnsignedShort(currentOffset + 2), labels);
+            Label handler = createLabel(readUnsignedShort(currentOffset + 4), labels);
+            String catchType = readUTF8(cpInfoOffsets[readUnsignedShort(currentOffset + 6)], charBuffer);
+            currentOffset += 8;
+            methodVisitor.visitTryCatchBlock(start, end, handler, catchType);
+        }
+
+        // Read the Code attributes to create a label for each referenced instruction (the variables
+        // are ordered as in Section 4.7 of the JVMS). Attribute offsets exclude the
+        // attribute_name_index and attribute_length fields.
+        // - The offset of the current 'stack_map_frame' in the StackMap[Table] attribute, or 0.
+        // Initially, this is the offset of the first 'stack_map_frame' entry. Then this offset is
+        // updated after each stack_map_frame is read.
+        int stackMapFrameOffset = 0;
+        // - The end offset of the StackMap[Table] attribute, or 0.
+        int stackMapTableEndOffset = 0;
+        // - Whether the stack map frames are compressed (i.e. in a StackMapTable) or not.
+        boolean compressedFrames = true;
+        // - The offset of the LocalVariableTable attribute, or 0.
+        int localVariableTableOffset = 0;
+        // - The offset of the LocalVariableTypeTable attribute, or 0.
+        int localVariableTypeTableOffset = 0;
+        // - The offset of each 'type_annotation' entry in the RuntimeVisibleTypeAnnotations
+        // attribute, or null.
+        int[] visibleTypeAnnotationOffsets = null;
+        // - The offset of each 'type_annotation' entry in the RuntimeInvisibleTypeAnnotations
+        // attribute, or null.
+        int[] invisibleTypeAnnotationOffsets = null;
+        // - The non standard attributes (linked with their {@link Attribute#nextAttribute} field).
+        //   This list in the <i>reverse order</i> or their order in the ClassFile structure.
+        Attribute attributes = null;
+
+        int attributesCount = readUnsignedShort(currentOffset);
+        currentOffset += 2;
+        while (attributesCount-- > 0) {
+            // Read the attribute_info's attribute_name and attribute_length fields.
+            String attributeName = readUTF8(currentOffset, charBuffer);
+            int attributeLength = readInt(currentOffset + 2);
+            currentOffset += 6;
+            if (Constants.LOCAL_VARIABLE_TABLE.equals(attributeName)) {
+                if ((context.parsingOptions & SKIP_DEBUG) == 0) {
+                    localVariableTableOffset = currentOffset;
+                    // Parse the attribute to find the corresponding (debug only) labels.
+                    int currentLocalVariableTableOffset = currentOffset;
+                    int localVariableTableLength = readUnsignedShort(currentLocalVariableTableOffset);
+                    currentLocalVariableTableOffset += 2;
+                    while (localVariableTableLength-- > 0) {
+                        int startPc = readUnsignedShort(currentLocalVariableTableOffset);
+                        createDebugLabel(startPc, labels);
+                        int length = readUnsignedShort(currentLocalVariableTableOffset + 2);
+                        createDebugLabel(startPc + length, labels);
+                        // Skip the name_index, descriptor_index and index fields (2 bytes each).
+                        currentLocalVariableTableOffset += 10;
+                    }
+                }
+            } else if (Constants.LOCAL_VARIABLE_TYPE_TABLE.equals(attributeName)) {
+                localVariableTypeTableOffset = currentOffset;
+                // Here we do not extract the labels corresponding to the attribute content. We assume they
+                // are the same or a subset of those of the LocalVariableTable attribute.
+            } else if (Constants.LINE_NUMBER_TABLE.equals(attributeName)) {
+                if ((context.parsingOptions & SKIP_DEBUG) == 0) {
+                    // Parse the attribute to find the corresponding (debug only) labels.
+                    int currentLineNumberTableOffset = currentOffset;
+                    int lineNumberTableLength = readUnsignedShort(currentLineNumberTableOffset);
+                    currentLineNumberTableOffset += 2;
+                    while (lineNumberTableLength-- > 0) {
+                        int startPc = readUnsignedShort(currentLineNumberTableOffset);
+                        int lineNumber = readUnsignedShort(currentLineNumberTableOffset + 2);
+                        currentLineNumberTableOffset += 4;
+                        createDebugLabel(startPc, labels);
+                        labels[startPc].addLineNumber(lineNumber);
+                    }
+                }
+            } else if (Constants.RUNTIME_VISIBLE_TYPE_ANNOTATIONS.equals(attributeName)) {
+                visibleTypeAnnotationOffsets = readTypeAnnotations(methodVisitor, context, currentOffset, /* visible = */ true);
+                // Here we do not extract the labels corresponding to the attribute content. This would
+                // require a full parsing of the attribute, which would need to be repeated when parsing
+                // the bytecode instructions (see below). Instead, the content of the attribute is read one
+                // type annotation at a time (i.e. after a type annotation has been visited, the next type
+                // annotation is read), and the labels it contains are also extracted one annotation at a
+                // time. This assumes that type annotations are ordered by increasing bytecode offset.
+            } else if (Constants.RUNTIME_INVISIBLE_TYPE_ANNOTATIONS.equals(attributeName)) {
+                invisibleTypeAnnotationOffsets = readTypeAnnotations(methodVisitor, context, currentOffset, /* visible = */ false);
+                // Same comment as above for the RuntimeVisibleTypeAnnotations attribute.
+            } else if (Constants.STACK_MAP_TABLE.equals(attributeName)) {
+                if ((context.parsingOptions & SKIP_FRAMES) == 0) {
+                    stackMapFrameOffset = currentOffset + 2;
+                    stackMapTableEndOffset = currentOffset + attributeLength;
+                }
+                // Here we do not extract the labels corresponding to the attribute content. This would
+                // require a full parsing of the attribute, which would need to be repeated when parsing
+                // the bytecode instructions (see below). Instead, the content of the attribute is read one
+                // frame at a time (i.e. after a frame has been visited, the next frame is read), and the
+                // labels it contains are also extracted one frame at a time. Thanks to the ordering of
+                // frames, having only a "one frame lookahead" is not a problem, i.e. it is not possible to
+                // see an offset smaller than the offset of the current instruction and for which no Label
+                // exist. Except for UNINITIALIZED type offsets. We solve this by parsing the stack map
+                // table without a full decoding (see below).
+            } else if ("StackMap".equals(attributeName)) {
+                if ((context.parsingOptions & SKIP_FRAMES) == 0) {
+                    stackMapFrameOffset = currentOffset + 2;
+                    stackMapTableEndOffset = currentOffset + attributeLength;
+                    compressedFrames = false;
+                }
+                // IMPORTANT! Here we assume that the frames are ordered, as in the StackMapTable attribute,
+                // although this is not guaranteed by the attribute format. This allows an incremental
+                // extraction of the labels corresponding to this attribute (see the comment above for the
+                // StackMapTable attribute).
+            } else {
+                Attribute attribute = readAttribute(context.attributePrototypes, attributeName, currentOffset, attributeLength, charBuffer,
+                        codeOffset, labels);
+                attribute.nextAttribute = attributes;
+                attributes = attribute;
+            }
+            currentOffset += attributeLength;
+        }
+
+        // Initialize the context fields related to stack map frames, and generate the first
+        // (implicit) stack map frame, if needed.
+        final boolean expandFrames = (context.parsingOptions & EXPAND_FRAMES) != 0;
+        if (stackMapFrameOffset != 0) {
+            // The bytecode offset of the first explicit frame is not offset_delta + 1 but only
+            // offset_delta. Setting the implicit frame offset to -1 allows us to use of the
+            // "offset_delta + 1" rule in all cases.
+            context.currentFrameOffset = -1;
+            context.currentFrameType = 0;
+            context.currentFrameLocalCount = 0;
+            context.currentFrameLocalCountDelta = 0;
+            context.currentFrameLocalTypes = new Object[maxLocals];
+            context.currentFrameStackCount = 0;
+            context.currentFrameStackTypes = new Object[maxStack];
+            if (expandFrames) {
+                computeImplicitFrame(context);
+            }
+            // Find the labels for UNINITIALIZED frame types. Instead of decoding each element of the
+            // stack map table, we look for 3 consecutive bytes that "look like" an UNINITIALIZED type
+            // (tag ITEM_Uninitialized, offset within bytecode bounds, NEW instruction at this offset).
+            // We may find false positives (i.e. not real UNINITIALIZED types), but this should be rare,
+            // and the only consequence will be the creation of an unneeded label. This is better than
+            // creating a label for each NEW instruction, and faster than fully decoding the whole stack
+            // map table.
+            for (int offset = stackMapFrameOffset; offset < stackMapTableEndOffset - 2; ++offset) {
+                if (classFileBuffer[offset] == Frame.ITEM_UNINITIALIZED) {
+                    int potentialBytecodeOffset = readUnsignedShort(offset + 1);
+                    if (potentialBytecodeOffset >= 0 && potentialBytecodeOffset < codeLength
+                            && (classFileBuffer[bytecodeStartOffset + potentialBytecodeOffset] & 0xFF) == Opcodes.NEW) {
+                        createLabel(potentialBytecodeOffset, labels);
+                    }
+                }
+            }
+        }
+        if (expandFrames && (context.parsingOptions & EXPAND_ASM_INSNS) != 0) {
+            // Expanding the ASM specific instructions can introduce F_INSERT frames, even if the method
+            // does not currently have any frame. These inserted frames must be computed by simulating the
+            // effect of the bytecode instructions, one by one, starting from the implicit first frame.
+            // For this, MethodWriter needs to know maxLocals before the first instruction is visited. To
+            // ensure this, we visit the implicit first frame here (passing only maxLocals - the rest is
+            // computed in MethodWriter).
+            methodVisitor.visitFrame(Opcodes.F_NEW, maxLocals, null, 0, null);
+        }
+
+        // Visit the bytecode instructions. First, introduce state variables for the incremental parsing
+        // of the type annotations.
+
+        // Index of the next runtime visible type annotation to read (in the
+        // visibleTypeAnnotationOffsets array).
+        int currentVisibleTypeAnnotationIndex = 0;
+        // The bytecode offset of the next runtime visible type annotation to read, or -1.
+        int currentVisibleTypeAnnotationBytecodeOffset = getTypeAnnotationBytecodeOffset(visibleTypeAnnotationOffsets, 0);
+        // Index of the next runtime invisible type annotation to read (in the
+        // invisibleTypeAnnotationOffsets array).
+        int currentInvisibleTypeAnnotationIndex = 0;
+        // The bytecode offset of the next runtime invisible type annotation to read, or -1.
+        int currentInvisibleTypeAnnotationBytecodeOffset = getTypeAnnotationBytecodeOffset(invisibleTypeAnnotationOffsets, 0);
+
+        // Whether a F_INSERT stack map frame must be inserted before the current instruction.
+        boolean insertFrame = false;
+
+        // The delta to subtract from a goto_w or jsr_w opcode to get the corresponding goto or jsr
+        // opcode, or 0 if goto_w and jsr_w must be left unchanged (i.e. when expanding ASM specific
+        // instructions).
+        final int wideJumpOpcodeDelta = (context.parsingOptions & EXPAND_ASM_INSNS) == 0 ? Constants.WIDE_JUMP_OPCODE_DELTA : 0;
+
+        currentOffset = bytecodeStartOffset;
+        while (currentOffset < bytecodeEndOffset) {
+            final int currentBytecodeOffset = currentOffset - bytecodeStartOffset;
+
+            // Visit the label and the line number(s) for this bytecode offset, if any.
+            Label currentLabel = labels[currentBytecodeOffset];
+            if (currentLabel != null) {
+                currentLabel.accept(methodVisitor, (context.parsingOptions & SKIP_DEBUG) == 0);
+            }
+
+            // Visit the stack map frame for this bytecode offset, if any.
+            while (stackMapFrameOffset != 0 && (context.currentFrameOffset == currentBytecodeOffset || context.currentFrameOffset == -1)) {
+                // If there is a stack map frame for this offset, make methodVisitor visit it, and read the
+                // next stack map frame if there is one.
+                if (context.currentFrameOffset != -1) {
+                    if (!compressedFrames || expandFrames) {
+                        methodVisitor.visitFrame(Opcodes.F_NEW, context.currentFrameLocalCount, context.currentFrameLocalTypes,
+                                context.currentFrameStackCount, context.currentFrameStackTypes);
+                    } else {
+                        methodVisitor.visitFrame(context.currentFrameType, context.currentFrameLocalCountDelta,
+                                context.currentFrameLocalTypes, context.currentFrameStackCount, context.currentFrameStackTypes);
+                    }
+                    // Since there is already a stack map frame for this bytecode offset, there is no need to
+                    // insert a new one.
+                    insertFrame = false;
+                }
+                if (stackMapFrameOffset < stackMapTableEndOffset) {
+                    stackMapFrameOffset = readStackMapFrame(stackMapFrameOffset, compressedFrames, expandFrames, context);
+                } else {
+                    stackMapFrameOffset = 0;
+                }
+            }
+
+            // Insert a stack map frame for this bytecode offset, if requested by setting insertFrame to
+            // true during the previous iteration. The actual frame content is computed in MethodWriter.
+            if (insertFrame) {
+                if ((context.parsingOptions & EXPAND_FRAMES) != 0) {
+                    methodVisitor.visitFrame(Constants.F_INSERT, 0, null, 0, null);
+                }
+                insertFrame = false;
+            }
+
+            // Visit the instruction at this bytecode offset.
+            int opcode = classFileBuffer[currentOffset] & 0xFF;
+            switch (opcode) {
+                case Constants.NOP:
+                case Constants.ACONST_NULL:
+                case Constants.ICONST_M1:
+                case Constants.ICONST_0:
+                case Constants.ICONST_1:
+                case Constants.ICONST_2:
+                case Constants.ICONST_3:
+                case Constants.ICONST_4:
+                case Constants.ICONST_5:
+                case Constants.LCONST_0:
+                case Constants.LCONST_1:
+                case Constants.FCONST_0:
+                case Constants.FCONST_1:
+                case Constants.FCONST_2:
+                case Constants.DCONST_0:
+                case Constants.DCONST_1:
+                case Constants.IALOAD:
+                case Constants.LALOAD:
+                case Constants.FALOAD:
+                case Constants.DALOAD:
+                case Constants.AALOAD:
+                case Constants.BALOAD:
+                case Constants.CALOAD:
+                case Constants.SALOAD:
+                case Constants.IASTORE:
+                case Constants.LASTORE:
+                case Constants.FASTORE:
+                case Constants.DASTORE:
+                case Constants.AASTORE:
+                case Constants.BASTORE:
+                case Constants.CASTORE:
+                case Constants.SASTORE:
+                case Constants.POP:
+                case Constants.POP2:
+                case Constants.DUP:
+                case Constants.DUP_X1:
+                case Constants.DUP_X2:
+                case Constants.DUP2:
+                case Constants.DUP2_X1:
+                case Constants.DUP2_X2:
+                case Constants.SWAP:
+                case Constants.IADD:
+                case Constants.LADD:
+                case Constants.FADD:
+                case Constants.DADD:
+                case Constants.ISUB:
+                case Constants.LSUB:
+                case Constants.FSUB:
+                case Constants.DSUB:
+                case Constants.IMUL:
+                case Constants.LMUL:
+                case Constants.FMUL:
+                case Constants.DMUL:
+                case Constants.IDIV:
+                case Constants.LDIV:
+                case Constants.FDIV:
+                case Constants.DDIV:
+                case Constants.IREM:
+                case Constants.LREM:
+                case Constants.FREM:
+                case Constants.DREM:
+                case Constants.INEG:
+                case Constants.LNEG:
+                case Constants.FNEG:
+                case Constants.DNEG:
+                case Constants.ISHL:
+                case Constants.LSHL:
+                case Constants.ISHR:
+                case Constants.LSHR:
+                case Constants.IUSHR:
+                case Constants.LUSHR:
+                case Constants.IAND:
+                case Constants.LAND:
+                case Constants.IOR:
+                case Constants.LOR:
+                case Constants.IXOR:
+                case Constants.LXOR:
+                case Constants.I2L:
+                case Constants.I2F:
+                case Constants.I2D:
+                case Constants.L2I:
+                case Constants.L2F:
+                case Constants.L2D:
+                case Constants.F2I:
+                case Constants.F2L:
+                case Constants.F2D:
+                case Constants.D2I:
+                case Constants.D2L:
+                case Constants.D2F:
+                case Constants.I2B:
+                case Constants.I2C:
+                case Constants.I2S:
+                case Constants.LCMP:
+                case Constants.FCMPL:
+                case Constants.FCMPG:
+                case Constants.DCMPL:
+                case Constants.DCMPG:
+                case Constants.IRETURN:
+                case Constants.LRETURN:
+                case Constants.FRETURN:
+                case Constants.DRETURN:
+                case Constants.ARETURN:
+                case Constants.RETURN:
+                case Constants.ARRAYLENGTH:
+                case Constants.ATHROW:
+                case Constants.MONITORENTER:
+                case Constants.MONITOREXIT:
+                    methodVisitor.visitInsn(opcode);
+                    currentOffset += 1;
+                    break;
+                case Constants.ILOAD_0:
+                case Constants.ILOAD_1:
+                case Constants.ILOAD_2:
+                case Constants.ILOAD_3:
+                case Constants.LLOAD_0:
+                case Constants.LLOAD_1:
+                case Constants.LLOAD_2:
+                case Constants.LLOAD_3:
+                case Constants.FLOAD_0:
+                case Constants.FLOAD_1:
+                case Constants.FLOAD_2:
+                case Constants.FLOAD_3:
+                case Constants.DLOAD_0:
+                case Constants.DLOAD_1:
+                case Constants.DLOAD_2:
+                case Constants.DLOAD_3:
+                case Constants.ALOAD_0:
+                case Constants.ALOAD_1:
+                case Constants.ALOAD_2:
+                case Constants.ALOAD_3:
+                    opcode -= Constants.ILOAD_0;
+                    methodVisitor.visitVarInsn(Opcodes.ILOAD + (opcode >> 2), opcode & 0x3);
+                    currentOffset += 1;
+                    break;
+                case Constants.ISTORE_0:
+                case Constants.ISTORE_1:
+                case Constants.ISTORE_2:
+                case Constants.ISTORE_3:
+                case Constants.LSTORE_0:
+                case Constants.LSTORE_1:
+                case Constants.LSTORE_2:
+                case Constants.LSTORE_3:
+                case Constants.FSTORE_0:
+                case Constants.FSTORE_1:
+                case Constants.FSTORE_2:
+                case Constants.FSTORE_3:
+                case Constants.DSTORE_0:
+                case Constants.DSTORE_1:
+                case Constants.DSTORE_2:
+                case Constants.DSTORE_3:
+                case Constants.ASTORE_0:
+                case Constants.ASTORE_1:
+                case Constants.ASTORE_2:
+                case Constants.ASTORE_3:
+                    opcode -= Constants.ISTORE_0;
+                    methodVisitor.visitVarInsn(Opcodes.ISTORE + (opcode >> 2), opcode & 0x3);
+                    currentOffset += 1;
+                    break;
+                case Constants.IFEQ:
+                case Constants.IFNE:
+                case Constants.IFLT:
+                case Constants.IFGE:
+                case Constants.IFGT:
+                case Constants.IFLE:
+                case Constants.IF_ICMPEQ:
+                case Constants.IF_ICMPNE:
+                case Constants.IF_ICMPLT:
+                case Constants.IF_ICMPGE:
+                case Constants.IF_ICMPGT:
+                case Constants.IF_ICMPLE:
+                case Constants.IF_ACMPEQ:
+                case Constants.IF_ACMPNE:
+                case Constants.GOTO:
+                case Constants.JSR:
+                case Constants.IFNULL:
+                case Constants.IFNONNULL:
+                    methodVisitor.visitJumpInsn(opcode, labels[currentBytecodeOffset + readShort(currentOffset + 1)]);
+                    currentOffset += 3;
+                    break;
+                case Constants.GOTO_W:
+                case Constants.JSR_W:
+                    methodVisitor.visitJumpInsn(opcode - wideJumpOpcodeDelta, labels[currentBytecodeOffset + readInt(currentOffset + 1)]);
+                    currentOffset += 5;
+                    break;
+                case Constants.ASM_IFEQ:
+                case Constants.ASM_IFNE:
+                case Constants.ASM_IFLT:
+                case Constants.ASM_IFGE:
+                case Constants.ASM_IFGT:
+                case Constants.ASM_IFLE:
+                case Constants.ASM_IF_ICMPEQ:
+                case Constants.ASM_IF_ICMPNE:
+                case Constants.ASM_IF_ICMPLT:
+                case Constants.ASM_IF_ICMPGE:
+                case Constants.ASM_IF_ICMPGT:
+                case Constants.ASM_IF_ICMPLE:
+                case Constants.ASM_IF_ACMPEQ:
+                case Constants.ASM_IF_ACMPNE:
+                case Constants.ASM_GOTO:
+                case Constants.ASM_JSR:
+                case Constants.ASM_IFNULL:
+                case Constants.ASM_IFNONNULL: {
+                    // A forward jump with an offset > 32767. In this case we automatically replace ASM_GOTO
+                    // with GOTO_W, ASM_JSR with JSR_W and ASM_IFxxx <l> with IFNOTxxx <L> GOTO_W <l> L:...,
+                    // where IFNOTxxx is the "opposite" opcode of ASMS_IFxxx (e.g. IFNE for ASM_IFEQ) and
+                    // where <L> designates the instruction just after the GOTO_W.
+                    // First, change the ASM specific opcodes ASM_IFEQ ... ASM_JSR, ASM_IFNULL and
+                    // ASM_IFNONNULL to IFEQ ... JSR, IFNULL and IFNONNULL.
+                    opcode = opcode < Constants.ASM_IFNULL ? opcode - Constants.ASM_OPCODE_DELTA : opcode
+                            - Constants.ASM_IFNULL_OPCODE_DELTA;
+                    Label target = labels[currentBytecodeOffset + readUnsignedShort(currentOffset + 1)];
+                    if (opcode == Opcodes.GOTO || opcode == Opcodes.JSR) {
+                        // Replace GOTO with GOTO_W and JSR with JSR_W.
+                        methodVisitor.visitJumpInsn(opcode + Constants.WIDE_JUMP_OPCODE_DELTA, target);
+                    } else {
+                        // Compute the "opposite" of opcode. This can be done by flipping the least
+                        // significant bit for IFNULL and IFNONNULL, and similarly for IFEQ ... IF_ACMPEQ
+                        // (with a pre and post offset by 1).
+                        opcode = opcode < Opcodes.GOTO ? ((opcode + 1) ^ 1) - 1 : opcode ^ 1;
+                        Label endif = createLabel(currentBytecodeOffset + 3, labels);
+                        methodVisitor.visitJumpInsn(opcode, endif);
+                        methodVisitor.visitJumpInsn(Constants.GOTO_W, target);
+                        // endif designates the instruction just after GOTO_W, and is visited as part of the
+                        // next instruction. Since it is a jump target, we need to insert a frame here.
+                        insertFrame = true;
+                    }
+                    currentOffset += 3;
+                    break;
+                }
+                case Constants.ASM_GOTO_W: {
+                    // Replace ASM_GOTO_W with GOTO_W.
+                    methodVisitor.visitJumpInsn(Constants.GOTO_W, labels[currentBytecodeOffset + readInt(currentOffset + 1)]);
+                    // The instruction just after is a jump target (because ASM_GOTO_W is used in patterns
+                    // IFNOTxxx <L> ASM_GOTO_W <l> L:..., see MethodWriter), so we need to insert a frame
+                    // here.
+                    insertFrame = true;
+                    currentOffset += 5;
+                    break;
+                }
+                case Constants.WIDE:
+                    opcode = classFileBuffer[currentOffset + 1] & 0xFF;
+                    if (opcode == Opcodes.IINC) {
+                        methodVisitor.visitIincInsn(readUnsignedShort(currentOffset + 2), readShort(currentOffset + 4));
+                        currentOffset += 6;
+                    } else {
+                        methodVisitor.visitVarInsn(opcode, readUnsignedShort(currentOffset + 2));
+                        currentOffset += 4;
+                    }
+                    break;
+                case Constants.TABLESWITCH: {
+                    // Skip 0 to 3 padding bytes.
+                    currentOffset += 4 - (currentBytecodeOffset & 3);
+                    // Read the instruction.
+                    Label defaultLabel = labels[currentBytecodeOffset + readInt(currentOffset)];
+                    int low = readInt(currentOffset + 4);
+                    int high = readInt(currentOffset + 8);
+                    currentOffset += 12;
+                    Label[] table = new Label[high - low + 1];
+                    for (int i = 0; i < table.length; ++i) {
+                        table[i] = labels[currentBytecodeOffset + readInt(currentOffset)];
+                        currentOffset += 4;
+                    }
+                    methodVisitor.visitTableSwitchInsn(low, high, defaultLabel, table);
+                    break;
+                }
+                case Constants.LOOKUPSWITCH: {
+                    // Skip 0 to 3 padding bytes.
+                    currentOffset += 4 - (currentBytecodeOffset & 3);
+                    // Read the instruction.
+                    Label defaultLabel = labels[currentBytecodeOffset + readInt(currentOffset)];
+                    int numPairs = readInt(currentOffset + 4);
+                    currentOffset += 8;
+                    int[] keys = new int[numPairs];
+                    Label[] values = new Label[numPairs];
+                    for (int i = 0; i < numPairs; ++i) {
+                        keys[i] = readInt(currentOffset);
+                        values[i] = labels[currentBytecodeOffset + readInt(currentOffset + 4)];
+                        currentOffset += 8;
+                    }
+                    methodVisitor.visitLookupSwitchInsn(defaultLabel, keys, values);
+                    break;
+                }
+                case Constants.ILOAD:
+                case Constants.LLOAD:
+                case Constants.FLOAD:
+                case Constants.DLOAD:
+                case Constants.ALOAD:
+                case Constants.ISTORE:
+                case Constants.LSTORE:
+                case Constants.FSTORE:
+                case Constants.DSTORE:
+                case Constants.ASTORE:
+                case Constants.RET:
+                    methodVisitor.visitVarInsn(opcode, classFileBuffer[currentOffset + 1] & 0xFF);
+                    currentOffset += 2;
+                    break;
+                case Constants.BIPUSH:
+                case Constants.NEWARRAY:
+                    methodVisitor.visitIntInsn(opcode, classFileBuffer[currentOffset + 1]);
+                    currentOffset += 2;
+                    break;
+                case Constants.SIPUSH:
+                    methodVisitor.visitIntInsn(opcode, readShort(currentOffset + 1));
+                    currentOffset += 3;
+                    break;
+                case Constants.LDC:
+                    methodVisitor.visitLdcInsn(readConst(classFileBuffer[currentOffset + 1] & 0xFF, charBuffer));
+                    currentOffset += 2;
+                    break;
+                case Constants.LDC_W:
+                case Constants.LDC2_W:
+                    methodVisitor.visitLdcInsn(readConst(readUnsignedShort(currentOffset + 1), charBuffer));
+                    currentOffset += 3;
+                    break;
+                case Constants.GETSTATIC:
+                case Constants.PUTSTATIC:
+                case Constants.GETFIELD:
+                case Constants.PUTFIELD:
+                case Constants.INVOKEVIRTUAL:
+                case Constants.INVOKESPECIAL:
+                case Constants.INVOKESTATIC:
+                case Constants.INVOKEINTERFACE: {
+                    int cpInfoOffset = cpInfoOffsets[readUnsignedShort(currentOffset + 1)];
+                    int nameAndTypeCpInfoOffset = cpInfoOffsets[readUnsignedShort(cpInfoOffset + 2)];
+                    String owner = readClass(cpInfoOffset, charBuffer);
+                    String name = readUTF8(nameAndTypeCpInfoOffset, charBuffer);
+                    String descriptor = readUTF8(nameAndTypeCpInfoOffset + 2, charBuffer);
+                    if (opcode < Opcodes.INVOKEVIRTUAL) {
+                        methodVisitor.visitFieldInsn(opcode, owner, name, descriptor);
+                    } else {
+                        boolean isInterface = classFileBuffer[cpInfoOffset - 1] == Symbol.CONSTANT_INTERFACE_METHODREF_TAG;
+                        methodVisitor.visitMethodInsn(opcode, owner, name, descriptor, isInterface);
+                    }
+                    if (opcode == Opcodes.INVOKEINTERFACE) {
+                        currentOffset += 5;
+                    } else {
+                        currentOffset += 3;
+                    }
+                    break;
+                }
+                case Constants.INVOKEDYNAMIC: {
+                    int cpInfoOffset = cpInfoOffsets[readUnsignedShort(currentOffset + 1)];
+                    int nameAndTypeCpInfoOffset = cpInfoOffsets[readUnsignedShort(cpInfoOffset + 2)];
+                    String name = readUTF8(nameAndTypeCpInfoOffset, charBuffer);
+                    String descriptor = readUTF8(nameAndTypeCpInfoOffset + 2, charBuffer);
+                    int bootstrapMethodOffset = bootstrapMethodOffsets[readUnsignedShort(cpInfoOffset)];
+                    Handle handle = (Handle) readConst(readUnsignedShort(bootstrapMethodOffset), charBuffer);
+                    Object[] bootstrapMethodArguments = new Object[readUnsignedShort(bootstrapMethodOffset + 2)];
+                    bootstrapMethodOffset += 4;
+                    for (int i = 0; i < bootstrapMethodArguments.length; i++) {
+                        bootstrapMethodArguments[i] = readConst(readUnsignedShort(bootstrapMethodOffset), charBuffer);
+                        bootstrapMethodOffset += 2;
+                    }
+                    methodVisitor.visitInvokeDynamicInsn(name, descriptor, handle, bootstrapMethodArguments);
+                    currentOffset += 5;
+                    break;
+                }
+                case Constants.NEW:
+                case Constants.ANEWARRAY:
+                case Constants.CHECKCAST:
+                case Constants.INSTANCEOF:
+                    methodVisitor.visitTypeInsn(opcode, readClass(currentOffset + 1, charBuffer));
+                    currentOffset += 3;
+                    break;
+                case Constants.IINC:
+                    methodVisitor.visitIincInsn(classFileBuffer[currentOffset + 1] & 0xFF, classFileBuffer[currentOffset + 2]);
+                    currentOffset += 3;
+                    break;
+                case Constants.MULTIANEWARRAY:
+                    methodVisitor.visitMultiANewArrayInsn(readClass(currentOffset + 1, charBuffer),
+                            classFileBuffer[currentOffset + 3] & 0xFF);
+                    currentOffset += 4;
+                    break;
+                default:
+                    throw new AssertionError();
+            }
+
+            // Visit the runtime visible instruction annotations, if any.
+            while (visibleTypeAnnotationOffsets != null && currentVisibleTypeAnnotationIndex < visibleTypeAnnotationOffsets.length
+                    && currentVisibleTypeAnnotationBytecodeOffset <= currentBytecodeOffset) {
+                if (currentVisibleTypeAnnotationBytecodeOffset == currentBytecodeOffset) {
+                    // Parse the target_type, target_info and target_path fields.
+                    int currentAnnotationOffset = readTypeAnnotationTarget(context,
+                            visibleTypeAnnotationOffsets[currentVisibleTypeAnnotationIndex]);
+                    // Parse the type_index field.
+                    String annotationDescriptor = readUTF8(currentAnnotationOffset, charBuffer);
+                    currentAnnotationOffset += 2;
+                    // Parse num_element_value_pairs and element_value_pairs and visit these values.
+                    readElementValues(methodVisitor.visitInsnAnnotation(context.currentTypeAnnotationTarget,
+                            context.currentTypeAnnotationTargetPath, annotationDescriptor, /* visible = */ true), currentAnnotationOffset,
+                            /* named = */ true, charBuffer);
+                }
+                currentVisibleTypeAnnotationBytecodeOffset = getTypeAnnotationBytecodeOffset(visibleTypeAnnotationOffsets,
+                        ++currentVisibleTypeAnnotationIndex);
+            }
+
+            // Visit the runtime invisible instruction annotations, if any.
+            while (invisibleTypeAnnotationOffsets != null && currentInvisibleTypeAnnotationIndex < invisibleTypeAnnotationOffsets.length
+                    && currentInvisibleTypeAnnotationBytecodeOffset <= currentBytecodeOffset) {
+                if (currentInvisibleTypeAnnotationBytecodeOffset == currentBytecodeOffset) {
+                    // Parse the target_type, target_info and target_path fields.
+                    int currentAnnotationOffset = readTypeAnnotationTarget(context,
+                            invisibleTypeAnnotationOffsets[currentInvisibleTypeAnnotationIndex]);
+                    // Parse the type_index field.
+                    String annotationDescriptor = readUTF8(currentAnnotationOffset, charBuffer);
+                    currentAnnotationOffset += 2;
+                    // Parse num_element_value_pairs and element_value_pairs and visit these values.
+                    readElementValues(methodVisitor.visitInsnAnnotation(context.currentTypeAnnotationTarget,
+                            context.currentTypeAnnotationTargetPath, annotationDescriptor, /* visible = */ false), currentAnnotationOffset,
+                            /* named = */ true, charBuffer);
+                }
+                currentInvisibleTypeAnnotationBytecodeOffset = getTypeAnnotationBytecodeOffset(invisibleTypeAnnotationOffsets,
+                        ++currentInvisibleTypeAnnotationIndex);
+            }
+        }
+        if (labels[codeLength] != null) {
+            methodVisitor.visitLabel(labels[codeLength]);
+        }
+
+        // Visit LocalVariableTable and LocalVariableTypeTable attributes.
+        if (localVariableTableOffset != 0 && (context.parsingOptions & SKIP_DEBUG) == 0) {
+            // The (start_pc, index, signature_index) fields of each entry of the LocalVariableTypeTable.
+            int[] typeTable = null;
+            if (localVariableTypeTableOffset != 0) {
+                typeTable = new int[readUnsignedShort(localVariableTypeTableOffset) * 3];
+                currentOffset = localVariableTypeTableOffset + 2;
+                int typeTableIndex = typeTable.length;
+                while (typeTableIndex > 0) {
+                    // Store the offset of 'signature_index', and the value of 'index' and 'start_pc'.
+                    typeTable[--typeTableIndex] = currentOffset + 6;
+                    typeTable[--typeTableIndex] = readUnsignedShort(currentOffset + 8);
+                    typeTable[--typeTableIndex] = readUnsignedShort(currentOffset);
+                    currentOffset += 10;
+                }
+            }
+            int localVariableTableLength = readUnsignedShort(localVariableTableOffset);
+            currentOffset = localVariableTableOffset + 2;
+            while (localVariableTableLength-- > 0) {
+                int startPc = readUnsignedShort(currentOffset);
+                int length = readUnsignedShort(currentOffset + 2);
+                String name = readUTF8(currentOffset + 4, charBuffer);
+                String descriptor = readUTF8(currentOffset + 6, charBuffer);
+                int index = readUnsignedShort(currentOffset + 8);
+                currentOffset += 10;
+                String signature = null;
+                if (typeTable != null) {
+                    for (int i = 0; i < typeTable.length; i += 3) {
+                        if (typeTable[i] == startPc && typeTable[i + 1] == index) {
+                            signature = readUTF8(typeTable[i + 2], charBuffer);
+                            break;
+                        }
+                    }
+                }
+                methodVisitor.visitLocalVariable(name, descriptor, signature, labels[startPc], labels[startPc + length], index);
+            }
+        }
+
+        // Visit the local variable type annotations of the RuntimeVisibleTypeAnnotations attribute.
+        if (visibleTypeAnnotationOffsets != null) {
+            for (int typeAnnotationOffset : visibleTypeAnnotationOffsets) {
+                int targetType = readByte(typeAnnotationOffset);
+                if (targetType == TypeReference.LOCAL_VARIABLE || targetType == TypeReference.RESOURCE_VARIABLE) {
+                    // Parse the target_type, target_info and target_path fields.
+                    currentOffset = readTypeAnnotationTarget(context, typeAnnotationOffset);
+                    // Parse the type_index field.
+                    String annotationDescriptor = readUTF8(currentOffset, charBuffer);
+                    currentOffset += 2;
+                    // Parse num_element_value_pairs and element_value_pairs and visit these values.
+                    readElementValues(methodVisitor.visitLocalVariableAnnotation(context.currentTypeAnnotationTarget,
+                            context.currentTypeAnnotationTargetPath, context.currentLocalVariableAnnotationRangeStarts,
+                            context.currentLocalVariableAnnotationRangeEnds, context.currentLocalVariableAnnotationRangeIndices,
+                            annotationDescriptor, /* visible = */ true), currentOffset, /* named = */ true, charBuffer);
+                }
+            }
+        }
+
+        // Visit the local variable type annotations of the RuntimeInvisibleTypeAnnotations attribute.
+        if (invisibleTypeAnnotationOffsets != null) {
+            for (int typeAnnotationOffset : invisibleTypeAnnotationOffsets) {
+                int targetType = readByte(typeAnnotationOffset);
+                if (targetType == TypeReference.LOCAL_VARIABLE || targetType == TypeReference.RESOURCE_VARIABLE) {
+                    // Parse the target_type, target_info and target_path fields.
+                    currentOffset = readTypeAnnotationTarget(context, typeAnnotationOffset);
+                    // Parse the type_index field.
+                    String annotationDescriptor = readUTF8(currentOffset, charBuffer);
+                    currentOffset += 2;
+                    // Parse num_element_value_pairs and element_value_pairs and visit these values.
+                    readElementValues(methodVisitor.visitLocalVariableAnnotation(context.currentTypeAnnotationTarget,
+                            context.currentTypeAnnotationTargetPath, context.currentLocalVariableAnnotationRangeStarts,
+                            context.currentLocalVariableAnnotationRangeEnds, context.currentLocalVariableAnnotationRangeIndices,
+                            annotationDescriptor, /* visible = */ false), currentOffset, /* named = */ true, charBuffer);
+                }
+            }
+        }
+
+        // Visit the non standard attributes.
+        while (attributes != null) {
+            // Copy and reset the nextAttribute field so that it can also be used in MethodWriter.
+            Attribute nextAttribute = attributes.nextAttribute;
+            attributes.nextAttribute = null;
+            methodVisitor.visitAttribute(attributes);
+            attributes = nextAttribute;
+        }
+
+        // Visit the max stack and max locals values.
+        methodVisitor.visitMaxs(maxStack, maxLocals);
+    }
+
+    /**
+     * Returns the label corresponding to the given bytecode offset. The default implementation of
+     * this method creates a label for the given offset if it has not been already created.
+     *
+     * @param bytecodeOffset a bytecode offset in a method.
+     * @param labels the already created labels, indexed by their offset. If a label already exists
+     *     for bytecodeOffset this method must not create a new one. Otherwise it must store the new
+     *     label in this array.
+     * @return a non null Label, which must be equal to labels[bytecodeOffset].
+     */
+    protected Label readLabel(final int bytecodeOffset, final Label[] labels) {
+        if (labels[bytecodeOffset] == null) {
+            labels[bytecodeOffset] = new Label();
+        }
+        return labels[bytecodeOffset];
+    }
+
+    /**
+     * Creates a label without the {@link Label#FLAG_DEBUG_ONLY} flag set, for the given bytecode
+     * offset. The label is created with a call to {@link #readLabel} and its {@link
+     * Label#FLAG_DEBUG_ONLY} flag is cleared.
+     *
+     * @param bytecodeOffset a bytecode offset in a method.
+     * @param labels the already created labels, indexed by their offset.
+     * @return a Label without the {@link Label#FLAG_DEBUG_ONLY} flag set.
+     */
+    private Label createLabel(final int bytecodeOffset, final Label[] labels) {
+        Label label = readLabel(bytecodeOffset, labels);
+        label.flags &= ~Label.FLAG_DEBUG_ONLY;
+        return label;
+    }
+
+    /**
+     * Creates a label with the {@link Label#FLAG_DEBUG_ONLY} flag set, if there is no already
+     * existing label for the given bytecode offset (otherwise does nothing). The label is created
+     * with a call to {@link #readLabel}.
+     *
+     * @param bytecodeOffset a bytecode offset in a method.
+     * @param labels the already created labels, indexed by their offset.
+     */
+    private void createDebugLabel(final int bytecodeOffset, final Label[] labels) {
+        if (labels[bytecodeOffset] == null) {
+            readLabel(bytecodeOffset, labels).flags |= Label.FLAG_DEBUG_ONLY;
+        }
+    }
+
+    // ----------------------------------------------------------------------------------------------
+    // Methods to parse annotations, type annotations and parameter annotations
+    // ----------------------------------------------------------------------------------------------
+
+    /**
+     * Parses a Runtime[In]VisibleTypeAnnotations attribute to find the offset of each type_annotation
+     * entry it contains, to find the corresponding labels, and to visit the try catch block
+     * annotations.
+     *
+     * @param methodVisitor the method visitor to be used to visit the try catch block annotations.
+     * @param context information about the class being parsed.
+     * @param runtimeTypeAnnotationsOffset the start offset of a Runtime[In]VisibleTypeAnnotations
+     *     attribute, excluding the attribute_info's attribute_name_index and attribute_length fields.
+     * @param visible true if the attribute to parse is a RuntimeVisibleTypeAnnotations attribute,
+     *     false it is a RuntimeInvisibleTypeAnnotations attribute.
+     * @return the start offset of each entry of the Runtime[In]VisibleTypeAnnotations_attribute's
+     *     'annotations' array field.
+     */
+    private int[] readTypeAnnotations(final MethodVisitor methodVisitor, final Context context, final int runtimeTypeAnnotationsOffset,
+            final boolean visible) {
+        char[] charBuffer = context.charBuffer;
+        int currentOffset = runtimeTypeAnnotationsOffset;
+        // Read the num_annotations field and create an array to store the type_annotation offsets.
+        int[] typeAnnotationsOffsets = new int[readUnsignedShort(currentOffset)];
+        currentOffset += 2;
+        // Parse the 'annotations' array field.
+        for (int i = 0; i < typeAnnotationsOffsets.length; ++i) {
+            typeAnnotationsOffsets[i] = currentOffset;
+            // Parse the type_annotation's target_type and the target_info fields. The size of the
+            // target_info field depends on the value of target_type.
+            int targetType = readInt(currentOffset);
+            switch (targetType >>> 24) {
+                case TypeReference.LOCAL_VARIABLE:
+                case TypeReference.RESOURCE_VARIABLE:
+                    // A localvar_target has a variable size, which depends on the value of their table_length
+                    // field. It also references bytecode offsets, for which we need labels.
+                    int tableLength = readUnsignedShort(currentOffset + 1);
+                    currentOffset += 3;
+                    while (tableLength-- > 0) {
+                        int startPc = readUnsignedShort(currentOffset);
+                        int length = readUnsignedShort(currentOffset + 2);
+                        // Skip the index field (2 bytes).
+                        currentOffset += 6;
+                        createLabel(startPc, context.currentMethodLabels);
+                        createLabel(startPc + length, context.currentMethodLabels);
+                    }
+                    break;
+                case TypeReference.CAST:
+                case TypeReference.CONSTRUCTOR_INVOCATION_TYPE_ARGUMENT:
+                case TypeReference.METHOD_INVOCATION_TYPE_ARGUMENT:
+                case TypeReference.CONSTRUCTOR_REFERENCE_TYPE_ARGUMENT:
+                case TypeReference.METHOD_REFERENCE_TYPE_ARGUMENT:
+                    currentOffset += 4;
+                    break;
+                case TypeReference.CLASS_EXTENDS:
+                case TypeReference.CLASS_TYPE_PARAMETER_BOUND:
+                case TypeReference.METHOD_TYPE_PARAMETER_BOUND:
+                case TypeReference.THROWS:
+                case TypeReference.EXCEPTION_PARAMETER:
+                case TypeReference.INSTANCEOF:
+                case TypeReference.NEW:
+                case TypeReference.CONSTRUCTOR_REFERENCE:
+                case TypeReference.METHOD_REFERENCE:
+                    currentOffset += 3;
+                    break;
+                case TypeReference.CLASS_TYPE_PARAMETER:
+                case TypeReference.METHOD_TYPE_PARAMETER:
+                case TypeReference.METHOD_FORMAL_PARAMETER:
+                case TypeReference.FIELD:
+                case TypeReference.METHOD_RETURN:
+                case TypeReference.METHOD_RECEIVER:
+                default:
+                    // TypeReference type which can't be used in Code attribute, or which is unknown.
+                    throw new IllegalArgumentException();
+            }
+            // Parse the rest of the type_annotation structure, starting with the target_path structure
+            // (whose size depends on its path_length field).
+            int pathLength = readByte(currentOffset);
+            if ((targetType >>> 24) == TypeReference.EXCEPTION_PARAMETER) {
+                // Parse the target_path structure and create a corresponding TypePath.
+                TypePath path = pathLength == 0 ? null : new TypePath(b, currentOffset);
+                currentOffset += 1 + 2 * pathLength;
+                // Parse the type_index field.
+                String annotationDescriptor = readUTF8(currentOffset, charBuffer);
+                currentOffset += 2;
+                // Parse num_element_value_pairs and element_value_pairs and visit these values.
+                currentOffset = readElementValues(
+                        methodVisitor.visitTryCatchAnnotation(targetType & 0xFFFFFF00, path, annotationDescriptor, visible), currentOffset,
+                        /* named = */ true, charBuffer);
+            } else {
+                // We don't want to visit the other target_type annotations, so we just skip them (which
+                // requires some parsing because the element_value_pairs array has a variable size). First,
+                // skip the target_path structure:
+                currentOffset += 3 + 2 * pathLength;
+                // Then skip the num_element_value_pairs and element_value_pairs fields (by reading them
+                // with a null AnnotationVisitor).
+                currentOffset = readElementValues(/* annotationVisitor = */ null, currentOffset, /* named = */ true, charBuffer);
+            }
+        }
+        return typeAnnotationsOffsets;
+    }
+
+    /**
+     * Returns the bytecode offset corresponding to the specified JVMS 'type_annotation' structure, or
+     * -1 if there is no such type_annotation of if it does not have a bytecode offset.
+     *
+     * @param typeAnnotationOffsets the offset of each 'type_annotation' entry in a
+     *     Runtime[In]VisibleTypeAnnotations attribute, or null.
+     * @param typeAnnotationIndex the index a 'type_annotation' entry in typeAnnotationOffsets.
+     * @return bytecode offset corresponding to the specified JVMS 'type_annotation' structure, or -1
+     *     if there is no such type_annotation of if it does not have a bytecode offset.
+     */
+    private int getTypeAnnotationBytecodeOffset(final int[] typeAnnotationOffsets, final int typeAnnotationIndex) {
+        if (typeAnnotationOffsets == null || typeAnnotationIndex >= typeAnnotationOffsets.length
+                || readByte(typeAnnotationOffsets[typeAnnotationIndex]) < TypeReference.INSTANCEOF) {
+            return -1;
+        }
+        return readUnsignedShort(typeAnnotationOffsets[typeAnnotationIndex] + 1);
+    }
+
+    /**
+     * Parses the header of a JVMS type_annotation structure to extract its target_type, target_info
+     * and target_path (the result is stored in the given context), and returns the start offset of
+     * the rest of the type_annotation structure.
+     *
+     * @param context information about the class being parsed. This is where the extracted
+     *     target_type and target_path must be stored.
+     * @param typeAnnotationOffset the start offset of a type_annotation structure.
+     * @return the start offset of the rest of the type_annotation structure.
+     */
+    private int readTypeAnnotationTarget(final Context context, final int typeAnnotationOffset) {
+        int currentOffset = typeAnnotationOffset;
+        // Parse and store the target_type structure.
+        int targetType = readInt(typeAnnotationOffset);
+        switch (targetType >>> 24) {
+            case TypeReference.CLASS_TYPE_PARAMETER:
+            case TypeReference.METHOD_TYPE_PARAMETER:
+            case TypeReference.METHOD_FORMAL_PARAMETER:
+                targetType &= 0xFFFF0000;
+                currentOffset += 2;
+                break;
+            case TypeReference.FIELD:
+            case TypeReference.METHOD_RETURN:
+            case TypeReference.METHOD_RECEIVER:
+                targetType &= 0xFF000000;
+                currentOffset += 1;
+                break;
+            case TypeReference.LOCAL_VARIABLE:
+            case TypeReference.RESOURCE_VARIABLE:
+                targetType &= 0xFF000000;
+                int tableLength = readUnsignedShort(currentOffset + 1);
+                currentOffset += 3;
+                context.currentLocalVariableAnnotationRangeStarts = new Label[tableLength];
+                context.currentLocalVariableAnnotationRangeEnds = new Label[tableLength];
+                context.currentLocalVariableAnnotationRangeIndices = new int[tableLength];
+                for (int i = 0; i < tableLength; ++i) {
+                    int startPc = readUnsignedShort(currentOffset);
+                    int length = readUnsignedShort(currentOffset + 2);
+                    int index = readUnsignedShort(currentOffset + 4);
+                    currentOffset += 6;
+                    context.currentLocalVariableAnnotationRangeStarts[i] = createLabel(startPc, context.currentMethodLabels);
+                    context.currentLocalVariableAnnotationRangeEnds[i] = createLabel(startPc + length, context.currentMethodLabels);
+                    context.currentLocalVariableAnnotationRangeIndices[i] = index;
+                }
+                break;
+            case TypeReference.CAST:
+            case TypeReference.CONSTRUCTOR_INVOCATION_TYPE_ARGUMENT:
+            case TypeReference.METHOD_INVOCATION_TYPE_ARGUMENT:
+            case TypeReference.CONSTRUCTOR_REFERENCE_TYPE_ARGUMENT:
+            case TypeReference.METHOD_REFERENCE_TYPE_ARGUMENT:
+                targetType &= 0xFF0000FF;
+                currentOffset += 4;
+                break;
+            case TypeReference.CLASS_EXTENDS:
+            case TypeReference.CLASS_TYPE_PARAMETER_BOUND:
+            case TypeReference.METHOD_TYPE_PARAMETER_BOUND:
+            case TypeReference.THROWS:
+            case TypeReference.EXCEPTION_PARAMETER:
+                targetType &= 0xFFFFFF00;
+                currentOffset += 3;
+                break;
+            case TypeReference.INSTANCEOF:
+            case TypeReference.NEW:
+            case TypeReference.CONSTRUCTOR_REFERENCE:
+            case TypeReference.METHOD_REFERENCE:
+                targetType &= 0xFF000000;
+                currentOffset += 3;
+                break;
+            default:
+                throw new IllegalArgumentException();
+        }
+        context.currentTypeAnnotationTarget = targetType;
+        // Parse and store the target_path structure.
+        int pathLength = readByte(currentOffset);
+        context.currentTypeAnnotationTargetPath = pathLength == 0 ? null : new TypePath(b, currentOffset);
+        // Return the start offset of the rest of the type_annotation structure.
+        return currentOffset + 1 + 2 * pathLength;
+    }
+
+    /**
+     * Reads a Runtime[In]VisibleParameterAnnotations attribute and makes the given visitor visit it.
+     *
+     * @param methodVisitor the visitor that must visit the parameter annotations.
+     * @param context information about the class being parsed.
+     * @param runtimeParameterAnnotationsOffset the start offset of a
+     *     Runtime[In]VisibleParameterAnnotations attribute, excluding the attribute_info's
+     *     attribute_name_index and attribute_length fields.
+     * @param visible true if the attribute to parse is a RuntimeVisibleParameterAnnotations
+     *     attribute, false it is a RuntimeInvisibleParameterAnnotations attribute.
+     */
+    private void readParameterAnnotations(final MethodVisitor methodVisitor, final Context context,
+            final int runtimeParameterAnnotationsOffset, final boolean visible) {
+        int currentOffset = runtimeParameterAnnotationsOffset;
+        int numParameters = b[currentOffset++] & 0xFF;
+        methodVisitor.visitAnnotableParameterCount(numParameters, visible);
+        char[] charBuffer = context.charBuffer;
+        for (int i = 0; i < numParameters; ++i) {
+            int numAnnotations = readUnsignedShort(currentOffset);
+            currentOffset += 2;
+            while (numAnnotations-- > 0) {
+                // Parse the type_index field.
+                String annotationDescriptor = readUTF8(currentOffset, charBuffer);
+                currentOffset += 2;
+                // Parse num_element_value_pairs and element_value_pairs and visit these values.
+                currentOffset = readElementValues(methodVisitor.visitParameterAnnotation(i, annotationDescriptor, visible), currentOffset,
+                        /* named = */ true, charBuffer);
+            }
+        }
+    }
+
+    /**
+     * Reads the element values of a JVMS 'annotation' structure and makes the given visitor visit
+     * them. This method can also be used to read the values of the JVMS 'array_value' field of an
+     * annotation's 'element_value'.
+     *
+     * @param annotationVisitor the visitor that must visit the values.
+     * @param annotationOffset the start offset of an 'annotation' structure (excluding its type_index
+     *     field) or of an 'array_value' structure.
+     * @param named if the annotation values are named or not. This should be true to parse the values
+     *     of a JVMS 'annotation' structure, and false to parse the JVMS 'array_value' of an
+     *     annotation's element_value.
+     * @param charBuffer the buffer used to read strings in the constant pool.
+     * @return the end offset of the JVMS 'annotation' or 'array_value' structure.
+     */
+    private int readElementValues(final AnnotationVisitor annotationVisitor, final int annotationOffset, final boolean named,
+            final char[] charBuffer) {
+        int currentOffset = annotationOffset;
+        // Read the num_element_value_pairs field (or num_values field for an array_value).
+        int numElementValuePairs = readUnsignedShort(currentOffset);
+        currentOffset += 2;
+        if (named) {
+            // Parse the element_value_pairs array.
+            while (numElementValuePairs-- > 0) {
+                String elementName = readUTF8(currentOffset, charBuffer);
+                currentOffset = readElementValue(annotationVisitor, currentOffset + 2, elementName, charBuffer);
+            }
+        } else {
+            // Parse the array_value array.
+            while (numElementValuePairs-- > 0) {
+                currentOffset = readElementValue(annotationVisitor, currentOffset, /* named = */ null, charBuffer);
+            }
+        }
+        if (annotationVisitor != null) {
+            annotationVisitor.visitEnd();
+        }
+        return currentOffset;
+    }
+
+    /**
+     * Reads a JVMS 'element_value' structure and makes the given visitor visit it.
+     *
+     * @param annotationVisitor the visitor that must visit the element_value structure.
+     * @param elementValueOffset the start offset in {@link #b} of the element_value structure to be
+     *     read.
+     * @param elementName the name of the element_value structure to be read, or {@literal null}.
+     * @param charBuffer the buffer used to read strings in the constant pool.
+     * @return the end offset of the JVMS 'element_value' structure.
+     */
+    private int readElementValue(final AnnotationVisitor annotationVisitor, final int elementValueOffset, final String elementName,
+            final char[] charBuffer) {
+        int currentOffset = elementValueOffset;
+        if (annotationVisitor == null) {
+            switch (b[currentOffset] & 0xFF) {
+                case 'e': // enum_const_value
+                    return currentOffset + 5;
+                case '@': // annotation_value
+                    return readElementValues(null, currentOffset + 3, /* named = */ true, charBuffer);
+                case '[': // array_value
+                    return readElementValues(null, currentOffset + 1, /* named = */ false, charBuffer);
+                default:
+                    return currentOffset + 3;
+            }
+        }
+        switch (b[currentOffset++] & 0xFF) {
+            case 'B': // const_value_index, CONSTANT_Integer
+                annotationVisitor.visit(elementName, (byte) readInt(cpInfoOffsets[readUnsignedShort(currentOffset)]));
+                currentOffset += 2;
+                break;
+            case 'C': // const_value_index, CONSTANT_Integer
+                annotationVisitor.visit(elementName, (char) readInt(cpInfoOffsets[readUnsignedShort(currentOffset)]));
+                currentOffset += 2;
+                break;
+            case 'D': // const_value_index, CONSTANT_Double
+            case 'F': // const_value_index, CONSTANT_Float
+            case 'I': // const_value_index, CONSTANT_Integer
+            case 'J': // const_value_index, CONSTANT_Long
+                annotationVisitor.visit(elementName, readConst(readUnsignedShort(currentOffset), charBuffer));
+                currentOffset += 2;
+                break;
+            case 'S': // const_value_index, CONSTANT_Integer
+                annotationVisitor.visit(elementName, (short) readInt(cpInfoOffsets[readUnsignedShort(currentOffset)]));
+                currentOffset += 2;
+                break;
+
+            case 'Z': // const_value_index, CONSTANT_Integer
+                annotationVisitor.visit(elementName,
+                        readInt(cpInfoOffsets[readUnsignedShort(currentOffset)]) == 0 ? Boolean.FALSE : Boolean.TRUE);
+                currentOffset += 2;
+                break;
+            case 's': // const_value_index, CONSTANT_Utf8
+                annotationVisitor.visit(elementName, readUTF8(currentOffset, charBuffer));
+                currentOffset += 2;
+                break;
+            case 'e': // enum_const_value
+                annotationVisitor.visitEnum(elementName, readUTF8(currentOffset, charBuffer), readUTF8(currentOffset + 2, charBuffer));
+                currentOffset += 4;
+                break;
+            case 'c': // class_info
+                annotationVisitor.visit(elementName, Type.getType(readUTF8(currentOffset, charBuffer)));
+                currentOffset += 2;
+                break;
+            case '@': // annotation_value
+                currentOffset = readElementValues(annotationVisitor.visitAnnotation(elementName, readUTF8(currentOffset, charBuffer)),
+                        currentOffset + 2, true, charBuffer);
+                break;
+            case '[': // array_value
+                int numValues = readUnsignedShort(currentOffset);
+                currentOffset += 2;
+                if (numValues == 0) {
+                    return readElementValues(annotationVisitor.visitArray(elementName), currentOffset - 2, /* named = */ false, charBuffer);
+                }
+                switch (b[currentOffset] & 0xFF) {
+                    case 'B':
+                        byte[] byteValues = new byte[numValues];
+                        for (int i = 0; i < numValues; i++) {
+                            byteValues[i] = (byte) readInt(cpInfoOffsets[readUnsignedShort(currentOffset + 1)]);
+                            currentOffset += 3;
+                        }
+                        annotationVisitor.visit(elementName, byteValues);
+                        break;
+                    case 'Z':
+                        boolean[] booleanValues = new boolean[numValues];
+                        for (int i = 0; i < numValues; i++) {
+                            booleanValues[i] = readInt(cpInfoOffsets[readUnsignedShort(currentOffset + 1)]) != 0;
+                            currentOffset += 3;
+                        }
+                        annotationVisitor.visit(elementName, booleanValues);
+                        break;
+                    case 'S':
+                        short[] shortValues = new short[numValues];
+                        for (int i = 0; i < numValues; i++) {
+                            shortValues[i] = (short) readInt(cpInfoOffsets[readUnsignedShort(currentOffset + 1)]);
+                            currentOffset += 3;
+                        }
+                        annotationVisitor.visit(elementName, shortValues);
+                        break;
+                    case 'C':
+                        char[] charValues = new char[numValues];
+                        for (int i = 0; i < numValues; i++) {
+                            charValues[i] = (char) readInt(cpInfoOffsets[readUnsignedShort(currentOffset + 1)]);
+                            currentOffset += 3;
+                        }
+                        annotationVisitor.visit(elementName, charValues);
+                        break;
+                    case 'I':
+                        int[] intValues = new int[numValues];
+                        for (int i = 0; i < numValues; i++) {
+                            intValues[i] = readInt(cpInfoOffsets[readUnsignedShort(currentOffset + 1)]);
+                            currentOffset += 3;
+                        }
+                        annotationVisitor.visit(elementName, intValues);
+                        break;
+                    case 'J':
+                        long[] longValues = new long[numValues];
+                        for (int i = 0; i < numValues; i++) {
+                            longValues[i] = readLong(cpInfoOffsets[readUnsignedShort(currentOffset + 1)]);
+                            currentOffset += 3;
+                        }
+                        annotationVisitor.visit(elementName, longValues);
+                        break;
+                    case 'F':
+                        float[] floatValues = new float[numValues];
+                        for (int i = 0; i < numValues; i++) {
+                            floatValues[i] = Float.intBitsToFloat(readInt(cpInfoOffsets[readUnsignedShort(currentOffset + 1)]));
+                            currentOffset += 3;
+                        }
+                        annotationVisitor.visit(elementName, floatValues);
+                        break;
+                    case 'D':
+                        double[] doubleValues = new double[numValues];
+                        for (int i = 0; i < numValues; i++) {
+                            doubleValues[i] = Double.longBitsToDouble(readLong(cpInfoOffsets[readUnsignedShort(currentOffset + 1)]));
+                            currentOffset += 3;
+                        }
+                        annotationVisitor.visit(elementName, doubleValues);
+                        break;
+                    default:
+                        currentOffset = readElementValues(annotationVisitor.visitArray(elementName), currentOffset - 2, /* named = */ false,
+                                charBuffer);
+                        break;
+                }
+                break;
+            default:
+                throw new IllegalArgumentException();
+        }
+        return currentOffset;
+    }
+
+    // ----------------------------------------------------------------------------------------------
+    // Methods to parse stack map frames
+    // ----------------------------------------------------------------------------------------------
+
+    /**
+     * Computes the implicit frame of the method currently being parsed (as defined in the given
+     * {@link Context}) and stores it in the given context.
+     *
+     * @param context information about the class being parsed.
+     */
+    private void computeImplicitFrame(final Context context) {
+        String methodDescriptor = context.currentMethodDescriptor;
+        Object[] locals = context.currentFrameLocalTypes;
+        int numLocal = 0;
+        if ((context.currentMethodAccessFlags & Opcodes.ACC_STATIC) == 0) {
+            if ("<init>".equals(context.currentMethodName)) {
+                locals[numLocal++] = Opcodes.UNINITIALIZED_THIS;
+            } else {
+                locals[numLocal++] = readClass(header + 2, context.charBuffer);
+            }
+        }
+        // Parse the method descriptor, one argument type descriptor at each iteration. Start by
+        // skipping the first method descriptor character, which is always '('.
+        int currentMethodDescritorOffset = 1;
+        while (true) {
+            int currentArgumentDescriptorStartOffset = currentMethodDescritorOffset;
+            switch (methodDescriptor.charAt(currentMethodDescritorOffset++)) {
+                case 'Z':
+                case 'C':
+                case 'B':
+                case 'S':
+                case 'I':
+                    locals[numLocal++] = Opcodes.INTEGER;
+                    break;
+                case 'F':
+                    locals[numLocal++] = Opcodes.FLOAT;
+                    break;
+                case 'J':
+                    locals[numLocal++] = Opcodes.LONG;
+                    break;
+                case 'D':
+                    locals[numLocal++] = Opcodes.DOUBLE;
+                    break;
+                case '[':
+                    while (methodDescriptor.charAt(currentMethodDescritorOffset) == '[') {
+                        ++currentMethodDescritorOffset;
+                    }
+                    if (methodDescriptor.charAt(currentMethodDescritorOffset) == 'L') {
+                        ++currentMethodDescritorOffset;
+                        while (methodDescriptor.charAt(currentMethodDescritorOffset) != ';') {
+                            ++currentMethodDescritorOffset;
+                        }
+                    }
+                    locals[numLocal++] = methodDescriptor.substring(currentArgumentDescriptorStartOffset, ++currentMethodDescritorOffset);
+                    break;
+                case 'L':
+                    while (methodDescriptor.charAt(currentMethodDescritorOffset) != ';') {
+                        ++currentMethodDescritorOffset;
+                    }
+                    locals[numLocal++] = methodDescriptor.substring(currentArgumentDescriptorStartOffset + 1,
+                            currentMethodDescritorOffset++);
+                    break;
+                default:
+                    context.currentFrameLocalCount = numLocal;
+                    return;
+            }
+        }
+    }
+
+    /**
+     * Reads a JVMS 'stack_map_frame' structure and stores the result in the given {@link Context}
+     * object. This method can also be used to read a full_frame structure, excluding its frame_type
+     * field (this is used to parse the legacy StackMap attributes).
+     *
+     * @param stackMapFrameOffset the start offset in {@link #b} of the stack_map_frame_value
+     *     structure to be read, or the start offset of a full_frame structure (excluding its
+     *     frame_type field).
+     * @param compressed true to read a 'stack_map_frame' structure, false to read a 'full_frame'
+     *     structure without its frame_type field.
+     * @param expand if the stack map frame must be expanded. See {@link #EXPAND_FRAMES}.
+     * @param context where the parsed stack map frame must be stored.
+     * @return the end offset of the JVMS 'stack_map_frame' or 'full_frame' structure.
+     */
+    private int readStackMapFrame(final int stackMapFrameOffset, final boolean compressed, final boolean expand, final Context context) {
+        int currentOffset = stackMapFrameOffset;
+        final char[] charBuffer = context.charBuffer;
+        final Label[] labels = context.currentMethodLabels;
+        int frameType;
+        if (compressed) {
+            // Read the frame_type field.
+            frameType = b[currentOffset++] & 0xFF;
+        } else {
+            frameType = Frame.FULL_FRAME;
+            context.currentFrameOffset = -1;
+        }
+        int offsetDelta;
+        context.currentFrameLocalCountDelta = 0;
+        if (frameType < Frame.SAME_LOCALS_1_STACK_ITEM_FRAME) {
+            offsetDelta = frameType;
+            context.currentFrameType = Opcodes.F_SAME;
+            context.currentFrameStackCount = 0;
+        } else if (frameType < Frame.RESERVED) {
+            offsetDelta = frameType - Frame.SAME_LOCALS_1_STACK_ITEM_FRAME;
+            currentOffset = readVerificationTypeInfo(currentOffset, context.currentFrameStackTypes, 0, charBuffer, labels);
+            context.currentFrameType = Opcodes.F_SAME1;
+            context.currentFrameStackCount = 1;
+        } else if (frameType >= Frame.SAME_LOCALS_1_STACK_ITEM_FRAME_EXTENDED) {
+            offsetDelta = readUnsignedShort(currentOffset);
+            currentOffset += 2;
+            if (frameType == Frame.SAME_LOCALS_1_STACK_ITEM_FRAME_EXTENDED) {
+                currentOffset = readVerificationTypeInfo(currentOffset, context.currentFrameStackTypes, 0, charBuffer, labels);
+                context.currentFrameType = Opcodes.F_SAME1;
+                context.currentFrameStackCount = 1;
+            } else if (frameType >= Frame.CHOP_FRAME && frameType < Frame.SAME_FRAME_EXTENDED) {
+                context.currentFrameType = Opcodes.F_CHOP;
+                context.currentFrameLocalCountDelta = Frame.SAME_FRAME_EXTENDED - frameType;
+                context.currentFrameLocalCount -= context.currentFrameLocalCountDelta;
+                context.currentFrameStackCount = 0;
+            } else if (frameType == Frame.SAME_FRAME_EXTENDED) {
+                context.currentFrameType = Opcodes.F_SAME;
+                context.currentFrameStackCount = 0;
+            } else if (frameType < Frame.FULL_FRAME) {
+                int local = expand ? context.currentFrameLocalCount : 0;
+                for (int k = frameType - Frame.SAME_FRAME_EXTENDED; k > 0; k--) {
+                    currentOffset = readVerificationTypeInfo(currentOffset, context.currentFrameLocalTypes, local++, charBuffer, labels);
+                }
+                context.currentFrameType = Opcodes.F_APPEND;
+                context.currentFrameLocalCountDelta = frameType - Frame.SAME_FRAME_EXTENDED;
+                context.currentFrameLocalCount += context.currentFrameLocalCountDelta;
+                context.currentFrameStackCount = 0;
+            } else {
+                final int numberOfLocals = readUnsignedShort(currentOffset);
+                currentOffset += 2;
+                context.currentFrameType = Opcodes.F_FULL;
+                context.currentFrameLocalCountDelta = numberOfLocals;
+                context.currentFrameLocalCount = numberOfLocals;
+                for (int local = 0; local < numberOfLocals; ++local) {
+                    currentOffset = readVerificationTypeInfo(currentOffset, context.currentFrameLocalTypes, local, charBuffer, labels);
+                }
+                final int numberOfStackItems = readUnsignedShort(currentOffset);
+                currentOffset += 2;
+                context.currentFrameStackCount = numberOfStackItems;
+                for (int stack = 0; stack < numberOfStackItems; ++stack) {
+                    currentOffset = readVerificationTypeInfo(currentOffset, context.currentFrameStackTypes, stack, charBuffer, labels);
+                }
+            }
+        } else {
+            throw new IllegalArgumentException();
+        }
+        context.currentFrameOffset += offsetDelta + 1;
+        createLabel(context.currentFrameOffset, labels);
+        return currentOffset;
+    }
+
+    /**
+     * Reads a JVMS 'verification_type_info' structure and stores it at the given index in the given
+     * array.
+     *
+     * @param verificationTypeInfoOffset the start offset of the 'verification_type_info' structure to
+     *     read.
+     * @param frame the array where the parsed type must be stored.
+     * @param index the index in 'frame' where the parsed type must be stored.
+     * @param charBuffer the buffer used to read strings in the constant pool.
+     * @param labels the labels of the method currently being parsed, indexed by their offset. If the
+     *     parsed type is an ITEM_Uninitialized, a new label for the corresponding NEW instruction is
+     *     stored in this array if it does not already exist.
+     * @return the end offset of the JVMS 'verification_type_info' structure.
+     */
+    private int readVerificationTypeInfo(final int verificationTypeInfoOffset, final Object[] frame, final int index,
+            final char[] charBuffer, final Label[] labels) {
+        int currentOffset = verificationTypeInfoOffset;
+        int tag = b[currentOffset++] & 0xFF;
+        switch (tag) {
+            case Frame.ITEM_TOP:
+                frame[index] = Opcodes.TOP;
+                break;
+            case Frame.ITEM_INTEGER:
+                frame[index] = Opcodes.INTEGER;
+                break;
+            case Frame.ITEM_FLOAT:
+                frame[index] = Opcodes.FLOAT;
+                break;
+            case Frame.ITEM_DOUBLE:
+                frame[index] = Opcodes.DOUBLE;
+                break;
+            case Frame.ITEM_LONG:
+                frame[index] = Opcodes.LONG;
+                break;
+            case Frame.ITEM_NULL:
+                frame[index] = Opcodes.NULL;
+                break;
+            case Frame.ITEM_UNINITIALIZED_THIS:
+                frame[index] = Opcodes.UNINITIALIZED_THIS;
+                break;
+            case Frame.ITEM_OBJECT:
+                frame[index] = readClass(currentOffset, charBuffer);
+                currentOffset += 2;
+                break;
+            case Frame.ITEM_UNINITIALIZED:
+                frame[index] = createLabel(readUnsignedShort(currentOffset), labels);
+                currentOffset += 2;
+                break;
+            default:
+                throw new IllegalArgumentException();
+        }
+        return currentOffset;
+    }
+
+    // ----------------------------------------------------------------------------------------------
+    // Methods to parse attributes
+    // ----------------------------------------------------------------------------------------------
+
+    /**
+     * Returns the offset in {@link #b} of the first ClassFile's 'attributes' array field entry.
+     *
+     * @return the offset in {@link #b} of the first ClassFile's 'attributes' array field entry.
+     */
+    final int getFirstAttributeOffset() {
+        // Skip the access_flags, this_class, super_class, and interfaces_count fields (using 2 bytes
+        // each), as well as the interfaces array field (2 bytes per interface).
+        int currentOffset = header + 8 + readUnsignedShort(header + 6) * 2;
+
+        // Read the fields_count field.
+        int fieldsCount = readUnsignedShort(currentOffset);
+        currentOffset += 2;
+        // Skip the 'fields' array field.
+        while (fieldsCount-- > 0) {
+            // Invariant: currentOffset is the offset of a field_info structure.
+            // Skip the access_flags, name_index and descriptor_index fields (2 bytes each), and read the
+            // attributes_count field.
+            int attributesCount = readUnsignedShort(currentOffset + 6);
+            currentOffset += 8;
+            // Skip the 'attributes' array field.
+            while (attributesCount-- > 0) {
+                // Invariant: currentOffset is the offset of an attribute_info structure.
+                // Read the attribute_length field (2 bytes after the start of the attribute_info) and skip
+                // this many bytes, plus 6 for the attribute_name_index and attribute_length fields
+                // (yielding the total size of the attribute_info structure).
+                currentOffset += 6 + readInt(currentOffset + 2);
+            }
+        }
+
+        // Skip the methods_count and 'methods' fields, using the same method as above.
+        int methodsCount = readUnsignedShort(currentOffset);
+        currentOffset += 2;
+        while (methodsCount-- > 0) {
+            int attributesCount = readUnsignedShort(currentOffset + 6);
+            currentOffset += 8;
+            while (attributesCount-- > 0) {
+                currentOffset += 6 + readInt(currentOffset + 2);
+            }
+        }
+
+        // Skip the ClassFile's attributes_count field.
+        return currentOffset + 2;
+    }
+
+    /**
+     * Reads the BootstrapMethods attribute to compute the offset of each bootstrap method.
+     *
+     * @param maxStringLength a conservative estimate of the maximum length of the strings contained
+     *     in the constant pool of the class.
+     * @return the offsets of the bootstrap methods or null.
+     */
+    private int[] readBootstrapMethodsAttribute(final int maxStringLength) {
+        char[] charBuffer = new char[maxStringLength];
+        int currentAttributeOffset = getFirstAttributeOffset();
+        int[] currentBootstrapMethodOffsets = null;
+        for (int i = readUnsignedShort(currentAttributeOffset - 2); i > 0; --i) {
+            // Read the attribute_info's attribute_name and attribute_length fields.
+            String attributeName = readUTF8(currentAttributeOffset, charBuffer);
+            int attributeLength = readInt(currentAttributeOffset + 2);
+            currentAttributeOffset += 6;
+            if (Constants.BOOTSTRAP_METHODS.equals(attributeName)) {
+                // Read the num_bootstrap_methods field and create an array of this size.
+                currentBootstrapMethodOffsets = new int[readUnsignedShort(currentAttributeOffset)];
+                // Compute and store the offset of each 'bootstrap_methods' array field entry.
+                int currentBootstrapMethodOffset = currentAttributeOffset + 2;
+                for (int j = 0; j < currentBootstrapMethodOffsets.length; ++j) {
+                    currentBootstrapMethodOffsets[j] = currentBootstrapMethodOffset;
+                    // Skip the bootstrap_method_ref and num_bootstrap_arguments fields (2 bytes each),
+                    // as well as the bootstrap_arguments array field (of size num_bootstrap_arguments * 2).
+                    currentBootstrapMethodOffset += 4 + readUnsignedShort(currentBootstrapMethodOffset + 2) * 2;
+                }
+                return currentBootstrapMethodOffsets;
+            }
+            currentAttributeOffset += attributeLength;
+        }
+        return null;
+    }
+
+    /**
+     * Reads a non standard JVMS 'attribute' structure in {@link #b}.
+     *
+     * @param attributePrototypes prototypes of the attributes that must be parsed during the visit of
+     *     the class. Any attribute whose type is not equal to the type of one the prototypes will not
+     *     be parsed: its byte array value will be passed unchanged to the ClassWriter.
+     * @param type the type of the attribute.
+     * @param offset the start offset of the JVMS 'attribute' structure in {@link #b}. The 6 attribute
+     *     header bytes (attribute_name_index and attribute_length) are not taken into account here.
+     * @param length the length of the attribute's content (excluding the 6 attribute header bytes).
+     * @param charBuffer the buffer to be used to read strings in the constant pool.
+     * @param codeAttributeOffset the start offset of the enclosing Code attribute in {@link #b}, or
+     *     -1 if the attribute to be read is not a code attribute. The 6 attribute header bytes
+     *     (attribute_name_index and attribute_length) are not taken into account here.
+     * @param labels the labels of the method's code, or {@literal null} if the attribute to be read
+     *     is not a code attribute.
+     * @return the attribute that has been read.
+     */
+    private Attribute readAttribute(final Attribute[] attributePrototypes, final String type, final int offset, final int length,
+            final char[] charBuffer, final int codeAttributeOffset, final Label[] labels) {
+        for (Attribute attributePrototype : attributePrototypes) {
+            if (attributePrototype.type.equals(type)) {
+                return attributePrototype.read(this, offset, length, charBuffer, codeAttributeOffset, labels);
+            }
+        }
+        return new Attribute(type).read(this, offset, length, null, -1, null);
+    }
+
+    // -----------------------------------------------------------------------------------------------
+    // Utility methods: low level parsing
+    // -----------------------------------------------------------------------------------------------
+
+    /**
+     * Returns the number of entries in the class's constant pool table.
+     *
+     * @return the number of entries in the class's constant pool table.
+     */
+    public int getItemCount() {
+        return cpInfoOffsets.length;
+    }
+
+    /**
+     * Returns the start offset in {@link #b} of a JVMS 'cp_info' structure (i.e. a constant pool
+     * entry), plus one. <i>This method is intended for {@link Attribute} sub classes, and is normally
+     * not needed by class generators or adapters.</i>
+     *
+     * @param constantPoolEntryIndex the index a constant pool entry in the class's constant pool
+     *     table.
+     * @return the start offset in {@link #b} of the corresponding JVMS 'cp_info' structure, plus one.
+     */
+    public int getItem(final int constantPoolEntryIndex) {
+        return cpInfoOffsets[constantPoolEntryIndex];
+    }
+
+    /**
+     * Returns a conservative estimate of the maximum length of the strings contained in the class's
+     * constant pool table.
+     *
+     * @return a conservative estimate of the maximum length of the strings contained in the class's
+     *     constant pool table.
+     */
+    public int getMaxStringLength() {
+        return maxStringLength;
+    }
+
+    /**
+     * Reads a byte value in {@link #b}. <i>This method is intended for {@link Attribute} sub classes,
+     * and is normally not needed by class generators or adapters.</i>
+     *
+     * @param offset the start offset of the value to be read in {@link #b}.
+     * @return the read value.
+     */
+    public int readByte(final int offset) {
+        return b[offset] & 0xFF;
+    }
+
+    /**
+     * Reads an unsigned short value in {@link #b}. <i>This method is intended for {@link Attribute}
+     * sub classes, and is normally not needed by class generators or adapters.</i>
+     *
+     * @param offset the start index of the value to be read in {@link #b}.
+     * @return the read value.
+     */
+    public int readUnsignedShort(final int offset) {
+        byte[] classFileBuffer = b;
+        return ((classFileBuffer[offset] & 0xFF) << 8) | (classFileBuffer[offset + 1] & 0xFF);
+    }
+
+    /**
+     * Reads a signed short value in {@link #b}. <i>This method is intended for {@link Attribute} sub
+     * classes, and is normally not needed by class generators or adapters.</i>
+     *
+     * @param offset the start offset of the value to be read in {@link #b}.
+     * @return the read value.
+     */
+    public short readShort(final int offset) {
+        byte[] classFileBuffer = b;
+        return (short) (((classFileBuffer[offset] & 0xFF) << 8) | (classFileBuffer[offset + 1] & 0xFF));
+    }
+
+    /**
+     * Reads a signed int value in {@link #b}. <i>This method is intended for {@link Attribute} sub
+     * classes, and is normally not needed by class generators or adapters.</i>
+     *
+     * @param offset the start offset of the value to be read in {@link #b}.
+     * @return the read value.
+     */
+    public int readInt(final int offset) {
+        byte[] classFileBuffer = b;
+        return ((classFileBuffer[offset] & 0xFF) << 24) | ((classFileBuffer[offset + 1] & 0xFF) << 16)
+                | ((classFileBuffer[offset + 2] & 0xFF) << 8) | (classFileBuffer[offset + 3] & 0xFF);
+    }
+
+    /**
+     * Reads a signed long value in {@link #b}. <i>This method is intended for {@link Attribute} sub
+     * classes, and is normally not needed by class generators or adapters.</i>
+     *
+     * @param offset the start offset of the value to be read in {@link #b}.
+     * @return the read value.
+     */
+    public long readLong(final int offset) {
+        long l1 = readInt(offset);
+        long l0 = readInt(offset + 4) & 0xFFFFFFFFL;
+        return (l1 << 32) | l0;
+    }
+
+    /**
+     * Reads a CONSTANT_Utf8 constant pool entry in {@link #b}. <i>This method is intended for {@link
+     * Attribute} sub classes, and is normally not needed by class generators or adapters.</i>
+     *
+     * @param offset the start offset of an unsigned short value in {@link #b}, whose value is the
+     *     index of a CONSTANT_Utf8 entry in the class's constant pool table.
+     * @param charBuffer the buffer to be used to read the string. This buffer must be sufficiently
+     *     large. It is not automatically resized.
+     * @return the String corresponding to the specified CONSTANT_Utf8 entry.
+     */
+    // DontCheck(AbbreviationAsWordInName): can't be renamed (for backward binary compatibility).
+    public String readUTF8(final int offset, final char[] charBuffer) {
+        int constantPoolEntryIndex = readUnsignedShort(offset);
+        if (offset == 0 || constantPoolEntryIndex == 0) {
+            return null;
+        }
+        return readUtf(constantPoolEntryIndex, charBuffer);
+    }
+
+    /**
+     * Reads a CONSTANT_Utf8 constant pool entry in {@link #b}.
+     *
+     * @param constantPoolEntryIndex the index of a CONSTANT_Utf8 entry in the class's constant pool
+     *     table.
+     * @param charBuffer the buffer to be used to read the string. This buffer must be sufficiently
+     *     large. It is not automatically resized.
+     * @return the String corresponding to the specified CONSTANT_Utf8 entry.
+     */
+    final String readUtf(final int constantPoolEntryIndex, final char[] charBuffer) {
+        String value = constantUtf8Values[constantPoolEntryIndex];
+        if (value != null) {
+            return value;
+        }
+        int cpInfoOffset = cpInfoOffsets[constantPoolEntryIndex];
+        return constantUtf8Values[constantPoolEntryIndex] = readUtf(cpInfoOffset + 2, readUnsignedShort(cpInfoOffset), charBuffer);
+    }
+
+    /**
+     * Reads an UTF8 string in {@link #b}.
+     *
+     * @param utfOffset the start offset of the UTF8 string to be read.
+     * @param utfLength the length of the UTF8 string to be read.
+     * @param charBuffer the buffer to be used to read the string. This buffer must be sufficiently
+     *     large. It is not automatically resized.
+     * @return the String corresponding to the specified UTF8 string.
+     */
+    private String readUtf(final int utfOffset, final int utfLength, final char[] charBuffer) {
+        int currentOffset = utfOffset;
+        int endOffset = currentOffset + utfLength;
+        int strLength = 0;
+        byte[] classFileBuffer = b;
+        while (currentOffset < endOffset) {
+            int currentByte = classFileBuffer[currentOffset++];
+            if ((currentByte & 0x80) == 0) {
+                charBuffer[strLength++] = (char) (currentByte & 0x7F);
+            } else if ((currentByte & 0xE0) == 0xC0) {
+                charBuffer[strLength++] = (char) (((currentByte & 0x1F) << 6) + (classFileBuffer[currentOffset++] & 0x3F));
+            } else {
+                charBuffer[strLength++] = (char) (((currentByte & 0xF) << 12) + ((classFileBuffer[currentOffset++] & 0x3F) << 6)
+                        + (classFileBuffer[currentOffset++] & 0x3F));
+            }
+        }
+        return new String(charBuffer, 0, strLength);
+    }
+
+    /**
+     * Reads a CONSTANT_Class, CONSTANT_String, CONSTANT_MethodType, CONSTANT_Module or
+     * CONSTANT_Package constant pool entry in {@link #b}. <i>This method is intended for {@link
+     * Attribute} sub classes, and is normally not needed by class generators or adapters.</i>
+     *
+     * @param offset the start offset of an unsigned short value in {@link #b}, whose value is the
+     *     index of a CONSTANT_Class, CONSTANT_String, CONSTANT_MethodType, CONSTANT_Module or
+     *     CONSTANT_Package entry in class's constant pool table.
+     * @param charBuffer the buffer to be used to read the item. This buffer must be sufficiently
+     *     large. It is not automatically resized.
+     * @return the String corresponding to the specified constant pool entry.
+     */
+    private String readStringish(final int offset, final char[] charBuffer) {
+        // Get the start offset of the cp_info structure (plus one), and read the CONSTANT_Utf8 entry
+        // designated by the first two bytes of this cp_info.
+        return readUTF8(cpInfoOffsets[readUnsignedShort(offset)], charBuffer);
+    }
+
+    /**
+     * Reads a CONSTANT_Class constant pool entry in {@link #b}. <i>This method is intended for {@link
+     * Attribute} sub classes, and is normally not needed by class generators or adapters.</i>
+     *
+     * @param offset the start offset of an unsigned short value in {@link #b}, whose value is the
+     *     index of a CONSTANT_Class entry in class's constant pool table.
+     * @param charBuffer the buffer to be used to read the item. This buffer must be sufficiently
+     *     large. It is not automatically resized.
+     * @return the String corresponding to the specified CONSTANT_Class entry.
+     */
+    public String readClass(final int offset, final char[] charBuffer) {
+        return readStringish(offset, charBuffer);
+    }
+
+    /**
+     * Reads a CONSTANT_Module constant pool entry in {@link #b}. <i>This method is intended for
+     * {@link Attribute} sub classes, and is normally not needed by class generators or adapters.</i>
+     *
+     * @param offset the start offset of an unsigned short value in {@link #b}, whose value is the
+     *     index of a CONSTANT_Module entry in class's constant pool table.
+     * @param charBuffer the buffer to be used to read the item. This buffer must be sufficiently
+     *     large. It is not automatically resized.
+     * @return the String corresponding to the specified CONSTANT_Module entry.
+     */
+    public String readModule(final int offset, final char[] charBuffer) {
+        return readStringish(offset, charBuffer);
+    }
+
+    /**
+     * Reads a CONSTANT_Package constant pool entry in {@link #b}. <i>This method is intended for
+     * {@link Attribute} sub classes, and is normally not needed by class generators or adapters.</i>
+     *
+     * @param offset the start offset of an unsigned short value in {@link #b}, whose value is the
+     *     index of a CONSTANT_Package entry in class's constant pool table.
+     * @param charBuffer the buffer to be used to read the item. This buffer must be sufficiently
+     *     large. It is not automatically resized.
+     * @return the String corresponding to the specified CONSTANT_Package entry.
+     */
+    public String readPackage(final int offset, final char[] charBuffer) {
+        return readStringish(offset, charBuffer);
+    }
+
+    /**
+     * Reads a CONSTANT_Dynamic constant pool entry in {@link #b}.
+     *
+     * @param constantPoolEntryIndex the index of a CONSTANT_Dynamic entry in the class's constant
+     *     pool table.
+     * @param charBuffer the buffer to be used to read the string. This buffer must be sufficiently
+     *     large. It is not automatically resized.
+     * @return the ConstantDynamic corresponding to the specified CONSTANT_Dynamic entry.
+     */
+    private ConstantDynamic readConstantDynamic(final int constantPoolEntryIndex, final char[] charBuffer) {
+        ConstantDynamic constantDynamic = constantDynamicValues[constantPoolEntryIndex];
+        if (constantDynamic != null) {
+            return constantDynamic;
+        }
+        int cpInfoOffset = cpInfoOffsets[constantPoolEntryIndex];
+        int nameAndTypeCpInfoOffset = cpInfoOffsets[readUnsignedShort(cpInfoOffset + 2)];
+        String name = readUTF8(nameAndTypeCpInfoOffset, charBuffer);
+        String descriptor = readUTF8(nameAndTypeCpInfoOffset + 2, charBuffer);
+        int bootstrapMethodOffset = bootstrapMethodOffsets[readUnsignedShort(cpInfoOffset)];
+        Handle handle = (Handle) readConst(readUnsignedShort(bootstrapMethodOffset), charBuffer);
+        Object[] bootstrapMethodArguments = new Object[readUnsignedShort(bootstrapMethodOffset + 2)];
+        bootstrapMethodOffset += 4;
+        for (int i = 0; i < bootstrapMethodArguments.length; i++) {
+            bootstrapMethodArguments[i] = readConst(readUnsignedShort(bootstrapMethodOffset), charBuffer);
+            bootstrapMethodOffset += 2;
+        }
+        return constantDynamicValues[constantPoolEntryIndex] = new ConstantDynamic(name, descriptor, handle, bootstrapMethodArguments);
+    }
+
+    /**
+     * Reads a numeric or string constant pool entry in {@link #b}. <i>This method is intended for
+     * {@link Attribute} sub classes, and is normally not needed by class generators or adapters.</i>
+     *
+     * @param constantPoolEntryIndex the index of a CONSTANT_Integer, CONSTANT_Float, CONSTANT_Long,
+     *     CONSTANT_Double, CONSTANT_Class, CONSTANT_String, CONSTANT_MethodType,
+     *     CONSTANT_MethodHandle or CONSTANT_Dynamic entry in the class's constant pool.
+     * @param charBuffer the buffer to be used to read strings. This buffer must be sufficiently
+     *     large. It is not automatically resized.
+     * @return the {@link Integer}, {@link Float}, {@link Long}, {@link Double}, {@link String},
+     *     {@link Type}, {@link Handle} or {@link ConstantDynamic} corresponding to the specified
+     *     constant pool entry.
+     */
+    public Object readConst(final int constantPoolEntryIndex, final char[] charBuffer) {
+        int cpInfoOffset = cpInfoOffsets[constantPoolEntryIndex];
+        switch (b[cpInfoOffset - 1]) {
+            case Symbol.CONSTANT_INTEGER_TAG:
+                return readInt(cpInfoOffset);
+            case Symbol.CONSTANT_FLOAT_TAG:
+                return Float.intBitsToFloat(readInt(cpInfoOffset));
+            case Symbol.CONSTANT_LONG_TAG:
+                return readLong(cpInfoOffset);
+            case Symbol.CONSTANT_DOUBLE_TAG:
+                return Double.longBitsToDouble(readLong(cpInfoOffset));
+            case Symbol.CONSTANT_CLASS_TAG:
+                return Type.getObjectType(readUTF8(cpInfoOffset, charBuffer));
+            case Symbol.CONSTANT_STRING_TAG:
+                return readUTF8(cpInfoOffset, charBuffer);
+            case Symbol.CONSTANT_METHOD_TYPE_TAG:
+                return Type.getMethodType(readUTF8(cpInfoOffset, charBuffer));
+            case Symbol.CONSTANT_METHOD_HANDLE_TAG:
+                int referenceKind = readByte(cpInfoOffset);
+                int referenceCpInfoOffset = cpInfoOffsets[readUnsignedShort(cpInfoOffset + 1)];
+                int nameAndTypeCpInfoOffset = cpInfoOffsets[readUnsignedShort(referenceCpInfoOffset + 2)];
+                String owner = readClass(referenceCpInfoOffset, charBuffer);
+                String name = readUTF8(nameAndTypeCpInfoOffset, charBuffer);
+                String descriptor = readUTF8(nameAndTypeCpInfoOffset + 2, charBuffer);
+                boolean isInterface = b[referenceCpInfoOffset - 1] == Symbol.CONSTANT_INTERFACE_METHODREF_TAG;
+                return new Handle(referenceKind, owner, name, descriptor, isInterface);
+            case Symbol.CONSTANT_DYNAMIC_TAG:
+                return readConstantDynamic(constantPoolEntryIndex, charBuffer);
+            default:
+                throw new IllegalArgumentException();
+        }
+    }
+}

--- a/core/src/main/java/org/mvel2/asm/ClassTooLargeException.java
+++ b/core/src/main/java/org/mvel2/asm/ClassTooLargeException.java
@@ -1,0 +1,72 @@
+// ASM: a very small and fast Java bytecode manipulation framework
+// Copyright (c) 2000-2011 INRIA, France Telecom
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+// 1. Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+// 2. Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+// 3. Neither the name of the copyright holders nor the names of its
+//    contributors may be used to endorse or promote products derived from
+//    this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+// THE POSSIBILITY OF SUCH DAMAGE.
+package org.mvel2.asm;
+
+/**
+ * Exception thrown when the constant pool of a class produced by a {@link ClassWriter} is too
+ * large.
+ *
+ * @author Jason Zaugg
+ */
+public final class ClassTooLargeException extends IndexOutOfBoundsException {
+
+    private static final long serialVersionUID = 160715609518896765L;
+
+    private final String className;
+    private final int constantPoolCount;
+
+    /**
+     * Constructs a new {@link ClassTooLargeException}.
+     *
+     * @param className the internal name of the class.
+     * @param constantPoolCount the number of constant pool items of the class.
+     */
+    public ClassTooLargeException(final String className, final int constantPoolCount) {
+        super("Class too large: " + className);
+        this.className = className;
+        this.constantPoolCount = constantPoolCount;
+    }
+
+    /**
+     * Returns the internal name of the class.
+     *
+     * @return the internal name of the class.
+     */
+    public String getClassName() {
+        return className;
+    }
+
+    /**
+     * Returns the number of constant pool items of the class.
+     *
+     * @return the number of constant pool items of the class.
+     */
+    public int getConstantPoolCount() {
+        return constantPoolCount;
+    }
+}

--- a/core/src/main/java/org/mvel2/asm/ClassVisitor.java
+++ b/core/src/main/java/org/mvel2/asm/ClassVisitor.java
@@ -1,0 +1,315 @@
+// ASM: a very small and fast Java bytecode manipulation framework
+// Copyright (c) 2000-2011 INRIA, France Telecom
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+// 1. Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+// 2. Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+// 3. Neither the name of the copyright holders nor the names of its
+//    contributors may be used to endorse or promote products derived from
+//    this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+// THE POSSIBILITY OF SUCH DAMAGE.
+package org.mvel2.asm;
+
+/**
+ * A visitor to visit a Java class. The methods of this class must be called in the following order:
+ * {@code visit} [ {@code visitSource} ] [ {@code visitModule} ][ {@code visitNestHost} ][ {@code
+ * visitOuterClass} ] ( {@code visitAnnotation} | {@code visitTypeAnnotation} | {@code
+ * visitAttribute} )* ( {@code visitNestMember} | {@code visitInnerClass} | {@code visitField} |
+ * {@code visitMethod} )* {@code visitEnd}.
+ *
+ * @author Eric Bruneton
+ */
+public abstract class ClassVisitor {
+
+    /**
+     * The ASM API version implemented by this visitor. The value of this field must be one of {@link
+     * Opcodes#ASM4}, {@link Opcodes#ASM5}, {@link Opcodes#ASM6} or {@link Opcodes#ASM7}.
+     */
+    protected final int api;
+
+    /** The class visitor to which this visitor must delegate method calls. May be null. */
+    protected ClassVisitor cv;
+
+    /**
+     * Constructs a new {@link ClassVisitor}.
+     *
+     * @param api the ASM API version implemented by this visitor. Must be one of {@link
+     *     Opcodes#ASM4}, {@link Opcodes#ASM5}, {@link Opcodes#ASM6} or {@link Opcodes#ASM7}.
+     */
+    public ClassVisitor(final int api) {
+        this(api, null);
+    }
+
+    /**
+     * Constructs a new {@link ClassVisitor}.
+     *
+     * @param api the ASM API version implemented by this visitor. Must be one of {@link
+     *     Opcodes#ASM4}, {@link Opcodes#ASM5}, {@link Opcodes#ASM6} or {@link Opcodes#ASM7}.
+     * @param classVisitor the class visitor to which this visitor must delegate method calls. May be
+     *     null.
+     */
+    public ClassVisitor(final int api, final ClassVisitor classVisitor) {
+        if (api != Opcodes.ASM6 && api != Opcodes.ASM5 && api != Opcodes.ASM4 && api != Opcodes.ASM7) {
+            throw new IllegalArgumentException();
+        }
+        this.api = api;
+        this.cv = classVisitor;
+    }
+
+    /**
+     * Visits the header of the class.
+     *
+     * @param version the class version. The minor version is stored in the 16 most significant bits,
+     *     and the major version in the 16 least significant bits.
+     * @param access the class's access flags (see {@link Opcodes}). This parameter also indicates if
+     *     the class is deprecated.
+     * @param name the internal name of the class (see {@link Type#getInternalName()}).
+     * @param signature the signature of this class. May be {@literal null} if the class is not a
+     *     generic one, and does not extend or implement generic classes or interfaces.
+     * @param superName the internal of name of the super class (see {@link Type#getInternalName()}).
+     *     For interfaces, the super class is {@link Object}. May be {@literal null}, but only for the
+     *     {@link Object} class.
+     * @param interfaces the internal names of the class's interfaces (see {@link
+     *     Type#getInternalName()}). May be {@literal null}.
+     */
+    public void visit(final int version, final int access, final String name, final String signature, final String superName,
+            final String[] interfaces) {
+        if (cv != null) {
+            cv.visit(version, access, name, signature, superName, interfaces);
+        }
+    }
+
+    /**
+     * Visits the source of the class.
+     *
+     * @param source the name of the source file from which the class was compiled. May be {@literal
+     *     null}.
+     * @param debug additional debug information to compute the correspondence between source and
+     *     compiled elements of the class. May be {@literal null}.
+     */
+    public void visitSource(final String source, final String debug) {
+        if (cv != null) {
+            cv.visitSource(source, debug);
+        }
+    }
+
+    /**
+     * Visit the module corresponding to the class.
+     *
+     * @param name the fully qualified name (using dots) of the module.
+     * @param access the module access flags, among {@code ACC_OPEN}, {@code ACC_SYNTHETIC} and {@code
+     *     ACC_MANDATED}.
+     * @param version the module version, or {@literal null}.
+     * @return a visitor to visit the module values, or {@literal null} if this visitor is not
+     *     interested in visiting this module.
+     */
+    public ModuleVisitor visitModule(final String name, final int access, final String version) {
+        if (api < Opcodes.ASM6) {
+            throw new UnsupportedOperationException("This feature requires ASM6");
+        }
+        if (cv != null) {
+            return cv.visitModule(name, access, version);
+        }
+        return null;
+    }
+
+    /**
+     * Visits the nest host class of the class. A nest is a set of classes of the same package that
+     * share access to their private members. One of these classes, called the host, lists the other
+     * members of the nest, which in turn should link to the host of their nest. This method must be
+     * called only once and only if the visited class is a non-host member of a nest. A class is
+     * implicitly its own nest, so it's invalid to call this method with the visited class name as
+     * argument.
+     *
+     * @param nestHost the internal name of the host class of the nest.
+     */
+    public void visitNestHost(final String nestHost) {
+        if (api < Opcodes.ASM7) {
+            throw new UnsupportedOperationException("This feature requires ASM7");
+        }
+        if (cv != null) {
+            cv.visitNestHost(nestHost);
+        }
+    }
+
+    /**
+     * Visits the enclosing class of the class. This method must be called only if the class has an
+     * enclosing class.
+     *
+     * @param owner internal name of the enclosing class of the class.
+     * @param name the name of the method that contains the class, or {@literal null} if the class is
+     *     not enclosed in a method of its enclosing class.
+     * @param descriptor the descriptor of the method that contains the class, or {@literal null} if
+     *     the class is not enclosed in a method of its enclosing class.
+     */
+    public void visitOuterClass(final String owner, final String name, final String descriptor) {
+        if (cv != null) {
+            cv.visitOuterClass(owner, name, descriptor);
+        }
+    }
+
+    /**
+     * Visits an annotation of the class.
+     *
+     * @param descriptor the class descriptor of the annotation class.
+     * @param visible {@literal true} if the annotation is visible at runtime.
+     * @return a visitor to visit the annotation values, or {@literal null} if this visitor is not
+     *     interested in visiting this annotation.
+     */
+    public AnnotationVisitor visitAnnotation(final String descriptor, final boolean visible) {
+        if (cv != null) {
+            return cv.visitAnnotation(descriptor, visible);
+        }
+        return null;
+    }
+
+    /**
+     * Visits an annotation on a type in the class signature.
+     *
+     * @param typeRef a reference to the annotated type. The sort of this type reference must be
+     *     {@link TypeReference#CLASS_TYPE_PARAMETER}, {@link
+     *     TypeReference#CLASS_TYPE_PARAMETER_BOUND} or {@link TypeReference#CLASS_EXTENDS}. See
+     *     {@link TypeReference}.
+     * @param typePath the path to the annotated type argument, wildcard bound, array element type, or
+     *     static inner type within 'typeRef'. May be {@literal null} if the annotation targets
+     *     'typeRef' as a whole.
+     * @param descriptor the class descriptor of the annotation class.
+     * @param visible {@literal true} if the annotation is visible at runtime.
+     * @return a visitor to visit the annotation values, or {@literal null} if this visitor is not
+     *     interested in visiting this annotation.
+     */
+    public AnnotationVisitor visitTypeAnnotation(final int typeRef, final TypePath typePath, final String descriptor,
+            final boolean visible) {
+        if (api < Opcodes.ASM5) {
+            throw new UnsupportedOperationException("This feature requires ASM5");
+        }
+        if (cv != null) {
+            return cv.visitTypeAnnotation(typeRef, typePath, descriptor, visible);
+        }
+        return null;
+    }
+
+    /**
+     * Visits a non standard attribute of the class.
+     *
+     * @param attribute an attribute.
+     */
+    public void visitAttribute(final Attribute attribute) {
+        if (cv != null) {
+            cv.visitAttribute(attribute);
+        }
+    }
+
+    /**
+     * Visits a member of the nest. A nest is a set of classes of the same package that share access
+     * to their private members. One of these classes, called the host, lists the other members of the
+     * nest, which in turn should link to the host of their nest. This method must be called only if
+     * the visited class is the host of a nest. A nest host is implicitly a member of its own nest, so
+     * it's invalid to call this method with the visited class name as argument.
+     *
+     * @param nestMember the internal name of a nest member.
+     */
+    public void visitNestMember(final String nestMember) {
+        if (api < Opcodes.ASM7) {
+            throw new UnsupportedOperationException("This feature requires ASM7");
+        }
+        if (cv != null) {
+            cv.visitNestMember(nestMember);
+        }
+    }
+
+    /**
+     * Visits information about an inner class. This inner class is not necessarily a member of the
+     * class being visited.
+     *
+     * @param name the internal name of an inner class (see {@link Type#getInternalName()}).
+     * @param outerName the internal name of the class to which the inner class belongs (see {@link
+     *     Type#getInternalName()}). May be {@literal null} for not member classes.
+     * @param innerName the (simple) name of the inner class inside its enclosing class. May be
+     *     {@literal null} for anonymous inner classes.
+     * @param access the access flags of the inner class as originally declared in the enclosing
+     *     class.
+     */
+    public void visitInnerClass(final String name, final String outerName, final String innerName, final int access) {
+        if (cv != null) {
+            cv.visitInnerClass(name, outerName, innerName, access);
+        }
+    }
+
+    /**
+     * Visits a field of the class.
+     *
+     * @param access the field's access flags (see {@link Opcodes}). This parameter also indicates if
+     *     the field is synthetic and/or deprecated.
+     * @param name the field's name.
+     * @param descriptor the field's descriptor (see {@link Type}).
+     * @param signature the field's signature. May be {@literal null} if the field's type does not use
+     *     generic types.
+     * @param value the field's initial value. This parameter, which may be {@literal null} if the
+     *     field does not have an initial value, must be an {@link Integer}, a {@link Float}, a {@link
+     *     Long}, a {@link Double} or a {@link String} (for {@code int}, {@code float}, {@code long}
+     *     or {@code String} fields respectively). <i>This parameter is only used for static
+     *     fields</i>. Its value is ignored for non static fields, which must be initialized through
+     *     bytecode instructions in constructors or methods.
+     * @return a visitor to visit field annotations and attributes, or {@literal null} if this class
+     *     visitor is not interested in visiting these annotations and attributes.
+     */
+    public FieldVisitor visitField(final int access, final String name, final String descriptor, final String signature,
+            final Object value) {
+        if (cv != null) {
+            return cv.visitField(access, name, descriptor, signature, value);
+        }
+        return null;
+    }
+
+    /**
+     * Visits a method of the class. This method <i>must</i> return a new {@link MethodVisitor}
+     * instance (or {@literal null}) each time it is called, i.e., it should not return a previously
+     * returned visitor.
+     *
+     * @param access the method's access flags (see {@link Opcodes}). This parameter also indicates if
+     *     the method is synthetic and/or deprecated.
+     * @param name the method's name.
+     * @param descriptor the method's descriptor (see {@link Type}).
+     * @param signature the method's signature. May be {@literal null} if the method parameters,
+     *     return type and exceptions do not use generic types.
+     * @param exceptions the internal names of the method's exception classes (see {@link
+     *     Type#getInternalName()}). May be {@literal null}.
+     * @return an object to visit the byte code of the method, or {@literal null} if this class
+     *     visitor is not interested in visiting the code of this method.
+     */
+    public MethodVisitor visitMethod(final int access, final String name, final String descriptor, final String signature,
+            final String[] exceptions) {
+        if (cv != null) {
+            return cv.visitMethod(access, name, descriptor, signature, exceptions);
+        }
+        return null;
+    }
+
+    /**
+     * Visits the end of the class. This method, which is the last one to be called, is used to inform
+     * the visitor that all the fields and methods of the class have been visited.
+     */
+    public void visitEnd() {
+        if (cv != null) {
+            cv.visitEnd();
+        }
+    }
+}

--- a/core/src/main/java/org/mvel2/asm/ClassWriter.java
+++ b/core/src/main/java/org/mvel2/asm/ClassWriter.java
@@ -1,0 +1,907 @@
+// ASM: a very small and fast Java bytecode manipulation framework
+// Copyright (c) 2000-2011 INRIA, France Telecom
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+// 1. Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+// 2. Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+// 3. Neither the name of the copyright holders nor the names of its
+//    contributors may be used to endorse or promote products derived from
+//    this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+// THE POSSIBILITY OF SUCH DAMAGE.
+package org.mvel2.asm;
+
+/**
+ * A {@link ClassVisitor} that generates a corresponding ClassFile structure, as defined in the Java
+ * Virtual Machine Specification (JVMS). It can be used alone, to generate a Java class "from
+ * scratch", or with one or more {@link ClassReader} and adapter {@link ClassVisitor} to generate a
+ * modified class from one or more existing Java classes.
+ *
+ * @see <a href="https://docs.oracle.com/javase/specs/jvms/se9/html/jvms-4.html">JVMS 4</a>
+ * @author Eric Bruneton
+ */
+public class ClassWriter extends ClassVisitor {
+
+    /**
+     * A flag to automatically compute the maximum stack size and the maximum number of local
+     * variables of methods. If this flag is set, then the arguments of the {@link
+     * MethodVisitor#visitMaxs} method of the {@link MethodVisitor} returned by the {@link
+     * #visitMethod} method will be ignored, and computed automatically from the signature and the
+     * bytecode of each method.
+     *
+     * <p><b>Note:</b> for classes whose version is {@link Opcodes#V1_7} of more, this option requires
+     * valid stack map frames. The maximum stack size is then computed from these frames, and from the
+     * bytecode instructions in between. If stack map frames are not present or must be recomputed,
+     * used {@link #COMPUTE_FRAMES} instead.
+     *
+     * @see #ClassWriter(int)
+     */
+    public static final int COMPUTE_MAXS = 1;
+
+    /**
+     * A flag to automatically compute the stack map frames of methods from scratch. If this flag is
+     * set, then the calls to the {@link MethodVisitor#visitFrame} method are ignored, and the stack
+     * map frames are recomputed from the methods bytecode. The arguments of the {@link
+     * MethodVisitor#visitMaxs} method are also ignored and recomputed from the bytecode. In other
+     * words, {@link #COMPUTE_FRAMES} implies {@link #COMPUTE_MAXS}.
+     *
+     * @see #ClassWriter(int)
+     */
+    public static final int COMPUTE_FRAMES = 2;
+
+    // Note: fields are ordered as in the ClassFile structure, and those related to attributes are
+    // ordered as in Section 4.7 of the JVMS.
+    /** The symbol table for this class (contains the constant_pool and the BootstrapMethods). */
+    private final SymbolTable symbolTable;
+    /**
+     * The minor_version and major_version fields of the JVMS ClassFile structure. minor_version is
+     * stored in the 16 most significant bits, and major_version in the 16 least significant bits.
+     */
+    private int version;
+    /**
+     * The access_flags field of the JVMS ClassFile structure. This field can contain ASM specific
+     * access flags, such as {@link Opcodes#ACC_DEPRECATED}, which are removed when generating the
+     * ClassFile structure.
+     */
+    private int accessFlags;
+
+    /** The this_class field of the JVMS ClassFile structure. */
+    private int thisClass;
+
+    /** The super_class field of the JVMS ClassFile structure. */
+    private int superClass;
+
+    /** The interface_count field of the JVMS ClassFile structure. */
+    private int interfaceCount;
+
+    /** The 'interfaces' array of the JVMS ClassFile structure. */
+    private int[] interfaces;
+
+    /**
+     * The fields of this class, stored in a linked list of {@link FieldWriter} linked via their
+     * {@link FieldWriter#fv} field. This field stores the first element of this list.
+     */
+    private FieldWriter firstField;
+
+    /**
+     * The fields of this class, stored in a linked list of {@link FieldWriter} linked via their
+     * {@link FieldWriter#fv} field. This field stores the last element of this list.
+     */
+    private FieldWriter lastField;
+
+    /**
+     * The methods of this class, stored in a linked list of {@link MethodWriter} linked via their
+     * {@link MethodWriter#mv} field. This field stores the first element of this list.
+     */
+    private MethodWriter firstMethod;
+
+    /**
+     * The methods of this class, stored in a linked list of {@link MethodWriter} linked via their
+     * {@link MethodWriter#mv} field. This field stores the last element of this list.
+     */
+    private MethodWriter lastMethod;
+
+    /** The number_of_classes field of the InnerClasses attribute, or 0. */
+    private int numberOfInnerClasses;
+
+    /** The 'classes' array of the InnerClasses attribute, or {@literal null}. */
+    private ByteVector innerClasses;
+
+    /** The class_index field of the EnclosingMethod attribute, or 0. */
+    private int enclosingClassIndex;
+
+    /** The method_index field of the EnclosingMethod attribute. */
+    private int enclosingMethodIndex;
+
+    /** The signature_index field of the Signature attribute, or 0. */
+    private int signatureIndex;
+
+    /** The source_file_index field of the SourceFile attribute, or 0. */
+    private int sourceFileIndex;
+
+    /** The debug_extension field of the SourceDebugExtension attribute, or {@literal null}. */
+    private ByteVector debugExtension;
+
+    /**
+     * The last runtime visible annotation of this class. The previous ones can be accessed with the
+     * {@link AnnotationWriter#previousAnnotation} field. May be {@literal null}.
+     */
+    private AnnotationWriter lastRuntimeVisibleAnnotation;
+
+    /**
+     * The last runtime invisible annotation of this class. The previous ones can be accessed with the
+     * {@link AnnotationWriter#previousAnnotation} field. May be {@literal null}.
+     */
+    private AnnotationWriter lastRuntimeInvisibleAnnotation;
+
+    /**
+     * The last runtime visible type annotation of this class. The previous ones can be accessed with
+     * the {@link AnnotationWriter#previousAnnotation} field. May be {@literal null}.
+     */
+    private AnnotationWriter lastRuntimeVisibleTypeAnnotation;
+
+    /**
+     * The last runtime invisible type annotation of this class. The previous ones can be accessed
+     * with the {@link AnnotationWriter#previousAnnotation} field. May be {@literal null}.
+     */
+    private AnnotationWriter lastRuntimeInvisibleTypeAnnotation;
+
+    /** The Module attribute of this class, or {@literal null}. */
+    private ModuleWriter moduleWriter;
+
+    /** The host_class_index field of the NestHost attribute, or 0. */
+    private int nestHostClassIndex;
+
+    /** The number_of_classes field of the NestMembers attribute, or 0. */
+    private int numberOfNestMemberClasses;
+
+    /** The 'classes' array of the NestMembers attribute, or {@literal null}. */
+    private ByteVector nestMemberClasses;
+
+    /**
+     * The first non standard attribute of this class. The next ones can be accessed with the {@link
+     * Attribute#nextAttribute} field. May be {@literal null}.
+     *
+     * <p><b>WARNING</b>: this list stores the attributes in the <i>reverse</i> order of their visit.
+     * firstAttribute is actually the last attribute visited in {@link #visitAttribute}. The {@link
+     * #toByteArray} method writes the attributes in the order defined by this list, i.e. in the
+     * reverse order specified by the user.
+     */
+    private Attribute firstAttribute;
+
+    /**
+     * Indicates what must be automatically computed in {@link MethodWriter}. Must be one of {@link
+     * MethodWriter#COMPUTE_NOTHING}, {@link MethodWriter#COMPUTE_MAX_STACK_AND_LOCAL}, {@link
+     * MethodWriter#COMPUTE_INSERTED_FRAMES}, or {@link MethodWriter#COMPUTE_ALL_FRAMES}.
+     */
+    private int compute;
+
+    // -----------------------------------------------------------------------------------------------
+    // Constructor
+    // -----------------------------------------------------------------------------------------------
+
+    /**
+     * Constructs a new {@link ClassWriter} object.
+     *
+     * @param flags option flags that can be used to modify the default behavior of this class. Must
+     *     be zero or more of {@link #COMPUTE_MAXS} and {@link #COMPUTE_FRAMES}.
+     */
+    public ClassWriter(final int flags) {
+        this(null, flags);
+    }
+
+    /**
+     * Constructs a new {@link ClassWriter} object and enables optimizations for "mostly add" bytecode
+     * transformations. These optimizations are the following:
+     *
+     * <ul>
+     *   <li>The constant pool and bootstrap methods from the original class are copied as is in the
+     *       new class, which saves time. New constant pool entries and new bootstrap methods will be
+     *       added at the end if necessary, but unused constant pool entries or bootstrap methods
+     *       <i>won't be removed</i>.
+     *   <li>Methods that are not transformed are copied as is in the new class, directly from the
+     *       original class bytecode (i.e. without emitting visit events for all the method
+     *       instructions), which saves a <i>lot</i> of time. Untransformed methods are detected by
+     *       the fact that the {@link ClassReader} receives {@link MethodVisitor} objects that come
+     *       from a {@link ClassWriter} (and not from any other {@link ClassVisitor} instance).
+     * </ul>
+     *
+     * @param classReader the {@link ClassReader} used to read the original class. It will be used to
+     *     copy the entire constant pool and bootstrap methods from the original class and also to
+     *     copy other fragments of original bytecode where applicable.
+     * @param flags option flags that can be used to modify the default behavior of this class.Must be
+     *     zero or more of {@link #COMPUTE_MAXS} and {@link #COMPUTE_FRAMES}. <i>These option flags do
+     *     not affect methods that are copied as is in the new class. This means that neither the
+     *     maximum stack size nor the stack frames will be computed for these methods</i>.
+     */
+    public ClassWriter(final ClassReader classReader, final int flags) {
+        super(Opcodes.ASM7);
+        symbolTable = classReader == null ? new SymbolTable(this) : new SymbolTable(this, classReader);
+        if ((flags & COMPUTE_FRAMES) != 0) {
+            this.compute = MethodWriter.COMPUTE_ALL_FRAMES;
+        } else if ((flags & COMPUTE_MAXS) != 0) {
+            this.compute = MethodWriter.COMPUTE_MAX_STACK_AND_LOCAL;
+        } else {
+            this.compute = MethodWriter.COMPUTE_NOTHING;
+        }
+    }
+
+    // -----------------------------------------------------------------------------------------------
+    // Implementation of the ClassVisitor abstract class
+    // -----------------------------------------------------------------------------------------------
+
+    @Override
+    public final void visit(final int version, final int access, final String name, final String signature, final String superName,
+            final String[] interfaces) {
+        this.version = version;
+        this.accessFlags = access;
+        this.thisClass = symbolTable.setMajorVersionAndClassName(version & 0xFFFF, name);
+        if (signature != null) {
+            this.signatureIndex = symbolTable.addConstantUtf8(signature);
+        }
+        this.superClass = superName == null ? 0 : symbolTable.addConstantClass(superName).index;
+        if (interfaces != null && interfaces.length > 0) {
+            interfaceCount = interfaces.length;
+            this.interfaces = new int[interfaceCount];
+            for (int i = 0; i < interfaceCount; ++i) {
+                this.interfaces[i] = symbolTable.addConstantClass(interfaces[i]).index;
+            }
+        }
+        if (compute == MethodWriter.COMPUTE_MAX_STACK_AND_LOCAL && (version & 0xFFFF) >= Opcodes.V1_7) {
+            compute = MethodWriter.COMPUTE_MAX_STACK_AND_LOCAL_FROM_FRAMES;
+        }
+    }
+
+    @Override
+    public final void visitSource(final String file, final String debug) {
+        if (file != null) {
+            sourceFileIndex = symbolTable.addConstantUtf8(file);
+        }
+        if (debug != null) {
+            debugExtension = new ByteVector().encodeUtf8(debug, 0, Integer.MAX_VALUE);
+        }
+    }
+
+    @Override
+    public final ModuleVisitor visitModule(final String name, final int access, final String version) {
+        return moduleWriter = new ModuleWriter(symbolTable, symbolTable.addConstantModule(name).index, access,
+                version == null ? 0 : symbolTable.addConstantUtf8(version));
+    }
+
+    @Override
+    public void visitNestHost(final String nestHost) {
+        nestHostClassIndex = symbolTable.addConstantClass(nestHost).index;
+    }
+
+    @Override
+    public final void visitOuterClass(final String owner, final String name, final String descriptor) {
+        enclosingClassIndex = symbolTable.addConstantClass(owner).index;
+        if (name != null && descriptor != null) {
+            enclosingMethodIndex = symbolTable.addConstantNameAndType(name, descriptor);
+        }
+    }
+
+    @Override
+    public final AnnotationVisitor visitAnnotation(final String descriptor, final boolean visible) {
+        // Create a ByteVector to hold an 'annotation' JVMS structure.
+        // See https://docs.oracle.com/javase/specs/jvms/se9/html/jvms-4.html#jvms-4.7.16.
+        ByteVector annotation = new ByteVector();
+        // Write type_index and reserve space for num_element_value_pairs.
+        annotation.putShort(symbolTable.addConstantUtf8(descriptor)).putShort(0);
+        if (visible) {
+            return lastRuntimeVisibleAnnotation = new AnnotationWriter(symbolTable, annotation, lastRuntimeVisibleAnnotation);
+        } else {
+            return lastRuntimeInvisibleAnnotation = new AnnotationWriter(symbolTable, annotation, lastRuntimeInvisibleAnnotation);
+        }
+    }
+
+    @Override
+    public final AnnotationVisitor visitTypeAnnotation(final int typeRef, final TypePath typePath, final String descriptor,
+            final boolean visible) {
+        // Create a ByteVector to hold a 'type_annotation' JVMS structure.
+        // See https://docs.oracle.com/javase/specs/jvms/se9/html/jvms-4.html#jvms-4.7.20.
+        ByteVector typeAnnotation = new ByteVector();
+        // Write target_type, target_info, and target_path.
+        TypeReference.putTarget(typeRef, typeAnnotation);
+        TypePath.put(typePath, typeAnnotation);
+        // Write type_index and reserve space for num_element_value_pairs.
+        typeAnnotation.putShort(symbolTable.addConstantUtf8(descriptor)).putShort(0);
+        if (visible) {
+            return lastRuntimeVisibleTypeAnnotation = new AnnotationWriter(symbolTable, typeAnnotation, lastRuntimeVisibleTypeAnnotation);
+        } else {
+            return lastRuntimeInvisibleTypeAnnotation = new AnnotationWriter(symbolTable, typeAnnotation,
+                    lastRuntimeInvisibleTypeAnnotation);
+        }
+    }
+
+    @Override
+    public final void visitAttribute(final Attribute attribute) {
+        // Store the attributes in the <i>reverse</i> order of their visit by this method.
+        attribute.nextAttribute = firstAttribute;
+        firstAttribute = attribute;
+    }
+
+    @Override
+    public void visitNestMember(final String nestMember) {
+        if (nestMemberClasses == null) {
+            nestMemberClasses = new ByteVector();
+        }
+        ++numberOfNestMemberClasses;
+        nestMemberClasses.putShort(symbolTable.addConstantClass(nestMember).index);
+    }
+
+    @Override
+    public final void visitInnerClass(final String name, final String outerName, final String innerName, final int access) {
+        if (innerClasses == null) {
+            innerClasses = new ByteVector();
+        }
+        // Section 4.7.6 of the JVMS states "Every CONSTANT_Class_info entry in the constant_pool table
+        // which represents a class or interface C that is not a package member must have exactly one
+        // corresponding entry in the classes array". To avoid duplicates we keep track in the info
+        // field of the Symbol of each CONSTANT_Class_info entry C whether an inner class entry has
+        // already been added for C. If so, we store the index of this inner class entry (plus one) in
+        // the info field. This trick allows duplicate detection in O(1) time.
+        Symbol nameSymbol = symbolTable.addConstantClass(name);
+        if (nameSymbol.info == 0) {
+            ++numberOfInnerClasses;
+            innerClasses.putShort(nameSymbol.index);
+            innerClasses.putShort(outerName == null ? 0 : symbolTable.addConstantClass(outerName).index);
+            innerClasses.putShort(innerName == null ? 0 : symbolTable.addConstantUtf8(innerName));
+            innerClasses.putShort(access);
+            nameSymbol.info = numberOfInnerClasses;
+        }
+        // Else, compare the inner classes entry nameSymbol.info - 1 with the arguments of this method
+        // and throw an exception if there is a difference?
+    }
+
+    @Override
+    public final FieldVisitor visitField(final int access, final String name, final String descriptor, final String signature,
+            final Object value) {
+        FieldWriter fieldWriter = new FieldWriter(symbolTable, access, name, descriptor, signature, value);
+        if (firstField == null) {
+            firstField = fieldWriter;
+        } else {
+            lastField.fv = fieldWriter;
+        }
+        return lastField = fieldWriter;
+    }
+
+    @Override
+    public final MethodVisitor visitMethod(final int access, final String name, final String descriptor, final String signature,
+            final String[] exceptions) {
+        MethodWriter methodWriter = new MethodWriter(symbolTable, access, name, descriptor, signature, exceptions, compute);
+        if (firstMethod == null) {
+            firstMethod = methodWriter;
+        } else {
+            lastMethod.mv = methodWriter;
+        }
+        return lastMethod = methodWriter;
+    }
+
+    @Override
+    public final void visitEnd() {
+        // Nothing to do.
+    }
+
+    // -----------------------------------------------------------------------------------------------
+    // Other public methods
+    // -----------------------------------------------------------------------------------------------
+
+    /**
+     * Returns the content of the class file that was built by this ClassWriter.
+     *
+     * @return the binary content of the JVMS ClassFile structure that was built by this ClassWriter.
+     * @throws ClassTooLargeException if the constant pool of the class is too large.
+     * @throws MethodTooLargeException if the Code attribute of a method is too large.
+     */
+    public byte[] toByteArray() throws ClassTooLargeException, MethodTooLargeException {
+        // First step: compute the size in bytes of the ClassFile structure.
+        // The magic field uses 4 bytes, 10 mandatory fields (minor_version, major_version,
+        // constant_pool_count, access_flags, this_class, super_class, interfaces_count, fields_count,
+        // methods_count and attributes_count) use 2 bytes each, and each interface uses 2 bytes too.
+        int size = 24 + 2 * interfaceCount;
+        int fieldsCount = 0;
+        FieldWriter fieldWriter = firstField;
+        while (fieldWriter != null) {
+            ++fieldsCount;
+            size += fieldWriter.computeFieldInfoSize();
+            fieldWriter = (FieldWriter) fieldWriter.fv;
+        }
+        int methodsCount = 0;
+        MethodWriter methodWriter = firstMethod;
+        while (methodWriter != null) {
+            ++methodsCount;
+            size += methodWriter.computeMethodInfoSize();
+            methodWriter = (MethodWriter) methodWriter.mv;
+        }
+        // For ease of reference, we use here the same attribute order as in Section 4.7 of the JVMS.
+        int attributesCount = 0;
+        if (innerClasses != null) {
+            ++attributesCount;
+            size += 8 + innerClasses.length;
+            symbolTable.addConstantUtf8(Constants.INNER_CLASSES);
+        }
+        if (enclosingClassIndex != 0) {
+            ++attributesCount;
+            size += 10;
+            symbolTable.addConstantUtf8(Constants.ENCLOSING_METHOD);
+        }
+        if ((accessFlags & Opcodes.ACC_SYNTHETIC) != 0 && (version & 0xFFFF) < Opcodes.V1_5) {
+            ++attributesCount;
+            size += 6;
+            symbolTable.addConstantUtf8(Constants.SYNTHETIC);
+        }
+        if (signatureIndex != 0) {
+            ++attributesCount;
+            size += 8;
+            symbolTable.addConstantUtf8(Constants.SIGNATURE);
+        }
+        if (sourceFileIndex != 0) {
+            ++attributesCount;
+            size += 8;
+            symbolTable.addConstantUtf8(Constants.SOURCE_FILE);
+        }
+        if (debugExtension != null) {
+            ++attributesCount;
+            size += 6 + debugExtension.length;
+            symbolTable.addConstantUtf8(Constants.SOURCE_DEBUG_EXTENSION);
+        }
+        if ((accessFlags & Opcodes.ACC_DEPRECATED) != 0) {
+            ++attributesCount;
+            size += 6;
+            symbolTable.addConstantUtf8(Constants.DEPRECATED);
+        }
+        if (lastRuntimeVisibleAnnotation != null) {
+            ++attributesCount;
+            size += lastRuntimeVisibleAnnotation.computeAnnotationsSize(Constants.RUNTIME_VISIBLE_ANNOTATIONS);
+        }
+        if (lastRuntimeInvisibleAnnotation != null) {
+            ++attributesCount;
+            size += lastRuntimeInvisibleAnnotation.computeAnnotationsSize(Constants.RUNTIME_INVISIBLE_ANNOTATIONS);
+        }
+        if (lastRuntimeVisibleTypeAnnotation != null) {
+            ++attributesCount;
+            size += lastRuntimeVisibleTypeAnnotation.computeAnnotationsSize(Constants.RUNTIME_VISIBLE_TYPE_ANNOTATIONS);
+        }
+        if (lastRuntimeInvisibleTypeAnnotation != null) {
+            ++attributesCount;
+            size += lastRuntimeInvisibleTypeAnnotation.computeAnnotationsSize(Constants.RUNTIME_INVISIBLE_TYPE_ANNOTATIONS);
+        }
+        if (symbolTable.computeBootstrapMethodsSize() > 0) {
+            ++attributesCount;
+            size += symbolTable.computeBootstrapMethodsSize();
+        }
+        if (moduleWriter != null) {
+            attributesCount += moduleWriter.getAttributeCount();
+            size += moduleWriter.computeAttributesSize();
+        }
+        if (nestHostClassIndex != 0) {
+            ++attributesCount;
+            size += 8;
+            symbolTable.addConstantUtf8(Constants.NEST_HOST);
+        }
+        if (nestMemberClasses != null) {
+            ++attributesCount;
+            size += 8 + nestMemberClasses.length;
+            symbolTable.addConstantUtf8(Constants.NEST_MEMBERS);
+        }
+        if (firstAttribute != null) {
+            attributesCount += firstAttribute.getAttributeCount();
+            size += firstAttribute.computeAttributesSize(symbolTable);
+        }
+        // IMPORTANT: this must be the last part of the ClassFile size computation, because the previous
+        // statements can add attribute names to the constant pool, thereby changing its size!
+        size += symbolTable.getConstantPoolLength();
+        int constantPoolCount = symbolTable.getConstantPoolCount();
+        if (constantPoolCount > 0xFFFF) {
+            throw new ClassTooLargeException(symbolTable.getClassName(), constantPoolCount);
+        }
+
+        // Second step: allocate a ByteVector of the correct size (in order to avoid any array copy in
+        // dynamic resizes) and fill it with the ClassFile content.
+        ByteVector result = new ByteVector(size);
+        result.putInt(0xCAFEBABE).putInt(version);
+        symbolTable.putConstantPool(result);
+        int mask = (version & 0xFFFF) < Opcodes.V1_5 ? Opcodes.ACC_SYNTHETIC : 0;
+        result.putShort(accessFlags & ~mask).putShort(thisClass).putShort(superClass);
+        result.putShort(interfaceCount);
+        for (int i = 0; i < interfaceCount; ++i) {
+            result.putShort(interfaces[i]);
+        }
+        result.putShort(fieldsCount);
+        fieldWriter = firstField;
+        while (fieldWriter != null) {
+            fieldWriter.putFieldInfo(result);
+            fieldWriter = (FieldWriter) fieldWriter.fv;
+        }
+        result.putShort(methodsCount);
+        boolean hasFrames = false;
+        boolean hasAsmInstructions = false;
+        methodWriter = firstMethod;
+        while (methodWriter != null) {
+            hasFrames |= methodWriter.hasFrames();
+            hasAsmInstructions |= methodWriter.hasAsmInstructions();
+            methodWriter.putMethodInfo(result);
+            methodWriter = (MethodWriter) methodWriter.mv;
+        }
+        // For ease of reference, we use here the same attribute order as in Section 4.7 of the JVMS.
+        result.putShort(attributesCount);
+        if (innerClasses != null) {
+            result.putShort(symbolTable.addConstantUtf8(Constants.INNER_CLASSES)).putInt(innerClasses.length + 2)
+                    .putShort(numberOfInnerClasses).putByteArray(innerClasses.data, 0, innerClasses.length);
+        }
+        if (enclosingClassIndex != 0) {
+            result.putShort(symbolTable.addConstantUtf8(Constants.ENCLOSING_METHOD)).putInt(4).putShort(enclosingClassIndex)
+                    .putShort(enclosingMethodIndex);
+        }
+        if ((accessFlags & Opcodes.ACC_SYNTHETIC) != 0 && (version & 0xFFFF) < Opcodes.V1_5) {
+            result.putShort(symbolTable.addConstantUtf8(Constants.SYNTHETIC)).putInt(0);
+        }
+        if (signatureIndex != 0) {
+            result.putShort(symbolTable.addConstantUtf8(Constants.SIGNATURE)).putInt(2).putShort(signatureIndex);
+        }
+        if (sourceFileIndex != 0) {
+            result.putShort(symbolTable.addConstantUtf8(Constants.SOURCE_FILE)).putInt(2).putShort(sourceFileIndex);
+        }
+        if (debugExtension != null) {
+            int length = debugExtension.length;
+            result.putShort(symbolTable.addConstantUtf8(Constants.SOURCE_DEBUG_EXTENSION)).putInt(length).putByteArray(debugExtension.data,
+                    0, length);
+        }
+        if ((accessFlags & Opcodes.ACC_DEPRECATED) != 0) {
+            result.putShort(symbolTable.addConstantUtf8(Constants.DEPRECATED)).putInt(0);
+        }
+        if (lastRuntimeVisibleAnnotation != null) {
+            lastRuntimeVisibleAnnotation.putAnnotations(symbolTable.addConstantUtf8(Constants.RUNTIME_VISIBLE_ANNOTATIONS), result);
+        }
+        if (lastRuntimeInvisibleAnnotation != null) {
+            lastRuntimeInvisibleAnnotation.putAnnotations(symbolTable.addConstantUtf8(Constants.RUNTIME_INVISIBLE_ANNOTATIONS), result);
+        }
+        if (lastRuntimeVisibleTypeAnnotation != null) {
+            lastRuntimeVisibleTypeAnnotation.putAnnotations(symbolTable.addConstantUtf8(Constants.RUNTIME_VISIBLE_TYPE_ANNOTATIONS),
+                    result);
+        }
+        if (lastRuntimeInvisibleTypeAnnotation != null) {
+            lastRuntimeInvisibleTypeAnnotation.putAnnotations(symbolTable.addConstantUtf8(Constants.RUNTIME_INVISIBLE_TYPE_ANNOTATIONS),
+                    result);
+        }
+        symbolTable.putBootstrapMethods(result);
+        if (moduleWriter != null) {
+            moduleWriter.putAttributes(result);
+        }
+        if (nestHostClassIndex != 0) {
+            result.putShort(symbolTable.addConstantUtf8(Constants.NEST_HOST)).putInt(2).putShort(nestHostClassIndex);
+        }
+        if (nestMemberClasses != null) {
+            result.putShort(symbolTable.addConstantUtf8(Constants.NEST_MEMBERS)).putInt(nestMemberClasses.length + 2)
+                    .putShort(numberOfNestMemberClasses).putByteArray(nestMemberClasses.data, 0, nestMemberClasses.length);
+        }
+        if (firstAttribute != null) {
+            firstAttribute.putAttributes(symbolTable, result);
+        }
+
+        // Third step: replace the ASM specific instructions, if any.
+        if (hasAsmInstructions) {
+            return replaceAsmInstructions(result.data, hasFrames);
+        } else {
+            return result.data;
+        }
+    }
+
+    /**
+     * Returns the equivalent of the given class file, with the ASM specific instructions replaced
+     * with standard ones. This is done with a ClassReader -&gt; ClassWriter round trip.
+     *
+     * @param classFile a class file containing ASM specific instructions, generated by this
+     *     ClassWriter.
+     * @param hasFrames whether there is at least one stack map frames in 'classFile'.
+     * @return an equivalent of 'classFile', with the ASM specific instructions replaced with standard
+     *     ones.
+     */
+    private byte[] replaceAsmInstructions(final byte[] classFile, final boolean hasFrames) {
+        final Attribute[] attributes = getAttributePrototypes();
+        firstField = null;
+        lastField = null;
+        firstMethod = null;
+        lastMethod = null;
+        lastRuntimeVisibleAnnotation = null;
+        lastRuntimeInvisibleAnnotation = null;
+        lastRuntimeVisibleTypeAnnotation = null;
+        lastRuntimeInvisibleTypeAnnotation = null;
+        moduleWriter = null;
+        nestHostClassIndex = 0;
+        numberOfNestMemberClasses = 0;
+        nestMemberClasses = null;
+        firstAttribute = null;
+        compute = hasFrames ? MethodWriter.COMPUTE_INSERTED_FRAMES : MethodWriter.COMPUTE_NOTHING;
+        new ClassReader(classFile, 0, /* checkClassVersion = */ false).accept(this, attributes,
+                (hasFrames ? ClassReader.EXPAND_FRAMES : 0) | ClassReader.EXPAND_ASM_INSNS);
+        return toByteArray();
+    }
+
+    /**
+     * Returns the prototypes of the attributes used by this class, its fields and its methods.
+     *
+     * @return the prototypes of the attributes used by this class, its fields and its methods.
+     */
+    private Attribute[] getAttributePrototypes() {
+        Attribute.Set attributePrototypes = new Attribute.Set();
+        attributePrototypes.addAttributes(firstAttribute);
+        FieldWriter fieldWriter = firstField;
+        while (fieldWriter != null) {
+            fieldWriter.collectAttributePrototypes(attributePrototypes);
+            fieldWriter = (FieldWriter) fieldWriter.fv;
+        }
+        MethodWriter methodWriter = firstMethod;
+        while (methodWriter != null) {
+            methodWriter.collectAttributePrototypes(attributePrototypes);
+            methodWriter = (MethodWriter) methodWriter.mv;
+        }
+        return attributePrototypes.toArray();
+    }
+
+    // -----------------------------------------------------------------------------------------------
+    // Utility methods: constant pool management for Attribute sub classes
+    // -----------------------------------------------------------------------------------------------
+
+    /**
+     * Adds a number or string constant to the constant pool of the class being build. Does nothing if
+     * the constant pool already contains a similar item. <i>This method is intended for {@link
+     * Attribute} sub classes, and is normally not needed by class generators or adapters.</i>
+     *
+     * @param value the value of the constant to be added to the constant pool. This parameter must be
+     *     an {@link Integer}, a {@link Float}, a {@link Long}, a {@link Double} or a {@link String}.
+     * @return the index of a new or already existing constant item with the given value.
+     */
+    public int newConst(final Object value) {
+        return symbolTable.addConstant(value).index;
+    }
+
+    /**
+     * Adds an UTF8 string to the constant pool of the class being build. Does nothing if the constant
+     * pool already contains a similar item. <i>This method is intended for {@link Attribute} sub
+     * classes, and is normally not needed by class generators or adapters.</i>
+     *
+     * @param value the String value.
+     * @return the index of a new or already existing UTF8 item.
+     */
+    // DontCheck(AbbreviationAsWordInName): can't be renamed (for backward binary compatibility).
+    public int newUTF8(final String value) {
+        return symbolTable.addConstantUtf8(value);
+    }
+
+    /**
+     * Adds a class reference to the constant pool of the class being build. Does nothing if the
+     * constant pool already contains a similar item. <i>This method is intended for {@link Attribute}
+     * sub classes, and is normally not needed by class generators or adapters.</i>
+     *
+     * @param value the internal name of the class.
+     * @return the index of a new or already existing class reference item.
+     */
+    public int newClass(final String value) {
+        return symbolTable.addConstantClass(value).index;
+    }
+
+    /**
+     * Adds a method type reference to the constant pool of the class being build. Does nothing if the
+     * constant pool already contains a similar item. <i>This method is intended for {@link Attribute}
+     * sub classes, and is normally not needed by class generators or adapters.</i>
+     *
+     * @param methodDescriptor method descriptor of the method type.
+     * @return the index of a new or already existing method type reference item.
+     */
+    public int newMethodType(final String methodDescriptor) {
+        return symbolTable.addConstantMethodType(methodDescriptor).index;
+    }
+
+    /**
+     * Adds a module reference to the constant pool of the class being build. Does nothing if the
+     * constant pool already contains a similar item. <i>This method is intended for {@link Attribute}
+     * sub classes, and is normally not needed by class generators or adapters.</i>
+     *
+     * @param moduleName name of the module.
+     * @return the index of a new or already existing module reference item.
+     */
+    public int newModule(final String moduleName) {
+        return symbolTable.addConstantModule(moduleName).index;
+    }
+
+    /**
+     * Adds a package reference to the constant pool of the class being build. Does nothing if the
+     * constant pool already contains a similar item. <i>This method is intended for {@link Attribute}
+     * sub classes, and is normally not needed by class generators or adapters.</i>
+     *
+     * @param packageName name of the package in its internal form.
+     * @return the index of a new or already existing module reference item.
+     */
+    public int newPackage(final String packageName) {
+        return symbolTable.addConstantPackage(packageName).index;
+    }
+
+    /**
+     * Adds a handle to the constant pool of the class being build. Does nothing if the constant pool
+     * already contains a similar item. <i>This method is intended for {@link Attribute} sub classes,
+     * and is normally not needed by class generators or adapters.</i>
+     *
+     * @param tag the kind of this handle. Must be {@link Opcodes#H_GETFIELD}, {@link
+     *     Opcodes#H_GETSTATIC}, {@link Opcodes#H_PUTFIELD}, {@link Opcodes#H_PUTSTATIC}, {@link
+     *     Opcodes#H_INVOKEVIRTUAL}, {@link Opcodes#H_INVOKESTATIC}, {@link Opcodes#H_INVOKESPECIAL},
+     *     {@link Opcodes#H_NEWINVOKESPECIAL} or {@link Opcodes#H_INVOKEINTERFACE}.
+     * @param owner the internal name of the field or method owner class.
+     * @param name the name of the field or method.
+     * @param descriptor the descriptor of the field or method.
+     * @return the index of a new or already existing method type reference item.
+     * @deprecated this method is superseded by {@link #newHandle(int, String, String, String,
+     *     boolean)}.
+     */
+    @Deprecated
+    public int newHandle(final int tag, final String owner, final String name, final String descriptor) {
+        return newHandle(tag, owner, name, descriptor, tag == Opcodes.H_INVOKEINTERFACE);
+    }
+
+    /**
+     * Adds a handle to the constant pool of the class being build. Does nothing if the constant pool
+     * already contains a similar item. <i>This method is intended for {@link Attribute} sub classes,
+     * and is normally not needed by class generators or adapters.</i>
+     *
+     * @param tag the kind of this handle. Must be {@link Opcodes#H_GETFIELD}, {@link
+     *     Opcodes#H_GETSTATIC}, {@link Opcodes#H_PUTFIELD}, {@link Opcodes#H_PUTSTATIC}, {@link
+     *     Opcodes#H_INVOKEVIRTUAL}, {@link Opcodes#H_INVOKESTATIC}, {@link Opcodes#H_INVOKESPECIAL},
+     *     {@link Opcodes#H_NEWINVOKESPECIAL} or {@link Opcodes#H_INVOKEINTERFACE}.
+     * @param owner the internal name of the field or method owner class.
+     * @param name the name of the field or method.
+     * @param descriptor the descriptor of the field or method.
+     * @param isInterface true if the owner is an interface.
+     * @return the index of a new or already existing method type reference item.
+     */
+    public int newHandle(final int tag, final String owner, final String name, final String descriptor, final boolean isInterface) {
+        return symbolTable.addConstantMethodHandle(tag, owner, name, descriptor, isInterface).index;
+    }
+
+    /**
+     * Adds a dynamic constant reference to the constant pool of the class being build. Does nothing
+     * if the constant pool already contains a similar item. <i>This method is intended for {@link
+     * Attribute} sub classes, and is normally not needed by class generators or adapters.</i>
+     *
+     * @param name name of the invoked method.
+     * @param descriptor field descriptor of the constant type.
+     * @param bootstrapMethodHandle the bootstrap method.
+     * @param bootstrapMethodArguments the bootstrap method constant arguments.
+     * @return the index of a new or already existing dynamic constant reference item.
+     */
+    public int newConstantDynamic(final String name, final String descriptor, final Handle bootstrapMethodHandle,
+            final Object... bootstrapMethodArguments) {
+        return symbolTable.addConstantDynamic(name, descriptor, bootstrapMethodHandle, bootstrapMethodArguments).index;
+    }
+
+    /**
+     * Adds an invokedynamic reference to the constant pool of the class being build. Does nothing if
+     * the constant pool already contains a similar item. <i>This method is intended for {@link
+     * Attribute} sub classes, and is normally not needed by class generators or adapters.</i>
+     *
+     * @param name name of the invoked method.
+     * @param descriptor descriptor of the invoke method.
+     * @param bootstrapMethodHandle the bootstrap method.
+     * @param bootstrapMethodArguments the bootstrap method constant arguments.
+     * @return the index of a new or already existing invokedynamic reference item.
+     */
+    public int newInvokeDynamic(final String name, final String descriptor, final Handle bootstrapMethodHandle,
+            final Object... bootstrapMethodArguments) {
+        return symbolTable.addConstantInvokeDynamic(name, descriptor, bootstrapMethodHandle, bootstrapMethodArguments).index;
+    }
+
+    /**
+     * Adds a field reference to the constant pool of the class being build. Does nothing if the
+     * constant pool already contains a similar item. <i>This method is intended for {@link Attribute}
+     * sub classes, and is normally not needed by class generators or adapters.</i>
+     *
+     * @param owner the internal name of the field's owner class.
+     * @param name the field's name.
+     * @param descriptor the field's descriptor.
+     * @return the index of a new or already existing field reference item.
+     */
+    public int newField(final String owner, final String name, final String descriptor) {
+        return symbolTable.addConstantFieldref(owner, name, descriptor).index;
+    }
+
+    /**
+     * Adds a method reference to the constant pool of the class being build. Does nothing if the
+     * constant pool already contains a similar item. <i>This method is intended for {@link Attribute}
+     * sub classes, and is normally not needed by class generators or adapters.</i>
+     *
+     * @param owner the internal name of the method's owner class.
+     * @param name the method's name.
+     * @param descriptor the method's descriptor.
+     * @param isInterface {@literal true} if {@code owner} is an interface.
+     * @return the index of a new or already existing method reference item.
+     */
+    public int newMethod(final String owner, final String name, final String descriptor, final boolean isInterface) {
+        return symbolTable.addConstantMethodref(owner, name, descriptor, isInterface).index;
+    }
+
+    /**
+     * Adds a name and type to the constant pool of the class being build. Does nothing if the
+     * constant pool already contains a similar item. <i>This method is intended for {@link Attribute}
+     * sub classes, and is normally not needed by class generators or adapters.</i>
+     *
+     * @param name a name.
+     * @param descriptor a type descriptor.
+     * @return the index of a new or already existing name and type item.
+     */
+    public int newNameType(final String name, final String descriptor) {
+        return symbolTable.addConstantNameAndType(name, descriptor);
+    }
+
+    // -----------------------------------------------------------------------------------------------
+    // Default method to compute common super classes when computing stack map frames
+    // -----------------------------------------------------------------------------------------------
+
+    /**
+     * Returns the common super type of the two given types. The default implementation of this method
+     * <i>loads</i> the two given classes and uses the java.lang.Class methods to find the common
+     * super class. It can be overridden to compute this common super type in other ways, in
+     * particular without actually loading any class, or to take into account the class that is
+     * currently being generated by this ClassWriter, which can of course not be loaded since it is
+     * under construction.
+     *
+     * @param type1 the internal name of a class.
+     * @param type2 the internal name of another class.
+     * @return the internal name of the common super class of the two given classes.
+     */
+    protected String getCommonSuperClass(final String type1, final String type2) {
+        ClassLoader classLoader = getClassLoader();
+        Class<?> class1;
+        try {
+            class1 = Class.forName(type1.replace('/', '.'), false, classLoader);
+        } catch (ClassNotFoundException e) {
+            throw new TypeNotPresentException(type1, e);
+        }
+        Class<?> class2;
+        try {
+            class2 = Class.forName(type2.replace('/', '.'), false, classLoader);
+        } catch (ClassNotFoundException e) {
+            throw new TypeNotPresentException(type2, e);
+        }
+        if (class1.isAssignableFrom(class2)) {
+            return type1;
+        }
+        if (class2.isAssignableFrom(class1)) {
+            return type2;
+        }
+        if (class1.isInterface() || class2.isInterface()) {
+            return "java/lang/Object";
+        } else {
+            do {
+                class1 = class1.getSuperclass();
+            } while (!class1.isAssignableFrom(class2));
+            return class1.getName().replace('.', '/');
+        }
+    }
+
+    /**
+     * Returns the {@link ClassLoader} to be used by the default implementation of {@link
+     * #getCommonSuperClass(String, String)}, that of this {@link ClassWriter}'s runtime type by
+     * default.
+     *
+     * @return ClassLoader
+     */
+    protected ClassLoader getClassLoader() {
+        return getClass().getClassLoader();
+    }
+}

--- a/core/src/main/java/org/mvel2/asm/ConstantDynamic.java
+++ b/core/src/main/java/org/mvel2/asm/ConstantDynamic.java
@@ -1,0 +1,166 @@
+// ASM: a very small and fast Java bytecode manipulation framework
+// Copyright (c) 2000-2011 INRIA, France Telecom
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+// 1. Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+// 2. Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+// 3. Neither the name of the copyright holders nor the names of its
+//    contributors may be used to endorse or promote products derived from
+//    this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+// THE POSSIBILITY OF SUCH DAMAGE.
+package org.mvel2.asm;
+
+import java.util.Arrays;
+
+/**
+ * A constant whose value is computed at runtime, with a bootstrap method.
+ *
+ * @author Remi Forax
+ */
+public final class ConstantDynamic {
+
+    /** The constant name (can be arbitrary). */
+    private final String name;
+
+    /** The constant type (must be a field descriptor). */
+    private final String descriptor;
+
+    /** The bootstrap method to use to compute the constant value at runtime. */
+    private final Handle bootstrapMethod;
+
+    /**
+     * The arguments to pass to the bootstrap method, in order to compute the constant value at
+     * runtime.
+     */
+    private final Object[] bootstrapMethodArguments;
+
+    /**
+     * Constructs a new {@link ConstantDynamic}.
+     *
+     * @param name the constant name (can be arbitrary).
+     * @param descriptor the constant type (must be a field descriptor).
+     * @param bootstrapMethod the bootstrap method to use to compute the constant value at runtime.
+     * @param bootstrapMethodArguments the arguments to pass to the bootstrap method, in order to
+     *     compute the constant value at runtime.
+     */
+    public ConstantDynamic(final String name, final String descriptor, final Handle bootstrapMethod,
+            final Object... bootstrapMethodArguments) {
+        this.name = name;
+        this.descriptor = descriptor;
+        this.bootstrapMethod = bootstrapMethod;
+        this.bootstrapMethodArguments = bootstrapMethodArguments;
+    }
+
+    /**
+     * Returns the name of this constant.
+     *
+     * @return the name of this constant.
+     */
+    public String getName() {
+        return name;
+    }
+
+    /**
+     * Returns the type of this constant.
+     *
+     * @return the type of this constant, as a field descriptor.
+     */
+    public String getDescriptor() {
+        return descriptor;
+    }
+
+    /**
+     * Returns the bootstrap method used to compute the value of this constant.
+     *
+     * @return the bootstrap method used to compute the value of this constant.
+     */
+    public Handle getBootstrapMethod() {
+        return bootstrapMethod;
+    }
+
+    /**
+     * Returns the number of arguments passed to the bootstrap method, in order to compute the value
+     * of this constant.
+     *
+     * @return the number of arguments passed to the bootstrap method, in order to compute the value
+     *     of this constant.
+     */
+    public int getBootstrapMethodArgumentCount() {
+        return bootstrapMethodArguments.length;
+    }
+
+    /**
+     * Returns an argument passed to the bootstrap method, in order to compute the value of this
+     * constant.
+     *
+     * @param index an argument index, between 0 and {@link #getBootstrapMethodArgumentCount()}
+     *     (exclusive).
+     * @return the argument passed to the bootstrap method, with the given index.
+     */
+    public Object getBootstrapMethodArgument(final int index) {
+        return bootstrapMethodArguments[index];
+    }
+
+    /**
+     * Returns the arguments to pass to the bootstrap method, in order to compute the value of this
+     * constant. WARNING: this array must not be modified, and must not be returned to the user.
+     *
+     * @return the arguments to pass to the bootstrap method, in order to compute the value of this
+     *     constant.
+     */
+    Object[] getBootstrapMethodArgumentsUnsafe() {
+        return bootstrapMethodArguments;
+    }
+
+    /**
+     * Returns the size of this constant.
+     *
+     * @return the size of this constant, i.e., 2 for {@code long} and {@code double}, 1 otherwise.
+     */
+    public int getSize() {
+        char firstCharOfDescriptor = descriptor.charAt(0);
+        return (firstCharOfDescriptor == 'J' || firstCharOfDescriptor == 'D') ? 2 : 1;
+    }
+
+    @Override
+    public boolean equals(final Object object) {
+        if (object == this) {
+            return true;
+        }
+        if (!(object instanceof ConstantDynamic)) {
+            return false;
+        }
+        ConstantDynamic constantDynamic = (ConstantDynamic) object;
+        return name.equals(constantDynamic.name) && descriptor.equals(constantDynamic.descriptor)
+                && bootstrapMethod.equals(constantDynamic.bootstrapMethod)
+                && Arrays.equals(bootstrapMethodArguments, constantDynamic.bootstrapMethodArguments);
+    }
+
+    @Override
+    public int hashCode() {
+        return name.hashCode() ^ Integer.rotateLeft(descriptor.hashCode(), 8) ^ Integer.rotateLeft(bootstrapMethod.hashCode(), 16)
+                ^ Integer.rotateLeft(Arrays.hashCode(bootstrapMethodArguments), 24);
+    }
+
+    @Override
+    public String toString() {
+        return name + " : " + descriptor + ' ' + bootstrapMethod + ' ' + Arrays.toString(bootstrapMethodArguments);
+    }
+}

--- a/core/src/main/java/org/mvel2/asm/Constants.java
+++ b/core/src/main/java/org/mvel2/asm/Constants.java
@@ -1,0 +1,177 @@
+// ASM: a very small and fast Java bytecode manipulation framework
+// Copyright (c) 2000-2011 INRIA, France Telecom
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+// 1. Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+// 2. Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+// 3. Neither the name of the copyright holders nor the names of its
+//    contributors may be used to endorse or promote products derived from
+//    this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+// THE POSSIBILITY OF SUCH DAMAGE.
+package org.mvel2.asm;
+
+/**
+ * Defines additional JVM opcodes, access flags and constants which are not part of the ASM public
+ * API.
+ *
+ * @see <a href="https://docs.oracle.com/javase/specs/jvms/se11/html/jvms-6.html">JVMS 6</a>
+ * @author Eric Bruneton
+ */
+final class Constants implements Opcodes {
+
+    // The ClassFile attribute names, in the order they are defined in
+    // https://docs.oracle.com/javase/specs/jvms/se11/html/jvms-4.html#jvms-4.7-300.
+
+    static final String CONSTANT_VALUE = "ConstantValue";
+    static final String CODE = "Code";
+    static final String STACK_MAP_TABLE = "StackMapTable";
+    static final String EXCEPTIONS = "Exceptions";
+    static final String INNER_CLASSES = "InnerClasses";
+    static final String ENCLOSING_METHOD = "EnclosingMethod";
+    static final String SYNTHETIC = "Synthetic";
+    static final String SIGNATURE = "Signature";
+    static final String SOURCE_FILE = "SourceFile";
+    static final String SOURCE_DEBUG_EXTENSION = "SourceDebugExtension";
+    static final String LINE_NUMBER_TABLE = "LineNumberTable";
+    static final String LOCAL_VARIABLE_TABLE = "LocalVariableTable";
+    static final String LOCAL_VARIABLE_TYPE_TABLE = "LocalVariableTypeTable";
+    static final String DEPRECATED = "Deprecated";
+    static final String RUNTIME_VISIBLE_ANNOTATIONS = "RuntimeVisibleAnnotations";
+    static final String RUNTIME_INVISIBLE_ANNOTATIONS = "RuntimeInvisibleAnnotations";
+    static final String RUNTIME_VISIBLE_PARAMETER_ANNOTATIONS = "RuntimeVisibleParameterAnnotations";
+    static final String RUNTIME_INVISIBLE_PARAMETER_ANNOTATIONS = "RuntimeInvisibleParameterAnnotations";
+    static final String RUNTIME_VISIBLE_TYPE_ANNOTATIONS = "RuntimeVisibleTypeAnnotations";
+    static final String RUNTIME_INVISIBLE_TYPE_ANNOTATIONS = "RuntimeInvisibleTypeAnnotations";
+    static final String ANNOTATION_DEFAULT = "AnnotationDefault";
+    static final String BOOTSTRAP_METHODS = "BootstrapMethods";
+    static final String METHOD_PARAMETERS = "MethodParameters";
+    static final String MODULE = "Module";
+    static final String MODULE_PACKAGES = "ModulePackages";
+    static final String MODULE_MAIN_CLASS = "ModuleMainClass";
+    static final String NEST_HOST = "NestHost";
+    static final String NEST_MEMBERS = "NestMembers";
+
+    // ASM specific access flags.
+    // WARNING: the 16 least significant bits must NOT be used, to avoid conflicts with standard
+    // access flags, and also to make sure that these flags are automatically filtered out when
+    // written in class files (because access flags are stored using 16 bits only).
+
+    static final int ACC_CONSTRUCTOR = 0x40000; // method access flag.
+
+    // ASM specific stack map frame types, used in {@link ClassVisitor#visitFrame}.
+
+    /**
+     * A frame inserted between already existing frames. This internal stack map frame type (in
+     * addition to the ones declared in {@link Opcodes}) can only be used if the frame content can be
+     * computed from the previous existing frame and from the instructions between this existing frame
+     * and the inserted one, without any knowledge of the type hierarchy. This kind of frame is only
+     * used when an unconditional jump is inserted in a method while expanding an ASM specific
+     * instruction. Keep in sync with Opcodes.java.
+     */
+    static final int F_INSERT = 256;
+
+    // The JVM opcode values which are not part of the ASM public API.
+    // See https://docs.oracle.com/javase/specs/jvms/se9/html/jvms-6.html.
+
+    static final int LDC_W = 19;
+    static final int LDC2_W = 20;
+    static final int ILOAD_0 = 26;
+    static final int ILOAD_1 = 27;
+    static final int ILOAD_2 = 28;
+    static final int ILOAD_3 = 29;
+    static final int LLOAD_0 = 30;
+    static final int LLOAD_1 = 31;
+    static final int LLOAD_2 = 32;
+    static final int LLOAD_3 = 33;
+    static final int FLOAD_0 = 34;
+    static final int FLOAD_1 = 35;
+    static final int FLOAD_2 = 36;
+    static final int FLOAD_3 = 37;
+    static final int DLOAD_0 = 38;
+    static final int DLOAD_1 = 39;
+    static final int DLOAD_2 = 40;
+    static final int DLOAD_3 = 41;
+    static final int ALOAD_0 = 42;
+    static final int ALOAD_1 = 43;
+    static final int ALOAD_2 = 44;
+    static final int ALOAD_3 = 45;
+    static final int ISTORE_0 = 59;
+    static final int ISTORE_1 = 60;
+    static final int ISTORE_2 = 61;
+    static final int ISTORE_3 = 62;
+    static final int LSTORE_0 = 63;
+    static final int LSTORE_1 = 64;
+    static final int LSTORE_2 = 65;
+    static final int LSTORE_3 = 66;
+    static final int FSTORE_0 = 67;
+    static final int FSTORE_1 = 68;
+    static final int FSTORE_2 = 69;
+    static final int FSTORE_3 = 70;
+    static final int DSTORE_0 = 71;
+    static final int DSTORE_1 = 72;
+    static final int DSTORE_2 = 73;
+    static final int DSTORE_3 = 74;
+    static final int ASTORE_0 = 75;
+    static final int ASTORE_1 = 76;
+    static final int ASTORE_2 = 77;
+    static final int ASTORE_3 = 78;
+    static final int WIDE = 196;
+    static final int GOTO_W = 200;
+    static final int JSR_W = 201;
+
+    // Constants to convert between normal and wide jump instructions.
+
+    // The delta between the GOTO_W and JSR_W opcodes and GOTO and JUMP.
+    static final int WIDE_JUMP_OPCODE_DELTA = GOTO_W - GOTO;
+
+    // Constants to convert JVM opcodes to the equivalent ASM specific opcodes, and vice versa.
+
+    // The delta between the ASM_IFEQ, ..., ASM_IF_ACMPNE, ASM_GOTO and ASM_JSR opcodes
+    // and IFEQ, ..., IF_ACMPNE, GOTO and JSR.
+    static final int ASM_OPCODE_DELTA = 49;
+
+    // The delta between the ASM_IFNULL and ASM_IFNONNULL opcodes and IFNULL and IFNONNULL.
+    static final int ASM_IFNULL_OPCODE_DELTA = 20;
+
+    // ASM specific opcodes, used for long forward jump instructions.
+
+    static final int ASM_IFEQ = IFEQ + ASM_OPCODE_DELTA;
+    static final int ASM_IFNE = IFNE + ASM_OPCODE_DELTA;
+    static final int ASM_IFLT = IFLT + ASM_OPCODE_DELTA;
+    static final int ASM_IFGE = IFGE + ASM_OPCODE_DELTA;
+    static final int ASM_IFGT = IFGT + ASM_OPCODE_DELTA;
+    static final int ASM_IFLE = IFLE + ASM_OPCODE_DELTA;
+    static final int ASM_IF_ICMPEQ = IF_ICMPEQ + ASM_OPCODE_DELTA;
+    static final int ASM_IF_ICMPNE = IF_ICMPNE + ASM_OPCODE_DELTA;
+    static final int ASM_IF_ICMPLT = IF_ICMPLT + ASM_OPCODE_DELTA;
+    static final int ASM_IF_ICMPGE = IF_ICMPGE + ASM_OPCODE_DELTA;
+    static final int ASM_IF_ICMPGT = IF_ICMPGT + ASM_OPCODE_DELTA;
+    static final int ASM_IF_ICMPLE = IF_ICMPLE + ASM_OPCODE_DELTA;
+    static final int ASM_IF_ACMPEQ = IF_ACMPEQ + ASM_OPCODE_DELTA;
+    static final int ASM_IF_ACMPNE = IF_ACMPNE + ASM_OPCODE_DELTA;
+    static final int ASM_GOTO = GOTO + ASM_OPCODE_DELTA;
+    static final int ASM_JSR = JSR + ASM_OPCODE_DELTA;
+    static final int ASM_IFNULL = IFNULL + ASM_IFNULL_OPCODE_DELTA;
+    static final int ASM_IFNONNULL = IFNONNULL + ASM_IFNULL_OPCODE_DELTA;
+    static final int ASM_GOTO_W = 220;
+
+    private Constants() {
+    }
+}

--- a/core/src/main/java/org/mvel2/asm/Context.java
+++ b/core/src/main/java/org/mvel2/asm/Context.java
@@ -1,0 +1,137 @@
+// ASM: a very small and fast Java bytecode manipulation framework
+// Copyright (c) 2000-2011 INRIA, France Telecom
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+// 1. Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+// 2. Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+// 3. Neither the name of the copyright holders nor the names of its
+//    contributors may be used to endorse or promote products derived from
+//    this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+// THE POSSIBILITY OF SUCH DAMAGE.
+
+package org.mvel2.asm;
+
+/**
+ * Information about a class being parsed in a {@link ClassReader}.
+ *
+ * @author Eric Bruneton
+ */
+final class Context {
+
+    /** The prototypes of the attributes that must be parsed in this class. */
+    Attribute[] attributePrototypes;
+
+    /**
+     * The options used to parse this class. One or more of {@link ClassReader#SKIP_CODE}, {@link
+     * ClassReader#SKIP_DEBUG}, {@link ClassReader#SKIP_FRAMES}, {@link ClassReader#EXPAND_FRAMES} or
+     * {@link ClassReader#EXPAND_ASM_INSNS}.
+     */
+    int parsingOptions;
+
+    /** The buffer used to read strings in the constant pool. */
+    char[] charBuffer;
+
+    // Information about the current method, i.e. the one read in the current (or latest) call
+    // to {@link ClassReader#readMethod()}.
+
+    /** The access flags of the current method. */
+    int currentMethodAccessFlags;
+
+    /** The name of the current method. */
+    String currentMethodName;
+
+    /** The descriptor of the current method. */
+    String currentMethodDescriptor;
+
+    /**
+     * The labels of the current method, indexed by bytecode offset (only bytecode offsets for which a
+     * label is needed have a non null associated Label).
+     */
+    Label[] currentMethodLabels;
+
+    // Information about the current type annotation target, i.e. the one read in the current
+    // (or latest) call to {@link ClassReader#readAnnotationTarget()}.
+
+    /**
+     * The target_type and target_info of the current type annotation target, encoded as described in
+     * {@link TypeReference}.
+     */
+    int currentTypeAnnotationTarget;
+
+    /** The target_path of the current type annotation target. */
+    TypePath currentTypeAnnotationTargetPath;
+
+    /** The start of each local variable range in the current local variable annotation. */
+    Label[] currentLocalVariableAnnotationRangeStarts;
+
+    /** The end of each local variable range in the current local variable annotation. */
+    Label[] currentLocalVariableAnnotationRangeEnds;
+
+    /**
+     * The local variable index of each local variable range in the current local variable annotation.
+     */
+    int[] currentLocalVariableAnnotationRangeIndices;
+
+    // Information about the current stack map frame, i.e. the one read in the current (or latest)
+    // call to {@link ClassReader#readFrame()}.
+
+    /** The bytecode offset of the current stack map frame. */
+    int currentFrameOffset;
+
+    /**
+     * The type of the current stack map frame. One of {@link Opcodes#F_FULL}, {@link
+     * Opcodes#F_APPEND}, {@link Opcodes#F_CHOP}, {@link Opcodes#F_SAME} or {@link Opcodes#F_SAME1}.
+     */
+    int currentFrameType;
+
+    /**
+     * The number of local variable types in the current stack map frame. Each type is represented
+     * with a single array element (even long and double).
+     */
+    int currentFrameLocalCount;
+
+    /**
+     * The delta number of local variable types in the current stack map frame (each type is
+     * represented with a single array element - even long and double). This is the number of local
+     * variable types in this frame, minus the number of local variable types in the previous frame.
+     */
+    int currentFrameLocalCountDelta;
+
+    /**
+     * The types of the local variables in the current stack map frame. Each type is represented with
+     * a single array element (even long and double), using the format described in {@link
+     * MethodVisitor#visitFrame}. Depending on {@link #currentFrameType}, this contains the types of
+     * all the local variables, or only those of the additional ones (compared to the previous frame).
+     */
+    Object[] currentFrameLocalTypes;
+
+    /**
+     * The number stack element types in the current stack map frame. Each type is represented with a
+     * single array element (even long and double).
+     */
+    int currentFrameStackCount;
+
+    /**
+     * The types of the stack elements in the current stack map frame. Each type is represented with a
+     * single array element (even long and double), using the format described in {@link
+     * MethodVisitor#visitFrame}.
+     */
+    Object[] currentFrameStackTypes;
+}

--- a/core/src/main/java/org/mvel2/asm/CurrentFrame.java
+++ b/core/src/main/java/org/mvel2/asm/CurrentFrame.java
@@ -1,0 +1,55 @@
+// ASM: a very small and fast Java bytecode manipulation framework
+// Copyright (c) 2000-2011 INRIA, France Telecom
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+// 1. Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+// 2. Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+// 3. Neither the name of the copyright holders nor the names of its
+//    contributors may be used to endorse or promote products derived from
+//    this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+// THE POSSIBILITY OF SUCH DAMAGE.
+
+package org.mvel2.asm;
+
+/**
+ * Information about the input stack map frame at the "current" instruction of a method. This is
+ * implemented as a Frame subclass for a "basic block" containing only one instruction.
+ *
+ * @author Eric Bruneton
+ */
+final class CurrentFrame extends Frame {
+
+    CurrentFrame(final Label owner) {
+        super(owner);
+    }
+
+    /**
+     * Sets this CurrentFrame to the input stack map frame of the next "current" instruction, i.e. the
+     * instruction just after the given one. It is assumed that the value of this object when this
+     * method is called is the stack map frame status just before the given instruction is executed.
+     */
+    @Override
+    void execute(final int opcode, final int arg, final Symbol symbolArg, final SymbolTable symbolTable) {
+        super.execute(opcode, arg, symbolArg, symbolTable);
+        Frame successor = new Frame(null);
+        merge(symbolTable, successor, 0);
+        copyFrom(successor);
+    }
+}

--- a/core/src/main/java/org/mvel2/asm/Edge.java
+++ b/core/src/main/java/org/mvel2/asm/Edge.java
@@ -1,0 +1,91 @@
+// ASM: a very small and fast Java bytecode manipulation framework
+// Copyright (c) 2000-2011 INRIA, France Telecom
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+// 1. Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+// 2. Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+// 3. Neither the name of the copyright holders nor the names of its
+//    contributors may be used to endorse or promote products derived from
+//    this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+// THE POSSIBILITY OF SUCH DAMAGE.
+package org.mvel2.asm;
+
+/**
+ * An edge in the control flow graph of a method. Each node of this graph is a basic block,
+ * represented with the Label corresponding to its first instruction. Each edge goes from one node
+ * to another, i.e. from one basic block to another (called the predecessor and successor blocks,
+ * respectively). An edge corresponds either to a jump or ret instruction or to an exception
+ * handler.
+ *
+ * @see Label
+ * @author Eric Bruneton
+ */
+final class Edge {
+
+    /**
+     * A control flow graph edge corresponding to a jump or ret instruction. Only used with {@link
+     * ClassWriter#COMPUTE_FRAMES}.
+     */
+    static final int JUMP = 0;
+
+    /**
+     * A control flow graph edge corresponding to an exception handler. Only used with {@link
+     * ClassWriter#COMPUTE_MAXS}.
+     */
+    static final int EXCEPTION = 0x7FFFFFFF;
+
+    /**
+     * Information about this control flow graph edge.
+     *
+     * <ul>
+     *   <li>If {@link ClassWriter#COMPUTE_MAXS} is used, this field contains either a stack size
+     *       delta (for an edge corresponding to a jump instruction), or the value EXCEPTION (for an
+     *       edge corresponding to an exception handler). The stack size delta is the stack size just
+     *       after the jump instruction, minus the stack size at the beginning of the predecessor
+     *       basic block, i.e. the one containing the jump instruction.
+     *   <li>If {@link ClassWriter#COMPUTE_FRAMES} is used, this field contains either the value JUMP
+     *       (for an edge corresponding to a jump instruction), or the index, in the {@link
+     *       ClassWriter} type table, of the exception type that is handled (for an edge corresponding
+     *       to an exception handler).
+     * </ul>
+     */
+    final int info;
+
+    /** The successor block of this control flow graph edge. */
+    final Label successor;
+
+    /**
+     * The next edge in the list of outgoing edges of a basic block. See {@link Label#outgoingEdges}.
+     */
+    Edge nextEdge;
+
+    /**
+     * Constructs a new Edge.
+     *
+     * @param info see {@link #info}.
+     * @param successor see {@link #successor}.
+     * @param nextEdge see {@link #nextEdge}.
+     */
+    Edge(final int info, final Label successor, final Edge nextEdge) {
+        this.info = info;
+        this.successor = successor;
+        this.nextEdge = nextEdge;
+    }
+}

--- a/core/src/main/java/org/mvel2/asm/FieldVisitor.java
+++ b/core/src/main/java/org/mvel2/asm/FieldVisitor.java
@@ -1,0 +1,133 @@
+// ASM: a very small and fast Java bytecode manipulation framework
+// Copyright (c) 2000-2011 INRIA, France Telecom
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+// 1. Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+// 2. Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+// 3. Neither the name of the copyright holders nor the names of its
+//    contributors may be used to endorse or promote products derived from
+//    this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+// THE POSSIBILITY OF SUCH DAMAGE.
+package org.mvel2.asm;
+
+/**
+ * A visitor to visit a Java field. The methods of this class must be called in the following order:
+ * ( {@code visitAnnotation} | {@code visitTypeAnnotation} | {@code visitAttribute} )* {@code
+ * visitEnd}.
+ *
+ * @author Eric Bruneton
+ */
+public abstract class FieldVisitor {
+
+    /**
+     * The ASM API version implemented by this visitor. The value of this field must be one of {@link
+     * Opcodes#ASM4}, {@link Opcodes#ASM5}, {@link Opcodes#ASM6} or {@link Opcodes#ASM7}.
+     */
+    protected final int api;
+
+    /** The field visitor to which this visitor must delegate method calls. May be null. */
+    protected FieldVisitor fv;
+
+    /**
+     * Constructs a new {@link FieldVisitor}.
+     *
+     * @param api the ASM API version implemented by this visitor. Must be one of {@link
+     *     Opcodes#ASM4}, {@link Opcodes#ASM5}, {@link Opcodes#ASM6} or {@link Opcodes#ASM7}.
+     */
+    public FieldVisitor(final int api) {
+        this(api, null);
+    }
+
+    /**
+     * Constructs a new {@link FieldVisitor}.
+     *
+     * @param api the ASM API version implemented by this visitor. Must be one of {@link
+     *     Opcodes#ASM4}, {@link Opcodes#ASM5}, {@link Opcodes#ASM6} or {@link Opcodes#ASM7}.
+     * @param fieldVisitor the field visitor to which this visitor must delegate method calls. May be
+     *     null.
+     */
+    public FieldVisitor(final int api, final FieldVisitor fieldVisitor) {
+        if (api != Opcodes.ASM6 && api != Opcodes.ASM5 && api != Opcodes.ASM4 && api != Opcodes.ASM7) {
+            throw new IllegalArgumentException();
+        }
+        this.api = api;
+        this.fv = fieldVisitor;
+    }
+
+    /**
+     * Visits an annotation of the field.
+     *
+     * @param descriptor the class descriptor of the annotation class.
+     * @param visible {@literal true} if the annotation is visible at runtime.
+     * @return a visitor to visit the annotation values, or {@literal null} if this visitor is not
+     *     interested in visiting this annotation.
+     */
+    public AnnotationVisitor visitAnnotation(final String descriptor, final boolean visible) {
+        if (fv != null) {
+            return fv.visitAnnotation(descriptor, visible);
+        }
+        return null;
+    }
+
+    /**
+     * Visits an annotation on the type of the field.
+     *
+     * @param typeRef a reference to the annotated type. The sort of this type reference must be
+     *     {@link TypeReference#FIELD}. See {@link TypeReference}.
+     * @param typePath the path to the annotated type argument, wildcard bound, array element type, or
+     *     static inner type within 'typeRef'. May be {@literal null} if the annotation targets
+     *     'typeRef' as a whole.
+     * @param descriptor the class descriptor of the annotation class.
+     * @param visible {@literal true} if the annotation is visible at runtime.
+     * @return a visitor to visit the annotation values, or {@literal null} if this visitor is not
+     *     interested in visiting this annotation.
+     */
+    public AnnotationVisitor visitTypeAnnotation(final int typeRef, final TypePath typePath, final String descriptor,
+            final boolean visible) {
+        if (api < Opcodes.ASM5) {
+            throw new UnsupportedOperationException("This feature requires ASM5");
+        }
+        if (fv != null) {
+            return fv.visitTypeAnnotation(typeRef, typePath, descriptor, visible);
+        }
+        return null;
+    }
+
+    /**
+     * Visits a non standard attribute of the field.
+     *
+     * @param attribute an attribute.
+     */
+    public void visitAttribute(final Attribute attribute) {
+        if (fv != null) {
+            fv.visitAttribute(attribute);
+        }
+    }
+
+    /**
+     * Visits the end of the field. This method, which is the last one to be called, is used to inform
+     * the visitor that all the annotations and attributes of the field have been visited.
+     */
+    public void visitEnd() {
+        if (fv != null) {
+            fv.visitEnd();
+        }
+    }
+}

--- a/core/src/main/java/org/mvel2/asm/FieldWriter.java
+++ b/core/src/main/java/org/mvel2/asm/FieldWriter.java
@@ -1,0 +1,321 @@
+// ASM: a very small and fast Java bytecode manipulation framework
+// Copyright (c) 2000-2011 INRIA, France Telecom
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+// 1. Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+// 2. Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+// 3. Neither the name of the copyright holders nor the names of its
+//    contributors may be used to endorse or promote products derived from
+//    this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+// THE POSSIBILITY OF SUCH DAMAGE.
+package org.mvel2.asm;
+
+/**
+ * A {@link FieldVisitor} that generates a corresponding 'field_info' structure, as defined in the
+ * Java Virtual Machine Specification (JVMS).
+ *
+ * @see <a href="https://docs.oracle.com/javase/specs/jvms/se9/html/jvms-4.html#jvms-4.5">JVMS
+ *     4.5</a>
+ * @author Eric Bruneton
+ */
+final class FieldWriter extends FieldVisitor {
+
+    /** Where the constants used in this FieldWriter must be stored. */
+    private final SymbolTable symbolTable;
+
+    // Note: fields are ordered as in the field_info structure, and those related to attributes are
+    // ordered as in Section 4.7 of the JVMS.
+
+    /**
+     * The access_flags field of the field_info JVMS structure. This field can contain ASM specific
+     * access flags, such as {@link Opcodes#ACC_DEPRECATED}, which are removed when generating the
+     * ClassFile structure.
+     */
+    private final int accessFlags;
+
+    /** The name_index field of the field_info JVMS structure. */
+    private final int nameIndex;
+
+    /** The descriptor_index field of the field_info JVMS structure. */
+    private final int descriptorIndex;
+
+    /**
+     * The signature_index field of the Signature attribute of this field_info, or 0 if there is no
+     * Signature attribute.
+     */
+    private int signatureIndex;
+
+    /**
+     * The constantvalue_index field of the ConstantValue attribute of this field_info, or 0 if there
+     * is no ConstantValue attribute.
+     */
+    private int constantValueIndex;
+
+    /**
+     * The last runtime visible annotation of this field. The previous ones can be accessed with the
+     * {@link AnnotationWriter#previousAnnotation} field. May be {@literal null}.
+     */
+    private AnnotationWriter lastRuntimeVisibleAnnotation;
+
+    /**
+     * The last runtime invisible annotation of this field. The previous ones can be accessed with the
+     * {@link AnnotationWriter#previousAnnotation} field. May be {@literal null}.
+     */
+    private AnnotationWriter lastRuntimeInvisibleAnnotation;
+
+    /**
+     * The last runtime visible type annotation of this field. The previous ones can be accessed with
+     * the {@link AnnotationWriter#previousAnnotation} field. May be {@literal null}.
+     */
+    private AnnotationWriter lastRuntimeVisibleTypeAnnotation;
+
+    /**
+     * The last runtime invisible type annotation of this field. The previous ones can be accessed
+     * with the {@link AnnotationWriter#previousAnnotation} field. May be {@literal null}.
+     */
+    private AnnotationWriter lastRuntimeInvisibleTypeAnnotation;
+
+    /**
+     * The first non standard attribute of this field. The next ones can be accessed with the {@link
+     * Attribute#nextAttribute} field. May be {@literal null}.
+     *
+     * <p><b>WARNING</b>: this list stores the attributes in the <i>reverse</i> order of their visit.
+     * firstAttribute is actually the last attribute visited in {@link #visitAttribute}. The {@link
+     * #putFieldInfo} method writes the attributes in the order defined by this list, i.e. in the
+     * reverse order specified by the user.
+     */
+    private Attribute firstAttribute;
+
+    // -----------------------------------------------------------------------------------------------
+    // Constructor
+    // -----------------------------------------------------------------------------------------------
+
+    /**
+     * Constructs a new {@link FieldWriter}.
+     *
+     * @param symbolTable where the constants used in this FieldWriter must be stored.
+     * @param access the field's access flags (see {@link Opcodes}).
+     * @param name the field's name.
+     * @param descriptor the field's descriptor (see {@link Type}).
+     * @param signature the field's signature. May be {@literal null}.
+     * @param constantValue the field's constant value. May be {@literal null}.
+     */
+    FieldWriter(final SymbolTable symbolTable, final int access, final String name, final String descriptor, final String signature,
+            final Object constantValue) {
+        super(Opcodes.ASM7);
+        this.symbolTable = symbolTable;
+        this.accessFlags = access;
+        this.nameIndex = symbolTable.addConstantUtf8(name);
+        this.descriptorIndex = symbolTable.addConstantUtf8(descriptor);
+        if (signature != null) {
+            this.signatureIndex = symbolTable.addConstantUtf8(signature);
+        }
+        if (constantValue != null) {
+            this.constantValueIndex = symbolTable.addConstant(constantValue).index;
+        }
+    }
+
+    // -----------------------------------------------------------------------------------------------
+    // Implementation of the FieldVisitor abstract class
+    // -----------------------------------------------------------------------------------------------
+
+    @Override
+    public AnnotationVisitor visitAnnotation(final String descriptor, final boolean visible) {
+        // Create a ByteVector to hold an 'annotation' JVMS structure.
+        // See https://docs.oracle.com/javase/specs/jvms/se9/html/jvms-4.html#jvms-4.7.16.
+        ByteVector annotation = new ByteVector();
+        // Write type_index and reserve space for num_element_value_pairs.
+        annotation.putShort(symbolTable.addConstantUtf8(descriptor)).putShort(0);
+        if (visible) {
+            return lastRuntimeVisibleAnnotation = new AnnotationWriter(symbolTable, annotation, lastRuntimeVisibleAnnotation);
+        } else {
+            return lastRuntimeInvisibleAnnotation = new AnnotationWriter(symbolTable, annotation, lastRuntimeInvisibleAnnotation);
+        }
+    }
+
+    @Override
+    public AnnotationVisitor visitTypeAnnotation(final int typeRef, final TypePath typePath, final String descriptor,
+            final boolean visible) {
+        // Create a ByteVector to hold a 'type_annotation' JVMS structure.
+        // See https://docs.oracle.com/javase/specs/jvms/se9/html/jvms-4.html#jvms-4.7.20.
+        ByteVector typeAnnotation = new ByteVector();
+        // Write target_type, target_info, and target_path.
+        TypeReference.putTarget(typeRef, typeAnnotation);
+        TypePath.put(typePath, typeAnnotation);
+        // Write type_index and reserve space for num_element_value_pairs.
+        typeAnnotation.putShort(symbolTable.addConstantUtf8(descriptor)).putShort(0);
+        if (visible) {
+            return lastRuntimeVisibleTypeAnnotation = new AnnotationWriter(symbolTable, typeAnnotation, lastRuntimeVisibleTypeAnnotation);
+        } else {
+            return lastRuntimeInvisibleTypeAnnotation = new AnnotationWriter(symbolTable, typeAnnotation,
+                    lastRuntimeInvisibleTypeAnnotation);
+        }
+    }
+
+    @Override
+    public void visitAttribute(final Attribute attribute) {
+        // Store the attributes in the <i>reverse</i> order of their visit by this method.
+        attribute.nextAttribute = firstAttribute;
+        firstAttribute = attribute;
+    }
+
+    @Override
+    public void visitEnd() {
+        // Nothing to do.
+    }
+
+    // -----------------------------------------------------------------------------------------------
+    // Utility methods
+    // -----------------------------------------------------------------------------------------------
+
+    /**
+     * Returns the size of the field_info JVMS structure generated by this FieldWriter. Also adds the
+     * names of the attributes of this field in the constant pool.
+     *
+     * @return the size in bytes of the field_info JVMS structure.
+     */
+    int computeFieldInfoSize() {
+        // The access_flags, name_index, descriptor_index and attributes_count fields use 8 bytes.
+        int size = 8;
+        // For ease of reference, we use here the same attribute order as in Section 4.7 of the JVMS.
+        if (constantValueIndex != 0) {
+            // ConstantValue attributes always use 8 bytes.
+            symbolTable.addConstantUtf8(Constants.CONSTANT_VALUE);
+            size += 8;
+        }
+        // Before Java 1.5, synthetic fields are represented with a Synthetic attribute.
+        if ((accessFlags & Opcodes.ACC_SYNTHETIC) != 0 && symbolTable.getMajorVersion() < Opcodes.V1_5) {
+            // Synthetic attributes always use 6 bytes.
+            symbolTable.addConstantUtf8(Constants.SYNTHETIC);
+            size += 6;
+        }
+        if (signatureIndex != 0) {
+            // Signature attributes always use 8 bytes.
+            symbolTable.addConstantUtf8(Constants.SIGNATURE);
+            size += 8;
+        }
+        // ACC_DEPRECATED is ASM specific, the ClassFile format uses a Deprecated attribute instead.
+        if ((accessFlags & Opcodes.ACC_DEPRECATED) != 0) {
+            // Deprecated attributes always use 6 bytes.
+            symbolTable.addConstantUtf8(Constants.DEPRECATED);
+            size += 6;
+        }
+        if (lastRuntimeVisibleAnnotation != null) {
+            size += lastRuntimeVisibleAnnotation.computeAnnotationsSize(Constants.RUNTIME_VISIBLE_ANNOTATIONS);
+        }
+        if (lastRuntimeInvisibleAnnotation != null) {
+            size += lastRuntimeInvisibleAnnotation.computeAnnotationsSize(Constants.RUNTIME_INVISIBLE_ANNOTATIONS);
+        }
+        if (lastRuntimeVisibleTypeAnnotation != null) {
+            size += lastRuntimeVisibleTypeAnnotation.computeAnnotationsSize(Constants.RUNTIME_VISIBLE_TYPE_ANNOTATIONS);
+        }
+        if (lastRuntimeInvisibleTypeAnnotation != null) {
+            size += lastRuntimeInvisibleTypeAnnotation.computeAnnotationsSize(Constants.RUNTIME_INVISIBLE_TYPE_ANNOTATIONS);
+        }
+        if (firstAttribute != null) {
+            size += firstAttribute.computeAttributesSize(symbolTable);
+        }
+        return size;
+    }
+
+    /**
+     * Puts the content of the field_info JVMS structure generated by this FieldWriter into the given
+     * ByteVector.
+     *
+     * @param output where the field_info structure must be put.
+     */
+    void putFieldInfo(final ByteVector output) {
+        boolean useSyntheticAttribute = symbolTable.getMajorVersion() < Opcodes.V1_5;
+        // Put the access_flags, name_index and descriptor_index fields.
+        int mask = useSyntheticAttribute ? Opcodes.ACC_SYNTHETIC : 0;
+        output.putShort(accessFlags & ~mask).putShort(nameIndex).putShort(descriptorIndex);
+        // Compute and put the attributes_count field.
+        // For ease of reference, we use here the same attribute order as in Section 4.7 of the JVMS.
+        int attributesCount = 0;
+        if (constantValueIndex != 0) {
+            ++attributesCount;
+        }
+        if ((accessFlags & Opcodes.ACC_SYNTHETIC) != 0 && useSyntheticAttribute) {
+            ++attributesCount;
+        }
+        if (signatureIndex != 0) {
+            ++attributesCount;
+        }
+        if ((accessFlags & Opcodes.ACC_DEPRECATED) != 0) {
+            ++attributesCount;
+        }
+        if (lastRuntimeVisibleAnnotation != null) {
+            ++attributesCount;
+        }
+        if (lastRuntimeInvisibleAnnotation != null) {
+            ++attributesCount;
+        }
+        if (lastRuntimeVisibleTypeAnnotation != null) {
+            ++attributesCount;
+        }
+        if (lastRuntimeInvisibleTypeAnnotation != null) {
+            ++attributesCount;
+        }
+        if (firstAttribute != null) {
+            attributesCount += firstAttribute.getAttributeCount();
+        }
+        output.putShort(attributesCount);
+        // Put the field_info attributes.
+        // For ease of reference, we use here the same attribute order as in Section 4.7 of the JVMS.
+        if (constantValueIndex != 0) {
+            output.putShort(symbolTable.addConstantUtf8(Constants.CONSTANT_VALUE)).putInt(2).putShort(constantValueIndex);
+        }
+        if ((accessFlags & Opcodes.ACC_SYNTHETIC) != 0 && useSyntheticAttribute) {
+            output.putShort(symbolTable.addConstantUtf8(Constants.SYNTHETIC)).putInt(0);
+        }
+        if (signatureIndex != 0) {
+            output.putShort(symbolTable.addConstantUtf8(Constants.SIGNATURE)).putInt(2).putShort(signatureIndex);
+        }
+        if ((accessFlags & Opcodes.ACC_DEPRECATED) != 0) {
+            output.putShort(symbolTable.addConstantUtf8(Constants.DEPRECATED)).putInt(0);
+        }
+        if (lastRuntimeVisibleAnnotation != null) {
+            lastRuntimeVisibleAnnotation.putAnnotations(symbolTable.addConstantUtf8(Constants.RUNTIME_VISIBLE_ANNOTATIONS), output);
+        }
+        if (lastRuntimeInvisibleAnnotation != null) {
+            lastRuntimeInvisibleAnnotation.putAnnotations(symbolTable.addConstantUtf8(Constants.RUNTIME_INVISIBLE_ANNOTATIONS), output);
+        }
+        if (lastRuntimeVisibleTypeAnnotation != null) {
+            lastRuntimeVisibleTypeAnnotation.putAnnotations(symbolTable.addConstantUtf8(Constants.RUNTIME_VISIBLE_TYPE_ANNOTATIONS),
+                    output);
+        }
+        if (lastRuntimeInvisibleTypeAnnotation != null) {
+            lastRuntimeInvisibleTypeAnnotation.putAnnotations(symbolTable.addConstantUtf8(Constants.RUNTIME_INVISIBLE_TYPE_ANNOTATIONS),
+                    output);
+        }
+        if (firstAttribute != null) {
+            firstAttribute.putAttributes(symbolTable, output);
+        }
+    }
+
+    /**
+     * Collects the attributes of this field into the given set of attribute prototypes.
+     *
+     * @param attributePrototypes a set of attribute prototypes.
+     */
+    final void collectAttributePrototypes(final Attribute.Set attributePrototypes) {
+        attributePrototypes.addAttributes(firstAttribute);
+    }
+}

--- a/core/src/main/java/org/mvel2/asm/Frame.java
+++ b/core/src/main/java/org/mvel2/asm/Frame.java
@@ -1,0 +1,1431 @@
+// ASM: a very small and fast Java bytecode manipulation framework
+// Copyright (c) 2000-2011 INRIA, France Telecom
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+// 1. Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+// 2. Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+// 3. Neither the name of the copyright holders nor the names of its
+//    contributors may be used to endorse or promote products derived from
+//    this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+// THE POSSIBILITY OF SUCH DAMAGE.
+package org.mvel2.asm;
+
+/**
+ * The input and output stack map frames of a basic block.
+ *
+ * <p>Stack map frames are computed in two steps:
+ *
+ * <ul>
+ *   <li>During the visit of each instruction in MethodWriter, the state of the frame at the end of
+ *       the current basic block is updated by simulating the action of the instruction on the
+ *       previous state of this so called "output frame".
+ *   <li>After all instructions have been visited, a fix point algorithm is used in MethodWriter to
+ *       compute the "input frame" of each basic block (i.e. the stack map frame at the beginning of
+ *       the basic block). See {@link MethodWriter#computeAllFrames}.
+ * </ul>
+ *
+ * <p>Output stack map frames are computed relatively to the input frame of the basic block, which
+ * is not yet known when output frames are computed. It is therefore necessary to be able to
+ * represent abstract types such as "the type at position x in the input frame locals" or "the type
+ * at position x from the top of the input frame stack" or even "the type at position x in the input
+ * frame, with y more (or less) array dimensions". This explains the rather complicated type format
+ * used in this class, explained below.
+ *
+ * <p>The local variables and the operand stack of input and output frames contain values called
+ * "abstract types" hereafter. An abstract type is represented with 4 fields named DIM, KIND, FLAGS
+ * and VALUE, packed in a single int value for better performance and memory efficiency:
+ *
+ * <pre>
+ *   =====================================
+ *   |.DIM|KIND|FLAG|...............VALUE|
+ *   =====================================
+ * </pre>
+ *
+ * <ul>
+ *   <li>the DIM field, stored in the 4 most significant bits, is a signed number of array
+ *       dimensions (from -8 to 7, included). It can be retrieved with {@link #DIM_MASK} and a right
+ *       shift of {@link #DIM_SHIFT}.
+ *   <li>the KIND field, stored in 4 bits, indicates the kind of VALUE used. These 4 bits can be
+ *       retrieved with {@link #KIND_MASK} and, without any shift, must be equal to {@link
+ *       #CONSTANT_KIND}, {@link #REFERENCE_KIND}, {@link #UNINITIALIZED_KIND}, {@link #LOCAL_KIND}
+ *       or {@link #STACK_KIND}.
+ *   <li>the FLAGS field, stored in 4 bits, contains up to 4 boolean flags. Currently only one flag
+ *       is defined, namely {@link #TOP_IF_LONG_OR_DOUBLE_FLAG}.
+ *   <li>the VALUE field, stored in the remaining 20 bits, contains either
+ *       <ul>
+ *         <li>one of the constants {@link #ITEM_TOP}, {@link #ITEM_ASM_BOOLEAN}, {@link
+ *             #ITEM_ASM_BYTE}, {@link #ITEM_ASM_CHAR} or {@link #ITEM_ASM_SHORT}, {@link
+ *             #ITEM_INTEGER}, {@link #ITEM_FLOAT}, {@link #ITEM_LONG}, {@link #ITEM_DOUBLE}, {@link
+ *             #ITEM_NULL} or {@link #ITEM_UNINITIALIZED_THIS}, if KIND is equal to {@link
+ *             #CONSTANT_KIND}.
+ *         <li>the index of a {@link Symbol#TYPE_TAG} {@link Symbol} in the type table of a {@link
+ *             SymbolTable}, if KIND is equal to {@link #REFERENCE_KIND}.
+ *         <li>the index of an {@link Symbol#UNINITIALIZED_TYPE_TAG} {@link Symbol} in the type
+ *             table of a SymbolTable, if KIND is equal to {@link #UNINITIALIZED_KIND}.
+ *         <li>the index of a local variable in the input stack frame, if KIND is equal to {@link
+ *             #LOCAL_KIND}.
+ *         <li>a position relatively to the top of the stack of the input stack frame, if KIND is
+ *             equal to {@link #STACK_KIND},
+ *       </ul>
+ * </ul>
+ *
+ * <p>Output frames can contain abstract types of any kind and with a positive or negative array
+ * dimension (and even unassigned types, represented by 0 - which does not correspond to any valid
+ * abstract type value). Input frames can only contain CONSTANT_KIND, REFERENCE_KIND or
+ * UNINITIALIZED_KIND abstract types of positive or null array dimension. In all cases the type
+ * table contains only internal type names (array type descriptors are forbidden - array dimensions
+ * must be represented through the DIM field).
+ *
+ * <p>The LONG and DOUBLE types are always represented by using two slots (LONG + TOP or DOUBLE +
+ * TOP), for local variables as well as in the operand stack. This is necessary to be able to
+ * simulate DUPx_y instructions, whose effect would be dependent on the concrete types represented
+ * by the abstract types in the stack (which are not always known).
+ *
+ * @author Eric Bruneton
+ */
+class Frame {
+
+    // Constants used in the StackMapTable attribute.
+    // See https://docs.oracle.com/javase/specs/jvms/se9/html/jvms-4.html#jvms-4.7.4.
+
+    static final int SAME_FRAME = 0;
+    static final int SAME_LOCALS_1_STACK_ITEM_FRAME = 64;
+    static final int RESERVED = 128;
+    static final int SAME_LOCALS_1_STACK_ITEM_FRAME_EXTENDED = 247;
+    static final int CHOP_FRAME = 248;
+    static final int SAME_FRAME_EXTENDED = 251;
+    static final int APPEND_FRAME = 252;
+    static final int FULL_FRAME = 255;
+
+    static final int ITEM_TOP = 0;
+    static final int ITEM_INTEGER = 1;
+    static final int ITEM_FLOAT = 2;
+    static final int ITEM_DOUBLE = 3;
+    static final int ITEM_LONG = 4;
+    static final int ITEM_NULL = 5;
+    static final int ITEM_UNINITIALIZED_THIS = 6;
+    static final int ITEM_OBJECT = 7;
+    static final int ITEM_UNINITIALIZED = 8;
+    // Additional, ASM specific constants used in abstract types below.
+    private static final int ITEM_ASM_BOOLEAN = 9;
+    private static final int ITEM_ASM_BYTE = 10;
+    private static final int ITEM_ASM_CHAR = 11;
+    private static final int ITEM_ASM_SHORT = 12;
+
+    // Bitmasks to get each field of an abstract type.
+
+    private static final int DIM_MASK = 0xF0000000;
+    private static final int KIND_MASK = 0x0F000000;
+    private static final int FLAGS_MASK = 0x00F00000;
+    private static final int VALUE_MASK = 0x000FFFFF;
+
+    // Constants to manipulate the DIM field of an abstract type.
+
+    /** The number of right shift bits to use to get the array dimensions of an abstract type. */
+    private static final int DIM_SHIFT = 28;
+
+    /** The constant to be added to an abstract type to get one with one more array dimension. */
+    private static final int ARRAY_OF = +1 << DIM_SHIFT;
+
+    /** The constant to be added to an abstract type to get one with one less array dimension. */
+    private static final int ELEMENT_OF = -1 << DIM_SHIFT;
+
+    // Possible values for the KIND field of an abstract type.
+
+    private static final int CONSTANT_KIND = 0x01000000;
+    private static final int REFERENCE_KIND = 0x02000000;
+    private static final int UNINITIALIZED_KIND = 0x03000000;
+    private static final int LOCAL_KIND = 0x04000000;
+    private static final int STACK_KIND = 0x05000000;
+
+    // Possible flags for the FLAGS field of an abstract type.
+
+    /**
+     * A flag used for LOCAL_KIND and STACK_KIND abstract types, indicating that if the resolved,
+     * concrete type is LONG or DOUBLE, TOP should be used instead (because the value has been
+     * partially overridden with an xSTORE instruction).
+     */
+    private static final int TOP_IF_LONG_OR_DOUBLE_FLAG = 0x00100000 & FLAGS_MASK;
+
+    // Useful predefined abstract types (all the possible CONSTANT_KIND types).
+
+    private static final int TOP = CONSTANT_KIND | ITEM_TOP;
+    private static final int BOOLEAN = CONSTANT_KIND | ITEM_ASM_BOOLEAN;
+    private static final int BYTE = CONSTANT_KIND | ITEM_ASM_BYTE;
+    private static final int CHAR = CONSTANT_KIND | ITEM_ASM_CHAR;
+    private static final int SHORT = CONSTANT_KIND | ITEM_ASM_SHORT;
+    private static final int INTEGER = CONSTANT_KIND | ITEM_INTEGER;
+    private static final int FLOAT = CONSTANT_KIND | ITEM_FLOAT;
+    private static final int LONG = CONSTANT_KIND | ITEM_LONG;
+    private static final int DOUBLE = CONSTANT_KIND | ITEM_DOUBLE;
+    private static final int NULL = CONSTANT_KIND | ITEM_NULL;
+    private static final int UNINITIALIZED_THIS = CONSTANT_KIND | ITEM_UNINITIALIZED_THIS;
+
+    // -----------------------------------------------------------------------------------------------
+    // Instance fields
+    // -----------------------------------------------------------------------------------------------
+
+    /** The basic block to which these input and output stack map frames correspond. */
+    Label owner;
+
+    /** The input stack map frame locals. This is an array of abstract types. */
+    private int[] inputLocals;
+
+    /** The input stack map frame stack. This is an array of abstract types. */
+    private int[] inputStack;
+
+    /** The output stack map frame locals. This is an array of abstract types. */
+    private int[] outputLocals;
+
+    /** The output stack map frame stack. This is an array of abstract types. */
+    private int[] outputStack;
+
+    /**
+     * The start of the output stack, relatively to the input stack. This offset is always negative or
+     * null. A null offset means that the output stack must be appended to the input stack. A -n
+     * offset means that the first n output stack elements must replace the top n input stack
+     * elements, and that the other elements must be appended to the input stack.
+     */
+    private short outputStackStart;
+
+    /** The index of the top stack element in {@link #outputStack}. */
+    private short outputStackTop;
+
+    /** The number of types that are initialized in the basic block. See {@link #initializations}. */
+    private int initializationCount;
+
+    /**
+     * The abstract types that are initialized in the basic block. A constructor invocation on an
+     * UNINITIALIZED or UNINITIALIZED_THIS abstract type must replace <i>every occurrence</i> of this
+     * type in the local variables and in the operand stack. This cannot be done during the first step
+     * of the algorithm since, during this step, the local variables and the operand stack types are
+     * still abstract. It is therefore necessary to store the abstract types of the constructors which
+     * are invoked in the basic block, in order to do this replacement during the second step of the
+     * algorithm, where the frames are fully computed. Note that this array can contain abstract types
+     * that are relative to the input locals or to the input stack.
+     */
+    private int[] initializations;
+
+    // -----------------------------------------------------------------------------------------------
+    // Constructor
+    // -----------------------------------------------------------------------------------------------
+
+    /**
+     * Constructs a new Frame.
+     *
+     * @param owner the basic block to which these input and output stack map frames correspond.
+     */
+    Frame(final Label owner) {
+        this.owner = owner;
+    }
+
+    /**
+     * Returns the abstract type corresponding to the given public API frame element type.
+     *
+     * @param symbolTable the type table to use to lookup and store type {@link Symbol}.
+     * @param type a frame element type described using the same format as in {@link
+     *     MethodVisitor#visitFrame}, i.e. either {@link Opcodes#TOP}, {@link Opcodes#INTEGER}, {@link
+     *     Opcodes#FLOAT}, {@link Opcodes#LONG}, {@link Opcodes#DOUBLE}, {@link Opcodes#NULL}, or
+     *     {@link Opcodes#UNINITIALIZED_THIS}, or the internal name of a class, or a Label designating
+     *     a NEW instruction (for uninitialized types).
+     * @return the abstract type corresponding to the given frame element type.
+     */
+    static int getAbstractTypeFromApiFormat(final SymbolTable symbolTable, final Object type) {
+        if (type instanceof Integer) {
+            return CONSTANT_KIND | ((Integer) type).intValue();
+        } else if (type instanceof String) {
+            String descriptor = Type.getObjectType((String) type).getDescriptor();
+            return getAbstractTypeFromDescriptor(symbolTable, descriptor, 0);
+        } else {
+            return UNINITIALIZED_KIND | symbolTable.addUninitializedType("", ((Label) type).bytecodeOffset);
+        }
+    }
+
+    // -----------------------------------------------------------------------------------------------
+    // Static methods to get abstract types from other type formats
+    // -----------------------------------------------------------------------------------------------
+
+    /**
+     * Returns the abstract type corresponding to the internal name of a class.
+     *
+     * @param symbolTable the type table to use to lookup and store type {@link Symbol}.
+     * @param internalName the internal name of a class. This must <i>not</i> be an array type
+     *     descriptor.
+     * @return the abstract type value corresponding to the given internal name.
+     */
+    static int getAbstractTypeFromInternalName(final SymbolTable symbolTable, final String internalName) {
+        return REFERENCE_KIND | symbolTable.addType(internalName);
+    }
+
+    /**
+     * Returns the abstract type corresponding to the given type descriptor.
+     *
+     * @param symbolTable the type table to use to lookup and store type {@link Symbol}.
+     * @param buffer a string ending with a type descriptor.
+     * @param offset the start offset of the type descriptor in buffer.
+     * @return the abstract type corresponding to the given type descriptor.
+     */
+    private static int getAbstractTypeFromDescriptor(final SymbolTable symbolTable, final String buffer, final int offset) {
+        String internalName;
+        switch (buffer.charAt(offset)) {
+            case 'V':
+                return 0;
+            case 'Z':
+            case 'C':
+            case 'B':
+            case 'S':
+            case 'I':
+                return INTEGER;
+            case 'F':
+                return FLOAT;
+            case 'J':
+                return LONG;
+            case 'D':
+                return DOUBLE;
+            case 'L':
+                internalName = buffer.substring(offset + 1, buffer.length() - 1);
+                return REFERENCE_KIND | symbolTable.addType(internalName);
+            case '[':
+                int elementDescriptorOffset = offset + 1;
+                while (buffer.charAt(elementDescriptorOffset) == '[') {
+                    ++elementDescriptorOffset;
+                }
+                int typeValue;
+                switch (buffer.charAt(elementDescriptorOffset)) {
+                    case 'Z':
+                        typeValue = BOOLEAN;
+                        break;
+                    case 'C':
+                        typeValue = CHAR;
+                        break;
+                    case 'B':
+                        typeValue = BYTE;
+                        break;
+                    case 'S':
+                        typeValue = SHORT;
+                        break;
+                    case 'I':
+                        typeValue = INTEGER;
+                        break;
+                    case 'F':
+                        typeValue = FLOAT;
+                        break;
+                    case 'J':
+                        typeValue = LONG;
+                        break;
+                    case 'D':
+                        typeValue = DOUBLE;
+                        break;
+                    case 'L':
+                        internalName = buffer.substring(elementDescriptorOffset + 1, buffer.length() - 1);
+                        typeValue = REFERENCE_KIND | symbolTable.addType(internalName);
+                        break;
+                    default:
+                        throw new IllegalArgumentException();
+                }
+                return ((elementDescriptorOffset - offset) << DIM_SHIFT) | typeValue;
+            default:
+                throw new IllegalArgumentException();
+        }
+    }
+
+    /**
+     * Merges the type at the given index in the given abstract type array with the given type.
+     * Returns {@literal true} if the type array has been modified by this operation.
+     *
+     * @param symbolTable the type table to use to lookup and store type {@link Symbol}.
+     * @param sourceType the abstract type with which the abstract type array element must be merged.
+     *     This type should be of {@link #CONSTANT_KIND}, {@link #REFERENCE_KIND} or {@link
+     *     #UNINITIALIZED_KIND} kind, with positive or null array dimensions.
+     * @param dstTypes an array of abstract types. These types should be of {@link #CONSTANT_KIND},
+     *     {@link #REFERENCE_KIND} or {@link #UNINITIALIZED_KIND} kind, with positive or null array
+     *     dimensions.
+     * @param dstIndex the index of the type that must be merged in dstTypes.
+     * @return {@literal true} if the type array has been modified by this operation.
+     */
+    private static boolean merge(final SymbolTable symbolTable, final int sourceType, final int[] dstTypes, final int dstIndex) {
+        int dstType = dstTypes[dstIndex];
+        if (dstType == sourceType) {
+            // If the types are equal, merge(sourceType, dstType) = dstType, so there is no change.
+            return false;
+        }
+        int srcType = sourceType;
+        if ((sourceType & ~DIM_MASK) == NULL) {
+            if (dstType == NULL) {
+                return false;
+            }
+            srcType = NULL;
+        }
+        if (dstType == 0) {
+            // If dstTypes[dstIndex] has never been assigned, merge(srcType, dstType) = srcType.
+            dstTypes[dstIndex] = srcType;
+            return true;
+        }
+        int mergedType;
+        if ((dstType & DIM_MASK) != 0 || (dstType & KIND_MASK) == REFERENCE_KIND) {
+            // If dstType is a reference type of any array dimension.
+            if (srcType == NULL) {
+                // If srcType is the NULL type, merge(srcType, dstType) = dstType, so there is no change.
+                return false;
+            } else if ((srcType & (DIM_MASK | KIND_MASK)) == (dstType & (DIM_MASK | KIND_MASK))) {
+                // If srcType has the same array dimension and the same kind as dstType.
+                if ((dstType & KIND_MASK) == REFERENCE_KIND) {
+                    // If srcType and dstType are reference types with the same array dimension,
+                    // merge(srcType, dstType) = dim(srcType) | common super class of srcType and dstType.
+                    mergedType = (srcType & DIM_MASK) | REFERENCE_KIND
+                            | symbolTable.addMergedType(srcType & VALUE_MASK, dstType & VALUE_MASK);
+                } else {
+                    // If srcType and dstType are array types of equal dimension but different element types,
+                    // merge(srcType, dstType) = dim(srcType) - 1 | java/lang/Object.
+                    int mergedDim = ELEMENT_OF + (srcType & DIM_MASK);
+                    mergedType = mergedDim | REFERENCE_KIND | symbolTable.addType("java/lang/Object");
+                }
+            } else if ((srcType & DIM_MASK) != 0 || (srcType & KIND_MASK) == REFERENCE_KIND) {
+                // If srcType is any other reference or array type,
+                // merge(srcType, dstType) = min(srcDdim, dstDim) | java/lang/Object
+                // where srcDim is the array dimension of srcType, minus 1 if srcType is an array type
+                // with a non reference element type (and similarly for dstDim).
+                int srcDim = srcType & DIM_MASK;
+                if (srcDim != 0 && (srcType & KIND_MASK) != REFERENCE_KIND) {
+                    srcDim = ELEMENT_OF + srcDim;
+                }
+                int dstDim = dstType & DIM_MASK;
+                if (dstDim != 0 && (dstType & KIND_MASK) != REFERENCE_KIND) {
+                    dstDim = ELEMENT_OF + dstDim;
+                }
+                mergedType = Math.min(srcDim, dstDim) | REFERENCE_KIND | symbolTable.addType("java/lang/Object");
+            } else {
+                // If srcType is any other type, merge(srcType, dstType) = TOP.
+                mergedType = TOP;
+            }
+        } else if (dstType == NULL) {
+            // If dstType is the NULL type, merge(srcType, dstType) = srcType, or TOP if srcType is not a
+            // an array type or a reference type.
+            mergedType = (srcType & DIM_MASK) != 0 || (srcType & KIND_MASK) == REFERENCE_KIND ? srcType : TOP;
+        } else {
+            // If dstType is any other type, merge(srcType, dstType) = TOP whatever srcType.
+            mergedType = TOP;
+        }
+        if (mergedType != dstType) {
+            dstTypes[dstIndex] = mergedType;
+            return true;
+        }
+        return false;
+    }
+
+    // -----------------------------------------------------------------------------------------------
+    // Methods related to the input frame
+    // -----------------------------------------------------------------------------------------------
+
+    /**
+     * Put the given abstract type in the given ByteVector, using the JVMS verification_type_info
+     * format used in StackMapTable attributes.
+     *
+     * @param symbolTable the type table to use to lookup and store type {@link Symbol}.
+     * @param abstractType an abstract type, restricted to {@link Frame#CONSTANT_KIND}, {@link
+     *     Frame#REFERENCE_KIND} or {@link Frame#UNINITIALIZED_KIND} types.
+     * @param output where the abstract type must be put.
+     * @see <a href="https://docs.oracle.com/javase/specs/jvms/se9/html/jvms-4.html#jvms-4.7.4">JVMS
+     *     4.7.4</a>
+     */
+    static void putAbstractType(final SymbolTable symbolTable, final int abstractType, final ByteVector output) {
+        int arrayDimensions = (abstractType & Frame.DIM_MASK) >> DIM_SHIFT;
+        if (arrayDimensions == 0) {
+            int typeValue = abstractType & VALUE_MASK;
+            switch (abstractType & KIND_MASK) {
+                case CONSTANT_KIND:
+                    output.putByte(typeValue);
+                    break;
+                case REFERENCE_KIND:
+                    output.putByte(ITEM_OBJECT).putShort(symbolTable.addConstantClass(symbolTable.getType(typeValue).value).index);
+                    break;
+                case UNINITIALIZED_KIND:
+                    output.putByte(ITEM_UNINITIALIZED).putShort((int) symbolTable.getType(typeValue).data);
+                    break;
+                default:
+                    throw new AssertionError();
+            }
+        } else {
+            // Case of an array type, we need to build its descriptor first.
+            StringBuilder typeDescriptor = new StringBuilder();
+            while (arrayDimensions-- > 0) {
+                typeDescriptor.append('[');
+            }
+            if ((abstractType & KIND_MASK) == REFERENCE_KIND) {
+                typeDescriptor.append('L').append(symbolTable.getType(abstractType & VALUE_MASK).value).append(';');
+            } else {
+                switch (abstractType & VALUE_MASK) {
+                    case Frame.ITEM_ASM_BOOLEAN:
+                        typeDescriptor.append('Z');
+                        break;
+                    case Frame.ITEM_ASM_BYTE:
+                        typeDescriptor.append('B');
+                        break;
+                    case Frame.ITEM_ASM_CHAR:
+                        typeDescriptor.append('C');
+                        break;
+                    case Frame.ITEM_ASM_SHORT:
+                        typeDescriptor.append('S');
+                        break;
+                    case Frame.ITEM_INTEGER:
+                        typeDescriptor.append('I');
+                        break;
+                    case Frame.ITEM_FLOAT:
+                        typeDescriptor.append('F');
+                        break;
+                    case Frame.ITEM_LONG:
+                        typeDescriptor.append('J');
+                        break;
+                    case Frame.ITEM_DOUBLE:
+                        typeDescriptor.append('D');
+                        break;
+                    default:
+                        throw new AssertionError();
+                }
+            }
+            output.putByte(ITEM_OBJECT).putShort(symbolTable.addConstantClass(typeDescriptor.toString()).index);
+        }
+    }
+
+    /**
+     * Sets this frame to the value of the given frame.
+     *
+     * <p>WARNING: after this method is called the two frames share the same data structures. It is
+     * recommended to discard the given frame to avoid unexpected side effects.
+     *
+     * @param frame The new frame value.
+     */
+    final void copyFrom(final Frame frame) {
+        inputLocals = frame.inputLocals;
+        inputStack = frame.inputStack;
+        outputStackStart = 0;
+        outputLocals = frame.outputLocals;
+        outputStack = frame.outputStack;
+        outputStackTop = frame.outputStackTop;
+        initializationCount = frame.initializationCount;
+        initializations = frame.initializations;
+    }
+
+    /**
+     * Sets the input frame from the given method description. This method is used to initialize the
+     * first frame of a method, which is implicit (i.e. not stored explicitly in the StackMapTable
+     * attribute).
+     *
+     * @param symbolTable the type table to use to lookup and store type {@link Symbol}.
+     * @param access the method's access flags.
+     * @param descriptor the method descriptor.
+     * @param maxLocals the maximum number of local variables of the method.
+     */
+    final void setInputFrameFromDescriptor(final SymbolTable symbolTable, final int access, final String descriptor, final int maxLocals) {
+        inputLocals = new int[maxLocals];
+        inputStack = new int[0];
+        int inputLocalIndex = 0;
+        if ((access & Opcodes.ACC_STATIC) == 0) {
+            if ((access & Constants.ACC_CONSTRUCTOR) == 0) {
+                inputLocals[inputLocalIndex++] = REFERENCE_KIND | symbolTable.addType(symbolTable.getClassName());
+            } else {
+                inputLocals[inputLocalIndex++] = UNINITIALIZED_THIS;
+            }
+        }
+        for (Type argumentType : Type.getArgumentTypes(descriptor)) {
+            int abstractType = getAbstractTypeFromDescriptor(symbolTable, argumentType.getDescriptor(), 0);
+            inputLocals[inputLocalIndex++] = abstractType;
+            if (abstractType == LONG || abstractType == DOUBLE) {
+                inputLocals[inputLocalIndex++] = TOP;
+            }
+        }
+        while (inputLocalIndex < maxLocals) {
+            inputLocals[inputLocalIndex++] = TOP;
+        }
+    }
+
+    // -----------------------------------------------------------------------------------------------
+    // Methods related to the output frame
+    // -----------------------------------------------------------------------------------------------
+
+    /**
+     * Sets the input frame from the given public API frame description.
+     *
+     * @param symbolTable the type table to use to lookup and store type {@link Symbol}.
+     * @param numLocal the number of local variables.
+     * @param local the local variable types, described using the same format as in {@link
+     *     MethodVisitor#visitFrame}.
+     * @param numStack the number of operand stack elements.
+     * @param stack the operand stack types, described using the same format as in {@link
+     *     MethodVisitor#visitFrame}.
+     */
+    final void setInputFrameFromApiFormat(final SymbolTable symbolTable, final int numLocal, final Object[] local, final int numStack,
+            final Object[] stack) {
+        int inputLocalIndex = 0;
+        for (int i = 0; i < numLocal; ++i) {
+            inputLocals[inputLocalIndex++] = getAbstractTypeFromApiFormat(symbolTable, local[i]);
+            if (local[i] == Opcodes.LONG || local[i] == Opcodes.DOUBLE) {
+                inputLocals[inputLocalIndex++] = TOP;
+            }
+        }
+        while (inputLocalIndex < inputLocals.length) {
+            inputLocals[inputLocalIndex++] = TOP;
+        }
+        int numStackTop = 0;
+        for (int i = 0; i < numStack; ++i) {
+            if (stack[i] == Opcodes.LONG || stack[i] == Opcodes.DOUBLE) {
+                ++numStackTop;
+            }
+        }
+        inputStack = new int[numStack + numStackTop];
+        int inputStackIndex = 0;
+        for (int i = 0; i < numStack; ++i) {
+            inputStack[inputStackIndex++] = getAbstractTypeFromApiFormat(symbolTable, stack[i]);
+            if (stack[i] == Opcodes.LONG || stack[i] == Opcodes.DOUBLE) {
+                inputStack[inputStackIndex++] = TOP;
+            }
+        }
+        outputStackTop = 0;
+        initializationCount = 0;
+    }
+
+    final int getInputStackSize() {
+        return inputStack.length;
+    }
+
+    /**
+     * Returns the abstract type stored at the given local variable index in the output frame.
+     *
+     * @param localIndex the index of the local variable whose value must be returned.
+     * @return the abstract type stored at the given local variable index in the output frame.
+     */
+    private int getLocal(final int localIndex) {
+        if (outputLocals == null || localIndex >= outputLocals.length) {
+            // If this local has never been assigned in this basic block, it is still equal to its value
+            // in the input frame.
+            return LOCAL_KIND | localIndex;
+        } else {
+            int abstractType = outputLocals[localIndex];
+            if (abstractType == 0) {
+                // If this local has never been assigned in this basic block, so it is still equal to its
+                // value in the input frame.
+                abstractType = outputLocals[localIndex] = LOCAL_KIND | localIndex;
+            }
+            return abstractType;
+        }
+    }
+
+    /**
+     * Replaces the abstract type stored at the given local variable index in the output frame.
+     *
+     * @param localIndex the index of the output frame local variable that must be set.
+     * @param abstractType the value that must be set.
+     */
+    private void setLocal(final int localIndex, final int abstractType) {
+        // Create and/or resize the output local variables array if necessary.
+        if (outputLocals == null) {
+            outputLocals = new int[10];
+        }
+        int outputLocalsLength = outputLocals.length;
+        if (localIndex >= outputLocalsLength) {
+            int[] newOutputLocals = new int[Math.max(localIndex + 1, 2 * outputLocalsLength)];
+            System.arraycopy(outputLocals, 0, newOutputLocals, 0, outputLocalsLength);
+            outputLocals = newOutputLocals;
+        }
+        // Set the local variable.
+        outputLocals[localIndex] = abstractType;
+    }
+
+    /**
+     * Pushes the given abstract type on the output frame stack.
+     *
+     * @param abstractType an abstract type.
+     */
+    private void push(final int abstractType) {
+        // Create and/or resize the output stack array if necessary.
+        if (outputStack == null) {
+            outputStack = new int[10];
+        }
+        int outputStackLength = outputStack.length;
+        if (outputStackTop >= outputStackLength) {
+            int[] newOutputStack = new int[Math.max(outputStackTop + 1, 2 * outputStackLength)];
+            System.arraycopy(outputStack, 0, newOutputStack, 0, outputStackLength);
+            outputStack = newOutputStack;
+        }
+        // Pushes the abstract type on the output stack.
+        outputStack[outputStackTop++] = abstractType;
+        // Updates the maximum size reached by the output stack, if needed (note that this size is
+        // relative to the input stack size, which is not known yet).
+        short outputStackSize = (short) (outputStackStart + outputStackTop);
+        if (outputStackSize > owner.outputStackMax) {
+            owner.outputStackMax = outputStackSize;
+        }
+    }
+
+    /**
+     * Pushes the abstract type corresponding to the given descriptor on the output frame stack.
+     *
+     * @param symbolTable the type table to use to lookup and store type {@link Symbol}.
+     * @param descriptor a type or method descriptor (in which case its return type is pushed).
+     */
+    private void push(final SymbolTable symbolTable, final String descriptor) {
+        int typeDescriptorOffset = descriptor.charAt(0) == '(' ? descriptor.indexOf(')') + 1 : 0;
+        int abstractType = getAbstractTypeFromDescriptor(symbolTable, descriptor, typeDescriptorOffset);
+        if (abstractType != 0) {
+            push(abstractType);
+            if (abstractType == LONG || abstractType == DOUBLE) {
+                push(TOP);
+            }
+        }
+    }
+
+    /**
+     * Pops an abstract type from the output frame stack and returns its value.
+     *
+     * @return the abstract type that has been popped from the output frame stack.
+     */
+    private int pop() {
+        if (outputStackTop > 0) {
+            return outputStack[--outputStackTop];
+        } else {
+            // If the output frame stack is empty, pop from the input stack.
+            return STACK_KIND | -(--outputStackStart);
+        }
+    }
+
+    // -----------------------------------------------------------------------------------------------
+    // Methods to handle uninitialized types
+    // -----------------------------------------------------------------------------------------------
+
+    /**
+     * Pops the given number of abstract types from the output frame stack.
+     *
+     * @param elements the number of abstract types that must be popped.
+     */
+    private void pop(final int elements) {
+        if (outputStackTop >= elements) {
+            outputStackTop -= elements;
+        } else {
+            // If the number of elements to be popped is greater than the number of elements in the output
+            // stack, clear it, and pop the remaining elements from the input stack.
+            outputStackStart -= elements - outputStackTop;
+            outputStackTop = 0;
+        }
+    }
+
+    /**
+     * Pops as many abstract types from the output frame stack as described by the given descriptor.
+     *
+     * @param descriptor a type or method descriptor (in which case its argument types are popped).
+     */
+    private void pop(final String descriptor) {
+        char firstDescriptorChar = descriptor.charAt(0);
+        if (firstDescriptorChar == '(') {
+            pop((Type.getArgumentsAndReturnSizes(descriptor) >> 2) - 1);
+        } else if (firstDescriptorChar == 'J' || firstDescriptorChar == 'D') {
+            pop(2);
+        } else {
+            pop(1);
+        }
+    }
+
+    // -----------------------------------------------------------------------------------------------
+    // Main method, to simulate the execution of each instruction on the output frame
+    // -----------------------------------------------------------------------------------------------
+
+    /**
+     * Adds an abstract type to the list of types on which a constructor is invoked in the basic
+     * block.
+     *
+     * @param abstractType an abstract type on a which a constructor is invoked.
+     */
+    private void addInitializedType(final int abstractType) {
+        // Create and/or resize the initializations array if necessary.
+        if (initializations == null) {
+            initializations = new int[2];
+        }
+        int initializationsLength = initializations.length;
+        if (initializationCount >= initializationsLength) {
+            int[] newInitializations = new int[Math.max(initializationCount + 1, 2 * initializationsLength)];
+            System.arraycopy(initializations, 0, newInitializations, 0, initializationsLength);
+            initializations = newInitializations;
+        }
+        // Store the abstract type.
+        initializations[initializationCount++] = abstractType;
+    }
+
+    // -----------------------------------------------------------------------------------------------
+    // Frame merging methods, used in the second step of the stack map frame computation algorithm
+    // -----------------------------------------------------------------------------------------------
+
+    /**
+     * Returns the "initialized" abstract type corresponding to the given abstract type.
+     *
+     * @param symbolTable the type table to use to lookup and store type {@link Symbol}.
+     * @param abstractType an abstract type.
+     * @return the REFERENCE_KIND abstract type corresponding to abstractType if it is
+     *     UNINITIALIZED_THIS or an UNINITIALIZED_KIND abstract type for one of the types on which a
+     *     constructor is invoked in the basic block. Otherwise returns abstractType.
+     */
+    private int getInitializedType(final SymbolTable symbolTable, final int abstractType) {
+        if (abstractType == UNINITIALIZED_THIS || (abstractType & (DIM_MASK | KIND_MASK)) == UNINITIALIZED_KIND) {
+            for (int i = 0; i < initializationCount; ++i) {
+                int initializedType = initializations[i];
+                int dim = initializedType & DIM_MASK;
+                int kind = initializedType & KIND_MASK;
+                int value = initializedType & VALUE_MASK;
+                if (kind == LOCAL_KIND) {
+                    initializedType = dim + inputLocals[value];
+                } else if (kind == STACK_KIND) {
+                    initializedType = dim + inputStack[inputStack.length - value];
+                }
+                if (abstractType == initializedType) {
+                    if (abstractType == UNINITIALIZED_THIS) {
+                        return REFERENCE_KIND | symbolTable.addType(symbolTable.getClassName());
+                    } else {
+                        return REFERENCE_KIND | symbolTable.addType(symbolTable.getType(abstractType & VALUE_MASK).value);
+                    }
+                }
+            }
+        }
+        return abstractType;
+    }
+
+    /**
+     * Simulates the action of the given instruction on the output stack frame.
+     *
+     * @param opcode the opcode of the instruction.
+     * @param arg the numeric operand of the instruction, if any.
+     * @param argSymbol the Symbol operand of the instruction, if any.
+     * @param symbolTable the type table to use to lookup and store type {@link Symbol}.
+     */
+    void execute(final int opcode, final int arg, final Symbol argSymbol, final SymbolTable symbolTable) {
+        // Abstract types popped from the stack or read from local variables.
+        int abstractType1;
+        int abstractType2;
+        int abstractType3;
+        int abstractType4;
+        switch (opcode) {
+            case Opcodes.NOP:
+            case Opcodes.INEG:
+            case Opcodes.LNEG:
+            case Opcodes.FNEG:
+            case Opcodes.DNEG:
+            case Opcodes.I2B:
+            case Opcodes.I2C:
+            case Opcodes.I2S:
+            case Opcodes.GOTO:
+            case Opcodes.RETURN:
+                break;
+            case Opcodes.ACONST_NULL:
+                push(NULL);
+                break;
+            case Opcodes.ICONST_M1:
+            case Opcodes.ICONST_0:
+            case Opcodes.ICONST_1:
+            case Opcodes.ICONST_2:
+            case Opcodes.ICONST_3:
+            case Opcodes.ICONST_4:
+            case Opcodes.ICONST_5:
+            case Opcodes.BIPUSH:
+            case Opcodes.SIPUSH:
+            case Opcodes.ILOAD:
+                push(INTEGER);
+                break;
+            case Opcodes.LCONST_0:
+            case Opcodes.LCONST_1:
+            case Opcodes.LLOAD:
+                push(LONG);
+                push(TOP);
+                break;
+            case Opcodes.FCONST_0:
+            case Opcodes.FCONST_1:
+            case Opcodes.FCONST_2:
+            case Opcodes.FLOAD:
+                push(FLOAT);
+                break;
+            case Opcodes.DCONST_0:
+            case Opcodes.DCONST_1:
+            case Opcodes.DLOAD:
+                push(DOUBLE);
+                push(TOP);
+                break;
+            case Opcodes.LDC:
+                switch (argSymbol.tag) {
+                    case Symbol.CONSTANT_INTEGER_TAG:
+                        push(INTEGER);
+                        break;
+                    case Symbol.CONSTANT_LONG_TAG:
+                        push(LONG);
+                        push(TOP);
+                        break;
+                    case Symbol.CONSTANT_FLOAT_TAG:
+                        push(FLOAT);
+                        break;
+                    case Symbol.CONSTANT_DOUBLE_TAG:
+                        push(DOUBLE);
+                        push(TOP);
+                        break;
+                    case Symbol.CONSTANT_CLASS_TAG:
+                        push(REFERENCE_KIND | symbolTable.addType("java/lang/Class"));
+                        break;
+                    case Symbol.CONSTANT_STRING_TAG:
+                        push(REFERENCE_KIND | symbolTable.addType("java/lang/String"));
+                        break;
+                    case Symbol.CONSTANT_METHOD_TYPE_TAG:
+                        push(REFERENCE_KIND | symbolTable.addType("java/lang/invoke/MethodType"));
+                        break;
+                    case Symbol.CONSTANT_METHOD_HANDLE_TAG:
+                        push(REFERENCE_KIND | symbolTable.addType("java/lang/invoke/MethodHandle"));
+                        break;
+                    case Symbol.CONSTANT_DYNAMIC_TAG:
+                        push(symbolTable, argSymbol.value);
+                        break;
+                    default:
+                        throw new AssertionError();
+                }
+                break;
+            case Opcodes.ALOAD:
+                push(getLocal(arg));
+                break;
+            case Opcodes.LALOAD:
+            case Opcodes.D2L:
+                pop(2);
+                push(LONG);
+                push(TOP);
+                break;
+            case Opcodes.DALOAD:
+            case Opcodes.L2D:
+                pop(2);
+                push(DOUBLE);
+                push(TOP);
+                break;
+            case Opcodes.AALOAD:
+                pop(1);
+                abstractType1 = pop();
+                push(abstractType1 == NULL ? abstractType1 : ELEMENT_OF + abstractType1);
+                break;
+            case Opcodes.ISTORE:
+            case Opcodes.FSTORE:
+            case Opcodes.ASTORE:
+                abstractType1 = pop();
+                setLocal(arg, abstractType1);
+                if (arg > 0) {
+                    int previousLocalType = getLocal(arg - 1);
+                    if (previousLocalType == LONG || previousLocalType == DOUBLE) {
+                        setLocal(arg - 1, TOP);
+                    } else if ((previousLocalType & KIND_MASK) == LOCAL_KIND || (previousLocalType & KIND_MASK) == STACK_KIND) {
+                        // The type of the previous local variable is not known yet, but if it later appears
+                        // to be LONG or DOUBLE, we should then use TOP instead.
+                        setLocal(arg - 1, previousLocalType | TOP_IF_LONG_OR_DOUBLE_FLAG);
+                    }
+                }
+                break;
+            case Opcodes.LSTORE:
+            case Opcodes.DSTORE:
+                pop(1);
+                abstractType1 = pop();
+                setLocal(arg, abstractType1);
+                setLocal(arg + 1, TOP);
+                if (arg > 0) {
+                    int previousLocalType = getLocal(arg - 1);
+                    if (previousLocalType == LONG || previousLocalType == DOUBLE) {
+                        setLocal(arg - 1, TOP);
+                    } else if ((previousLocalType & KIND_MASK) == LOCAL_KIND || (previousLocalType & KIND_MASK) == STACK_KIND) {
+                        // The type of the previous local variable is not known yet, but if it later appears
+                        // to be LONG or DOUBLE, we should then use TOP instead.
+                        setLocal(arg - 1, previousLocalType | TOP_IF_LONG_OR_DOUBLE_FLAG);
+                    }
+                }
+                break;
+            case Opcodes.IASTORE:
+            case Opcodes.BASTORE:
+            case Opcodes.CASTORE:
+            case Opcodes.SASTORE:
+            case Opcodes.FASTORE:
+            case Opcodes.AASTORE:
+                pop(3);
+                break;
+            case Opcodes.LASTORE:
+            case Opcodes.DASTORE:
+                pop(4);
+                break;
+            case Opcodes.POP:
+            case Opcodes.IFEQ:
+            case Opcodes.IFNE:
+            case Opcodes.IFLT:
+            case Opcodes.IFGE:
+            case Opcodes.IFGT:
+            case Opcodes.IFLE:
+            case Opcodes.IRETURN:
+            case Opcodes.FRETURN:
+            case Opcodes.ARETURN:
+            case Opcodes.TABLESWITCH:
+            case Opcodes.LOOKUPSWITCH:
+            case Opcodes.ATHROW:
+            case Opcodes.MONITORENTER:
+            case Opcodes.MONITOREXIT:
+            case Opcodes.IFNULL:
+            case Opcodes.IFNONNULL:
+                pop(1);
+                break;
+            case Opcodes.POP2:
+            case Opcodes.IF_ICMPEQ:
+            case Opcodes.IF_ICMPNE:
+            case Opcodes.IF_ICMPLT:
+            case Opcodes.IF_ICMPGE:
+            case Opcodes.IF_ICMPGT:
+            case Opcodes.IF_ICMPLE:
+            case Opcodes.IF_ACMPEQ:
+            case Opcodes.IF_ACMPNE:
+            case Opcodes.LRETURN:
+            case Opcodes.DRETURN:
+                pop(2);
+                break;
+            case Opcodes.DUP:
+                abstractType1 = pop();
+                push(abstractType1);
+                push(abstractType1);
+                break;
+            case Opcodes.DUP_X1:
+                abstractType1 = pop();
+                abstractType2 = pop();
+                push(abstractType1);
+                push(abstractType2);
+                push(abstractType1);
+                break;
+            case Opcodes.DUP_X2:
+                abstractType1 = pop();
+                abstractType2 = pop();
+                abstractType3 = pop();
+                push(abstractType1);
+                push(abstractType3);
+                push(abstractType2);
+                push(abstractType1);
+                break;
+            case Opcodes.DUP2:
+                abstractType1 = pop();
+                abstractType2 = pop();
+                push(abstractType2);
+                push(abstractType1);
+                push(abstractType2);
+                push(abstractType1);
+                break;
+            case Opcodes.DUP2_X1:
+                abstractType1 = pop();
+                abstractType2 = pop();
+                abstractType3 = pop();
+                push(abstractType2);
+                push(abstractType1);
+                push(abstractType3);
+                push(abstractType2);
+                push(abstractType1);
+                break;
+            case Opcodes.DUP2_X2:
+                abstractType1 = pop();
+                abstractType2 = pop();
+                abstractType3 = pop();
+                abstractType4 = pop();
+                push(abstractType2);
+                push(abstractType1);
+                push(abstractType4);
+                push(abstractType3);
+                push(abstractType2);
+                push(abstractType1);
+                break;
+            case Opcodes.SWAP:
+                abstractType1 = pop();
+                abstractType2 = pop();
+                push(abstractType1);
+                push(abstractType2);
+                break;
+            case Opcodes.IALOAD:
+            case Opcodes.BALOAD:
+            case Opcodes.CALOAD:
+            case Opcodes.SALOAD:
+            case Opcodes.IADD:
+            case Opcodes.ISUB:
+            case Opcodes.IMUL:
+            case Opcodes.IDIV:
+            case Opcodes.IREM:
+            case Opcodes.IAND:
+            case Opcodes.IOR:
+            case Opcodes.IXOR:
+            case Opcodes.ISHL:
+            case Opcodes.ISHR:
+            case Opcodes.IUSHR:
+            case Opcodes.L2I:
+            case Opcodes.D2I:
+            case Opcodes.FCMPL:
+            case Opcodes.FCMPG:
+                pop(2);
+                push(INTEGER);
+                break;
+            case Opcodes.LADD:
+            case Opcodes.LSUB:
+            case Opcodes.LMUL:
+            case Opcodes.LDIV:
+            case Opcodes.LREM:
+            case Opcodes.LAND:
+            case Opcodes.LOR:
+            case Opcodes.LXOR:
+                pop(4);
+                push(LONG);
+                push(TOP);
+                break;
+            case Opcodes.FALOAD:
+            case Opcodes.FADD:
+            case Opcodes.FSUB:
+            case Opcodes.FMUL:
+            case Opcodes.FDIV:
+            case Opcodes.FREM:
+            case Opcodes.L2F:
+            case Opcodes.D2F:
+                pop(2);
+                push(FLOAT);
+                break;
+            case Opcodes.DADD:
+            case Opcodes.DSUB:
+            case Opcodes.DMUL:
+            case Opcodes.DDIV:
+            case Opcodes.DREM:
+                pop(4);
+                push(DOUBLE);
+                push(TOP);
+                break;
+            case Opcodes.LSHL:
+            case Opcodes.LSHR:
+            case Opcodes.LUSHR:
+                pop(3);
+                push(LONG);
+                push(TOP);
+                break;
+            case Opcodes.IINC:
+                setLocal(arg, INTEGER);
+                break;
+            case Opcodes.I2L:
+            case Opcodes.F2L:
+                pop(1);
+                push(LONG);
+                push(TOP);
+                break;
+            case Opcodes.I2F:
+                pop(1);
+                push(FLOAT);
+                break;
+            case Opcodes.I2D:
+            case Opcodes.F2D:
+                pop(1);
+                push(DOUBLE);
+                push(TOP);
+                break;
+            case Opcodes.F2I:
+            case Opcodes.ARRAYLENGTH:
+            case Opcodes.INSTANCEOF:
+                pop(1);
+                push(INTEGER);
+                break;
+            case Opcodes.LCMP:
+            case Opcodes.DCMPL:
+            case Opcodes.DCMPG:
+                pop(4);
+                push(INTEGER);
+                break;
+            case Opcodes.JSR:
+            case Opcodes.RET:
+                throw new IllegalArgumentException("JSR/RET are not supported with computeFrames option");
+            case Opcodes.GETSTATIC:
+                push(symbolTable, argSymbol.value);
+                break;
+            case Opcodes.PUTSTATIC:
+                pop(argSymbol.value);
+                break;
+            case Opcodes.GETFIELD:
+                pop(1);
+                push(symbolTable, argSymbol.value);
+                break;
+            case Opcodes.PUTFIELD:
+                pop(argSymbol.value);
+                pop();
+                break;
+            case Opcodes.INVOKEVIRTUAL:
+            case Opcodes.INVOKESPECIAL:
+            case Opcodes.INVOKESTATIC:
+            case Opcodes.INVOKEINTERFACE:
+                pop(argSymbol.value);
+                if (opcode != Opcodes.INVOKESTATIC) {
+                    abstractType1 = pop();
+                    if (opcode == Opcodes.INVOKESPECIAL && argSymbol.name.charAt(0) == '<') {
+                        addInitializedType(abstractType1);
+                    }
+                }
+                push(symbolTable, argSymbol.value);
+                break;
+            case Opcodes.INVOKEDYNAMIC:
+                pop(argSymbol.value);
+                push(symbolTable, argSymbol.value);
+                break;
+            case Opcodes.NEW:
+                push(UNINITIALIZED_KIND | symbolTable.addUninitializedType(argSymbol.value, arg));
+                break;
+            case Opcodes.NEWARRAY:
+                pop();
+                switch (arg) {
+                    case Opcodes.T_BOOLEAN:
+                        push(ARRAY_OF | BOOLEAN);
+                        break;
+                    case Opcodes.T_CHAR:
+                        push(ARRAY_OF | CHAR);
+                        break;
+                    case Opcodes.T_BYTE:
+                        push(ARRAY_OF | BYTE);
+                        break;
+                    case Opcodes.T_SHORT:
+                        push(ARRAY_OF | SHORT);
+                        break;
+                    case Opcodes.T_INT:
+                        push(ARRAY_OF | INTEGER);
+                        break;
+                    case Opcodes.T_FLOAT:
+                        push(ARRAY_OF | FLOAT);
+                        break;
+                    case Opcodes.T_DOUBLE:
+                        push(ARRAY_OF | DOUBLE);
+                        break;
+                    case Opcodes.T_LONG:
+                        push(ARRAY_OF | LONG);
+                        break;
+                    default:
+                        throw new IllegalArgumentException();
+                }
+                break;
+            case Opcodes.ANEWARRAY:
+                String arrayElementType = argSymbol.value;
+                pop();
+                if (arrayElementType.charAt(0) == '[') {
+                    push(symbolTable, '[' + arrayElementType);
+                } else {
+                    push(ARRAY_OF | REFERENCE_KIND | symbolTable.addType(arrayElementType));
+                }
+                break;
+            case Opcodes.CHECKCAST:
+                String castType = argSymbol.value;
+                pop();
+                if (castType.charAt(0) == '[') {
+                    push(symbolTable, castType);
+                } else {
+                    push(REFERENCE_KIND | symbolTable.addType(castType));
+                }
+                break;
+            case Opcodes.MULTIANEWARRAY:
+                pop(arg);
+                push(symbolTable, argSymbol.value);
+                break;
+            default:
+                throw new IllegalArgumentException();
+        }
+    }
+
+    // -----------------------------------------------------------------------------------------------
+    // Frame output methods, to generate StackMapFrame attributes
+    // -----------------------------------------------------------------------------------------------
+
+    /**
+     * Merges the input frame of the given {@link Frame} with the input and output frames of this
+     * {@link Frame}. Returns {@literal true} if the given frame has been changed by this operation
+     * (the input and output frames of this {@link Frame} are never changed).
+     *
+     * @param symbolTable the type table to use to lookup and store type {@link Symbol}.
+     * @param dstFrame the {@link Frame} whose input frame must be updated. This should be the frame
+     *     of a successor, in the control flow graph, of the basic block corresponding to this frame.
+     * @param catchTypeIndex if 'frame' corresponds to an exception handler basic block, the type
+     *     table index of the caught exception type, otherwise 0.
+     * @return {@literal true} if the input frame of 'frame' has been changed by this operation.
+     */
+    final boolean merge(final SymbolTable symbolTable, final Frame dstFrame, final int catchTypeIndex) {
+        boolean frameChanged = false;
+
+        // Compute the concrete types of the local variables at the end of the basic block corresponding
+        // to this frame, by resolving its abstract output types, and merge these concrete types with
+        // those of the local variables in the input frame of dstFrame.
+        int numLocal = inputLocals.length;
+        int numStack = inputStack.length;
+        if (dstFrame.inputLocals == null) {
+            dstFrame.inputLocals = new int[numLocal];
+            frameChanged = true;
+        }
+        for (int i = 0; i < numLocal; ++i) {
+            int concreteOutputType;
+            if (outputLocals != null && i < outputLocals.length) {
+                int abstractOutputType = outputLocals[i];
+                if (abstractOutputType == 0) {
+                    // If the local variable has never been assigned in this basic block, it is equal to its
+                    // value at the beginning of the block.
+                    concreteOutputType = inputLocals[i];
+                } else {
+                    int dim = abstractOutputType & DIM_MASK;
+                    int kind = abstractOutputType & KIND_MASK;
+                    if (kind == LOCAL_KIND) {
+                        // By definition, a LOCAL_KIND type designates the concrete type of a local variable at
+                        // the beginning of the basic block corresponding to this frame (which is known when
+                        // this method is called, but was not when the abstract type was computed).
+                        concreteOutputType = dim + inputLocals[abstractOutputType & VALUE_MASK];
+                        if ((abstractOutputType & TOP_IF_LONG_OR_DOUBLE_FLAG) != 0
+                                && (concreteOutputType == LONG || concreteOutputType == DOUBLE)) {
+                            concreteOutputType = TOP;
+                        }
+                    } else if (kind == STACK_KIND) {
+                        // By definition, a STACK_KIND type designates the concrete type of a local variable at
+                        // the beginning of the basic block corresponding to this frame (which is known when
+                        // this method is called, but was not when the abstract type was computed).
+                        concreteOutputType = dim + inputStack[numStack - (abstractOutputType & VALUE_MASK)];
+                        if ((abstractOutputType & TOP_IF_LONG_OR_DOUBLE_FLAG) != 0
+                                && (concreteOutputType == LONG || concreteOutputType == DOUBLE)) {
+                            concreteOutputType = TOP;
+                        }
+                    } else {
+                        concreteOutputType = abstractOutputType;
+                    }
+                }
+            } else {
+                // If the local variable has never been assigned in this basic block, it is equal to its
+                // value at the beginning of the block.
+                concreteOutputType = inputLocals[i];
+            }
+            // concreteOutputType might be an uninitialized type from the input locals or from the input
+            // stack. However, if a constructor has been called for this class type in the basic block,
+            // then this type is no longer uninitialized at the end of basic block.
+            if (initializations != null) {
+                concreteOutputType = getInitializedType(symbolTable, concreteOutputType);
+            }
+            frameChanged |= merge(symbolTable, concreteOutputType, dstFrame.inputLocals, i);
+        }
+
+        // If dstFrame is an exception handler block, it can be reached from any instruction of the
+        // basic block corresponding to this frame, in particular from the first one. Therefore, the
+        // input locals of dstFrame should be compatible (i.e. merged) with the input locals of this
+        // frame (and the input stack of dstFrame should be compatible, i.e. merged, with a one
+        // element stack containing the caught exception type).
+        if (catchTypeIndex > 0) {
+            for (int i = 0; i < numLocal; ++i) {
+                frameChanged |= merge(symbolTable, inputLocals[i], dstFrame.inputLocals, i);
+            }
+            if (dstFrame.inputStack == null) {
+                dstFrame.inputStack = new int[1];
+                frameChanged = true;
+            }
+            frameChanged |= merge(symbolTable, catchTypeIndex, dstFrame.inputStack, 0);
+            return frameChanged;
+        }
+
+        // Compute the concrete types of the stack operands at the end of the basic block corresponding
+        // to this frame, by resolving its abstract output types, and merge these concrete types with
+        // those of the stack operands in the input frame of dstFrame.
+        int numInputStack = inputStack.length + outputStackStart;
+        if (dstFrame.inputStack == null) {
+            dstFrame.inputStack = new int[numInputStack + outputStackTop];
+            frameChanged = true;
+        }
+        // First, do this for the stack operands that have not been popped in the basic block
+        // corresponding to this frame, and which are therefore equal to their value in the input
+        // frame (except for uninitialized types, which may have been initialized).
+        for (int i = 0; i < numInputStack; ++i) {
+            int concreteOutputType = inputStack[i];
+            if (initializations != null) {
+                concreteOutputType = getInitializedType(symbolTable, concreteOutputType);
+            }
+            frameChanged |= merge(symbolTable, concreteOutputType, dstFrame.inputStack, i);
+        }
+        // Then, do this for the stack operands that have pushed in the basic block (this code is the
+        // same as the one above for local variables).
+        for (int i = 0; i < outputStackTop; ++i) {
+            int concreteOutputType;
+            int abstractOutputType = outputStack[i];
+            int dim = abstractOutputType & DIM_MASK;
+            int kind = abstractOutputType & KIND_MASK;
+            if (kind == LOCAL_KIND) {
+                concreteOutputType = dim + inputLocals[abstractOutputType & VALUE_MASK];
+                if ((abstractOutputType & TOP_IF_LONG_OR_DOUBLE_FLAG) != 0
+                        && (concreteOutputType == LONG || concreteOutputType == DOUBLE)) {
+                    concreteOutputType = TOP;
+                }
+            } else if (kind == STACK_KIND) {
+                concreteOutputType = dim + inputStack[numStack - (abstractOutputType & VALUE_MASK)];
+                if ((abstractOutputType & TOP_IF_LONG_OR_DOUBLE_FLAG) != 0
+                        && (concreteOutputType == LONG || concreteOutputType == DOUBLE)) {
+                    concreteOutputType = TOP;
+                }
+            } else {
+                concreteOutputType = abstractOutputType;
+            }
+            if (initializations != null) {
+                concreteOutputType = getInitializedType(symbolTable, concreteOutputType);
+            }
+            frameChanged |= merge(symbolTable, concreteOutputType, dstFrame.inputStack, numInputStack + i);
+        }
+        return frameChanged;
+    }
+
+    /**
+     * Makes the given {@link MethodWriter} visit the input frame of this {@link Frame}. The visit is
+     * done with the {@link MethodWriter#visitFrameStart}, {@link MethodWriter#visitAbstractType} and
+     * {@link MethodWriter#visitFrameEnd} methods.
+     *
+     * @param methodWriter the {@link MethodWriter} that should visit the input frame of this {@link
+     *     Frame}.
+     */
+    final void accept(final MethodWriter methodWriter) {
+        // Compute the number of locals, ignoring TOP types that are just after a LONG or a DOUBLE, and
+        // all trailing TOP types.
+        int[] localTypes = inputLocals;
+        int numLocal = 0;
+        int numTrailingTop = 0;
+        int i = 0;
+        while (i < localTypes.length) {
+            int localType = localTypes[i];
+            i += (localType == LONG || localType == DOUBLE) ? 2 : 1;
+            if (localType == TOP) {
+                numTrailingTop++;
+            } else {
+                numLocal += numTrailingTop + 1;
+                numTrailingTop = 0;
+            }
+        }
+        // Compute the stack size, ignoring TOP types that are just after a LONG or a DOUBLE.
+        int[] stackTypes = inputStack;
+        int numStack = 0;
+        i = 0;
+        while (i < stackTypes.length) {
+            int stackType = stackTypes[i];
+            i += (stackType == LONG || stackType == DOUBLE) ? 2 : 1;
+            numStack++;
+        }
+        // Visit the frame and its content.
+        int frameIndex = methodWriter.visitFrameStart(owner.bytecodeOffset, numLocal, numStack);
+        i = 0;
+        while (numLocal-- > 0) {
+            int localType = localTypes[i];
+            i += (localType == LONG || localType == DOUBLE) ? 2 : 1;
+            methodWriter.visitAbstractType(frameIndex++, localType);
+        }
+        i = 0;
+        while (numStack-- > 0) {
+            int stackType = stackTypes[i];
+            i += (stackType == LONG || stackType == DOUBLE) ? 2 : 1;
+            methodWriter.visitAbstractType(frameIndex++, stackType);
+        }
+        methodWriter.visitFrameEnd();
+    }
+}

--- a/core/src/main/java/org/mvel2/asm/Handle.java
+++ b/core/src/main/java/org/mvel2/asm/Handle.java
@@ -1,0 +1,179 @@
+// ASM: a very small and fast Java bytecode manipulation framework
+// Copyright (c) 2000-2011 INRIA, France Telecom
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+// 1. Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+// 2. Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+// 3. Neither the name of the copyright holders nor the names of its
+//    contributors may be used to endorse or promote products derived from
+//    this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+// THE POSSIBILITY OF SUCH DAMAGE.
+
+package org.mvel2.asm;
+
+/**
+ * A reference to a field or a method.
+ *
+ * @author Remi Forax
+ * @author Eric Bruneton
+ */
+public final class Handle {
+
+    /**
+     * The kind of field or method designated by this Handle. Should be {@link Opcodes#H_GETFIELD},
+     * {@link Opcodes#H_GETSTATIC}, {@link Opcodes#H_PUTFIELD}, {@link Opcodes#H_PUTSTATIC}, {@link
+     * Opcodes#H_INVOKEVIRTUAL}, {@link Opcodes#H_INVOKESTATIC}, {@link Opcodes#H_INVOKESPECIAL},
+     * {@link Opcodes#H_NEWINVOKESPECIAL} or {@link Opcodes#H_INVOKEINTERFACE}.
+     */
+    private final int tag;
+
+    /** The internal name of the class that owns the field or method designated by this handle. */
+    private final String owner;
+
+    /** The name of the field or method designated by this handle. */
+    private final String name;
+
+    /** The descriptor of the field or method designated by this handle. */
+    private final String descriptor;
+
+    /** Whether the owner is an interface or not. */
+    private final boolean isInterface;
+
+    /**
+     * Constructs a new field or method handle.
+     *
+     * @param tag the kind of field or method designated by this Handle. Must be {@link
+     *     Opcodes#H_GETFIELD}, {@link Opcodes#H_GETSTATIC}, {@link Opcodes#H_PUTFIELD}, {@link
+     *     Opcodes#H_PUTSTATIC}, {@link Opcodes#H_INVOKEVIRTUAL}, {@link Opcodes#H_INVOKESTATIC},
+     *     {@link Opcodes#H_INVOKESPECIAL}, {@link Opcodes#H_NEWINVOKESPECIAL} or {@link
+     *     Opcodes#H_INVOKEINTERFACE}.
+     * @param owner the internal name of the class that owns the field or method designated by this
+     *     handle.
+     * @param name the name of the field or method designated by this handle.
+     * @param descriptor the descriptor of the field or method designated by this handle.
+     * @deprecated this constructor has been superseded by {@link #Handle(int, String, String, String,
+     *     boolean)}.
+     */
+    @Deprecated
+    public Handle(final int tag, final String owner, final String name, final String descriptor) {
+        this(tag, owner, name, descriptor, tag == Opcodes.H_INVOKEINTERFACE);
+    }
+
+    /**
+     * Constructs a new field or method handle.
+     *
+     * @param tag the kind of field or method designated by this Handle. Must be {@link
+     *     Opcodes#H_GETFIELD}, {@link Opcodes#H_GETSTATIC}, {@link Opcodes#H_PUTFIELD}, {@link
+     *     Opcodes#H_PUTSTATIC}, {@link Opcodes#H_INVOKEVIRTUAL}, {@link Opcodes#H_INVOKESTATIC},
+     *     {@link Opcodes#H_INVOKESPECIAL}, {@link Opcodes#H_NEWINVOKESPECIAL} or {@link
+     *     Opcodes#H_INVOKEINTERFACE}.
+     * @param owner the internal name of the class that owns the field or method designated by this
+     *     handle.
+     * @param name the name of the field or method designated by this handle.
+     * @param descriptor the descriptor of the field or method designated by this handle.
+     * @param isInterface whether the owner is an interface or not.
+     */
+    public Handle(final int tag, final String owner, final String name, final String descriptor, final boolean isInterface) {
+        this.tag = tag;
+        this.owner = owner;
+        this.name = name;
+        this.descriptor = descriptor;
+        this.isInterface = isInterface;
+    }
+
+    /**
+     * Returns the kind of field or method designated by this handle.
+     *
+     * @return {@link Opcodes#H_GETFIELD}, {@link Opcodes#H_GETSTATIC}, {@link Opcodes#H_PUTFIELD},
+     *     {@link Opcodes#H_PUTSTATIC}, {@link Opcodes#H_INVOKEVIRTUAL}, {@link
+     *     Opcodes#H_INVOKESTATIC}, {@link Opcodes#H_INVOKESPECIAL}, {@link
+     *     Opcodes#H_NEWINVOKESPECIAL} or {@link Opcodes#H_INVOKEINTERFACE}.
+     */
+    public int getTag() {
+        return tag;
+    }
+
+    /**
+     * Returns the internal name of the class that owns the field or method designated by this handle.
+     *
+     * @return the internal name of the class that owns the field or method designated by this handle.
+     */
+    public String getOwner() {
+        return owner;
+    }
+
+    /**
+     * Returns the name of the field or method designated by this handle.
+     *
+     * @return the name of the field or method designated by this handle.
+     */
+    public String getName() {
+        return name;
+    }
+
+    /**
+     * Returns the descriptor of the field or method designated by this handle.
+     *
+     * @return the descriptor of the field or method designated by this handle.
+     */
+    public String getDesc() {
+        return descriptor;
+    }
+
+    /**
+     * Returns true if the owner of the field or method designated by this handle is an interface.
+     *
+     * @return true if the owner of the field or method designated by this handle is an interface.
+     */
+    public boolean isInterface() {
+        return isInterface;
+    }
+
+    @Override
+    public boolean equals(final Object object) {
+        if (object == this) {
+            return true;
+        }
+        if (!(object instanceof Handle)) {
+            return false;
+        }
+        Handle handle = (Handle) object;
+        return tag == handle.tag && isInterface == handle.isInterface && owner.equals(handle.owner) && name.equals(handle.name)
+                && descriptor.equals(handle.descriptor);
+    }
+
+    @Override
+    public int hashCode() {
+        return tag + (isInterface ? 64 : 0) + owner.hashCode() * name.hashCode() * descriptor.hashCode();
+    }
+
+    /**
+     * Returns the textual representation of this handle. The textual representation is:
+     *
+     * <ul>
+     *   <li>for a reference to a class: owner "." name descriptor " (" tag ")",
+     *   <li>for a reference to an interface: owner "." name descriptor " (" tag " itf)".
+     * </ul>
+     */
+    @Override
+    public String toString() {
+        return owner + '.' + name + descriptor + " (" + tag + (isInterface ? " itf" : "") + ')';
+    }
+}

--- a/core/src/main/java/org/mvel2/asm/Handler.java
+++ b/core/src/main/java/org/mvel2/asm/Handler.java
@@ -1,0 +1,190 @@
+// ASM: a very small and fast Java bytecode manipulation framework
+// Copyright (c) 2000-2011 INRIA, France Telecom
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+// 1. Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+// 2. Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+// 3. Neither the name of the copyright holders nor the names of its
+//    contributors may be used to endorse or promote products derived from
+//    this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+// THE POSSIBILITY OF SUCH DAMAGE.
+package org.mvel2.asm;
+
+/**
+ * Information about an exception handler. Corresponds to an element of the exception_table array of
+ * a Code attribute, as defined in the Java Virtual Machine Specification (JVMS). Handler instances
+ * can be chained together, with their {@link #nextHandler} field, to describe a full JVMS
+ * exception_table array.
+ *
+ * @see <a href="https://docs.oracle.com/javase/specs/jvms/se9/html/jvms-4.html#jvms-4.7.3">JVMS
+ *     4.7.3</a>
+ * @author Eric Bruneton
+ */
+final class Handler {
+
+    /**
+     * The start_pc field of this JVMS exception_table entry. Corresponds to the beginning of the
+     * exception handler's scope (inclusive).
+     */
+    final Label startPc;
+
+    /**
+     * The end_pc field of this JVMS exception_table entry. Corresponds to the end of the exception
+     * handler's scope (exclusive).
+     */
+    final Label endPc;
+
+    /**
+     * The handler_pc field of this JVMS exception_table entry. Corresponding to the beginning of the
+     * exception handler's code.
+     */
+    final Label handlerPc;
+
+    /**
+     * The catch_type field of this JVMS exception_table entry. This is the constant pool index of the
+     * internal name of the type of exceptions handled by this handler, or 0 to catch any exceptions.
+     */
+    final int catchType;
+
+    /**
+     * The internal name of the type of exceptions handled by this handler, or {@literal null} to
+     * catch any exceptions.
+     */
+    final String catchTypeDescriptor;
+
+    /** The next exception handler. */
+    Handler nextHandler;
+
+    /**
+     * Constructs a new Handler.
+     *
+     * @param startPc the start_pc field of this JVMS exception_table entry.
+     * @param endPc the end_pc field of this JVMS exception_table entry.
+     * @param handlerPc the handler_pc field of this JVMS exception_table entry.
+     * @param catchType The catch_type field of this JVMS exception_table entry.
+     * @param catchTypeDescriptor The internal name of the type of exceptions handled by this handler,
+     *     or {@literal null} to catch any exceptions.
+     */
+    Handler(final Label startPc, final Label endPc, final Label handlerPc, final int catchType, final String catchTypeDescriptor) {
+        this.startPc = startPc;
+        this.endPc = endPc;
+        this.handlerPc = handlerPc;
+        this.catchType = catchType;
+        this.catchTypeDescriptor = catchTypeDescriptor;
+    }
+
+    /**
+     * Constructs a new Handler from the given one, with a different scope.
+     *
+     * @param handler an existing Handler.
+     * @param startPc the start_pc field of this JVMS exception_table entry.
+     * @param endPc the end_pc field of this JVMS exception_table entry.
+     */
+    Handler(final Handler handler, final Label startPc, final Label endPc) {
+        this(startPc, endPc, handler.handlerPc, handler.catchType, handler.catchTypeDescriptor);
+        this.nextHandler = handler.nextHandler;
+    }
+
+    /**
+     * Removes the range between start and end from the Handler list that begins with the given
+     * element.
+     *
+     * @param firstHandler the beginning of a Handler list. May be {@literal null}.
+     * @param start the start of the range to be removed.
+     * @param end the end of the range to be removed. Maybe {@literal null}.
+     * @return the exception handler list with the start-end range removed.
+     */
+    static Handler removeRange(final Handler firstHandler, final Label start, final Label end) {
+        if (firstHandler == null) {
+            return null;
+        } else {
+            firstHandler.nextHandler = removeRange(firstHandler.nextHandler, start, end);
+        }
+        int handlerStart = firstHandler.startPc.bytecodeOffset;
+        int handlerEnd = firstHandler.endPc.bytecodeOffset;
+        int rangeStart = start.bytecodeOffset;
+        int rangeEnd = end == null ? Integer.MAX_VALUE : end.bytecodeOffset;
+        // Return early if [handlerStart,handlerEnd[ and [rangeStart,rangeEnd[ don't intersect.
+        if (rangeStart >= handlerEnd || rangeEnd <= handlerStart) {
+            return firstHandler;
+        }
+        if (rangeStart <= handlerStart) {
+            if (rangeEnd >= handlerEnd) {
+                // If [handlerStart,handlerEnd[ is included in [rangeStart,rangeEnd[, remove firstHandler.
+                return firstHandler.nextHandler;
+            } else {
+                // [handlerStart,handlerEnd[ - [rangeStart,rangeEnd[ = [rangeEnd,handlerEnd[
+                return new Handler(firstHandler, end, firstHandler.endPc);
+            }
+        } else if (rangeEnd >= handlerEnd) {
+            // [handlerStart,handlerEnd[ - [rangeStart,rangeEnd[ = [handlerStart,rangeStart[
+            return new Handler(firstHandler, firstHandler.startPc, start);
+        } else {
+            // [handlerStart,handlerEnd[ - [rangeStart,rangeEnd[ =
+            //     [handlerStart,rangeStart[ + [rangeEnd,handerEnd[
+            firstHandler.nextHandler = new Handler(firstHandler, end, firstHandler.endPc);
+            return new Handler(firstHandler, firstHandler.startPc, start);
+        }
+    }
+
+    /**
+     * Returns the number of elements of the Handler list that begins with the given element.
+     *
+     * @param firstHandler the beginning of a Handler list. May be {@literal null}.
+     * @return the number of elements of the Handler list that begins with 'handler'.
+     */
+    static int getExceptionTableLength(final Handler firstHandler) {
+        int length = 0;
+        Handler handler = firstHandler;
+        while (handler != null) {
+            length++;
+            handler = handler.nextHandler;
+        }
+        return length;
+    }
+
+    /**
+     * Returns the size in bytes of the JVMS exception_table corresponding to the Handler list that
+     * begins with the given element. <i>This includes the exception_table_length field.</i>
+     *
+     * @param firstHandler the beginning of a Handler list. May be {@literal null}.
+     * @return the size in bytes of the exception_table_length and exception_table structures.
+     */
+    static int getExceptionTableSize(final Handler firstHandler) {
+        return 2 + 8 * getExceptionTableLength(firstHandler);
+    }
+
+    /**
+     * Puts the JVMS exception_table corresponding to the Handler list that begins with the given
+     * element. <i>This includes the exception_table_length field.</i>
+     *
+     * @param firstHandler the beginning of a Handler list. May be {@literal null}.
+     * @param output where the exception_table_length and exception_table structures must be put.
+     */
+    static void putExceptionTable(final Handler firstHandler, final ByteVector output) {
+        output.putShort(getExceptionTableLength(firstHandler));
+        Handler handler = firstHandler;
+        while (handler != null) {
+            output.putShort(handler.startPc.bytecodeOffset).putShort(handler.endPc.bytecodeOffset)
+                    .putShort(handler.handlerPc.bytecodeOffset).putShort(handler.catchType);
+            handler = handler.nextHandler;
+        }
+    }
+}

--- a/core/src/main/java/org/mvel2/asm/Label.java
+++ b/core/src/main/java/org/mvel2/asm/Label.java
@@ -1,0 +1,602 @@
+// ASM: a very small and fast Java bytecode manipulation framework
+// Copyright (c) 2000-2011 INRIA, France Telecom
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+// 1. Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+// 2. Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+// 3. Neither the name of the copyright holders nor the names of its
+//    contributors may be used to endorse or promote products derived from
+//    this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+// THE POSSIBILITY OF SUCH DAMAGE.
+package org.mvel2.asm;
+
+/**
+ * A position in the bytecode of a method. Labels are used for jump, goto, and switch instructions,
+ * and for try catch blocks. A label designates the <i>instruction</i> that is just after. Note
+ * however that there can be other elements between a label and the instruction it designates (such
+ * as other labels, stack map frames, line numbers, etc.).
+ *
+ * @author Eric Bruneton
+ */
+public class Label {
+
+    /**
+     * A flag indicating that a label is only used for debug attributes. Such a label is not the start
+     * of a basic block, the target of a jump instruction, or an exception handler. It can be safely
+     * ignored in control flow graph analysis algorithms (for optimization purposes).
+     */
+    static final int FLAG_DEBUG_ONLY = 1;
+
+    /**
+     * A flag indicating that a label is the target of a jump instruction, or the start of an
+     * exception handler.
+     */
+    static final int FLAG_JUMP_TARGET = 2;
+
+    /** A flag indicating that the bytecode offset of a label is known. */
+    static final int FLAG_RESOLVED = 4;
+
+    /** A flag indicating that a label corresponds to a reachable basic block. */
+    static final int FLAG_REACHABLE = 8;
+
+    /**
+     * A flag indicating that the basic block corresponding to a label ends with a subroutine call. By
+     * construction in {@link MethodWriter#visitJumpInsn}, labels with this flag set have at least two
+     * outgoing edges:
+     *
+     * <ul>
+     *   <li>the first one corresponds to the instruction that follows the jsr instruction in the
+     *       bytecode, i.e. where execution continues when it returns from the jsr call. This is a
+     *       virtual control flow edge, since execution never goes directly from the jsr to the next
+     *       instruction. Instead, it goes to the subroutine and eventually returns to the instruction
+     *       following the jsr. This virtual edge is used to compute the real outgoing edges of the
+     *       basic blocks ending with a ret instruction, in {@link #addSubroutineRetSuccessors}.
+     *   <li>the second one corresponds to the target of the jsr instruction,
+     * </ul>
+     */
+    static final int FLAG_SUBROUTINE_CALLER = 16;
+
+    /**
+     * A flag indicating that the basic block corresponding to a label is the start of a subroutine.
+     */
+    static final int FLAG_SUBROUTINE_START = 32;
+
+    /** A flag indicating that the basic block corresponding to a label is the end of a subroutine. */
+    static final int FLAG_SUBROUTINE_END = 64;
+
+    /**
+     * The number of elements to add to the {@link #otherLineNumbers} array when it needs to be
+     * resized to store a new source line number.
+     */
+    static final int LINE_NUMBERS_CAPACITY_INCREMENT = 4;
+
+    /**
+     * The number of elements to add to the {@link #forwardReferences} array when it needs to be
+     * resized to store a new forward reference.
+     */
+    static final int FORWARD_REFERENCES_CAPACITY_INCREMENT = 6;
+
+    /**
+     * The bit mask to extract the type of a forward reference to this label. The extracted type is
+     * either {@link #FORWARD_REFERENCE_TYPE_SHORT} or {@link #FORWARD_REFERENCE_TYPE_WIDE}.
+     *
+     * @see #forwardReferences
+     */
+    static final int FORWARD_REFERENCE_TYPE_MASK = 0xF0000000;
+
+    /**
+     * The type of forward references stored with two bytes in the bytecode. This is the case, for
+     * instance, of a forward reference from an ifnull instruction.
+     */
+    static final int FORWARD_REFERENCE_TYPE_SHORT = 0x10000000;
+
+    /**
+     * The type of forward references stored in four bytes in the bytecode. This is the case, for
+     * instance, of a forward reference from a lookupswitch instruction.
+     */
+    static final int FORWARD_REFERENCE_TYPE_WIDE = 0x20000000;
+
+    /**
+     * The bit mask to extract the 'handle' of a forward reference to this label. The extracted handle
+     * is the bytecode offset where the forward reference value is stored (using either 2 or 4 bytes,
+     * as indicated by the {@link #FORWARD_REFERENCE_TYPE_MASK}).
+     *
+     * @see #forwardReferences
+     */
+    static final int FORWARD_REFERENCE_HANDLE_MASK = 0x0FFFFFFF;
+
+    /**
+     * A sentinel element used to indicate the end of a list of labels.
+     *
+     * @see #nextListElement
+     */
+    static final Label EMPTY_LIST = new Label();
+
+    /**
+     * A user managed state associated with this label. Warning: this field is used by the ASM tree
+     * package. In order to use it with the ASM tree package you must override the getLabelNode method
+     * in MethodNode.
+     */
+    public Object info;
+
+    /**
+     * The type and status of this label or its corresponding basic block. Must be zero or more of
+     * {@link #FLAG_DEBUG_ONLY}, {@link #FLAG_JUMP_TARGET}, {@link #FLAG_RESOLVED}, {@link
+     * #FLAG_REACHABLE}, {@link #FLAG_SUBROUTINE_CALLER}, {@link #FLAG_SUBROUTINE_START}, {@link
+     * #FLAG_SUBROUTINE_END}.
+     */
+    short flags;
+    /**
+     * The offset of this label in the bytecode of its method, in bytes. This value is set if and only
+     * if the {@link #FLAG_RESOLVED} flag is set.
+     */
+    int bytecodeOffset;
+    /**
+     * The number of elements in the input stack of the basic block corresponding to this label. This
+     * field is computed in {@link MethodWriter#computeMaxStackAndLocal}.
+     */
+    short inputStackSize;
+    /**
+     * The number of elements in the output stack, at the end of the basic block corresponding to this
+     * label. This field is only computed for basic blocks that end with a RET instruction.
+     */
+    short outputStackSize;
+    /**
+     * The maximum height reached by the output stack, relatively to the top of the input stack, in
+     * the basic block corresponding to this label. This maximum is always positive or null.
+     */
+    short outputStackMax;
+
+    // -----------------------------------------------------------------------------------------------
+
+    // Fields for the control flow and data flow graph analysis algorithms (used to compute the
+    // maximum stack size or the stack map frames). A control flow graph contains one node per "basic
+    // block", and one edge per "jump" from one basic block to another. Each node (i.e., each basic
+    // block) is represented with the Label object that corresponds to the first instruction of this
+    // basic block. Each node also stores the list of its successors in the graph, as a linked list of
+    // Edge objects.
+    //
+    // The control flow analysis algorithms used to compute the maximum stack size or the stack map
+    // frames are similar and use two steps. The first step, during the visit of each instruction,
+    // builds information about the state of the local variables and the operand stack at the end of
+    // each basic block, called the "output frame", <i>relatively</i> to the frame state at the
+    // beginning of the basic block, which is called the "input frame", and which is <i>unknown</i>
+    // during this step. The second step, in {@link MethodWriter#computeAllFrames} and {@link
+    // MethodWriter#computeMaxStackAndLocal}, is a fix point algorithm
+    // that computes information about the input frame of each basic block, from the input state of
+    // the first basic block (known from the method signature), and by the using the previously
+    // computed relative output frames.
+    //
+    // The algorithm used to compute the maximum stack size only computes the relative output and
+    // absolute input stack heights, while the algorithm used to compute stack map frames computes
+    // relative output frames and absolute input frames.
+    /**
+     * The id of the subroutine to which this basic block belongs, or 0. If the basic block belongs to
+     * several subroutines, this is the id of the "oldest" subroutine that contains it (with the
+     * convention that a subroutine calling another one is "older" than the callee). This field is
+     * computed in {@link MethodWriter#computeMaxStackAndLocal}, if the method contains JSR
+     * instructions.
+     */
+    short subroutineId;
+    /**
+     * The input and output stack map frames of the basic block corresponding to this label. This
+     * field is only used when the {@link MethodWriter#COMPUTE_ALL_FRAMES} or {@link
+     * MethodWriter#COMPUTE_INSERTED_FRAMES} option is used.
+     */
+    Frame frame;
+    /**
+     * The successor of this label, in the order they are visited in {@link MethodVisitor#visitLabel}.
+     * This linked list does not include labels used for debug info only. If the {@link
+     * MethodWriter#COMPUTE_ALL_FRAMES} or {@link MethodWriter#COMPUTE_INSERTED_FRAMES} option is used
+     * then it does not contain either successive labels that denote the same bytecode offset (in this
+     * case only the first label appears in this list).
+     */
+    Label nextBasicBlock;
+    /**
+     * The outgoing edges of the basic block corresponding to this label, in the control flow graph of
+     * its method. These edges are stored in a linked list of {@link Edge} objects, linked to each
+     * other by their {@link Edge#nextEdge} field.
+     */
+    Edge outgoingEdges;
+    /**
+     * The next element in the list of labels to which this label belongs, or null if it does not
+     * belong to any list. All lists of labels must end with the {@link #EMPTY_LIST} sentinel, in
+     * order to ensure that this field is null if and only if this label does not belong to a list of
+     * labels. Note that there can be several lists of labels at the same time, but that a label can
+     * belong to at most one list at a time (unless some lists share a common tail, but this is not
+     * used in practice).
+     *
+     * <p>List of labels are used in {@link MethodWriter#computeAllFrames} and {@link
+     * MethodWriter#computeMaxStackAndLocal} to compute stack map frames and the maximum stack size,
+     * respectively, as well as in {@link #markSubroutine} and {@link #addSubroutineRetSuccessors} to
+     * compute the basic blocks belonging to subroutines and their outgoing edges. Outside of these
+     * methods, this field should be null (this property is a precondition and a postcondition of
+     * these methods).
+     */
+    Label nextListElement;
+    /**
+     * The source line number corresponding to this label, or 0. If there are several source line
+     * numbers corresponding to this label, the first one is stored in this field, and the remaining
+     * ones are stored in {@link #otherLineNumbers}.
+     */
+    private short lineNumber;
+    /**
+     * The source line numbers corresponding to this label, in addition to {@link #lineNumber}, or
+     * null. The first element of this array is the number n of source line numbers it contains, which
+     * are stored between indices 1 and n (inclusive).
+     */
+    private int[] otherLineNumbers;
+    /**
+     * The forward references to this label. The first element is the number of forward references,
+     * times 2 (this corresponds to the index of the last element actually used in this array). Then,
+     * each forward reference is described with two consecutive integers noted
+     * 'sourceInsnBytecodeOffset' and 'reference':
+     *
+     * <ul>
+     *   <li>'sourceInsnBytecodeOffset' is the bytecode offset of the instruction that contains the
+     *       forward reference,
+     *   <li>'reference' contains the type and the offset in the bytecode where the forward reference
+     *       value must be stored, which can be extracted with {@link #FORWARD_REFERENCE_TYPE_MASK}
+     *       and {@link #FORWARD_REFERENCE_HANDLE_MASK}.
+     * </ul>
+     *
+     * <p>For instance, for an ifnull instruction at bytecode offset x, 'sourceInsnBytecodeOffset' is
+     * equal to x, and 'reference' is of type {@link #FORWARD_REFERENCE_TYPE_SHORT} with value x + 1
+     * (because the ifnull instruction uses a 2 bytes bytecode offset operand stored one byte after
+     * the start of the instruction itself). For the default case of a lookupswitch instruction at
+     * bytecode offset x, 'sourceInsnBytecodeOffset' is equal to x, and 'reference' is of type {@link
+     * #FORWARD_REFERENCE_TYPE_WIDE} with value between x + 1 and x + 4 (because the lookupswitch
+     * instruction uses a 4 bytes bytecode offset operand stored one to four bytes after the start of
+     * the instruction itself).
+     */
+    private int[] forwardReferences;
+
+    // -----------------------------------------------------------------------------------------------
+    // Constructor and accessors
+    // -----------------------------------------------------------------------------------------------
+
+    /** Constructs a new label. */
+    public Label() {
+        // Nothing to do.
+    }
+
+    /**
+     * Returns the bytecode offset corresponding to this label. This offset is computed from the start
+     * of the method's bytecode. <i>This method is intended for {@link Attribute} sub classes, and is
+     * normally not needed by class generators or adapters.</i>
+     *
+     * @return the bytecode offset corresponding to this label.
+     * @throws IllegalStateException if this label is not resolved yet.
+     */
+    public int getOffset() {
+        if ((flags & FLAG_RESOLVED) == 0) {
+            throw new IllegalStateException("Label offset position has not been resolved yet");
+        }
+        return bytecodeOffset;
+    }
+
+    /**
+     * Returns the "canonical" {@link Label} instance corresponding to this label's bytecode offset,
+     * if known, otherwise the label itself. The canonical instance is the first label (in the order
+     * of their visit by {@link MethodVisitor#visitLabel}) corresponding to this bytecode offset. It
+     * cannot be known for labels which have not been visited yet.
+     *
+     * <p><i>This method should only be used when the {@link MethodWriter#COMPUTE_ALL_FRAMES} option
+     * is used.</i>
+     *
+     * @return the label itself if {@link #frame} is null, otherwise the Label's frame owner. This
+     *     corresponds to the "canonical" label instance described above thanks to the way the label
+     *     frame is set in {@link MethodWriter#visitLabel}.
+     */
+    final Label getCanonicalInstance() {
+        return frame == null ? this : frame.owner;
+    }
+
+    // -----------------------------------------------------------------------------------------------
+    // Methods to manage line numbers
+    // -----------------------------------------------------------------------------------------------
+
+    /**
+     * Adds a source line number corresponding to this label.
+     *
+     * @param lineNumber a source line number (which should be strictly positive).
+     */
+    final void addLineNumber(final int lineNumber) {
+        if (this.lineNumber == 0) {
+            this.lineNumber = (short) lineNumber;
+        } else {
+            if (otherLineNumbers == null) {
+                otherLineNumbers = new int[LINE_NUMBERS_CAPACITY_INCREMENT];
+            }
+            int otherLineNumberIndex = ++otherLineNumbers[0];
+            if (otherLineNumberIndex >= otherLineNumbers.length) {
+                int[] newLineNumbers = new int[otherLineNumbers.length + LINE_NUMBERS_CAPACITY_INCREMENT];
+                System.arraycopy(otherLineNumbers, 0, newLineNumbers, 0, otherLineNumbers.length);
+                otherLineNumbers = newLineNumbers;
+            }
+            otherLineNumbers[otherLineNumberIndex] = lineNumber;
+        }
+    }
+
+    /**
+     * Makes the given visitor visit this label and its source line numbers, if applicable.
+     *
+     * @param methodVisitor a method visitor.
+     * @param visitLineNumbers whether to visit of the label's source line numbers, if any.
+     */
+    final void accept(final MethodVisitor methodVisitor, final boolean visitLineNumbers) {
+        methodVisitor.visitLabel(this);
+        if (visitLineNumbers && lineNumber != 0) {
+            methodVisitor.visitLineNumber(lineNumber & 0xFFFF, this);
+            if (otherLineNumbers != null) {
+                for (int i = 1; i <= otherLineNumbers[0]; ++i) {
+                    methodVisitor.visitLineNumber(otherLineNumbers[i], this);
+                }
+            }
+        }
+    }
+
+    // -----------------------------------------------------------------------------------------------
+    // Methods to compute offsets and to manage forward references
+    // -----------------------------------------------------------------------------------------------
+
+    /**
+     * Puts a reference to this label in the bytecode of a method. If the bytecode offset of the label
+     * is known, the relative bytecode offset between the label and the instruction referencing it is
+     * computed and written directly. Otherwise, a null relative offset is written and a new forward
+     * reference is declared for this label.
+     *
+     * @param code the bytecode of the method. This is where the reference is appended.
+     * @param sourceInsnBytecodeOffset the bytecode offset of the instruction that contains the
+     *     reference to be appended.
+     * @param wideReference whether the reference must be stored in 4 bytes (instead of 2 bytes).
+     */
+    final void put(final ByteVector code, final int sourceInsnBytecodeOffset, final boolean wideReference) {
+        if ((flags & FLAG_RESOLVED) == 0) {
+            if (wideReference) {
+                addForwardReference(sourceInsnBytecodeOffset, FORWARD_REFERENCE_TYPE_WIDE, code.length);
+                code.putInt(-1);
+            } else {
+                addForwardReference(sourceInsnBytecodeOffset, FORWARD_REFERENCE_TYPE_SHORT, code.length);
+                code.putShort(-1);
+            }
+        } else {
+            if (wideReference) {
+                code.putInt(bytecodeOffset - sourceInsnBytecodeOffset);
+            } else {
+                code.putShort(bytecodeOffset - sourceInsnBytecodeOffset);
+            }
+        }
+    }
+
+    /**
+     * Adds a forward reference to this label. This method must be called only for a true forward
+     * reference, i.e. only if this label is not resolved yet. For backward references, the relative
+     * bytecode offset of the reference can be, and must be, computed and stored directly.
+     *
+     * @param sourceInsnBytecodeOffset the bytecode offset of the instruction that contains the
+     *     reference stored at referenceHandle.
+     * @param referenceType either {@link #FORWARD_REFERENCE_TYPE_SHORT} or {@link
+     *     #FORWARD_REFERENCE_TYPE_WIDE}.
+     * @param referenceHandle the offset in the bytecode where the forward reference value must be
+     *     stored.
+     */
+    private void addForwardReference(final int sourceInsnBytecodeOffset, final int referenceType, final int referenceHandle) {
+        if (forwardReferences == null) {
+            forwardReferences = new int[FORWARD_REFERENCES_CAPACITY_INCREMENT];
+        }
+        int lastElementIndex = forwardReferences[0];
+        if (lastElementIndex + 2 >= forwardReferences.length) {
+            int[] newValues = new int[forwardReferences.length + FORWARD_REFERENCES_CAPACITY_INCREMENT];
+            System.arraycopy(forwardReferences, 0, newValues, 0, forwardReferences.length);
+            forwardReferences = newValues;
+        }
+        forwardReferences[++lastElementIndex] = sourceInsnBytecodeOffset;
+        forwardReferences[++lastElementIndex] = referenceType | referenceHandle;
+        forwardReferences[0] = lastElementIndex;
+    }
+
+    /**
+     * Sets the bytecode offset of this label to the given value and resolves the forward references
+     * to this label, if any. This method must be called when this label is added to the bytecode of
+     * the method, i.e. when its bytecode offset becomes known. This method fills in the blanks that
+     * where left in the bytecode by each forward reference previously added to this label.
+     *
+     * @param code the bytecode of the method.
+     * @param bytecodeOffset the bytecode offset of this label.
+     * @return {@literal true} if a blank that was left for this label was too small to store the
+     *     offset. In such a case the corresponding jump instruction is replaced with an equivalent
+     *     ASM specific instruction using an unsigned two bytes offset. These ASM specific
+     *     instructions are later replaced with standard bytecode instructions with wider offsets (4
+     *     bytes instead of 2), in ClassReader.
+     */
+    final boolean resolve(final byte[] code, final int bytecodeOffset) {
+        this.flags |= FLAG_RESOLVED;
+        this.bytecodeOffset = bytecodeOffset;
+        if (forwardReferences == null) {
+            return false;
+        }
+        boolean hasAsmInstructions = false;
+        for (int i = forwardReferences[0]; i > 0; i -= 2) {
+            final int sourceInsnBytecodeOffset = forwardReferences[i - 1];
+            final int reference = forwardReferences[i];
+            final int relativeOffset = bytecodeOffset - sourceInsnBytecodeOffset;
+            int handle = reference & FORWARD_REFERENCE_HANDLE_MASK;
+            if ((reference & FORWARD_REFERENCE_TYPE_MASK) == FORWARD_REFERENCE_TYPE_SHORT) {
+                if (relativeOffset < Short.MIN_VALUE || relativeOffset > Short.MAX_VALUE) {
+                    // Change the opcode of the jump instruction, in order to be able to find it later in
+                    // ClassReader. These ASM specific opcodes are similar to jump instruction opcodes, except
+                    // that the 2 bytes offset is unsigned (and can therefore represent values from 0 to
+                    // 65535, which is sufficient since the size of a method is limited to 65535 bytes).
+                    int opcode = code[sourceInsnBytecodeOffset] & 0xFF;
+                    if (opcode < Opcodes.IFNULL) {
+                        // Change IFEQ ... JSR to ASM_IFEQ ... ASM_JSR.
+                        code[sourceInsnBytecodeOffset] = (byte) (opcode + Constants.ASM_OPCODE_DELTA);
+                    } else {
+                        // Change IFNULL and IFNONNULL to ASM_IFNULL and ASM_IFNONNULL.
+                        code[sourceInsnBytecodeOffset] = (byte) (opcode + Constants.ASM_IFNULL_OPCODE_DELTA);
+                    }
+                    hasAsmInstructions = true;
+                }
+                code[handle++] = (byte) (relativeOffset >>> 8);
+                code[handle] = (byte) relativeOffset;
+            } else {
+                code[handle++] = (byte) (relativeOffset >>> 24);
+                code[handle++] = (byte) (relativeOffset >>> 16);
+                code[handle++] = (byte) (relativeOffset >>> 8);
+                code[handle] = (byte) relativeOffset;
+            }
+        }
+        return hasAsmInstructions;
+    }
+
+    // -----------------------------------------------------------------------------------------------
+    // Methods related to subroutines
+    // -----------------------------------------------------------------------------------------------
+
+    /**
+     * Finds the basic blocks that belong to the subroutine starting with the basic block
+     * corresponding to this label, and marks these blocks as belonging to this subroutine. This
+     * method follows the control flow graph to find all the blocks that are reachable from the
+     * current basic block WITHOUT following any jsr target.
+     *
+     * <p>Note: a precondition and postcondition of this method is that all labels must have a null
+     * {@link #nextListElement}.
+     *
+     * @param subroutineId the id of the subroutine starting with the basic block corresponding to
+     *     this label.
+     */
+    final void markSubroutine(final short subroutineId) {
+        // Data flow algorithm: put this basic block in a list of blocks to process (which are blocks
+        // belonging to subroutine subroutineId) and, while there are blocks to process, remove one from
+        // the list, mark it as belonging to the subroutine, and add its successor basic blocks in the
+        // control flow graph to the list of blocks to process (if not already done).
+        Label listOfBlocksToProcess = this;
+        listOfBlocksToProcess.nextListElement = EMPTY_LIST;
+        while (listOfBlocksToProcess != EMPTY_LIST) {
+            // Remove a basic block from the list of blocks to process.
+            Label basicBlock = listOfBlocksToProcess;
+            listOfBlocksToProcess = listOfBlocksToProcess.nextListElement;
+            basicBlock.nextListElement = null;
+
+            // If it is not already marked as belonging to a subroutine, mark it as belonging to
+            // subroutineId and add its successors to the list of blocks to process (unless already done).
+            if (basicBlock.subroutineId == 0) {
+                basicBlock.subroutineId = subroutineId;
+                listOfBlocksToProcess = basicBlock.pushSuccessors(listOfBlocksToProcess);
+            }
+        }
+    }
+
+    /**
+     * Finds the basic blocks that end a subroutine starting with the basic block corresponding to
+     * this label and, for each one of them, adds an outgoing edge to the basic block following the
+     * given subroutine call. In other words, completes the control flow graph by adding the edges
+     * corresponding to the return from this subroutine, when called from the given caller basic
+     * block.
+     *
+     * <p>Note: a precondition and postcondition of this method is that all labels must have a null
+     * {@link #nextListElement}.
+     *
+     * @param subroutineCaller a basic block that ends with a jsr to the basic block corresponding to
+     *     this label. This label is supposed to correspond to the start of a subroutine.
+     */
+    final void addSubroutineRetSuccessors(final Label subroutineCaller) {
+        // Data flow algorithm: put this basic block in a list blocks to process (which are blocks
+        // belonging to a subroutine starting with this label) and, while there are blocks to process,
+        // remove one from the list, put it in a list of blocks that have been processed, add a return
+        // edge to the successor of subroutineCaller if applicable, and add its successor basic blocks
+        // in the control flow graph to the list of blocks to process (if not already done).
+        Label listOfProcessedBlocks = EMPTY_LIST;
+        Label listOfBlocksToProcess = this;
+        listOfBlocksToProcess.nextListElement = EMPTY_LIST;
+        while (listOfBlocksToProcess != EMPTY_LIST) {
+            // Move a basic block from the list of blocks to process to the list of processed blocks.
+            Label basicBlock = listOfBlocksToProcess;
+            listOfBlocksToProcess = basicBlock.nextListElement;
+            basicBlock.nextListElement = listOfProcessedBlocks;
+            listOfProcessedBlocks = basicBlock;
+
+            // Add an edge from this block to the successor of the caller basic block, if this block is
+            // the end of a subroutine and if this block and subroutineCaller do not belong to the same
+            // subroutine.
+            if ((basicBlock.flags & FLAG_SUBROUTINE_END) != 0 && basicBlock.subroutineId != subroutineCaller.subroutineId) {
+                basicBlock.outgoingEdges = new Edge(basicBlock.outputStackSize,
+                        // By construction, the first outgoing edge of a basic block that ends with a jsr
+                        // instruction leads to the jsr continuation block, i.e. where execution continues
+                        // when ret is called (see {@link #FLAG_SUBROUTINE_CALLER}).
+                        subroutineCaller.outgoingEdges.successor, basicBlock.outgoingEdges);
+            }
+            // Add its successors to the list of blocks to process. Note that {@link #pushSuccessors} does
+            // not push basic blocks which are already in a list. Here this means either in the list of
+            // blocks to process, or in the list of already processed blocks. This second list is
+            // important to make sure we don't reprocess an already processed block.
+            listOfBlocksToProcess = basicBlock.pushSuccessors(listOfBlocksToProcess);
+        }
+        // Reset the {@link #nextListElement} of all the basic blocks that have been processed to null,
+        // so that this method can be called again with a different subroutine or subroutine caller.
+        while (listOfProcessedBlocks != EMPTY_LIST) {
+            Label newListOfProcessedBlocks = listOfProcessedBlocks.nextListElement;
+            listOfProcessedBlocks.nextListElement = null;
+            listOfProcessedBlocks = newListOfProcessedBlocks;
+        }
+    }
+
+    /**
+     * Adds the successors of this label in the method's control flow graph (except those
+     * corresponding to a jsr target, and those already in a list of labels) to the given list of
+     * blocks to process, and returns the new list.
+     *
+     * @param listOfLabelsToProcess a list of basic blocks to process, linked together with their
+     *     {@link #nextListElement} field.
+     * @return the new list of blocks to process.
+     */
+    private Label pushSuccessors(final Label listOfLabelsToProcess) {
+        Label newListOfLabelsToProcess = listOfLabelsToProcess;
+        Edge outgoingEdge = outgoingEdges;
+        while (outgoingEdge != null) {
+            // By construction, the second outgoing edge of a basic block that ends with a jsr instruction
+            // leads to the jsr target (see {@link #FLAG_SUBROUTINE_CALLER}).
+            boolean isJsrTarget = (flags & Label.FLAG_SUBROUTINE_CALLER) != 0 && outgoingEdge == outgoingEdges.nextEdge;
+            if (!isJsrTarget && outgoingEdge.successor.nextListElement == null) {
+                // Add this successor to the list of blocks to process, if it does not already belong to a
+                // list of labels.
+                outgoingEdge.successor.nextListElement = newListOfLabelsToProcess;
+                newListOfLabelsToProcess = outgoingEdge.successor;
+            }
+            outgoingEdge = outgoingEdge.nextEdge;
+        }
+        return newListOfLabelsToProcess;
+    }
+
+    // -----------------------------------------------------------------------------------------------
+    // Overridden Object methods
+    // -----------------------------------------------------------------------------------------------
+
+    /**
+     * Returns a string representation of this label.
+     *
+     * @return a string representation of this label.
+     */
+    @Override
+    public String toString() {
+        return "L" + System.identityHashCode(this);
+    }
+}

--- a/core/src/main/java/org/mvel2/asm/MethodTooLargeException.java
+++ b/core/src/main/java/org/mvel2/asm/MethodTooLargeException.java
@@ -1,0 +1,96 @@
+// ASM: a very small and fast Java bytecode manipulation framework
+// Copyright (c) 2000-2011 INRIA, France Telecom
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+// 1. Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+// 2. Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+// 3. Neither the name of the copyright holders nor the names of its
+//    contributors may be used to endorse or promote products derived from
+//    this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+// THE POSSIBILITY OF SUCH DAMAGE.
+package org.mvel2.asm;
+
+/**
+ * Exception thrown when the Code attribute of a method produced by a {@link ClassWriter} is too
+ * large.
+ *
+ * @author Jason Zaugg
+ */
+public final class MethodTooLargeException extends IndexOutOfBoundsException {
+
+    private static final long serialVersionUID = 6807380416709738314L;
+
+    private final String className;
+    private final String methodName;
+    private final String descriptor;
+    private final int codeSize;
+
+    /**
+     * Constructs a new {@link MethodTooLargeException}.
+     *
+     * @param className the internal name of the owner class.
+     * @param methodName the name of the method.
+     * @param descriptor the descriptor of the method.
+     * @param codeSize the size of the method's Code attribute, in bytes.
+     */
+    public MethodTooLargeException(final String className, final String methodName, final String descriptor, final int codeSize) {
+        super("Method too large: " + className + "." + methodName + " " + descriptor);
+        this.className = className;
+        this.methodName = methodName;
+        this.descriptor = descriptor;
+        this.codeSize = codeSize;
+    }
+
+    /**
+     * Returns the internal name of the owner class.
+     *
+     * @return the internal name of the owner class.
+     */
+    public String getClassName() {
+        return className;
+    }
+
+    /**
+     * Returns the name of the method.
+     *
+     * @return the name of the method.
+     */
+    public String getMethodName() {
+        return methodName;
+    }
+
+    /**
+     * Returns the descriptor of the method.
+     *
+     * @return the descriptor of the method.
+     */
+    public String getDescriptor() {
+        return descriptor;
+    }
+
+    /**
+     * Returns the size of the method's Code attribute, in bytes.
+     *
+     * @return the size of the method's Code attribute, in bytes.
+     */
+    public int getCodeSize() {
+        return codeSize;
+    }
+}

--- a/core/src/main/java/org/mvel2/asm/MethodVisitor.java
+++ b/core/src/main/java/org/mvel2/asm/MethodVisitor.java
@@ -1,0 +1,750 @@
+// ASM: a very small and fast Java bytecode manipulation framework
+// Copyright (c) 2000-2011 INRIA, France Telecom
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+// 1. Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+// 2. Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+// 3. Neither the name of the copyright holders nor the names of its
+//    contributors may be used to endorse or promote products derived from
+//    this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+// THE POSSIBILITY OF SUCH DAMAGE.
+package org.mvel2.asm;
+
+/**
+ * A visitor to visit a Java method. The methods of this class must be called in the following
+ * order: ( {@code visitParameter} )* [ {@code visitAnnotationDefault} ] ( {@code visitAnnotation} |
+ * {@code visitAnnotableParameterCount} | {@code visitParameterAnnotation} {@code
+ * visitTypeAnnotation} | {@code visitAttribute} )* [ {@code visitCode} ( {@code visitFrame} |
+ * {@code visit<i>X</i>Insn} | {@code visitLabel} | {@code visitInsnAnnotation} | {@code
+ * visitTryCatchBlock} | {@code visitTryCatchAnnotation} | {@code visitLocalVariable} | {@code
+ * visitLocalVariableAnnotation} | {@code visitLineNumber} )* {@code visitMaxs} ] {@code visitEnd}.
+ * In addition, the {@code visit<i>X</i>Insn} and {@code visitLabel} methods must be called in the
+ * sequential order of the bytecode instructions of the visited code, {@code visitInsnAnnotation}
+ * must be called <i>after</i> the annotated instruction, {@code visitTryCatchBlock} must be called
+ * <i>before</i> the labels passed as arguments have been visited, {@code
+ * visitTryCatchBlockAnnotation} must be called <i>after</i> the corresponding try catch block has
+ * been visited, and the {@code visitLocalVariable}, {@code visitLocalVariableAnnotation} and {@code
+ * visitLineNumber} methods must be called <i>after</i> the labels passed as arguments have been
+ * visited.
+ *
+ * @author Eric Bruneton
+ */
+public abstract class MethodVisitor {
+
+    private static final String REQUIRES_ASM5 = "This feature requires ASM5";
+
+    /**
+     * The ASM API version implemented by this visitor. The value of this field must be one of {@link
+     * Opcodes#ASM4}, {@link Opcodes#ASM5}, {@link Opcodes#ASM6} or {@link Opcodes#ASM7}.
+     */
+    protected final int api;
+
+    /** The method visitor to which this visitor must delegate method calls. May be null. */
+    protected MethodVisitor mv;
+
+    /**
+     * Constructs a new {@link MethodVisitor}.
+     *
+     * @param api the ASM API version implemented by this visitor. Must be one of {@link
+     *     Opcodes#ASM4}, {@link Opcodes#ASM5}, {@link Opcodes#ASM6} or {@link Opcodes#ASM7}.
+     */
+    public MethodVisitor(final int api) {
+        this(api, null);
+    }
+
+    /**
+     * Constructs a new {@link MethodVisitor}.
+     *
+     * @param api the ASM API version implemented by this visitor. Must be one of {@link
+     *     Opcodes#ASM4}, {@link Opcodes#ASM5}, {@link Opcodes#ASM6} or {@link Opcodes#ASM7}.
+     * @param methodVisitor the method visitor to which this visitor must delegate method calls. May
+     *     be null.
+     */
+    public MethodVisitor(final int api, final MethodVisitor methodVisitor) {
+        if (api != Opcodes.ASM6 && api != Opcodes.ASM5 && api != Opcodes.ASM4 && api != Opcodes.ASM7) {
+            throw new IllegalArgumentException();
+        }
+        this.api = api;
+        this.mv = methodVisitor;
+    }
+
+    // -----------------------------------------------------------------------------------------------
+    // Parameters, annotations and non standard attributes
+    // -----------------------------------------------------------------------------------------------
+
+    /**
+     * Visits a parameter of this method.
+     *
+     * @param name parameter name or null if none is provided.
+     * @param access the parameter's access flags, only {@code ACC_FINAL}, {@code ACC_SYNTHETIC}
+     *     or/and {@code ACC_MANDATED} are allowed (see {@link Opcodes}).
+     */
+    public void visitParameter(final String name, final int access) {
+        if (api < Opcodes.ASM5) {
+            throw new UnsupportedOperationException(REQUIRES_ASM5);
+        }
+        if (mv != null) {
+            mv.visitParameter(name, access);
+        }
+    }
+
+    /**
+     * Visits the default value of this annotation interface method.
+     *
+     * @return a visitor to the visit the actual default value of this annotation interface method, or
+     *     {@literal null} if this visitor is not interested in visiting this default value. The
+     *     'name' parameters passed to the methods of this annotation visitor are ignored. Moreover,
+     *     exacly one visit method must be called on this annotation visitor, followed by visitEnd.
+     */
+    public AnnotationVisitor visitAnnotationDefault() {
+        if (mv != null) {
+            return mv.visitAnnotationDefault();
+        }
+        return null;
+    }
+
+    /**
+     * Visits an annotation of this method.
+     *
+     * @param descriptor the class descriptor of the annotation class.
+     * @param visible {@literal true} if the annotation is visible at runtime.
+     * @return a visitor to visit the annotation values, or {@literal null} if this visitor is not
+     *     interested in visiting this annotation.
+     */
+    public AnnotationVisitor visitAnnotation(final String descriptor, final boolean visible) {
+        if (mv != null) {
+            return mv.visitAnnotation(descriptor, visible);
+        }
+        return null;
+    }
+
+    /**
+     * Visits an annotation on a type in the method signature.
+     *
+     * @param typeRef a reference to the annotated type. The sort of this type reference must be
+     *     {@link TypeReference#METHOD_TYPE_PARAMETER}, {@link
+     *     TypeReference#METHOD_TYPE_PARAMETER_BOUND}, {@link TypeReference#METHOD_RETURN}, {@link
+     *     TypeReference#METHOD_RECEIVER}, {@link TypeReference#METHOD_FORMAL_PARAMETER} or {@link
+     *     TypeReference#THROWS}. See {@link TypeReference}.
+     * @param typePath the path to the annotated type argument, wildcard bound, array element type, or
+     *     static inner type within 'typeRef'. May be {@literal null} if the annotation targets
+     *     'typeRef' as a whole.
+     * @param descriptor the class descriptor of the annotation class.
+     * @param visible {@literal true} if the annotation is visible at runtime.
+     * @return a visitor to visit the annotation values, or {@literal null} if this visitor is not
+     *     interested in visiting this annotation.
+     */
+    public AnnotationVisitor visitTypeAnnotation(final int typeRef, final TypePath typePath, final String descriptor,
+            final boolean visible) {
+        if (api < Opcodes.ASM5) {
+            throw new UnsupportedOperationException(REQUIRES_ASM5);
+        }
+        if (mv != null) {
+            return mv.visitTypeAnnotation(typeRef, typePath, descriptor, visible);
+        }
+        return null;
+    }
+
+    /**
+     * Visits the number of method parameters that can have annotations. By default (i.e. when this
+     * method is not called), all the method parameters defined by the method descriptor can have
+     * annotations.
+     *
+     * @param parameterCount the number of method parameters than can have annotations. This number
+     *     must be less or equal than the number of parameter types in the method descriptor. It can
+     *     be strictly less when a method has synthetic parameters and when these parameters are
+     *     ignored when computing parameter indices for the purpose of parameter annotations (see
+     *     https://docs.oracle.com/javase/specs/jvms/se9/html/jvms-4.html#jvms-4.7.18).
+     * @param visible {@literal true} to define the number of method parameters that can have
+     *     annotations visible at runtime, {@literal false} to define the number of method parameters
+     *     that can have annotations invisible at runtime.
+     */
+    public void visitAnnotableParameterCount(final int parameterCount, final boolean visible) {
+        if (mv != null) {
+            mv.visitAnnotableParameterCount(parameterCount, visible);
+        }
+    }
+
+    /**
+     * Visits an annotation of a parameter this method.
+     *
+     * @param parameter the parameter index. This index must be strictly smaller than the number of
+     *     parameters in the method descriptor, and strictly smaller than the parameter count
+     *     specified in {@link #visitAnnotableParameterCount}. Important note: <i>a parameter index i
+     *     is not required to correspond to the i'th parameter descriptor in the method
+     *     descriptor</i>, in particular in case of synthetic parameters (see
+     *     https://docs.oracle.com/javase/specs/jvms/se9/html/jvms-4.html#jvms-4.7.18).
+     * @param descriptor the class descriptor of the annotation class.
+     * @param visible {@literal true} if the annotation is visible at runtime.
+     * @return a visitor to visit the annotation values, or {@literal null} if this visitor is not
+     *     interested in visiting this annotation.
+     */
+    public AnnotationVisitor visitParameterAnnotation(final int parameter, final String descriptor, final boolean visible) {
+        if (mv != null) {
+            return mv.visitParameterAnnotation(parameter, descriptor, visible);
+        }
+        return null;
+    }
+
+    /**
+     * Visits a non standard attribute of this method.
+     *
+     * @param attribute an attribute.
+     */
+    public void visitAttribute(final Attribute attribute) {
+        if (mv != null) {
+            mv.visitAttribute(attribute);
+        }
+    }
+
+    /** Starts the visit of the method's code, if any (i.e. non abstract method). */
+    public void visitCode() {
+        if (mv != null) {
+            mv.visitCode();
+        }
+    }
+
+    /**
+     * Visits the current state of the local variables and operand stack elements. This method must(*)
+     * be called <i>just before</i> any instruction <b>i</b> that follows an unconditional branch
+     * instruction such as GOTO or THROW, that is the target of a jump instruction, or that starts an
+     * exception handler block. The visited types must describe the values of the local variables and
+     * of the operand stack elements <i>just before</i> <b>i</b> is executed.<br>
+     * <br>
+     * (*) this is mandatory only for classes whose version is greater than or equal to {@link
+     * Opcodes#V1_6}. <br>
+     * <br>
+     * The frames of a method must be given either in expanded form, or in compressed form (all frames
+     * must use the same format, i.e. you must not mix expanded and compressed frames within a single
+     * method):
+     *
+     * <ul>
+     *   <li>In expanded form, all frames must have the F_NEW type.
+     *   <li>In compressed form, frames are basically "deltas" from the state of the previous frame:
+     *       <ul>
+     *         <li>{@link Opcodes#F_SAME} representing frame with exactly the same locals as the
+     *             previous frame and with the empty stack.
+     *         <li>{@link Opcodes#F_SAME1} representing frame with exactly the same locals as the
+     *             previous frame and with single value on the stack ( <code>numStack</code> is 1 and
+     *             <code>stack[0]</code> contains value for the type of the stack item).
+     *         <li>{@link Opcodes#F_APPEND} representing frame with current locals are the same as the
+     *             locals in the previous frame, except that additional locals are defined (<code>
+     *             numLocal</code> is 1, 2 or 3 and <code>local</code> elements contains values
+     *             representing added types).
+     *         <li>{@link Opcodes#F_CHOP} representing frame with current locals are the same as the
+     *             locals in the previous frame, except that the last 1-3 locals are absent and with
+     *             the empty stack (<code>numLocal</code> is 1, 2 or 3).
+     *         <li>{@link Opcodes#F_FULL} representing complete frame data.
+     *       </ul>
+     * </ul>
+     *
+     * <br>
+     * In both cases the first frame, corresponding to the method's parameters and access flags, is
+     * implicit and must not be visited. Also, it is illegal to visit two or more frames for the same
+     * code location (i.e., at least one instruction must be visited between two calls to visitFrame).
+     *
+     * @param type the type of this stack map frame. Must be {@link Opcodes#F_NEW} for expanded
+     *     frames, or {@link Opcodes#F_FULL}, {@link Opcodes#F_APPEND}, {@link Opcodes#F_CHOP}, {@link
+     *     Opcodes#F_SAME} or {@link Opcodes#F_APPEND}, {@link Opcodes#F_SAME1} for compressed frames.
+     * @param numLocal the number of local variables in the visited frame.
+     * @param local the local variable types in this frame. This array must not be modified. Primitive
+     *     types are represented by {@link Opcodes#TOP}, {@link Opcodes#INTEGER}, {@link
+     *     Opcodes#FLOAT}, {@link Opcodes#LONG}, {@link Opcodes#DOUBLE}, {@link Opcodes#NULL} or
+     *     {@link Opcodes#UNINITIALIZED_THIS} (long and double are represented by a single element).
+     *     Reference types are represented by String objects (representing internal names), and
+     *     uninitialized types by Label objects (this label designates the NEW instruction that
+     *     created this uninitialized value).
+     * @param numStack the number of operand stack elements in the visited frame.
+     * @param stack the operand stack types in this frame. This array must not be modified. Its
+     *     content has the same format as the "local" array.
+     * @throws IllegalStateException if a frame is visited just after another one, without any
+     *     instruction between the two (unless this frame is a Opcodes#F_SAME frame, in which case it
+     *     is silently ignored).
+     */
+    public void visitFrame(final int type, final int numLocal, final Object[] local, final int numStack, final Object[] stack) {
+        if (mv != null) {
+            mv.visitFrame(type, numLocal, local, numStack, stack);
+        }
+    }
+
+    // -----------------------------------------------------------------------------------------------
+    // Normal instructions
+    // -----------------------------------------------------------------------------------------------
+
+    /**
+     * Visits a zero operand instruction.
+     *
+     * @param opcode the opcode of the instruction to be visited. This opcode is either NOP,
+     *     ACONST_NULL, ICONST_M1, ICONST_0, ICONST_1, ICONST_2, ICONST_3, ICONST_4, ICONST_5,
+     *     LCONST_0, LCONST_1, FCONST_0, FCONST_1, FCONST_2, DCONST_0, DCONST_1, IALOAD, LALOAD,
+     *     FALOAD, DALOAD, AALOAD, BALOAD, CALOAD, SALOAD, IASTORE, LASTORE, FASTORE, DASTORE,
+     *     AASTORE, BASTORE, CASTORE, SASTORE, POP, POP2, DUP, DUP_X1, DUP_X2, DUP2, DUP2_X1, DUP2_X2,
+     *     SWAP, IADD, LADD, FADD, DADD, ISUB, LSUB, FSUB, DSUB, IMUL, LMUL, FMUL, DMUL, IDIV, LDIV,
+     *     FDIV, DDIV, IREM, LREM, FREM, DREM, INEG, LNEG, FNEG, DNEG, ISHL, LSHL, ISHR, LSHR, IUSHR,
+     *     LUSHR, IAND, LAND, IOR, LOR, IXOR, LXOR, I2L, I2F, I2D, L2I, L2F, L2D, F2I, F2L, F2D, D2I,
+     *     D2L, D2F, I2B, I2C, I2S, LCMP, FCMPL, FCMPG, DCMPL, DCMPG, IRETURN, LRETURN, FRETURN,
+     *     DRETURN, ARETURN, RETURN, ARRAYLENGTH, ATHROW, MONITORENTER, or MONITOREXIT.
+     */
+    public void visitInsn(final int opcode) {
+        if (mv != null) {
+            mv.visitInsn(opcode);
+        }
+    }
+
+    /**
+     * Visits an instruction with a single int operand.
+     *
+     * @param opcode the opcode of the instruction to be visited. This opcode is either BIPUSH, SIPUSH
+     *     or NEWARRAY.
+     * @param operand the operand of the instruction to be visited.<br>
+     *     When opcode is BIPUSH, operand value should be between Byte.MIN_VALUE and Byte.MAX_VALUE.
+     *     <br>
+     *     When opcode is SIPUSH, operand value should be between Short.MIN_VALUE and Short.MAX_VALUE.
+     *     <br>
+     *     When opcode is NEWARRAY, operand value should be one of {@link Opcodes#T_BOOLEAN}, {@link
+     *     Opcodes#T_CHAR}, {@link Opcodes#T_FLOAT}, {@link Opcodes#T_DOUBLE}, {@link Opcodes#T_BYTE},
+     *     {@link Opcodes#T_SHORT}, {@link Opcodes#T_INT} or {@link Opcodes#T_LONG}.
+     */
+    public void visitIntInsn(final int opcode, final int operand) {
+        if (mv != null) {
+            mv.visitIntInsn(opcode, operand);
+        }
+    }
+
+    /**
+     * Visits a local variable instruction. A local variable instruction is an instruction that loads
+     * or stores the value of a local variable.
+     *
+     * @param opcode the opcode of the local variable instruction to be visited. This opcode is either
+     *     ILOAD, LLOAD, FLOAD, DLOAD, ALOAD, ISTORE, LSTORE, FSTORE, DSTORE, ASTORE or RET.
+     * @param var the operand of the instruction to be visited. This operand is the index of a local
+     *     variable.
+     */
+    public void visitVarInsn(final int opcode, final int var) {
+        if (mv != null) {
+            mv.visitVarInsn(opcode, var);
+        }
+    }
+
+    /**
+     * Visits a type instruction. A type instruction is an instruction that takes the internal name of
+     * a class as parameter.
+     *
+     * @param opcode the opcode of the type instruction to be visited. This opcode is either NEW,
+     *     ANEWARRAY, CHECKCAST or INSTANCEOF.
+     * @param type the operand of the instruction to be visited. This operand must be the internal
+     *     name of an object or array class (see {@link Type#getInternalName()}).
+     */
+    public void visitTypeInsn(final int opcode, final String type) {
+        if (mv != null) {
+            mv.visitTypeInsn(opcode, type);
+        }
+    }
+
+    /**
+     * Visits a field instruction. A field instruction is an instruction that loads or stores the
+     * value of a field of an object.
+     *
+     * @param opcode the opcode of the type instruction to be visited. This opcode is either
+     *     GETSTATIC, PUTSTATIC, GETFIELD or PUTFIELD.
+     * @param owner the internal name of the field's owner class (see {@link Type#getInternalName()}).
+     * @param name the field's name.
+     * @param descriptor the field's descriptor (see {@link Type}).
+     */
+    public void visitFieldInsn(final int opcode, final String owner, final String name, final String descriptor) {
+        if (mv != null) {
+            mv.visitFieldInsn(opcode, owner, name, descriptor);
+        }
+    }
+
+    /**
+     * Visits a method instruction. A method instruction is an instruction that invokes a method.
+     *
+     * @param opcode the opcode of the type instruction to be visited. This opcode is either
+     *     INVOKEVIRTUAL, INVOKESPECIAL, INVOKESTATIC or INVOKEINTERFACE.
+     * @param owner the internal name of the method's owner class (see {@link
+     *     Type#getInternalName()}).
+     * @param name the method's name.
+     * @param descriptor the method's descriptor (see {@link Type}).
+     * @deprecated use {@link #visitMethodInsn(int, String, String, String, boolean)} instead.
+     */
+    @Deprecated
+    public void visitMethodInsn(final int opcode, final String owner, final String name, final String descriptor) {
+        if (api >= Opcodes.ASM5) {
+            boolean isInterface = opcode == Opcodes.INVOKEINTERFACE;
+            visitMethodInsn(opcode, owner, name, descriptor, isInterface);
+            return;
+        }
+        if (mv != null) {
+            mv.visitMethodInsn(opcode, owner, name, descriptor);
+        }
+    }
+
+    /**
+     * Visits a method instruction. A method instruction is an instruction that invokes a method.
+     *
+     * @param opcode the opcode of the type instruction to be visited. This opcode is either
+     *     INVOKEVIRTUAL, INVOKESPECIAL, INVOKESTATIC or INVOKEINTERFACE.
+     * @param owner the internal name of the method's owner class (see {@link
+     *     Type#getInternalName()}).
+     * @param name the method's name.
+     * @param descriptor the method's descriptor (see {@link Type}).
+     * @param isInterface if the method's owner class is an interface.
+     */
+    public void visitMethodInsn(final int opcode, final String owner, final String name, final String descriptor,
+            final boolean isInterface) {
+        if (api < Opcodes.ASM5) {
+            if (isInterface != (opcode == Opcodes.INVOKEINTERFACE)) {
+                throw new IllegalArgumentException("INVOKESPECIAL/STATIC on interfaces requires ASM5");
+            }
+            visitMethodInsn(opcode, owner, name, descriptor);
+            return;
+        }
+        if (mv != null) {
+            mv.visitMethodInsn(opcode, owner, name, descriptor, isInterface);
+        }
+    }
+
+    /**
+     * Visits an invokedynamic instruction.
+     *
+     * @param name the method's name.
+     * @param descriptor the method's descriptor (see {@link Type}).
+     * @param bootstrapMethodHandle the bootstrap method.
+     * @param bootstrapMethodArguments the bootstrap method constant arguments. Each argument must be
+     *     an {@link Integer}, {@link Float}, {@link Long}, {@link Double}, {@link String}, {@link
+     *     Type}, {@link Handle} or {@link ConstantDynamic} value. This method is allowed to modify
+     *     the content of the array so a caller should expect that this array may change.
+     */
+    public void visitInvokeDynamicInsn(final String name, final String descriptor, final Handle bootstrapMethodHandle,
+            final Object... bootstrapMethodArguments) {
+        if (api < Opcodes.ASM5) {
+            throw new UnsupportedOperationException(REQUIRES_ASM5);
+        }
+        if (mv != null) {
+            mv.visitInvokeDynamicInsn(name, descriptor, bootstrapMethodHandle, bootstrapMethodArguments);
+        }
+    }
+
+    /**
+     * Visits a jump instruction. A jump instruction is an instruction that may jump to another
+     * instruction.
+     *
+     * @param opcode the opcode of the type instruction to be visited. This opcode is either IFEQ,
+     *     IFNE, IFLT, IFGE, IFGT, IFLE, IF_ICMPEQ, IF_ICMPNE, IF_ICMPLT, IF_ICMPGE, IF_ICMPGT,
+     *     IF_ICMPLE, IF_ACMPEQ, IF_ACMPNE, GOTO, JSR, IFNULL or IFNONNULL.
+     * @param label the operand of the instruction to be visited. This operand is a label that
+     *     designates the instruction to which the jump instruction may jump.
+     */
+    public void visitJumpInsn(final int opcode, final Label label) {
+        if (mv != null) {
+            mv.visitJumpInsn(opcode, label);
+        }
+    }
+
+    /**
+     * Visits a label. A label designates the instruction that will be visited just after it.
+     *
+     * @param label a {@link Label} object.
+     */
+    public void visitLabel(final Label label) {
+        if (mv != null) {
+            mv.visitLabel(label);
+        }
+    }
+
+    // -----------------------------------------------------------------------------------------------
+    // Special instructions
+    // -----------------------------------------------------------------------------------------------
+
+    /**
+     * Visits a LDC instruction. Note that new constant types may be added in future versions of the
+     * Java Virtual Machine. To easily detect new constant types, implementations of this method
+     * should check for unexpected constant types, like this:
+     *
+     * <pre>
+     * if (cst instanceof Integer) {
+     *     // ...
+     * } else if (cst instanceof Float) {
+     *     // ...
+     * } else if (cst instanceof Long) {
+     *     // ...
+     * } else if (cst instanceof Double) {
+     *     // ...
+     * } else if (cst instanceof String) {
+     *     // ...
+     * } else if (cst instanceof Type) {
+     *     int sort = ((Type) cst).getSort();
+     *     if (sort == Type.OBJECT) {
+     *         // ...
+     *     } else if (sort == Type.ARRAY) {
+     *         // ...
+     *     } else if (sort == Type.METHOD) {
+     *         // ...
+     *     } else {
+     *         // throw an exception
+     *     }
+     * } else if (cst instanceof Handle) {
+     *     // ...
+     * } else if (cst instanceof ConstantDynamic) {
+     *     // ...
+     * } else {
+     *     // throw an exception
+     * }
+     * </pre>
+     *
+     * @param value the constant to be loaded on the stack. This parameter must be a non null {@link
+     *     Integer}, a {@link Float}, a {@link Long}, a {@link Double}, a {@link String}, a {@link
+     *     Type} of OBJECT or ARRAY sort for {@code .class} constants, for classes whose version is
+     *     49, a {@link Type} of METHOD sort for MethodType, a {@link Handle} for MethodHandle
+     *     constants, for classes whose version is 51 or a {@link ConstantDynamic} for a constant
+     *     dynamic for classes whose version is 55.
+     */
+    public void visitLdcInsn(final Object value) {
+        if (api < Opcodes.ASM5 && (value instanceof Handle || (value instanceof Type && ((Type) value).getSort() == Type.METHOD))) {
+            throw new UnsupportedOperationException(REQUIRES_ASM5);
+        }
+        if (api != Opcodes.ASM7 && value instanceof ConstantDynamic) {
+            throw new UnsupportedOperationException("This feature requires ASM7");
+        }
+        if (mv != null) {
+            mv.visitLdcInsn(value);
+        }
+    }
+
+    /**
+     * Visits an IINC instruction.
+     *
+     * @param var index of the local variable to be incremented.
+     * @param increment amount to increment the local variable by.
+     */
+    public void visitIincInsn(final int var, final int increment) {
+        if (mv != null) {
+            mv.visitIincInsn(var, increment);
+        }
+    }
+
+    /**
+     * Visits a TABLESWITCH instruction.
+     *
+     * @param min the minimum key value.
+     * @param max the maximum key value.
+     * @param dflt beginning of the default handler block.
+     * @param labels beginnings of the handler blocks. {@code labels[i]} is the beginning of the
+     *     handler block for the {@code min + i} key.
+     */
+    public void visitTableSwitchInsn(final int min, final int max, final Label dflt, final Label... labels) {
+        if (mv != null) {
+            mv.visitTableSwitchInsn(min, max, dflt, labels);
+        }
+    }
+
+    /**
+     * Visits a LOOKUPSWITCH instruction.
+     *
+     * @param dflt beginning of the default handler block.
+     * @param keys the values of the keys.
+     * @param labels beginnings of the handler blocks. {@code labels[i]} is the beginning of the
+     *     handler block for the {@code keys[i]} key.
+     */
+    public void visitLookupSwitchInsn(final Label dflt, final int[] keys, final Label[] labels) {
+        if (mv != null) {
+            mv.visitLookupSwitchInsn(dflt, keys, labels);
+        }
+    }
+
+    /**
+     * Visits a MULTIANEWARRAY instruction.
+     *
+     * @param descriptor an array type descriptor (see {@link Type}).
+     * @param numDimensions the number of dimensions of the array to allocate.
+     */
+    public void visitMultiANewArrayInsn(final String descriptor, final int numDimensions) {
+        if (mv != null) {
+            mv.visitMultiANewArrayInsn(descriptor, numDimensions);
+        }
+    }
+
+    /**
+     * Visits an annotation on an instruction. This method must be called just <i>after</i> the
+     * annotated instruction. It can be called several times for the same instruction.
+     *
+     * @param typeRef a reference to the annotated type. The sort of this type reference must be
+     *     {@link TypeReference#INSTANCEOF}, {@link TypeReference#NEW}, {@link
+     *     TypeReference#CONSTRUCTOR_REFERENCE}, {@link TypeReference#METHOD_REFERENCE}, {@link
+     *     TypeReference#CAST}, {@link TypeReference#CONSTRUCTOR_INVOCATION_TYPE_ARGUMENT}, {@link
+     *     TypeReference#METHOD_INVOCATION_TYPE_ARGUMENT}, {@link
+     *     TypeReference#CONSTRUCTOR_REFERENCE_TYPE_ARGUMENT}, or {@link
+     *     TypeReference#METHOD_REFERENCE_TYPE_ARGUMENT}. See {@link TypeReference}.
+     * @param typePath the path to the annotated type argument, wildcard bound, array element type, or
+     *     static inner type within 'typeRef'. May be {@literal null} if the annotation targets
+     *     'typeRef' as a whole.
+     * @param descriptor the class descriptor of the annotation class.
+     * @param visible {@literal true} if the annotation is visible at runtime.
+     * @return a visitor to visit the annotation values, or {@literal null} if this visitor is not
+     *     interested in visiting this annotation.
+     */
+    public AnnotationVisitor visitInsnAnnotation(final int typeRef, final TypePath typePath, final String descriptor,
+            final boolean visible) {
+        if (api < Opcodes.ASM5) {
+            throw new UnsupportedOperationException(REQUIRES_ASM5);
+        }
+        if (mv != null) {
+            return mv.visitInsnAnnotation(typeRef, typePath, descriptor, visible);
+        }
+        return null;
+    }
+
+    // -----------------------------------------------------------------------------------------------
+    // Exceptions table entries, debug information, max stack and max locals
+    // -----------------------------------------------------------------------------------------------
+
+    /**
+     * Visits a try catch block.
+     *
+     * @param start the beginning of the exception handler's scope (inclusive).
+     * @param end the end of the exception handler's scope (exclusive).
+     * @param handler the beginning of the exception handler's code.
+     * @param type the internal name of the type of exceptions handled by the handler, or {@literal
+     *     null} to catch any exceptions (for "finally" blocks).
+     * @throws IllegalArgumentException if one of the labels has already been visited by this visitor
+     *     (by the {@link #visitLabel} method).
+     */
+    public void visitTryCatchBlock(final Label start, final Label end, final Label handler, final String type) {
+        if (mv != null) {
+            mv.visitTryCatchBlock(start, end, handler, type);
+        }
+    }
+
+    /**
+     * Visits an annotation on an exception handler type. This method must be called <i>after</i> the
+     * {@link #visitTryCatchBlock} for the annotated exception handler. It can be called several times
+     * for the same exception handler.
+     *
+     * @param typeRef a reference to the annotated type. The sort of this type reference must be
+     *     {@link TypeReference#EXCEPTION_PARAMETER}. See {@link TypeReference}.
+     * @param typePath the path to the annotated type argument, wildcard bound, array element type, or
+     *     static inner type within 'typeRef'. May be {@literal null} if the annotation targets
+     *     'typeRef' as a whole.
+     * @param descriptor the class descriptor of the annotation class.
+     * @param visible {@literal true} if the annotation is visible at runtime.
+     * @return a visitor to visit the annotation values, or {@literal null} if this visitor is not
+     *     interested in visiting this annotation.
+     */
+    public AnnotationVisitor visitTryCatchAnnotation(final int typeRef, final TypePath typePath, final String descriptor,
+            final boolean visible) {
+        if (api < Opcodes.ASM5) {
+            throw new UnsupportedOperationException(REQUIRES_ASM5);
+        }
+        if (mv != null) {
+            return mv.visitTryCatchAnnotation(typeRef, typePath, descriptor, visible);
+        }
+        return null;
+    }
+
+    /**
+     * Visits a local variable declaration.
+     *
+     * @param name the name of a local variable.
+     * @param descriptor the type descriptor of this local variable.
+     * @param signature the type signature of this local variable. May be {@literal null} if the local
+     *     variable type does not use generic types.
+     * @param start the first instruction corresponding to the scope of this local variable
+     *     (inclusive).
+     * @param end the last instruction corresponding to the scope of this local variable (exclusive).
+     * @param index the local variable's index.
+     * @throws IllegalArgumentException if one of the labels has not already been visited by this
+     *     visitor (by the {@link #visitLabel} method).
+     */
+    public void visitLocalVariable(final String name, final String descriptor, final String signature, final Label start, final Label end,
+            final int index) {
+        if (mv != null) {
+            mv.visitLocalVariable(name, descriptor, signature, start, end, index);
+        }
+    }
+
+    /**
+     * Visits an annotation on a local variable type.
+     *
+     * @param typeRef a reference to the annotated type. The sort of this type reference must be
+     *     {@link TypeReference#LOCAL_VARIABLE} or {@link TypeReference#RESOURCE_VARIABLE}. See {@link
+     *     TypeReference}.
+     * @param typePath the path to the annotated type argument, wildcard bound, array element type, or
+     *     static inner type within 'typeRef'. May be {@literal null} if the annotation targets
+     *     'typeRef' as a whole.
+     * @param start the fist instructions corresponding to the continuous ranges that make the scope
+     *     of this local variable (inclusive).
+     * @param end the last instructions corresponding to the continuous ranges that make the scope of
+     *     this local variable (exclusive). This array must have the same size as the 'start' array.
+     * @param index the local variable's index in each range. This array must have the same size as
+     *     the 'start' array.
+     * @param descriptor the class descriptor of the annotation class.
+     * @param visible {@literal true} if the annotation is visible at runtime.
+     * @return a visitor to visit the annotation values, or {@literal null} if this visitor is not
+     *     interested in visiting this annotation.
+     */
+    public AnnotationVisitor visitLocalVariableAnnotation(final int typeRef, final TypePath typePath, final Label[] start,
+            final Label[] end, final int[] index, final String descriptor, final boolean visible) {
+        if (api < Opcodes.ASM5) {
+            throw new UnsupportedOperationException(REQUIRES_ASM5);
+        }
+        if (mv != null) {
+            return mv.visitLocalVariableAnnotation(typeRef, typePath, start, end, index, descriptor, visible);
+        }
+        return null;
+    }
+
+    /**
+     * Visits a line number declaration.
+     *
+     * @param line a line number. This number refers to the source file from which the class was
+     *     compiled.
+     * @param start the first instruction corresponding to this line number.
+     * @throws IllegalArgumentException if {@code start} has not already been visited by this visitor
+     *     (by the {@link #visitLabel} method).
+     */
+    public void visitLineNumber(final int line, final Label start) {
+        if (mv != null) {
+            mv.visitLineNumber(line, start);
+        }
+    }
+
+    /**
+     * Visits the maximum stack size and the maximum number of local variables of the method.
+     *
+     * @param maxStack maximum stack size of the method.
+     * @param maxLocals maximum number of local variables for the method.
+     */
+    public void visitMaxs(final int maxStack, final int maxLocals) {
+        if (mv != null) {
+            mv.visitMaxs(maxStack, maxLocals);
+        }
+    }
+
+    /**
+     * Visits the end of the method. This method, which is the last one to be called, is used to
+     * inform the visitor that all the annotations and attributes of the method have been visited.
+     */
+    public void visitEnd() {
+        if (mv != null) {
+            mv.visitEnd();
+        }
+    }
+}

--- a/core/src/main/java/org/mvel2/asm/MethodWriter.java
+++ b/core/src/main/java/org/mvel2/asm/MethodWriter.java
@@ -1,0 +1,2237 @@
+// ASM: a very small and fast Java bytecode manipulation framework
+// Copyright (c) 2000-2011 INRIA, France Telecom
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+// 1. Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+// 2. Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+// 3. Neither the name of the copyright holders nor the names of its
+//    contributors may be used to endorse or promote products derived from
+//    this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+// THE POSSIBILITY OF SUCH DAMAGE.
+package org.mvel2.asm;
+
+/**
+ * A {@link MethodVisitor} that generates a corresponding 'method_info' structure, as defined in the
+ * Java Virtual Machine Specification (JVMS).
+ *
+ * @see <a href="https://docs.oracle.com/javase/specs/jvms/se9/html/jvms-4.html#jvms-4.6">JVMS
+ *     4.6</a>
+ * @author Eric Bruneton
+ * @author Eugene Kuleshov
+ */
+final class MethodWriter extends MethodVisitor {
+
+    /** Indicates that nothing must be computed. */
+    static final int COMPUTE_NOTHING = 0;
+
+    /**
+     * Indicates that the maximum stack size and the maximum number of local variables must be
+     * computed, from scratch.
+     */
+    static final int COMPUTE_MAX_STACK_AND_LOCAL = 1;
+
+    /**
+     * Indicates that the maximum stack size and the maximum number of local variables must be
+     * computed, from the existing stack map frames. This can be done more efficiently than with the
+     * control flow graph algorithm used for {@link #COMPUTE_MAX_STACK_AND_LOCAL}, by using a linear
+     * scan of the bytecode instructions.
+     */
+    static final int COMPUTE_MAX_STACK_AND_LOCAL_FROM_FRAMES = 2;
+
+    /**
+     * Indicates that the stack map frames of type F_INSERT must be computed. The other frames are not
+     * computed. They should all be of type F_NEW and should be sufficient to compute the content of
+     * the F_INSERT frames, together with the bytecode instructions between a F_NEW and a F_INSERT
+     * frame - and without any knowledge of the type hierarchy (by definition of F_INSERT).
+     */
+    static final int COMPUTE_INSERTED_FRAMES = 3;
+
+    /**
+     * Indicates that all the stack map frames must be computed. In this case the maximum stack size
+     * and the maximum number of local variables is also computed.
+     */
+    static final int COMPUTE_ALL_FRAMES = 4;
+
+    /** Indicates that {@link #STACK_SIZE_DELTA} is not applicable (not constant or never used). */
+    private static final int NA = 0;
+
+    /**
+     * The stack size variation corresponding to each JVM opcode. The stack size variation for opcode
+     * 'o' is given by the array element at index 'o'.
+     *
+     * @see <a href="https://docs.oracle.com/javase/specs/jvms/se9/html/jvms-6.html">JVMS 6</a>
+     */
+    private static final int[] STACK_SIZE_DELTA = { 0, // nop = 0 (0x0)
+            1, // aconst_null = 1 (0x1)
+            1, // iconst_m1 = 2 (0x2)
+            1, // iconst_0 = 3 (0x3)
+            1, // iconst_1 = 4 (0x4)
+            1, // iconst_2 = 5 (0x5)
+            1, // iconst_3 = 6 (0x6)
+            1, // iconst_4 = 7 (0x7)
+            1, // iconst_5 = 8 (0x8)
+            2, // lconst_0 = 9 (0x9)
+            2, // lconst_1 = 10 (0xa)
+            1, // fconst_0 = 11 (0xb)
+            1, // fconst_1 = 12 (0xc)
+            1, // fconst_2 = 13 (0xd)
+            2, // dconst_0 = 14 (0xe)
+            2, // dconst_1 = 15 (0xf)
+            1, // bipush = 16 (0x10)
+            1, // sipush = 17 (0x11)
+            1, // ldc = 18 (0x12)
+            NA, // ldc_w = 19 (0x13)
+            NA, // ldc2_w = 20 (0x14)
+            1, // iload = 21 (0x15)
+            2, // lload = 22 (0x16)
+            1, // fload = 23 (0x17)
+            2, // dload = 24 (0x18)
+            1, // aload = 25 (0x19)
+            NA, // iload_0 = 26 (0x1a)
+            NA, // iload_1 = 27 (0x1b)
+            NA, // iload_2 = 28 (0x1c)
+            NA, // iload_3 = 29 (0x1d)
+            NA, // lload_0 = 30 (0x1e)
+            NA, // lload_1 = 31 (0x1f)
+            NA, // lload_2 = 32 (0x20)
+            NA, // lload_3 = 33 (0x21)
+            NA, // fload_0 = 34 (0x22)
+            NA, // fload_1 = 35 (0x23)
+            NA, // fload_2 = 36 (0x24)
+            NA, // fload_3 = 37 (0x25)
+            NA, // dload_0 = 38 (0x26)
+            NA, // dload_1 = 39 (0x27)
+            NA, // dload_2 = 40 (0x28)
+            NA, // dload_3 = 41 (0x29)
+            NA, // aload_0 = 42 (0x2a)
+            NA, // aload_1 = 43 (0x2b)
+            NA, // aload_2 = 44 (0x2c)
+            NA, // aload_3 = 45 (0x2d)
+            -1, // iaload = 46 (0x2e)
+            0, // laload = 47 (0x2f)
+            -1, // faload = 48 (0x30)
+            0, // daload = 49 (0x31)
+            -1, // aaload = 50 (0x32)
+            -1, // baload = 51 (0x33)
+            -1, // caload = 52 (0x34)
+            -1, // saload = 53 (0x35)
+            -1, // istore = 54 (0x36)
+            -2, // lstore = 55 (0x37)
+            -1, // fstore = 56 (0x38)
+            -2, // dstore = 57 (0x39)
+            -1, // astore = 58 (0x3a)
+            NA, // istore_0 = 59 (0x3b)
+            NA, // istore_1 = 60 (0x3c)
+            NA, // istore_2 = 61 (0x3d)
+            NA, // istore_3 = 62 (0x3e)
+            NA, // lstore_0 = 63 (0x3f)
+            NA, // lstore_1 = 64 (0x40)
+            NA, // lstore_2 = 65 (0x41)
+            NA, // lstore_3 = 66 (0x42)
+            NA, // fstore_0 = 67 (0x43)
+            NA, // fstore_1 = 68 (0x44)
+            NA, // fstore_2 = 69 (0x45)
+            NA, // fstore_3 = 70 (0x46)
+            NA, // dstore_0 = 71 (0x47)
+            NA, // dstore_1 = 72 (0x48)
+            NA, // dstore_2 = 73 (0x49)
+            NA, // dstore_3 = 74 (0x4a)
+            NA, // astore_0 = 75 (0x4b)
+            NA, // astore_1 = 76 (0x4c)
+            NA, // astore_2 = 77 (0x4d)
+            NA, // astore_3 = 78 (0x4e)
+            -3, // iastore = 79 (0x4f)
+            -4, // lastore = 80 (0x50)
+            -3, // fastore = 81 (0x51)
+            -4, // dastore = 82 (0x52)
+            -3, // aastore = 83 (0x53)
+            -3, // bastore = 84 (0x54)
+            -3, // castore = 85 (0x55)
+            -3, // sastore = 86 (0x56)
+            -1, // pop = 87 (0x57)
+            -2, // pop2 = 88 (0x58)
+            1, // dup = 89 (0x59)
+            1, // dup_x1 = 90 (0x5a)
+            1, // dup_x2 = 91 (0x5b)
+            2, // dup2 = 92 (0x5c)
+            2, // dup2_x1 = 93 (0x5d)
+            2, // dup2_x2 = 94 (0x5e)
+            0, // swap = 95 (0x5f)
+            -1, // iadd = 96 (0x60)
+            -2, // ladd = 97 (0x61)
+            -1, // fadd = 98 (0x62)
+            -2, // dadd = 99 (0x63)
+            -1, // isub = 100 (0x64)
+            -2, // lsub = 101 (0x65)
+            -1, // fsub = 102 (0x66)
+            -2, // dsub = 103 (0x67)
+            -1, // imul = 104 (0x68)
+            -2, // lmul = 105 (0x69)
+            -1, // fmul = 106 (0x6a)
+            -2, // dmul = 107 (0x6b)
+            -1, // idiv = 108 (0x6c)
+            -2, // ldiv = 109 (0x6d)
+            -1, // fdiv = 110 (0x6e)
+            -2, // ddiv = 111 (0x6f)
+            -1, // irem = 112 (0x70)
+            -2, // lrem = 113 (0x71)
+            -1, // frem = 114 (0x72)
+            -2, // drem = 115 (0x73)
+            0, // ineg = 116 (0x74)
+            0, // lneg = 117 (0x75)
+            0, // fneg = 118 (0x76)
+            0, // dneg = 119 (0x77)
+            -1, // ishl = 120 (0x78)
+            -1, // lshl = 121 (0x79)
+            -1, // ishr = 122 (0x7a)
+            -1, // lshr = 123 (0x7b)
+            -1, // iushr = 124 (0x7c)
+            -1, // lushr = 125 (0x7d)
+            -1, // iand = 126 (0x7e)
+            -2, // land = 127 (0x7f)
+            -1, // ior = 128 (0x80)
+            -2, // lor = 129 (0x81)
+            -1, // ixor = 130 (0x82)
+            -2, // lxor = 131 (0x83)
+            0, // iinc = 132 (0x84)
+            1, // i2l = 133 (0x85)
+            0, // i2f = 134 (0x86)
+            1, // i2d = 135 (0x87)
+            -1, // l2i = 136 (0x88)
+            -1, // l2f = 137 (0x89)
+            0, // l2d = 138 (0x8a)
+            0, // f2i = 139 (0x8b)
+            1, // f2l = 140 (0x8c)
+            1, // f2d = 141 (0x8d)
+            -1, // d2i = 142 (0x8e)
+            0, // d2l = 143 (0x8f)
+            -1, // d2f = 144 (0x90)
+            0, // i2b = 145 (0x91)
+            0, // i2c = 146 (0x92)
+            0, // i2s = 147 (0x93)
+            -3, // lcmp = 148 (0x94)
+            -1, // fcmpl = 149 (0x95)
+            -1, // fcmpg = 150 (0x96)
+            -3, // dcmpl = 151 (0x97)
+            -3, // dcmpg = 152 (0x98)
+            -1, // ifeq = 153 (0x99)
+            -1, // ifne = 154 (0x9a)
+            -1, // iflt = 155 (0x9b)
+            -1, // ifge = 156 (0x9c)
+            -1, // ifgt = 157 (0x9d)
+            -1, // ifle = 158 (0x9e)
+            -2, // if_icmpeq = 159 (0x9f)
+            -2, // if_icmpne = 160 (0xa0)
+            -2, // if_icmplt = 161 (0xa1)
+            -2, // if_icmpge = 162 (0xa2)
+            -2, // if_icmpgt = 163 (0xa3)
+            -2, // if_icmple = 164 (0xa4)
+            -2, // if_acmpeq = 165 (0xa5)
+            -2, // if_acmpne = 166 (0xa6)
+            0, // goto = 167 (0xa7)
+            1, // jsr = 168 (0xa8)
+            0, // ret = 169 (0xa9)
+            -1, // tableswitch = 170 (0xaa)
+            -1, // lookupswitch = 171 (0xab)
+            -1, // ireturn = 172 (0xac)
+            -2, // lreturn = 173 (0xad)
+            -1, // freturn = 174 (0xae)
+            -2, // dreturn = 175 (0xaf)
+            -1, // areturn = 176 (0xb0)
+            0, // return = 177 (0xb1)
+            NA, // getstatic = 178 (0xb2)
+            NA, // putstatic = 179 (0xb3)
+            NA, // getfield = 180 (0xb4)
+            NA, // putfield = 181 (0xb5)
+            NA, // invokevirtual = 182 (0xb6)
+            NA, // invokespecial = 183 (0xb7)
+            NA, // invokestatic = 184 (0xb8)
+            NA, // invokeinterface = 185 (0xb9)
+            NA, // invokedynamic = 186 (0xba)
+            1, // new = 187 (0xbb)
+            0, // newarray = 188 (0xbc)
+            0, // anewarray = 189 (0xbd)
+            0, // arraylength = 190 (0xbe)
+            NA, // athrow = 191 (0xbf)
+            0, // checkcast = 192 (0xc0)
+            0, // instanceof = 193 (0xc1)
+            -1, // monitorenter = 194 (0xc2)
+            -1, // monitorexit = 195 (0xc3)
+            NA, // wide = 196 (0xc4)
+            NA, // multianewarray = 197 (0xc5)
+            -1, // ifnull = 198 (0xc6)
+            -1, // ifnonnull = 199 (0xc7)
+            NA, // goto_w = 200 (0xc8)
+            NA // jsr_w = 201 (0xc9)
+    };
+
+    /** Where the constants used in this MethodWriter must be stored. */
+    private final SymbolTable symbolTable;
+
+    // Note: fields are ordered as in the method_info structure, and those related to attributes are
+    // ordered as in Section 4.7 of the JVMS.
+
+    /**
+     * The access_flags field of the method_info JVMS structure. This field can contain ASM specific
+     * access flags, such as {@link Opcodes#ACC_DEPRECATED}, which are removed when generating the
+     * ClassFile structure.
+     */
+    private final int accessFlags;
+
+    /** The name_index field of the method_info JVMS structure. */
+    private final int nameIndex;
+
+    /** The name of this method. */
+    private final String name;
+
+    /** The descriptor_index field of the method_info JVMS structure. */
+    private final int descriptorIndex;
+
+    /** The descriptor of this method. */
+    private final String descriptor;
+
+    // Code attribute fields and sub attributes:
+    /** The 'code' field of the Code attribute. */
+    private final ByteVector code = new ByteVector();
+    /** The number_of_exceptions field of the Exceptions attribute. */
+    private final int numberOfExceptions;
+    /** The exception_index_table array of the Exceptions attribute, or {@literal null}. */
+    private final int[] exceptionIndexTable;
+    /** The signature_index field of the Signature attribute. */
+    private final int signatureIndex;
+    /**
+     * Indicates what must be computed. Must be one of {@link #COMPUTE_ALL_FRAMES}, {@link
+     * #COMPUTE_INSERTED_FRAMES}, {@link #COMPUTE_MAX_STACK_AND_LOCAL} or {@link #COMPUTE_NOTHING}.
+     */
+    private final int compute;
+    /** The max_stack field of the Code attribute. */
+    private int maxStack;
+    /** The max_locals field of the Code attribute. */
+    private int maxLocals;
+    /**
+     * The first element in the exception handler list (used to generate the exception_table of the
+     * Code attribute). The next ones can be accessed with the {@link Handler#nextHandler} field. May
+     * be {@literal null}.
+     */
+    private Handler firstHandler;
+    /**
+     * The last element in the exception handler list (used to generate the exception_table of the
+     * Code attribute). The next ones can be accessed with the {@link Handler#nextHandler} field. May
+     * be {@literal null}.
+     */
+    private Handler lastHandler;
+    /** The line_number_table_length field of the LineNumberTable code attribute. */
+    private int lineNumberTableLength;
+    /** The line_number_table array of the LineNumberTable code attribute, or {@literal null}. */
+    private ByteVector lineNumberTable;
+    /** The local_variable_table_length field of the LocalVariableTable code attribute. */
+    private int localVariableTableLength;
+    /**
+     * The local_variable_table array of the LocalVariableTable code attribute, or {@literal null}.
+     */
+    private ByteVector localVariableTable;
+    /** The local_variable_type_table_length field of the LocalVariableTypeTable code attribute. */
+    private int localVariableTypeTableLength;
+    /**
+     * The local_variable_type_table array of the LocalVariableTypeTable code attribute, or {@literal
+     * null}.
+     */
+    private ByteVector localVariableTypeTable;
+    /** The number_of_entries field of the StackMapTable code attribute. */
+    private int stackMapTableNumberOfEntries;
+
+    // Other method_info attributes:
+    /** The 'entries' array of the StackMapTable code attribute. */
+    private ByteVector stackMapTableEntries;
+    /**
+     * The last runtime visible type annotation of the Code attribute. The previous ones can be
+     * accessed with the {@link AnnotationWriter#previousAnnotation} field. May be {@literal null}.
+     */
+    private AnnotationWriter lastCodeRuntimeVisibleTypeAnnotation;
+    /**
+     * The last runtime invisible type annotation of the Code attribute. The previous ones can be
+     * accessed with the {@link AnnotationWriter#previousAnnotation} field. May be {@literal null}.
+     */
+    private AnnotationWriter lastCodeRuntimeInvisibleTypeAnnotation;
+    /**
+     * The first non standard attribute of the Code attribute. The next ones can be accessed with the
+     * {@link Attribute#nextAttribute} field. May be {@literal null}.
+     *
+     * <p><b>WARNING</b>: this list stores the attributes in the <i>reverse</i> order of their visit.
+     * firstAttribute is actually the last attribute visited in {@link #visitAttribute}. The {@link
+     * #putMethodInfo} method writes the attributes in the order defined by this list, i.e. in the
+     * reverse order specified by the user.
+     */
+    private Attribute firstCodeAttribute;
+    /**
+     * The last runtime visible annotation of this method. The previous ones can be accessed with the
+     * {@link AnnotationWriter#previousAnnotation} field. May be {@literal null}.
+     */
+    private AnnotationWriter lastRuntimeVisibleAnnotation;
+    /**
+     * The last runtime invisible annotation of this method. The previous ones can be accessed with
+     * the {@link AnnotationWriter#previousAnnotation} field. May be {@literal null}.
+     */
+    private AnnotationWriter lastRuntimeInvisibleAnnotation;
+    /** The number of method parameters that can have runtime visible annotations, or 0. */
+    private int visibleAnnotableParameterCount;
+    /**
+     * The runtime visible parameter annotations of this method. Each array element contains the last
+     * annotation of a parameter (which can be {@literal null} - the previous ones can be accessed
+     * with the {@link AnnotationWriter#previousAnnotation} field). May be {@literal null}.
+     */
+    private AnnotationWriter[] lastRuntimeVisibleParameterAnnotations;
+    /** The number of method parameters that can have runtime visible annotations, or 0. */
+    private int invisibleAnnotableParameterCount;
+    /**
+     * The runtime invisible parameter annotations of this method. Each array element contains the
+     * last annotation of a parameter (which can be {@literal null} - the previous ones can be
+     * accessed with the {@link AnnotationWriter#previousAnnotation} field). May be {@literal null}.
+     */
+    private AnnotationWriter[] lastRuntimeInvisibleParameterAnnotations;
+    /**
+     * The last runtime visible type annotation of this method. The previous ones can be accessed with
+     * the {@link AnnotationWriter#previousAnnotation} field. May be {@literal null}.
+     */
+    private AnnotationWriter lastRuntimeVisibleTypeAnnotation;
+    /**
+     * The last runtime invisible type annotation of this method. The previous ones can be accessed
+     * with the {@link AnnotationWriter#previousAnnotation} field. May be {@literal null}.
+     */
+    private AnnotationWriter lastRuntimeInvisibleTypeAnnotation;
+    /** The default_value field of the AnnotationDefault attribute, or {@literal null}. */
+    private ByteVector defaultValue;
+    /** The parameters_count field of the MethodParameters attribute. */
+    private int parametersCount;
+    /** The 'parameters' array of the MethodParameters attribute, or {@literal null}. */
+    private ByteVector parameters;
+
+    // -----------------------------------------------------------------------------------------------
+    // Fields used to compute the maximum stack size and number of locals, and the stack map frames
+    // -----------------------------------------------------------------------------------------------
+    /**
+     * The first non standard attribute of this method. The next ones can be accessed with the {@link
+     * Attribute#nextAttribute} field. May be {@literal null}.
+     *
+     * <p><b>WARNING</b>: this list stores the attributes in the <i>reverse</i> order of their visit.
+     * firstAttribute is actually the last attribute visited in {@link #visitAttribute}. The {@link
+     * #putMethodInfo} method writes the attributes in the order defined by this list, i.e. in the
+     * reverse order specified by the user.
+     */
+    private Attribute firstAttribute;
+    /**
+     * The first basic block of the method. The next ones (in bytecode offset order) can be accessed
+     * with the {@link Label#nextBasicBlock} field.
+     */
+    private Label firstBasicBlock;
+
+    /**
+     * The last basic block of the method (in bytecode offset order). This field is updated each time
+     * a basic block is encountered, and is used to append it at the end of the basic block list.
+     */
+    private Label lastBasicBlock;
+
+    /**
+     * The current basic block, i.e. the basic block of the last visited instruction. When {@link
+     * #compute} is equal to {@link #COMPUTE_MAX_STACK_AND_LOCAL} or {@link #COMPUTE_ALL_FRAMES}, this
+     * field is {@literal null} for unreachable code. When {@link #compute} is equal to {@link
+     * #COMPUTE_MAX_STACK_AND_LOCAL_FROM_FRAMES} or {@link #COMPUTE_INSERTED_FRAMES}, this field stays
+     * unchanged throughout the whole method (i.e. the whole code is seen as a single basic block;
+     * indeed, the existing frames are sufficient by hypothesis to compute any intermediate frame -
+     * and the maximum stack size as well - without using any control flow graph).
+     */
+    private Label currentBasicBlock;
+
+    /**
+     * The relative stack size after the last visited instruction. This size is relative to the
+     * beginning of {@link #currentBasicBlock}, i.e. the true stack size after the last visited
+     * instruction is equal to the {@link Label#inputStackSize} of the current basic block plus {@link
+     * #relativeStackSize}. When {@link #compute} is equal to {@link
+     * #COMPUTE_MAX_STACK_AND_LOCAL_FROM_FRAMES}, {@link #currentBasicBlock} is always the start of
+     * the method, so this relative size is also equal to the absolute stack size after the last
+     * visited instruction.
+     */
+    private int relativeStackSize;
+
+    /**
+     * The maximum relative stack size after the last visited instruction. This size is relative to
+     * the beginning of {@link #currentBasicBlock}, i.e. the true maximum stack size after the last
+     * visited instruction is equal to the {@link Label#inputStackSize} of the current basic block
+     * plus {@link #maxRelativeStackSize}.When {@link #compute} is equal to {@link
+     * #COMPUTE_MAX_STACK_AND_LOCAL_FROM_FRAMES}, {@link #currentBasicBlock} is always the start of
+     * the method, so this relative size is also equal to the absolute maximum stack size after the
+     * last visited instruction.
+     */
+    private int maxRelativeStackSize;
+
+    /** The number of local variables in the last visited stack map frame. */
+    private int currentLocals;
+
+    /** The bytecode offset of the last frame that was written in {@link #stackMapTableEntries}. */
+    private int previousFrameOffset;
+
+    /**
+     * The last frame that was written in {@link #stackMapTableEntries}. This field has the same
+     * format as {@link #currentFrame}.
+     */
+    private int[] previousFrame;
+
+    /**
+     * The current stack map frame. The first element contains the bytecode offset of the instruction
+     * to which the frame corresponds, the second element is the number of locals and the third one is
+     * the number of stack elements. The local variables start at index 3 and are followed by the
+     * operand stack elements. In summary frame[0] = offset, frame[1] = numLocal, frame[2] = numStack.
+     * Local variables and operand stack entries contain abstract types, as defined in {@link Frame},
+     * but restricted to {@link Frame#CONSTANT_KIND}, {@link Frame#REFERENCE_KIND} or {@link
+     * Frame#UNINITIALIZED_KIND} abstract types. Long and double types use only one array entry.
+     */
+    private int[] currentFrame;
+
+    /** Whether this method contains subroutines. */
+    private boolean hasSubroutines;
+
+    // -----------------------------------------------------------------------------------------------
+    // Other miscellaneous status fields
+    // -----------------------------------------------------------------------------------------------
+
+    /** Whether the bytecode of this method contains ASM specific instructions. */
+    private boolean hasAsmInstructions;
+
+    /**
+     * The start offset of the last visited instruction. Used to set the offset field of type
+     * annotations of type 'offset_target' (see <a
+     * href="https://docs.oracle.com/javase/specs/jvms/se9/html/jvms-4.html#jvms-4.7.20.1">JVMS
+     * 4.7.20.1</a>).
+     */
+    private int lastBytecodeOffset;
+
+    /**
+     * The offset in bytes in {@link SymbolTable#getSource} from which the method_info for this method
+     * (excluding its first 6 bytes) must be copied, or 0.
+     */
+    private int sourceOffset;
+
+    /**
+     * The length in bytes in {@link SymbolTable#getSource} which must be copied to get the
+     * method_info for this method (excluding its first 6 bytes for access_flags, name_index and
+     * descriptor_index).
+     */
+    private int sourceLength;
+
+    // -----------------------------------------------------------------------------------------------
+    // Constructor and accessors
+    // -----------------------------------------------------------------------------------------------
+
+    /**
+     * Constructs a new {@link MethodWriter}.
+     *
+     * @param symbolTable where the constants used in this AnnotationWriter must be stored.
+     * @param access the method's access flags (see {@link Opcodes}).
+     * @param name the method's name.
+     * @param descriptor the method's descriptor (see {@link Type}).
+     * @param signature the method's signature. May be {@literal null}.
+     * @param exceptions the internal names of the method's exceptions. May be {@literal null}.
+     * @param compute indicates what must be computed (see #compute).
+     */
+    MethodWriter(final SymbolTable symbolTable, final int access, final String name, final String descriptor, final String signature,
+            final String[] exceptions, final int compute) {
+        super(Opcodes.ASM7);
+        this.symbolTable = symbolTable;
+        this.accessFlags = "<init>".equals(name) ? access | Constants.ACC_CONSTRUCTOR : access;
+        this.nameIndex = symbolTable.addConstantUtf8(name);
+        this.name = name;
+        this.descriptorIndex = symbolTable.addConstantUtf8(descriptor);
+        this.descriptor = descriptor;
+        this.signatureIndex = signature == null ? 0 : symbolTable.addConstantUtf8(signature);
+        if (exceptions != null && exceptions.length > 0) {
+            numberOfExceptions = exceptions.length;
+            this.exceptionIndexTable = new int[numberOfExceptions];
+            for (int i = 0; i < numberOfExceptions; ++i) {
+                this.exceptionIndexTable[i] = symbolTable.addConstantClass(exceptions[i]).index;
+            }
+        } else {
+            numberOfExceptions = 0;
+            this.exceptionIndexTable = null;
+        }
+        this.compute = compute;
+        if (compute != COMPUTE_NOTHING) {
+            // Update maxLocals and currentLocals.
+            int argumentsSize = Type.getArgumentsAndReturnSizes(descriptor) >> 2;
+            if ((access & Opcodes.ACC_STATIC) != 0) {
+                --argumentsSize;
+            }
+            maxLocals = argumentsSize;
+            currentLocals = argumentsSize;
+            // Create and visit the label for the first basic block.
+            firstBasicBlock = new Label();
+            visitLabel(firstBasicBlock);
+        }
+    }
+
+    boolean hasFrames() {
+        return stackMapTableNumberOfEntries > 0;
+    }
+
+    boolean hasAsmInstructions() {
+        return hasAsmInstructions;
+    }
+
+    // -----------------------------------------------------------------------------------------------
+    // Implementation of the MethodVisitor abstract class
+    // -----------------------------------------------------------------------------------------------
+
+    @Override
+    public void visitParameter(final String name, final int access) {
+        if (parameters == null) {
+            parameters = new ByteVector();
+        }
+        ++parametersCount;
+        parameters.putShort((name == null) ? 0 : symbolTable.addConstantUtf8(name)).putShort(access);
+    }
+
+    @Override
+    public AnnotationVisitor visitAnnotationDefault() {
+        defaultValue = new ByteVector();
+        return new AnnotationWriter(symbolTable, /* useNamedValues = */ false, defaultValue, null);
+    }
+
+    @Override
+    public AnnotationVisitor visitAnnotation(final String descriptor, final boolean visible) {
+        // Create a ByteVector to hold an 'annotation' JVMS structure.
+        // See https://docs.oracle.com/javase/specs/jvms/se9/html/jvms-4.html#jvms-4.7.16.
+        ByteVector annotation = new ByteVector();
+        // Write type_index and reserve space for num_element_value_pairs.
+        annotation.putShort(symbolTable.addConstantUtf8(descriptor)).putShort(0);
+        if (visible) {
+            return lastRuntimeVisibleAnnotation = new AnnotationWriter(symbolTable, annotation, lastRuntimeVisibleAnnotation);
+        } else {
+            return lastRuntimeInvisibleAnnotation = new AnnotationWriter(symbolTable, annotation, lastRuntimeInvisibleAnnotation);
+        }
+    }
+
+    @Override
+    public AnnotationVisitor visitTypeAnnotation(final int typeRef, final TypePath typePath, final String descriptor,
+            final boolean visible) {
+        // Create a ByteVector to hold a 'type_annotation' JVMS structure.
+        // See https://docs.oracle.com/javase/specs/jvms/se9/html/jvms-4.html#jvms-4.7.20.
+        ByteVector typeAnnotation = new ByteVector();
+        // Write target_type, target_info, and target_path.
+        TypeReference.putTarget(typeRef, typeAnnotation);
+        TypePath.put(typePath, typeAnnotation);
+        // Write type_index and reserve space for num_element_value_pairs.
+        typeAnnotation.putShort(symbolTable.addConstantUtf8(descriptor)).putShort(0);
+        if (visible) {
+            return lastRuntimeVisibleTypeAnnotation = new AnnotationWriter(symbolTable, typeAnnotation, lastRuntimeVisibleTypeAnnotation);
+        } else {
+            return lastRuntimeInvisibleTypeAnnotation = new AnnotationWriter(symbolTable, typeAnnotation,
+                    lastRuntimeInvisibleTypeAnnotation);
+        }
+    }
+
+    @Override
+    public void visitAnnotableParameterCount(final int parameterCount, final boolean visible) {
+        if (visible) {
+            visibleAnnotableParameterCount = parameterCount;
+        } else {
+            invisibleAnnotableParameterCount = parameterCount;
+        }
+    }
+
+    @Override
+    public AnnotationVisitor visitParameterAnnotation(final int parameter, final String annotationDescriptor, final boolean visible) {
+        // Create a ByteVector to hold an 'annotation' JVMS structure.
+        // See https://docs.oracle.com/javase/specs/jvms/se9/html/jvms-4.html#jvms-4.7.16.
+        ByteVector annotation = new ByteVector();
+        // Write type_index and reserve space for num_element_value_pairs.
+        annotation.putShort(symbolTable.addConstantUtf8(annotationDescriptor)).putShort(0);
+        if (visible) {
+            if (lastRuntimeVisibleParameterAnnotations == null) {
+                lastRuntimeVisibleParameterAnnotations = new AnnotationWriter[Type.getArgumentTypes(descriptor).length];
+            }
+            return lastRuntimeVisibleParameterAnnotations[parameter] = new AnnotationWriter(symbolTable, annotation,
+                    lastRuntimeVisibleParameterAnnotations[parameter]);
+        } else {
+            if (lastRuntimeInvisibleParameterAnnotations == null) {
+                lastRuntimeInvisibleParameterAnnotations = new AnnotationWriter[Type.getArgumentTypes(descriptor).length];
+            }
+            return lastRuntimeInvisibleParameterAnnotations[parameter] = new AnnotationWriter(symbolTable, annotation,
+                    lastRuntimeInvisibleParameterAnnotations[parameter]);
+        }
+    }
+
+    @Override
+    public void visitAttribute(final Attribute attribute) {
+        // Store the attributes in the <i>reverse</i> order of their visit by this method.
+        if (attribute.isCodeAttribute()) {
+            attribute.nextAttribute = firstCodeAttribute;
+            firstCodeAttribute = attribute;
+        } else {
+            attribute.nextAttribute = firstAttribute;
+            firstAttribute = attribute;
+        }
+    }
+
+    @Override
+    public void visitCode() {
+        // Nothing to do.
+    }
+
+    @Override
+    public void visitFrame(final int type, final int numLocal, final Object[] local, final int numStack, final Object[] stack) {
+        if (compute == COMPUTE_ALL_FRAMES) {
+            return;
+        }
+
+        if (compute == COMPUTE_INSERTED_FRAMES) {
+            if (currentBasicBlock.frame == null) {
+                // This should happen only once, for the implicit first frame (which is explicitly visited
+                // in ClassReader if the EXPAND_ASM_INSNS option is used - and COMPUTE_INSERTED_FRAMES
+                // can't be set if EXPAND_ASM_INSNS is not used).
+                currentBasicBlock.frame = new CurrentFrame(currentBasicBlock);
+                currentBasicBlock.frame.setInputFrameFromDescriptor(symbolTable, accessFlags, descriptor, numLocal);
+                currentBasicBlock.frame.accept(this);
+            } else {
+                if (type == Opcodes.F_NEW) {
+                    currentBasicBlock.frame.setInputFrameFromApiFormat(symbolTable, numLocal, local, numStack, stack);
+                }
+                // If type is not F_NEW then it is F_INSERT by hypothesis, and currentBlock.frame contains
+                // the stack map frame at the current instruction, computed from the last F_NEW frame and
+                // the bytecode instructions in between (via calls to CurrentFrame#execute).
+                currentBasicBlock.frame.accept(this);
+            }
+        } else if (type == Opcodes.F_NEW) {
+            if (previousFrame == null) {
+                int argumentsSize = Type.getArgumentsAndReturnSizes(descriptor) >> 2;
+                Frame implicitFirstFrame = new Frame(new Label());
+                implicitFirstFrame.setInputFrameFromDescriptor(symbolTable, accessFlags, descriptor, argumentsSize);
+                implicitFirstFrame.accept(this);
+            }
+            currentLocals = numLocal;
+            int frameIndex = visitFrameStart(code.length, numLocal, numStack);
+            for (int i = 0; i < numLocal; ++i) {
+                currentFrame[frameIndex++] = Frame.getAbstractTypeFromApiFormat(symbolTable, local[i]);
+            }
+            for (int i = 0; i < numStack; ++i) {
+                currentFrame[frameIndex++] = Frame.getAbstractTypeFromApiFormat(symbolTable, stack[i]);
+            }
+            visitFrameEnd();
+        } else {
+            int offsetDelta;
+            if (stackMapTableEntries == null) {
+                stackMapTableEntries = new ByteVector();
+                offsetDelta = code.length;
+            } else {
+                offsetDelta = code.length - previousFrameOffset - 1;
+                if (offsetDelta < 0) {
+                    if (type == Opcodes.F_SAME) {
+                        return;
+                    } else {
+                        throw new IllegalStateException();
+                    }
+                }
+            }
+
+            switch (type) {
+                case Opcodes.F_FULL:
+                    currentLocals = numLocal;
+                    stackMapTableEntries.putByte(Frame.FULL_FRAME).putShort(offsetDelta).putShort(numLocal);
+                    for (int i = 0; i < numLocal; ++i) {
+                        putFrameType(local[i]);
+                    }
+                    stackMapTableEntries.putShort(numStack);
+                    for (int i = 0; i < numStack; ++i) {
+                        putFrameType(stack[i]);
+                    }
+                    break;
+                case Opcodes.F_APPEND:
+                    currentLocals += numLocal;
+                    stackMapTableEntries.putByte(Frame.SAME_FRAME_EXTENDED + numLocal).putShort(offsetDelta);
+                    for (int i = 0; i < numLocal; ++i) {
+                        putFrameType(local[i]);
+                    }
+                    break;
+                case Opcodes.F_CHOP:
+                    currentLocals -= numLocal;
+                    stackMapTableEntries.putByte(Frame.SAME_FRAME_EXTENDED - numLocal).putShort(offsetDelta);
+                    break;
+                case Opcodes.F_SAME:
+                    if (offsetDelta < 64) {
+                        stackMapTableEntries.putByte(offsetDelta);
+                    } else {
+                        stackMapTableEntries.putByte(Frame.SAME_FRAME_EXTENDED).putShort(offsetDelta);
+                    }
+                    break;
+                case Opcodes.F_SAME1:
+                    if (offsetDelta < 64) {
+                        stackMapTableEntries.putByte(Frame.SAME_LOCALS_1_STACK_ITEM_FRAME + offsetDelta);
+                    } else {
+                        stackMapTableEntries.putByte(Frame.SAME_LOCALS_1_STACK_ITEM_FRAME_EXTENDED).putShort(offsetDelta);
+                    }
+                    putFrameType(stack[0]);
+                    break;
+                default:
+                    throw new IllegalArgumentException();
+            }
+
+            previousFrameOffset = code.length;
+            ++stackMapTableNumberOfEntries;
+        }
+
+        if (compute == COMPUTE_MAX_STACK_AND_LOCAL_FROM_FRAMES) {
+            relativeStackSize = numStack;
+            for (int i = 0; i < numStack; ++i) {
+                if (stack[i] == Opcodes.LONG || stack[i] == Opcodes.DOUBLE) {
+                    relativeStackSize++;
+                }
+            }
+            if (relativeStackSize > maxRelativeStackSize) {
+                maxRelativeStackSize = relativeStackSize;
+            }
+        }
+
+        maxStack = Math.max(maxStack, numStack);
+        maxLocals = Math.max(maxLocals, currentLocals);
+    }
+
+    @Override
+    public void visitInsn(final int opcode) {
+        lastBytecodeOffset = code.length;
+        // Add the instruction to the bytecode of the method.
+        code.putByte(opcode);
+        // If needed, update the maximum stack size and number of locals, and stack map frames.
+        if (currentBasicBlock != null) {
+            if (compute == COMPUTE_ALL_FRAMES || compute == COMPUTE_INSERTED_FRAMES) {
+                currentBasicBlock.frame.execute(opcode, 0, null, null);
+            } else {
+                int size = relativeStackSize + STACK_SIZE_DELTA[opcode];
+                if (size > maxRelativeStackSize) {
+                    maxRelativeStackSize = size;
+                }
+                relativeStackSize = size;
+            }
+            if ((opcode >= Opcodes.IRETURN && opcode <= Opcodes.RETURN) || opcode == Opcodes.ATHROW) {
+                endCurrentBasicBlockWithNoSuccessor();
+            }
+        }
+    }
+
+    @Override
+    public void visitIntInsn(final int opcode, final int operand) {
+        lastBytecodeOffset = code.length;
+        // Add the instruction to the bytecode of the method.
+        if (opcode == Opcodes.SIPUSH) {
+            code.put12(opcode, operand);
+        } else { // BIPUSH or NEWARRAY
+            code.put11(opcode, operand);
+        }
+        // If needed, update the maximum stack size and number of locals, and stack map frames.
+        if (currentBasicBlock != null) {
+            if (compute == COMPUTE_ALL_FRAMES || compute == COMPUTE_INSERTED_FRAMES) {
+                currentBasicBlock.frame.execute(opcode, operand, null, null);
+            } else if (opcode != Opcodes.NEWARRAY) {
+                // The stack size delta is 1 for BIPUSH or SIPUSH, and 0 for NEWARRAY.
+                int size = relativeStackSize + 1;
+                if (size > maxRelativeStackSize) {
+                    maxRelativeStackSize = size;
+                }
+                relativeStackSize = size;
+            }
+        }
+    }
+
+    @Override
+    public void visitVarInsn(final int opcode, final int var) {
+        lastBytecodeOffset = code.length;
+        // Add the instruction to the bytecode of the method.
+        if (var < 4 && opcode != Opcodes.RET) {
+            int optimizedOpcode;
+            if (opcode < Opcodes.ISTORE) {
+                optimizedOpcode = Constants.ILOAD_0 + ((opcode - Opcodes.ILOAD) << 2) + var;
+            } else {
+                optimizedOpcode = Constants.ISTORE_0 + ((opcode - Opcodes.ISTORE) << 2) + var;
+            }
+            code.putByte(optimizedOpcode);
+        } else if (var >= 256) {
+            code.putByte(Constants.WIDE).put12(opcode, var);
+        } else {
+            code.put11(opcode, var);
+        }
+        // If needed, update the maximum stack size and number of locals, and stack map frames.
+        if (currentBasicBlock != null) {
+            if (compute == COMPUTE_ALL_FRAMES || compute == COMPUTE_INSERTED_FRAMES) {
+                currentBasicBlock.frame.execute(opcode, var, null, null);
+            } else {
+                if (opcode == Opcodes.RET) {
+                    // No stack size delta.
+                    currentBasicBlock.flags |= Label.FLAG_SUBROUTINE_END;
+                    currentBasicBlock.outputStackSize = (short) relativeStackSize;
+                    endCurrentBasicBlockWithNoSuccessor();
+                } else { // xLOAD or xSTORE
+                    int size = relativeStackSize + STACK_SIZE_DELTA[opcode];
+                    if (size > maxRelativeStackSize) {
+                        maxRelativeStackSize = size;
+                    }
+                    relativeStackSize = size;
+                }
+            }
+        }
+        if (compute != COMPUTE_NOTHING) {
+            int currentMaxLocals;
+            if (opcode == Opcodes.LLOAD || opcode == Opcodes.DLOAD || opcode == Opcodes.LSTORE || opcode == Opcodes.DSTORE) {
+                currentMaxLocals = var + 2;
+            } else {
+                currentMaxLocals = var + 1;
+            }
+            if (currentMaxLocals > maxLocals) {
+                maxLocals = currentMaxLocals;
+            }
+        }
+        if (opcode >= Opcodes.ISTORE && compute == COMPUTE_ALL_FRAMES && firstHandler != null) {
+            // If there are exception handler blocks, each instruction within a handler range is, in
+            // theory, a basic block (since execution can jump from this instruction to the exception
+            // handler). As a consequence, the local variable types at the beginning of the handler
+            // block should be the merge of the local variable types at all the instructions within the
+            // handler range. However, instead of creating a basic block for each instruction, we can
+            // get the same result in a more efficient way. Namely, by starting a new basic block after
+            // each xSTORE instruction, which is what we do here.
+            visitLabel(new Label());
+        }
+    }
+
+    @Override
+    public void visitTypeInsn(final int opcode, final String type) {
+        lastBytecodeOffset = code.length;
+        // Add the instruction to the bytecode of the method.
+        Symbol typeSymbol = symbolTable.addConstantClass(type);
+        code.put12(opcode, typeSymbol.index);
+        // If needed, update the maximum stack size and number of locals, and stack map frames.
+        if (currentBasicBlock != null) {
+            if (compute == COMPUTE_ALL_FRAMES || compute == COMPUTE_INSERTED_FRAMES) {
+                currentBasicBlock.frame.execute(opcode, lastBytecodeOffset, typeSymbol, symbolTable);
+            } else if (opcode == Opcodes.NEW) {
+                // The stack size delta is 1 for NEW, and 0 for ANEWARRAY, CHECKCAST, or INSTANCEOF.
+                int size = relativeStackSize + 1;
+                if (size > maxRelativeStackSize) {
+                    maxRelativeStackSize = size;
+                }
+                relativeStackSize = size;
+            }
+        }
+    }
+
+    @Override
+    public void visitFieldInsn(final int opcode, final String owner, final String name, final String descriptor) {
+        lastBytecodeOffset = code.length;
+        // Add the instruction to the bytecode of the method.
+        Symbol fieldrefSymbol = symbolTable.addConstantFieldref(owner, name, descriptor);
+        code.put12(opcode, fieldrefSymbol.index);
+        // If needed, update the maximum stack size and number of locals, and stack map frames.
+        if (currentBasicBlock != null) {
+            if (compute == COMPUTE_ALL_FRAMES || compute == COMPUTE_INSERTED_FRAMES) {
+                currentBasicBlock.frame.execute(opcode, 0, fieldrefSymbol, symbolTable);
+            } else {
+                int size;
+                char firstDescChar = descriptor.charAt(0);
+                switch (opcode) {
+                    case Opcodes.GETSTATIC:
+                        size = relativeStackSize + (firstDescChar == 'D' || firstDescChar == 'J' ? 2 : 1);
+                        break;
+                    case Opcodes.PUTSTATIC:
+                        size = relativeStackSize + (firstDescChar == 'D' || firstDescChar == 'J' ? -2 : -1);
+                        break;
+                    case Opcodes.GETFIELD:
+                        size = relativeStackSize + (firstDescChar == 'D' || firstDescChar == 'J' ? 1 : 0);
+                        break;
+                    case Opcodes.PUTFIELD:
+                    default:
+                        size = relativeStackSize + (firstDescChar == 'D' || firstDescChar == 'J' ? -3 : -2);
+                        break;
+                }
+                if (size > maxRelativeStackSize) {
+                    maxRelativeStackSize = size;
+                }
+                relativeStackSize = size;
+            }
+        }
+    }
+
+    @Override
+    public void visitMethodInsn(final int opcode, final String owner, final String name, final String descriptor,
+            final boolean isInterface) {
+        lastBytecodeOffset = code.length;
+        // Add the instruction to the bytecode of the method.
+        Symbol methodrefSymbol = symbolTable.addConstantMethodref(owner, name, descriptor, isInterface);
+        if (opcode == Opcodes.INVOKEINTERFACE) {
+            code.put12(Opcodes.INVOKEINTERFACE, methodrefSymbol.index).put11(methodrefSymbol.getArgumentsAndReturnSizes() >> 2, 0);
+        } else {
+            code.put12(opcode, methodrefSymbol.index);
+        }
+        // If needed, update the maximum stack size and number of locals, and stack map frames.
+        if (currentBasicBlock != null) {
+            if (compute == COMPUTE_ALL_FRAMES || compute == COMPUTE_INSERTED_FRAMES) {
+                currentBasicBlock.frame.execute(opcode, 0, methodrefSymbol, symbolTable);
+            } else {
+                int argumentsAndReturnSize = methodrefSymbol.getArgumentsAndReturnSizes();
+                int stackSizeDelta = (argumentsAndReturnSize & 3) - (argumentsAndReturnSize >> 2);
+                int size;
+                if (opcode == Opcodes.INVOKESTATIC) {
+                    size = relativeStackSize + stackSizeDelta + 1;
+                } else {
+                    size = relativeStackSize + stackSizeDelta;
+                }
+                if (size > maxRelativeStackSize) {
+                    maxRelativeStackSize = size;
+                }
+                relativeStackSize = size;
+            }
+        }
+    }
+
+    @Override
+    public void visitInvokeDynamicInsn(final String name, final String descriptor, final Handle bootstrapMethodHandle,
+            final Object... bootstrapMethodArguments) {
+        lastBytecodeOffset = code.length;
+        // Add the instruction to the bytecode of the method.
+        Symbol invokeDynamicSymbol = symbolTable.addConstantInvokeDynamic(name, descriptor, bootstrapMethodHandle,
+                bootstrapMethodArguments);
+        code.put12(Opcodes.INVOKEDYNAMIC, invokeDynamicSymbol.index);
+        code.putShort(0);
+        // If needed, update the maximum stack size and number of locals, and stack map frames.
+        if (currentBasicBlock != null) {
+            if (compute == COMPUTE_ALL_FRAMES || compute == COMPUTE_INSERTED_FRAMES) {
+                currentBasicBlock.frame.execute(Opcodes.INVOKEDYNAMIC, 0, invokeDynamicSymbol, symbolTable);
+            } else {
+                int argumentsAndReturnSize = invokeDynamicSymbol.getArgumentsAndReturnSizes();
+                int stackSizeDelta = (argumentsAndReturnSize & 3) - (argumentsAndReturnSize >> 2) + 1;
+                int size = relativeStackSize + stackSizeDelta;
+                if (size > maxRelativeStackSize) {
+                    maxRelativeStackSize = size;
+                }
+                relativeStackSize = size;
+            }
+        }
+    }
+
+    @Override
+    public void visitJumpInsn(final int opcode, final Label label) {
+        lastBytecodeOffset = code.length;
+        // Add the instruction to the bytecode of the method.
+        // Compute the 'base' opcode, i.e. GOTO or JSR if opcode is GOTO_W or JSR_W, otherwise opcode.
+        int baseOpcode = opcode >= Constants.GOTO_W ? opcode - Constants.WIDE_JUMP_OPCODE_DELTA : opcode;
+        boolean nextInsnIsJumpTarget = false;
+        if ((label.flags & Label.FLAG_RESOLVED) != 0 && label.bytecodeOffset - code.length < Short.MIN_VALUE) {
+            // Case of a backward jump with an offset < -32768. In this case we automatically replace GOTO
+            // with GOTO_W, JSR with JSR_W and IFxxx <l> with IFNOTxxx <L> GOTO_W <l> L:..., where
+            // IFNOTxxx is the "opposite" opcode of IFxxx (e.g. IFNE for IFEQ) and where <L> designates
+            // the instruction just after the GOTO_W.
+            if (baseOpcode == Opcodes.GOTO) {
+                code.putByte(Constants.GOTO_W);
+            } else if (baseOpcode == Opcodes.JSR) {
+                code.putByte(Constants.JSR_W);
+            } else {
+                // Put the "opposite" opcode of baseOpcode. This can be done by flipping the least
+                // significant bit for IFNULL and IFNONNULL, and similarly for IFEQ ... IF_ACMPEQ (with a
+                // pre and post offset by 1). The jump offset is 8 bytes (3 for IFNOTxxx, 5 for GOTO_W).
+                code.putByte(baseOpcode >= Opcodes.IFNULL ? baseOpcode ^ 1 : ((baseOpcode + 1) ^ 1) - 1);
+                code.putShort(8);
+                // Here we could put a GOTO_W in theory, but if ASM specific instructions are used in this
+                // method or another one, and if the class has frames, we will need to insert a frame after
+                // this GOTO_W during the additional ClassReader -> ClassWriter round trip to remove the ASM
+                // specific instructions. To not miss this additional frame, we need to use an ASM_GOTO_W
+                // here, which has the unfortunate effect of forcing this additional round trip (which in
+                // some case would not have been really necessary, but we can't know this at this point).
+                code.putByte(Constants.ASM_GOTO_W);
+                hasAsmInstructions = true;
+                // The instruction after the GOTO_W becomes the target of the IFNOT instruction.
+                nextInsnIsJumpTarget = true;
+            }
+            label.put(code, code.length - 1, true);
+        } else if (baseOpcode != opcode) {
+            // Case of a GOTO_W or JSR_W specified by the user (normally ClassReader when used to remove
+            // ASM specific instructions). In this case we keep the original instruction.
+            code.putByte(opcode);
+            label.put(code, code.length - 1, true);
+        } else {
+            // Case of a jump with an offset >= -32768, or of a jump with an unknown offset. In these
+            // cases we store the offset in 2 bytes (which will be increased via a ClassReader ->
+            // ClassWriter round trip if it turns out that 2 bytes are not sufficient).
+            code.putByte(baseOpcode);
+            label.put(code, code.length - 1, false);
+        }
+
+        // If needed, update the maximum stack size and number of locals, and stack map frames.
+        if (currentBasicBlock != null) {
+            Label nextBasicBlock = null;
+            if (compute == COMPUTE_ALL_FRAMES) {
+                currentBasicBlock.frame.execute(baseOpcode, 0, null, null);
+                // Record the fact that 'label' is the target of a jump instruction.
+                label.getCanonicalInstance().flags |= Label.FLAG_JUMP_TARGET;
+                // Add 'label' as a successor of the current basic block.
+                addSuccessorToCurrentBasicBlock(Edge.JUMP, label);
+                if (baseOpcode != Opcodes.GOTO) {
+                    // The next instruction starts a new basic block (except for GOTO: by default the code
+                    // following a goto is unreachable - unless there is an explicit label for it - and we
+                    // should not compute stack frame types for its instructions).
+                    nextBasicBlock = new Label();
+                }
+            } else if (compute == COMPUTE_INSERTED_FRAMES) {
+                currentBasicBlock.frame.execute(baseOpcode, 0, null, null);
+            } else if (compute == COMPUTE_MAX_STACK_AND_LOCAL_FROM_FRAMES) {
+                // No need to update maxRelativeStackSize (the stack size delta is always negative).
+                relativeStackSize += STACK_SIZE_DELTA[baseOpcode];
+            } else {
+                if (baseOpcode == Opcodes.JSR) {
+                    // Record the fact that 'label' designates a subroutine, if not already done.
+                    if ((label.flags & Label.FLAG_SUBROUTINE_START) == 0) {
+                        label.flags |= Label.FLAG_SUBROUTINE_START;
+                        hasSubroutines = true;
+                    }
+                    currentBasicBlock.flags |= Label.FLAG_SUBROUTINE_CALLER;
+                    // Note that, by construction in this method, a block which calls a subroutine has at
+                    // least two successors in the control flow graph: the first one (added below) leads to
+                    // the instruction after the JSR, while the second one (added here) leads to the JSR
+                    // target. Note that the first successor is virtual (it does not correspond to a possible
+                    // execution path): it is only used to compute the successors of the basic blocks ending
+                    // with a ret, in {@link Label#addSubroutineRetSuccessors}.
+                    addSuccessorToCurrentBasicBlock(relativeStackSize + 1, label);
+                    // The instruction after the JSR starts a new basic block.
+                    nextBasicBlock = new Label();
+                } else {
+                    // No need to update maxRelativeStackSize (the stack size delta is always negative).
+                    relativeStackSize += STACK_SIZE_DELTA[baseOpcode];
+                    addSuccessorToCurrentBasicBlock(relativeStackSize, label);
+                }
+            }
+            // If the next instruction starts a new basic block, call visitLabel to add the label of this
+            // instruction as a successor of the current block, and to start a new basic block.
+            if (nextBasicBlock != null) {
+                if (nextInsnIsJumpTarget) {
+                    nextBasicBlock.flags |= Label.FLAG_JUMP_TARGET;
+                }
+                visitLabel(nextBasicBlock);
+            }
+            if (baseOpcode == Opcodes.GOTO) {
+                endCurrentBasicBlockWithNoSuccessor();
+            }
+        }
+    }
+
+    @Override
+    public void visitLabel(final Label label) {
+        // Resolve the forward references to this label, if any.
+        hasAsmInstructions |= label.resolve(code.data, code.length);
+        // visitLabel starts a new basic block (except for debug only labels), so we need to update the
+        // previous and current block references and list of successors.
+        if ((label.flags & Label.FLAG_DEBUG_ONLY) != 0) {
+            return;
+        }
+        if (compute == COMPUTE_ALL_FRAMES) {
+            if (currentBasicBlock != null) {
+                if (label.bytecodeOffset == currentBasicBlock.bytecodeOffset) {
+                    // We use {@link Label#getCanonicalInstance} to store the state of a basic block in only
+                    // one place, but this does not work for labels which have not been visited yet.
+                    // Therefore, when we detect here two labels having the same bytecode offset, we need to
+                    // - consolidate the state scattered in these two instances into the canonical instance:
+                    currentBasicBlock.flags |= (label.flags & Label.FLAG_JUMP_TARGET);
+                    // - make sure the two instances share the same Frame instance (the implementation of
+                    // {@link Label#getCanonicalInstance} relies on this property; here label.frame should be
+                    // null):
+                    label.frame = currentBasicBlock.frame;
+                    // - and make sure to NOT assign 'label' into 'currentBasicBlock' or 'lastBasicBlock', so
+                    // that they still refer to the canonical instance for this bytecode offset.
+                    return;
+                }
+                // End the current basic block (with one new successor).
+                addSuccessorToCurrentBasicBlock(Edge.JUMP, label);
+            }
+            // Append 'label' at the end of the basic block list.
+            if (lastBasicBlock != null) {
+                if (label.bytecodeOffset == lastBasicBlock.bytecodeOffset) {
+                    // Same comment as above.
+                    lastBasicBlock.flags |= (label.flags & Label.FLAG_JUMP_TARGET);
+                    // Here label.frame should be null.
+                    label.frame = lastBasicBlock.frame;
+                    currentBasicBlock = lastBasicBlock;
+                    return;
+                }
+                lastBasicBlock.nextBasicBlock = label;
+            }
+            lastBasicBlock = label;
+            // Make it the new current basic block.
+            currentBasicBlock = label;
+            // Here label.frame should be null.
+            label.frame = new Frame(label);
+        } else if (compute == COMPUTE_INSERTED_FRAMES) {
+            if (currentBasicBlock == null) {
+                // This case should happen only once, for the visitLabel call in the constructor. Indeed, if
+                // compute is equal to COMPUTE_INSERTED_FRAMES, currentBasicBlock stays unchanged.
+                currentBasicBlock = label;
+            } else {
+                // Update the frame owner so that a correct frame offset is computed in Frame.accept().
+                currentBasicBlock.frame.owner = label;
+            }
+        } else if (compute == COMPUTE_MAX_STACK_AND_LOCAL) {
+            if (currentBasicBlock != null) {
+                // End the current basic block (with one new successor).
+                currentBasicBlock.outputStackMax = (short) maxRelativeStackSize;
+                addSuccessorToCurrentBasicBlock(relativeStackSize, label);
+            }
+            // Start a new current basic block, and reset the current and maximum relative stack sizes.
+            currentBasicBlock = label;
+            relativeStackSize = 0;
+            maxRelativeStackSize = 0;
+            // Append the new basic block at the end of the basic block list.
+            if (lastBasicBlock != null) {
+                lastBasicBlock.nextBasicBlock = label;
+            }
+            lastBasicBlock = label;
+        } else if (compute == COMPUTE_MAX_STACK_AND_LOCAL_FROM_FRAMES && currentBasicBlock == null) {
+            // This case should happen only once, for the visitLabel call in the constructor. Indeed, if
+            // compute is equal to COMPUTE_MAX_STACK_AND_LOCAL_FROM_FRAMES, currentBasicBlock stays
+            // unchanged.
+            currentBasicBlock = label;
+        }
+    }
+
+    @Override
+    public void visitLdcInsn(final Object value) {
+        lastBytecodeOffset = code.length;
+        // Add the instruction to the bytecode of the method.
+        Symbol constantSymbol = symbolTable.addConstant(value);
+        int constantIndex = constantSymbol.index;
+        char firstDescriptorChar;
+        boolean isLongOrDouble = constantSymbol.tag == Symbol.CONSTANT_LONG_TAG || constantSymbol.tag == Symbol.CONSTANT_DOUBLE_TAG
+                || (constantSymbol.tag == Symbol.CONSTANT_DYNAMIC_TAG
+                        && ((firstDescriptorChar = constantSymbol.value.charAt(0)) == 'J' || firstDescriptorChar == 'D'));
+        if (isLongOrDouble) {
+            code.put12(Constants.LDC2_W, constantIndex);
+        } else if (constantIndex >= 256) {
+            code.put12(Constants.LDC_W, constantIndex);
+        } else {
+            code.put11(Opcodes.LDC, constantIndex);
+        }
+        // If needed, update the maximum stack size and number of locals, and stack map frames.
+        if (currentBasicBlock != null) {
+            if (compute == COMPUTE_ALL_FRAMES || compute == COMPUTE_INSERTED_FRAMES) {
+                currentBasicBlock.frame.execute(Opcodes.LDC, 0, constantSymbol, symbolTable);
+            } else {
+                int size = relativeStackSize + (isLongOrDouble ? 2 : 1);
+                if (size > maxRelativeStackSize) {
+                    maxRelativeStackSize = size;
+                }
+                relativeStackSize = size;
+            }
+        }
+    }
+
+    @Override
+    public void visitIincInsn(final int var, final int increment) {
+        lastBytecodeOffset = code.length;
+        // Add the instruction to the bytecode of the method.
+        if ((var > 255) || (increment > 127) || (increment < -128)) {
+            code.putByte(Constants.WIDE).put12(Opcodes.IINC, var).putShort(increment);
+        } else {
+            code.putByte(Opcodes.IINC).put11(var, increment);
+        }
+        // If needed, update the maximum stack size and number of locals, and stack map frames.
+        if (currentBasicBlock != null && (compute == COMPUTE_ALL_FRAMES || compute == COMPUTE_INSERTED_FRAMES)) {
+            currentBasicBlock.frame.execute(Opcodes.IINC, var, null, null);
+        }
+        if (compute != COMPUTE_NOTHING) {
+            int currentMaxLocals = var + 1;
+            if (currentMaxLocals > maxLocals) {
+                maxLocals = currentMaxLocals;
+            }
+        }
+    }
+
+    @Override
+    public void visitTableSwitchInsn(final int min, final int max, final Label dflt, final Label... labels) {
+        lastBytecodeOffset = code.length;
+        // Add the instruction to the bytecode of the method.
+        code.putByte(Opcodes.TABLESWITCH).putByteArray(null, 0, (4 - code.length % 4) % 4);
+        dflt.put(code, lastBytecodeOffset, true);
+        code.putInt(min).putInt(max);
+        for (Label label : labels) {
+            label.put(code, lastBytecodeOffset, true);
+        }
+        // If needed, update the maximum stack size and number of locals, and stack map frames.
+        visitSwitchInsn(dflt, labels);
+    }
+
+    @Override
+    public void visitLookupSwitchInsn(final Label dflt, final int[] keys, final Label[] labels) {
+        lastBytecodeOffset = code.length;
+        // Add the instruction to the bytecode of the method.
+        code.putByte(Opcodes.LOOKUPSWITCH).putByteArray(null, 0, (4 - code.length % 4) % 4);
+        dflt.put(code, lastBytecodeOffset, true);
+        code.putInt(labels.length);
+        for (int i = 0; i < labels.length; ++i) {
+            code.putInt(keys[i]);
+            labels[i].put(code, lastBytecodeOffset, true);
+        }
+        // If needed, update the maximum stack size and number of locals, and stack map frames.
+        visitSwitchInsn(dflt, labels);
+    }
+
+    private void visitSwitchInsn(final Label dflt, final Label[] labels) {
+        if (currentBasicBlock != null) {
+            if (compute == COMPUTE_ALL_FRAMES) {
+                currentBasicBlock.frame.execute(Opcodes.LOOKUPSWITCH, 0, null, null);
+                // Add all the labels as successors of the current basic block.
+                addSuccessorToCurrentBasicBlock(Edge.JUMP, dflt);
+                dflt.getCanonicalInstance().flags |= Label.FLAG_JUMP_TARGET;
+                for (Label label : labels) {
+                    addSuccessorToCurrentBasicBlock(Edge.JUMP, label);
+                    label.getCanonicalInstance().flags |= Label.FLAG_JUMP_TARGET;
+                }
+            } else if (compute == COMPUTE_MAX_STACK_AND_LOCAL) {
+                // No need to update maxRelativeStackSize (the stack size delta is always negative).
+                --relativeStackSize;
+                // Add all the labels as successors of the current basic block.
+                addSuccessorToCurrentBasicBlock(relativeStackSize, dflt);
+                for (Label label : labels) {
+                    addSuccessorToCurrentBasicBlock(relativeStackSize, label);
+                }
+            }
+            // End the current basic block.
+            endCurrentBasicBlockWithNoSuccessor();
+        }
+    }
+
+    @Override
+    public void visitMultiANewArrayInsn(final String descriptor, final int numDimensions) {
+        lastBytecodeOffset = code.length;
+        // Add the instruction to the bytecode of the method.
+        Symbol descSymbol = symbolTable.addConstantClass(descriptor);
+        code.put12(Opcodes.MULTIANEWARRAY, descSymbol.index).putByte(numDimensions);
+        // If needed, update the maximum stack size and number of locals, and stack map frames.
+        if (currentBasicBlock != null) {
+            if (compute == COMPUTE_ALL_FRAMES || compute == COMPUTE_INSERTED_FRAMES) {
+                currentBasicBlock.frame.execute(Opcodes.MULTIANEWARRAY, numDimensions, descSymbol, symbolTable);
+            } else {
+                // No need to update maxRelativeStackSize (the stack size delta is always negative).
+                relativeStackSize += 1 - numDimensions;
+            }
+        }
+    }
+
+    @Override
+    public AnnotationVisitor visitInsnAnnotation(final int typeRef, final TypePath typePath, final String descriptor,
+            final boolean visible) {
+        // Create a ByteVector to hold a 'type_annotation' JVMS structure.
+        // See https://docs.oracle.com/javase/specs/jvms/se9/html/jvms-4.html#jvms-4.7.20.
+        ByteVector typeAnnotation = new ByteVector();
+        // Write target_type, target_info, and target_path.
+        TypeReference.putTarget((typeRef & 0xFF0000FF) | (lastBytecodeOffset << 8), typeAnnotation);
+        TypePath.put(typePath, typeAnnotation);
+        // Write type_index and reserve space for num_element_value_pairs.
+        typeAnnotation.putShort(symbolTable.addConstantUtf8(descriptor)).putShort(0);
+        if (visible) {
+            return lastCodeRuntimeVisibleTypeAnnotation = new AnnotationWriter(symbolTable, typeAnnotation,
+                    lastCodeRuntimeVisibleTypeAnnotation);
+        } else {
+            return lastCodeRuntimeInvisibleTypeAnnotation = new AnnotationWriter(symbolTable, typeAnnotation,
+                    lastCodeRuntimeInvisibleTypeAnnotation);
+        }
+    }
+
+    @Override
+    public void visitTryCatchBlock(final Label start, final Label end, final Label handler, final String type) {
+        Handler newHandler = new Handler(start, end, handler, type != null ? symbolTable.addConstantClass(type).index : 0, type);
+        if (firstHandler == null) {
+            firstHandler = newHandler;
+        } else {
+            lastHandler.nextHandler = newHandler;
+        }
+        lastHandler = newHandler;
+    }
+
+    @Override
+    public AnnotationVisitor visitTryCatchAnnotation(final int typeRef, final TypePath typePath, final String descriptor,
+            final boolean visible) {
+        // Create a ByteVector to hold a 'type_annotation' JVMS structure.
+        // See https://docs.oracle.com/javase/specs/jvms/se9/html/jvms-4.html#jvms-4.7.20.
+        ByteVector typeAnnotation = new ByteVector();
+        // Write target_type, target_info, and target_path.
+        TypeReference.putTarget(typeRef, typeAnnotation);
+        TypePath.put(typePath, typeAnnotation);
+        // Write type_index and reserve space for num_element_value_pairs.
+        typeAnnotation.putShort(symbolTable.addConstantUtf8(descriptor)).putShort(0);
+        if (visible) {
+            return lastCodeRuntimeVisibleTypeAnnotation = new AnnotationWriter(symbolTable, typeAnnotation,
+                    lastCodeRuntimeVisibleTypeAnnotation);
+        } else {
+            return lastCodeRuntimeInvisibleTypeAnnotation = new AnnotationWriter(symbolTable, typeAnnotation,
+                    lastCodeRuntimeInvisibleTypeAnnotation);
+        }
+    }
+
+    @Override
+    public void visitLocalVariable(final String name, final String descriptor, final String signature, final Label start, final Label end,
+            final int index) {
+        if (signature != null) {
+            if (localVariableTypeTable == null) {
+                localVariableTypeTable = new ByteVector();
+            }
+            ++localVariableTypeTableLength;
+            localVariableTypeTable.putShort(start.bytecodeOffset).putShort(end.bytecodeOffset - start.bytecodeOffset)
+                    .putShort(symbolTable.addConstantUtf8(name)).putShort(symbolTable.addConstantUtf8(signature)).putShort(index);
+        }
+        if (localVariableTable == null) {
+            localVariableTable = new ByteVector();
+        }
+        ++localVariableTableLength;
+        localVariableTable.putShort(start.bytecodeOffset).putShort(end.bytecodeOffset - start.bytecodeOffset)
+                .putShort(symbolTable.addConstantUtf8(name)).putShort(symbolTable.addConstantUtf8(descriptor)).putShort(index);
+        if (compute != COMPUTE_NOTHING) {
+            char firstDescChar = descriptor.charAt(0);
+            int currentMaxLocals = index + (firstDescChar == 'J' || firstDescChar == 'D' ? 2 : 1);
+            if (currentMaxLocals > maxLocals) {
+                maxLocals = currentMaxLocals;
+            }
+        }
+    }
+
+    @Override
+    public AnnotationVisitor visitLocalVariableAnnotation(final int typeRef, final TypePath typePath, final Label[] start,
+            final Label[] end, final int[] index, final String descriptor, final boolean visible) {
+        // Create a ByteVector to hold a 'type_annotation' JVMS structure.
+        // See https://docs.oracle.com/javase/specs/jvms/se9/html/jvms-4.html#jvms-4.7.20.
+        ByteVector typeAnnotation = new ByteVector();
+        // Write target_type, target_info, and target_path.
+        typeAnnotation.putByte(typeRef >>> 24).putShort(start.length);
+        for (int i = 0; i < start.length; ++i) {
+            typeAnnotation.putShort(start[i].bytecodeOffset).putShort(end[i].bytecodeOffset - start[i].bytecodeOffset).putShort(index[i]);
+        }
+        TypePath.put(typePath, typeAnnotation);
+        // Write type_index and reserve space for num_element_value_pairs.
+        typeAnnotation.putShort(symbolTable.addConstantUtf8(descriptor)).putShort(0);
+        if (visible) {
+            return lastCodeRuntimeVisibleTypeAnnotation = new AnnotationWriter(symbolTable, typeAnnotation,
+                    lastCodeRuntimeVisibleTypeAnnotation);
+        } else {
+            return lastCodeRuntimeInvisibleTypeAnnotation = new AnnotationWriter(symbolTable, typeAnnotation,
+                    lastCodeRuntimeInvisibleTypeAnnotation);
+        }
+    }
+
+    @Override
+    public void visitLineNumber(final int line, final Label start) {
+        if (lineNumberTable == null) {
+            lineNumberTable = new ByteVector();
+        }
+        ++lineNumberTableLength;
+        lineNumberTable.putShort(start.bytecodeOffset);
+        lineNumberTable.putShort(line);
+    }
+
+    @Override
+    public void visitMaxs(final int maxStack, final int maxLocals) {
+        if (compute == COMPUTE_ALL_FRAMES) {
+            computeAllFrames();
+        } else if (compute == COMPUTE_MAX_STACK_AND_LOCAL) {
+            computeMaxStackAndLocal();
+        } else if (compute == COMPUTE_MAX_STACK_AND_LOCAL_FROM_FRAMES) {
+            this.maxStack = maxRelativeStackSize;
+        } else {
+            this.maxStack = maxStack;
+            this.maxLocals = maxLocals;
+        }
+    }
+
+    /** Computes all the stack map frames of the method, from scratch. */
+    private void computeAllFrames() {
+        // Complete the control flow graph with exception handler blocks.
+        Handler handler = firstHandler;
+        while (handler != null) {
+            String catchTypeDescriptor = handler.catchTypeDescriptor == null ? "java/lang/Throwable" : handler.catchTypeDescriptor;
+            int catchType = Frame.getAbstractTypeFromInternalName(symbolTable, catchTypeDescriptor);
+            // Mark handlerBlock as an exception handler.
+            Label handlerBlock = handler.handlerPc.getCanonicalInstance();
+            handlerBlock.flags |= Label.FLAG_JUMP_TARGET;
+            // Add handlerBlock as a successor of all the basic blocks in the exception handler range.
+            Label handlerRangeBlock = handler.startPc.getCanonicalInstance();
+            Label handlerRangeEnd = handler.endPc.getCanonicalInstance();
+            while (handlerRangeBlock != handlerRangeEnd) {
+                handlerRangeBlock.outgoingEdges = new Edge(catchType, handlerBlock, handlerRangeBlock.outgoingEdges);
+                handlerRangeBlock = handlerRangeBlock.nextBasicBlock;
+            }
+            handler = handler.nextHandler;
+        }
+
+        // Create and visit the first (implicit) frame.
+        Frame firstFrame = firstBasicBlock.frame;
+        firstFrame.setInputFrameFromDescriptor(symbolTable, accessFlags, descriptor, this.maxLocals);
+        firstFrame.accept(this);
+
+        // Fix point algorithm: add the first basic block to a list of blocks to process (i.e. blocks
+        // whose stack map frame has changed) and, while there are blocks to process, remove one from
+        // the list and update the stack map frames of its successor blocks in the control flow graph
+        // (which might change them, in which case these blocks must be processed too, and are thus
+        // added to the list of blocks to process). Also compute the maximum stack size of the method,
+        // as a by-product.
+        Label listOfBlocksToProcess = firstBasicBlock;
+        listOfBlocksToProcess.nextListElement = Label.EMPTY_LIST;
+        int maxStackSize = 0;
+        while (listOfBlocksToProcess != Label.EMPTY_LIST) {
+            // Remove a basic block from the list of blocks to process.
+            Label basicBlock = listOfBlocksToProcess;
+            listOfBlocksToProcess = listOfBlocksToProcess.nextListElement;
+            basicBlock.nextListElement = null;
+            // By definition, basicBlock is reachable.
+            basicBlock.flags |= Label.FLAG_REACHABLE;
+            // Update the (absolute) maximum stack size.
+            int maxBlockStackSize = basicBlock.frame.getInputStackSize() + basicBlock.outputStackMax;
+            if (maxBlockStackSize > maxStackSize) {
+                maxStackSize = maxBlockStackSize;
+            }
+            // Update the successor blocks of basicBlock in the control flow graph.
+            Edge outgoingEdge = basicBlock.outgoingEdges;
+            while (outgoingEdge != null) {
+                Label successorBlock = outgoingEdge.successor.getCanonicalInstance();
+                boolean successorBlockChanged = basicBlock.frame.merge(symbolTable, successorBlock.frame, outgoingEdge.info);
+                if (successorBlockChanged && successorBlock.nextListElement == null) {
+                    // If successorBlock has changed it must be processed. Thus, if it is not already in the
+                    // list of blocks to process, add it to this list.
+                    successorBlock.nextListElement = listOfBlocksToProcess;
+                    listOfBlocksToProcess = successorBlock;
+                }
+                outgoingEdge = outgoingEdge.nextEdge;
+            }
+        }
+
+        // Loop over all the basic blocks and visit the stack map frames that must be stored in the
+        // StackMapTable attribute. Also replace unreachable code with NOP* ATHROW, and remove it from
+        // exception handler ranges.
+        Label basicBlock = firstBasicBlock;
+        while (basicBlock != null) {
+            if ((basicBlock.flags & (Label.FLAG_JUMP_TARGET | Label.FLAG_REACHABLE)) == (Label.FLAG_JUMP_TARGET | Label.FLAG_REACHABLE)) {
+                basicBlock.frame.accept(this);
+            }
+            if ((basicBlock.flags & Label.FLAG_REACHABLE) == 0) {
+                // Find the start and end bytecode offsets of this unreachable block.
+                Label nextBasicBlock = basicBlock.nextBasicBlock;
+                int startOffset = basicBlock.bytecodeOffset;
+                int endOffset = (nextBasicBlock == null ? code.length : nextBasicBlock.bytecodeOffset) - 1;
+                if (endOffset >= startOffset) {
+                    // Replace its instructions with NOP ... NOP ATHROW.
+                    for (int i = startOffset; i < endOffset; ++i) {
+                        code.data[i] = Opcodes.NOP;
+                    }
+                    code.data[endOffset] = (byte) Opcodes.ATHROW;
+                    // Emit a frame for this unreachable block, with no local and a Throwable on the stack
+                    // (so that the ATHROW could consume this Throwable if it were reachable).
+                    int frameIndex = visitFrameStart(startOffset, /* numLocal = */ 0, /* numStack = */ 1);
+                    currentFrame[frameIndex] = Frame.getAbstractTypeFromInternalName(symbolTable, "java/lang/Throwable");
+                    visitFrameEnd();
+                    // Remove this unreachable basic block from the exception handler ranges.
+                    firstHandler = Handler.removeRange(firstHandler, basicBlock, nextBasicBlock);
+                    // The maximum stack size is now at least one, because of the Throwable declared above.
+                    maxStackSize = Math.max(maxStackSize, 1);
+                }
+            }
+            basicBlock = basicBlock.nextBasicBlock;
+        }
+
+        this.maxStack = maxStackSize;
+    }
+
+    /** Computes the maximum stack size of the method. */
+    private void computeMaxStackAndLocal() {
+        // Complete the control flow graph with exception handler blocks.
+        Handler handler = firstHandler;
+        while (handler != null) {
+            Label handlerBlock = handler.handlerPc;
+            Label handlerRangeBlock = handler.startPc;
+            Label handlerRangeEnd = handler.endPc;
+            // Add handlerBlock as a successor of all the basic blocks in the exception handler range.
+            while (handlerRangeBlock != handlerRangeEnd) {
+                if ((handlerRangeBlock.flags & Label.FLAG_SUBROUTINE_CALLER) == 0) {
+                    handlerRangeBlock.outgoingEdges = new Edge(Edge.EXCEPTION, handlerBlock, handlerRangeBlock.outgoingEdges);
+                } else {
+                    // If handlerRangeBlock is a JSR block, add handlerBlock after the first two outgoing
+                    // edges to preserve the hypothesis about JSR block successors order (see
+                    // {@link #visitJumpInsn}).
+                    handlerRangeBlock.outgoingEdges.nextEdge.nextEdge = new Edge(Edge.EXCEPTION, handlerBlock,
+                            handlerRangeBlock.outgoingEdges.nextEdge.nextEdge);
+                }
+                handlerRangeBlock = handlerRangeBlock.nextBasicBlock;
+            }
+            handler = handler.nextHandler;
+        }
+
+        // Complete the control flow graph with the successor blocks of subroutines, if needed.
+        if (hasSubroutines) {
+            // First step: find the subroutines. This step determines, for each basic block, to which
+            // subroutine(s) it belongs. Start with the main "subroutine":
+            short numSubroutines = 1;
+            firstBasicBlock.markSubroutine(numSubroutines);
+            // Then, mark the subroutines called by the main subroutine, then the subroutines called by
+            // those called by the main subroutine, etc.
+            for (short currentSubroutine = 1; currentSubroutine <= numSubroutines; ++currentSubroutine) {
+                Label basicBlock = firstBasicBlock;
+                while (basicBlock != null) {
+                    if ((basicBlock.flags & Label.FLAG_SUBROUTINE_CALLER) != 0 && basicBlock.subroutineId == currentSubroutine) {
+                        Label jsrTarget = basicBlock.outgoingEdges.nextEdge.successor;
+                        if (jsrTarget.subroutineId == 0) {
+                            // If this subroutine has not been marked yet, find its basic blocks.
+                            jsrTarget.markSubroutine(++numSubroutines);
+                        }
+                    }
+                    basicBlock = basicBlock.nextBasicBlock;
+                }
+            }
+            // Second step: find the successors in the control flow graph of each subroutine basic block
+            // 'r' ending with a RET instruction. These successors are the virtual successors of the basic
+            // blocks ending with JSR instructions (see {@link #visitJumpInsn)} that can reach 'r'.
+            Label basicBlock = firstBasicBlock;
+            while (basicBlock != null) {
+                if ((basicBlock.flags & Label.FLAG_SUBROUTINE_CALLER) != 0) {
+                    // By construction, jsr targets are stored in the second outgoing edge of basic blocks
+                    // that ends with a jsr instruction (see {@link #FLAG_SUBROUTINE_CALLER}).
+                    Label subroutine = basicBlock.outgoingEdges.nextEdge.successor;
+                    subroutine.addSubroutineRetSuccessors(basicBlock);
+                }
+                basicBlock = basicBlock.nextBasicBlock;
+            }
+        }
+
+        // Data flow algorithm: put the first basic block in a list of blocks to process (i.e. blocks
+        // whose input stack size has changed) and, while there are blocks to process, remove one
+        // from the list, update the input stack size of its successor blocks in the control flow
+        // graph, and add these blocks to the list of blocks to process (if not already done).
+        Label listOfBlocksToProcess = firstBasicBlock;
+        listOfBlocksToProcess.nextListElement = Label.EMPTY_LIST;
+        int maxStackSize = maxStack;
+        while (listOfBlocksToProcess != Label.EMPTY_LIST) {
+            // Remove a basic block from the list of blocks to process. Note that we don't reset
+            // basicBlock.nextListElement to null on purpose, to make sure we don't reprocess already
+            // processed basic blocks.
+            Label basicBlock = listOfBlocksToProcess;
+            listOfBlocksToProcess = listOfBlocksToProcess.nextListElement;
+            // Compute the (absolute) input stack size and maximum stack size of this block.
+            int inputStackTop = basicBlock.inputStackSize;
+            int maxBlockStackSize = inputStackTop + basicBlock.outputStackMax;
+            // Update the absolute maximum stack size of the method.
+            if (maxBlockStackSize > maxStackSize) {
+                maxStackSize = maxBlockStackSize;
+            }
+            // Update the input stack size of the successor blocks of basicBlock in the control flow
+            // graph, and add these blocks to the list of blocks to process, if not already done.
+            Edge outgoingEdge = basicBlock.outgoingEdges;
+            if ((basicBlock.flags & Label.FLAG_SUBROUTINE_CALLER) != 0) {
+                // Ignore the first outgoing edge of the basic blocks ending with a jsr: these are virtual
+                // edges which lead to the instruction just after the jsr, and do not correspond to a
+                // possible execution path (see {@link #visitJumpInsn} and
+                // {@link Label#FLAG_SUBROUTINE_CALLER}).
+                outgoingEdge = outgoingEdge.nextEdge;
+            }
+            while (outgoingEdge != null) {
+                Label successorBlock = outgoingEdge.successor;
+                if (successorBlock.nextListElement == null) {
+                    successorBlock.inputStackSize = (short) (outgoingEdge.info == Edge.EXCEPTION ? 1 : inputStackTop + outgoingEdge.info);
+                    successorBlock.nextListElement = listOfBlocksToProcess;
+                    listOfBlocksToProcess = successorBlock;
+                }
+                outgoingEdge = outgoingEdge.nextEdge;
+            }
+        }
+        this.maxStack = maxStackSize;
+    }
+
+    @Override
+    public void visitEnd() {
+        // Nothing to do.
+    }
+
+    // -----------------------------------------------------------------------------------------------
+    // Utility methods: control flow analysis algorithm
+    // -----------------------------------------------------------------------------------------------
+
+    /**
+     * Adds a successor to {@link #currentBasicBlock} in the control flow graph.
+     *
+     * @param info information about the control flow edge to be added.
+     * @param successor the successor block to be added to the current basic block.
+     */
+    private void addSuccessorToCurrentBasicBlock(final int info, final Label successor) {
+        currentBasicBlock.outgoingEdges = new Edge(info, successor, currentBasicBlock.outgoingEdges);
+    }
+
+    /**
+     * Ends the current basic block. This method must be used in the case where the current basic
+     * block does not have any successor.
+     *
+     * <p>WARNING: this method must be called after the currently visited instruction has been put in
+     * {@link #code} (if frames are computed, this method inserts a new Label to start a new basic
+     * block after the current instruction).
+     */
+    private void endCurrentBasicBlockWithNoSuccessor() {
+        if (compute == COMPUTE_ALL_FRAMES) {
+            Label nextBasicBlock = new Label();
+            nextBasicBlock.frame = new Frame(nextBasicBlock);
+            nextBasicBlock.resolve(code.data, code.length);
+            lastBasicBlock.nextBasicBlock = nextBasicBlock;
+            lastBasicBlock = nextBasicBlock;
+            currentBasicBlock = null;
+        } else if (compute == COMPUTE_MAX_STACK_AND_LOCAL) {
+            currentBasicBlock.outputStackMax = (short) maxRelativeStackSize;
+            currentBasicBlock = null;
+        }
+    }
+
+    // -----------------------------------------------------------------------------------------------
+    // Utility methods: stack map frames
+    // -----------------------------------------------------------------------------------------------
+
+    /**
+     * Starts the visit of a new stack map frame, stored in {@link #currentFrame}.
+     *
+     * @param offset the bytecode offset of the instruction to which the frame corresponds.
+     * @param numLocal the number of local variables in the frame.
+     * @param numStack the number of stack elements in the frame.
+     * @return the index of the next element to be written in this frame.
+     */
+    int visitFrameStart(final int offset, final int numLocal, final int numStack) {
+        int frameLength = 3 + numLocal + numStack;
+        if (currentFrame == null || currentFrame.length < frameLength) {
+            currentFrame = new int[frameLength];
+        }
+        currentFrame[0] = offset;
+        currentFrame[1] = numLocal;
+        currentFrame[2] = numStack;
+        return 3;
+    }
+
+    /**
+     * Sets an abstract type in {@link #currentFrame}.
+     *
+     * @param frameIndex the index of the element to be set in {@link #currentFrame}.
+     * @param abstractType an abstract type.
+     */
+    void visitAbstractType(final int frameIndex, final int abstractType) {
+        currentFrame[frameIndex] = abstractType;
+    }
+
+    /**
+     * Ends the visit of {@link #currentFrame} by writing it in the StackMapTable entries and by
+     * updating the StackMapTable number_of_entries (except if the current frame is the first one,
+     * which is implicit in StackMapTable). Then resets {@link #currentFrame} to {@literal null}.
+     */
+    void visitFrameEnd() {
+        if (previousFrame != null) {
+            if (stackMapTableEntries == null) {
+                stackMapTableEntries = new ByteVector();
+            }
+            putFrame();
+            ++stackMapTableNumberOfEntries;
+        }
+        previousFrame = currentFrame;
+        currentFrame = null;
+    }
+
+    /** Compresses and writes {@link #currentFrame} in a new StackMapTable entry. */
+    private void putFrame() {
+        final int numLocal = currentFrame[1];
+        final int numStack = currentFrame[2];
+        if (symbolTable.getMajorVersion() < Opcodes.V1_6) {
+            // Generate a StackMap attribute entry, which are always uncompressed.
+            stackMapTableEntries.putShort(currentFrame[0]).putShort(numLocal);
+            putAbstractTypes(3, 3 + numLocal);
+            stackMapTableEntries.putShort(numStack);
+            putAbstractTypes(3 + numLocal, 3 + numLocal + numStack);
+            return;
+        }
+        final int offsetDelta = stackMapTableNumberOfEntries == 0 ? currentFrame[0] : currentFrame[0] - previousFrame[0] - 1;
+        final int previousNumlocal = previousFrame[1];
+        final int numLocalDelta = numLocal - previousNumlocal;
+        int type = Frame.FULL_FRAME;
+        if (numStack == 0) {
+            switch (numLocalDelta) {
+                case -3:
+                case -2:
+                case -1:
+                    type = Frame.CHOP_FRAME;
+                    break;
+                case 0:
+                    type = offsetDelta < 64 ? Frame.SAME_FRAME : Frame.SAME_FRAME_EXTENDED;
+                    break;
+                case 1:
+                case 2:
+                case 3:
+                    type = Frame.APPEND_FRAME;
+                    break;
+                default:
+                    // Keep the FULL_FRAME type.
+                    break;
+            }
+        } else if (numLocalDelta == 0 && numStack == 1) {
+            type = offsetDelta < 63 ? Frame.SAME_LOCALS_1_STACK_ITEM_FRAME : Frame.SAME_LOCALS_1_STACK_ITEM_FRAME_EXTENDED;
+        }
+        if (type != Frame.FULL_FRAME) {
+            // Verify if locals are the same as in the previous frame.
+            int frameIndex = 3;
+            for (int i = 0; i < previousNumlocal && i < numLocal; i++) {
+                if (currentFrame[frameIndex] != previousFrame[frameIndex]) {
+                    type = Frame.FULL_FRAME;
+                    break;
+                }
+                frameIndex++;
+            }
+        }
+        switch (type) {
+            case Frame.SAME_FRAME:
+                stackMapTableEntries.putByte(offsetDelta);
+                break;
+            case Frame.SAME_LOCALS_1_STACK_ITEM_FRAME:
+                stackMapTableEntries.putByte(Frame.SAME_LOCALS_1_STACK_ITEM_FRAME + offsetDelta);
+                putAbstractTypes(3 + numLocal, 4 + numLocal);
+                break;
+            case Frame.SAME_LOCALS_1_STACK_ITEM_FRAME_EXTENDED:
+                stackMapTableEntries.putByte(Frame.SAME_LOCALS_1_STACK_ITEM_FRAME_EXTENDED).putShort(offsetDelta);
+                putAbstractTypes(3 + numLocal, 4 + numLocal);
+                break;
+            case Frame.SAME_FRAME_EXTENDED:
+                stackMapTableEntries.putByte(Frame.SAME_FRAME_EXTENDED).putShort(offsetDelta);
+                break;
+            case Frame.CHOP_FRAME:
+                stackMapTableEntries.putByte(Frame.SAME_FRAME_EXTENDED + numLocalDelta).putShort(offsetDelta);
+                break;
+            case Frame.APPEND_FRAME:
+                stackMapTableEntries.putByte(Frame.SAME_FRAME_EXTENDED + numLocalDelta).putShort(offsetDelta);
+                putAbstractTypes(3 + previousNumlocal, 3 + numLocal);
+                break;
+            case Frame.FULL_FRAME:
+            default:
+                stackMapTableEntries.putByte(Frame.FULL_FRAME).putShort(offsetDelta).putShort(numLocal);
+                putAbstractTypes(3, 3 + numLocal);
+                stackMapTableEntries.putShort(numStack);
+                putAbstractTypes(3 + numLocal, 3 + numLocal + numStack);
+                break;
+        }
+    }
+
+    /**
+     * Puts some abstract types of {@link #currentFrame} in {@link #stackMapTableEntries} , using the
+     * JVMS verification_type_info format used in StackMapTable attributes.
+     *
+     * @param start index of the first type in {@link #currentFrame} to write.
+     * @param end index of last type in {@link #currentFrame} to write (exclusive).
+     */
+    private void putAbstractTypes(final int start, final int end) {
+        for (int i = start; i < end; ++i) {
+            Frame.putAbstractType(symbolTable, currentFrame[i], stackMapTableEntries);
+        }
+    }
+
+    /**
+     * Puts the given public API frame element type in {@link #stackMapTableEntries} , using the JVMS
+     * verification_type_info format used in StackMapTable attributes.
+     *
+     * @param type a frame element type described using the same format as in {@link
+     *     MethodVisitor#visitFrame}, i.e. either {@link Opcodes#TOP}, {@link Opcodes#INTEGER}, {@link
+     *     Opcodes#FLOAT}, {@link Opcodes#LONG}, {@link Opcodes#DOUBLE}, {@link Opcodes#NULL}, or
+     *     {@link Opcodes#UNINITIALIZED_THIS}, or the internal name of a class, or a Label designating
+     *     a NEW instruction (for uninitialized types).
+     */
+    private void putFrameType(final Object type) {
+        if (type instanceof Integer) {
+            stackMapTableEntries.putByte(((Integer) type).intValue());
+        } else if (type instanceof String) {
+            stackMapTableEntries.putByte(Frame.ITEM_OBJECT).putShort(symbolTable.addConstantClass((String) type).index);
+        } else {
+            stackMapTableEntries.putByte(Frame.ITEM_UNINITIALIZED).putShort(((Label) type).bytecodeOffset);
+        }
+    }
+
+    // -----------------------------------------------------------------------------------------------
+    // Utility methods
+    // -----------------------------------------------------------------------------------------------
+
+    /**
+     * Returns whether the attributes of this method can be copied from the attributes of the given
+     * method (assuming there is no method visitor between the given ClassReader and this
+     * MethodWriter). This method should only be called just after this MethodWriter has been created,
+     * and before any content is visited. It returns true if the attributes corresponding to the
+     * constructor arguments (at most a Signature, an Exception, a Deprecated and a Synthetic
+     * attribute) are the same as the corresponding attributes in the given method.
+     *
+     * @param source the source ClassReader from which the attributes of this method might be copied.
+     * @param methodInfoOffset the offset in 'source.b' of the method_info JVMS structure from which
+     *     the attributes of this method might be copied.
+     * @param methodInfoLength the length in 'source.b' of the method_info JVMS structure from which
+     *     the attributes of this method might be copied.
+     * @param hasSyntheticAttribute whether the method_info JVMS structure from which the attributes
+     *     of this method might be copied contains a Synthetic attribute.
+     * @param hasDeprecatedAttribute whether the method_info JVMS structure from which the attributes
+     *     of this method might be copied contains a Deprecated attribute.
+     * @param descriptorIndex the descriptor_index field of the method_info JVMS structure from which
+     *     the attributes of this method might be copied.
+     * @param signatureIndex the constant pool index contained in the Signature attribute of the
+     *     method_info JVMS structure from which the attributes of this method might be copied, or 0.
+     * @param exceptionsOffset the offset in 'source.b' of the Exceptions attribute of the method_info
+     *     JVMS structure from which the attributes of this method might be copied, or 0.
+     * @return whether the attributes of this method can be copied from the attributes of the
+     *     method_info JVMS structure in 'source.b', between 'methodInfoOffset' and 'methodInfoOffset'
+     *     + 'methodInfoLength'.
+     */
+    boolean canCopyMethodAttributes(final ClassReader source, final int methodInfoOffset, final int methodInfoLength,
+            final boolean hasSyntheticAttribute, final boolean hasDeprecatedAttribute, final int descriptorIndex, final int signatureIndex,
+            final int exceptionsOffset) {
+        // If the method descriptor has changed, with more locals than the max_locals field of the
+        // original Code attribute, if any, then the original method attributes can't be copied. A
+        // conservative check on the descriptor changes alone ensures this (being more precise is not
+        // worth the additional complexity, because these cases should be rare -- if a transform changes
+        // a method descriptor, most of the time it needs to change the method's code too).
+        if (source != symbolTable.getSource() || descriptorIndex != this.descriptorIndex || signatureIndex != this.signatureIndex
+                || hasDeprecatedAttribute != ((accessFlags & Opcodes.ACC_DEPRECATED) != 0)) {
+            return false;
+        }
+        boolean needSyntheticAttribute = symbolTable.getMajorVersion() < Opcodes.V1_5 && (accessFlags & Opcodes.ACC_SYNTHETIC) != 0;
+        if (hasSyntheticAttribute != needSyntheticAttribute) {
+            return false;
+        }
+        if (exceptionsOffset == 0) {
+            if (numberOfExceptions != 0) {
+                return false;
+            }
+        } else if (source.readUnsignedShort(exceptionsOffset) == numberOfExceptions) {
+            int currentExceptionOffset = exceptionsOffset + 2;
+            for (int i = 0; i < numberOfExceptions; ++i) {
+                if (source.readUnsignedShort(currentExceptionOffset) != exceptionIndexTable[i]) {
+                    return false;
+                }
+                currentExceptionOffset += 2;
+            }
+        }
+        // Don't copy the attributes yet, instead store their location in the source class reader so
+        // they can be copied later, in {@link #putMethodInfo}. Note that we skip the 6 header bytes
+        // of the method_info JVMS structure.
+        this.sourceOffset = methodInfoOffset + 6;
+        this.sourceLength = methodInfoLength - 6;
+        return true;
+    }
+
+    /**
+     * Returns the size of the method_info JVMS structure generated by this MethodWriter. Also add the
+     * names of the attributes of this method in the constant pool.
+     *
+     * @return the size in bytes of the method_info JVMS structure.
+     */
+    int computeMethodInfoSize() {
+        // If this method_info must be copied from an existing one, the size computation is trivial.
+        if (sourceOffset != 0) {
+            // sourceLength excludes the first 6 bytes for access_flags, name_index and descriptor_index.
+            return 6 + sourceLength;
+        }
+        // 2 bytes each for access_flags, name_index, descriptor_index and attributes_count.
+        int size = 8;
+        // For ease of reference, we use here the same attribute order as in Section 4.7 of the JVMS.
+        if (code.length > 0) {
+            if (code.length > 65535) {
+                throw new MethodTooLargeException(symbolTable.getClassName(), name, descriptor, code.length);
+            }
+            symbolTable.addConstantUtf8(Constants.CODE);
+            // The Code attribute has 6 header bytes, plus 2, 2, 4 and 2 bytes respectively for max_stack,
+            // max_locals, code_length and attributes_count, plus the bytecode and the exception table.
+            size += 16 + code.length + Handler.getExceptionTableSize(firstHandler);
+            if (stackMapTableEntries != null) {
+                boolean useStackMapTable = symbolTable.getMajorVersion() >= Opcodes.V1_6;
+                symbolTable.addConstantUtf8(useStackMapTable ? Constants.STACK_MAP_TABLE : "StackMap");
+                // 6 header bytes and 2 bytes for number_of_entries.
+                size += 8 + stackMapTableEntries.length;
+            }
+            if (lineNumberTable != null) {
+                symbolTable.addConstantUtf8(Constants.LINE_NUMBER_TABLE);
+                // 6 header bytes and 2 bytes for line_number_table_length.
+                size += 8 + lineNumberTable.length;
+            }
+            if (localVariableTable != null) {
+                symbolTable.addConstantUtf8(Constants.LOCAL_VARIABLE_TABLE);
+                // 6 header bytes and 2 bytes for local_variable_table_length.
+                size += 8 + localVariableTable.length;
+            }
+            if (localVariableTypeTable != null) {
+                symbolTable.addConstantUtf8(Constants.LOCAL_VARIABLE_TYPE_TABLE);
+                // 6 header bytes and 2 bytes for local_variable_type_table_length.
+                size += 8 + localVariableTypeTable.length;
+            }
+            if (lastCodeRuntimeVisibleTypeAnnotation != null) {
+                size += lastCodeRuntimeVisibleTypeAnnotation.computeAnnotationsSize(Constants.RUNTIME_VISIBLE_TYPE_ANNOTATIONS);
+            }
+            if (lastCodeRuntimeInvisibleTypeAnnotation != null) {
+                size += lastCodeRuntimeInvisibleTypeAnnotation.computeAnnotationsSize(Constants.RUNTIME_INVISIBLE_TYPE_ANNOTATIONS);
+            }
+            if (firstCodeAttribute != null) {
+                size += firstCodeAttribute.computeAttributesSize(symbolTable, code.data, code.length, maxStack, maxLocals);
+            }
+        }
+        if (numberOfExceptions > 0) {
+            symbolTable.addConstantUtf8(Constants.EXCEPTIONS);
+            size += 8 + 2 * numberOfExceptions;
+        }
+        boolean useSyntheticAttribute = symbolTable.getMajorVersion() < Opcodes.V1_5;
+        if ((accessFlags & Opcodes.ACC_SYNTHETIC) != 0 && useSyntheticAttribute) {
+            symbolTable.addConstantUtf8(Constants.SYNTHETIC);
+            size += 6;
+        }
+        if (signatureIndex != 0) {
+            symbolTable.addConstantUtf8(Constants.SIGNATURE);
+            size += 8;
+        }
+        if ((accessFlags & Opcodes.ACC_DEPRECATED) != 0) {
+            symbolTable.addConstantUtf8(Constants.DEPRECATED);
+            size += 6;
+        }
+        if (lastRuntimeVisibleAnnotation != null) {
+            size += lastRuntimeVisibleAnnotation.computeAnnotationsSize(Constants.RUNTIME_VISIBLE_ANNOTATIONS);
+        }
+        if (lastRuntimeInvisibleAnnotation != null) {
+            size += lastRuntimeInvisibleAnnotation.computeAnnotationsSize(Constants.RUNTIME_INVISIBLE_ANNOTATIONS);
+        }
+        if (lastRuntimeVisibleParameterAnnotations != null) {
+            size += AnnotationWriter.computeParameterAnnotationsSize(Constants.RUNTIME_VISIBLE_PARAMETER_ANNOTATIONS,
+                    lastRuntimeVisibleParameterAnnotations,
+                    visibleAnnotableParameterCount == 0 ? lastRuntimeVisibleParameterAnnotations.length : visibleAnnotableParameterCount);
+        }
+        if (lastRuntimeInvisibleParameterAnnotations != null) {
+            size += AnnotationWriter.computeParameterAnnotationsSize(Constants.RUNTIME_INVISIBLE_PARAMETER_ANNOTATIONS,
+                    lastRuntimeInvisibleParameterAnnotations,
+                    invisibleAnnotableParameterCount == 0 ? lastRuntimeInvisibleParameterAnnotations.length : invisibleAnnotableParameterCount);
+        }
+        if (lastRuntimeVisibleTypeAnnotation != null) {
+            size += lastRuntimeVisibleTypeAnnotation.computeAnnotationsSize(Constants.RUNTIME_VISIBLE_TYPE_ANNOTATIONS);
+        }
+        if (lastRuntimeInvisibleTypeAnnotation != null) {
+            size += lastRuntimeInvisibleTypeAnnotation.computeAnnotationsSize(Constants.RUNTIME_INVISIBLE_TYPE_ANNOTATIONS);
+        }
+        if (defaultValue != null) {
+            symbolTable.addConstantUtf8(Constants.ANNOTATION_DEFAULT);
+            size += 6 + defaultValue.length;
+        }
+        if (parameters != null) {
+            symbolTable.addConstantUtf8(Constants.METHOD_PARAMETERS);
+            // 6 header bytes and 1 byte for parameters_count.
+            size += 7 + parameters.length;
+        }
+        if (firstAttribute != null) {
+            size += firstAttribute.computeAttributesSize(symbolTable);
+        }
+        return size;
+    }
+
+    /**
+     * Puts the content of the method_info JVMS structure generated by this MethodWriter into the
+     * given ByteVector.
+     *
+     * @param output where the method_info structure must be put.
+     */
+    void putMethodInfo(final ByteVector output) {
+        boolean useSyntheticAttribute = symbolTable.getMajorVersion() < Opcodes.V1_5;
+        int mask = useSyntheticAttribute ? Opcodes.ACC_SYNTHETIC : 0;
+        output.putShort(accessFlags & ~mask).putShort(nameIndex).putShort(descriptorIndex);
+        // If this method_info must be copied from an existing one, copy it now and return early.
+        if (sourceOffset != 0) {
+            output.putByteArray(symbolTable.getSource().b, sourceOffset, sourceLength);
+            return;
+        }
+        // For ease of reference, we use here the same attribute order as in Section 4.7 of the JVMS.
+        int attributeCount = 0;
+        if (code.length > 0) {
+            ++attributeCount;
+        }
+        if (numberOfExceptions > 0) {
+            ++attributeCount;
+        }
+        if ((accessFlags & Opcodes.ACC_SYNTHETIC) != 0 && useSyntheticAttribute) {
+            ++attributeCount;
+        }
+        if (signatureIndex != 0) {
+            ++attributeCount;
+        }
+        if ((accessFlags & Opcodes.ACC_DEPRECATED) != 0) {
+            ++attributeCount;
+        }
+        if (lastRuntimeVisibleAnnotation != null) {
+            ++attributeCount;
+        }
+        if (lastRuntimeInvisibleAnnotation != null) {
+            ++attributeCount;
+        }
+        if (lastRuntimeVisibleParameterAnnotations != null) {
+            ++attributeCount;
+        }
+        if (lastRuntimeInvisibleParameterAnnotations != null) {
+            ++attributeCount;
+        }
+        if (lastRuntimeVisibleTypeAnnotation != null) {
+            ++attributeCount;
+        }
+        if (lastRuntimeInvisibleTypeAnnotation != null) {
+            ++attributeCount;
+        }
+        if (defaultValue != null) {
+            ++attributeCount;
+        }
+        if (parameters != null) {
+            ++attributeCount;
+        }
+        if (firstAttribute != null) {
+            attributeCount += firstAttribute.getAttributeCount();
+        }
+        // For ease of reference, we use here the same attribute order as in Section 4.7 of the JVMS.
+        output.putShort(attributeCount);
+        if (code.length > 0) {
+            // 2, 2, 4 and 2 bytes respectively for max_stack, max_locals, code_length and
+            // attributes_count, plus the bytecode and the exception table.
+            int size = 10 + code.length + Handler.getExceptionTableSize(firstHandler);
+            int codeAttributeCount = 0;
+            if (stackMapTableEntries != null) {
+                // 6 header bytes and 2 bytes for number_of_entries.
+                size += 8 + stackMapTableEntries.length;
+                ++codeAttributeCount;
+            }
+            if (lineNumberTable != null) {
+                // 6 header bytes and 2 bytes for line_number_table_length.
+                size += 8 + lineNumberTable.length;
+                ++codeAttributeCount;
+            }
+            if (localVariableTable != null) {
+                // 6 header bytes and 2 bytes for local_variable_table_length.
+                size += 8 + localVariableTable.length;
+                ++codeAttributeCount;
+            }
+            if (localVariableTypeTable != null) {
+                // 6 header bytes and 2 bytes for local_variable_type_table_length.
+                size += 8 + localVariableTypeTable.length;
+                ++codeAttributeCount;
+            }
+            if (lastCodeRuntimeVisibleTypeAnnotation != null) {
+                size += lastCodeRuntimeVisibleTypeAnnotation.computeAnnotationsSize(Constants.RUNTIME_VISIBLE_TYPE_ANNOTATIONS);
+                ++codeAttributeCount;
+            }
+            if (lastCodeRuntimeInvisibleTypeAnnotation != null) {
+                size += lastCodeRuntimeInvisibleTypeAnnotation.computeAnnotationsSize(Constants.RUNTIME_INVISIBLE_TYPE_ANNOTATIONS);
+                ++codeAttributeCount;
+            }
+            if (firstCodeAttribute != null) {
+                size += firstCodeAttribute.computeAttributesSize(symbolTable, code.data, code.length, maxStack, maxLocals);
+                codeAttributeCount += firstCodeAttribute.getAttributeCount();
+            }
+            output.putShort(symbolTable.addConstantUtf8(Constants.CODE)).putInt(size).putShort(maxStack).putShort(maxLocals)
+                    .putInt(code.length).putByteArray(code.data, 0, code.length);
+            Handler.putExceptionTable(firstHandler, output);
+            output.putShort(codeAttributeCount);
+            if (stackMapTableEntries != null) {
+                boolean useStackMapTable = symbolTable.getMajorVersion() >= Opcodes.V1_6;
+                output.putShort(symbolTable.addConstantUtf8(useStackMapTable ? Constants.STACK_MAP_TABLE : "StackMap"))
+                        .putInt(2 + stackMapTableEntries.length).putShort(stackMapTableNumberOfEntries)
+                        .putByteArray(stackMapTableEntries.data, 0, stackMapTableEntries.length);
+            }
+            if (lineNumberTable != null) {
+                output.putShort(symbolTable.addConstantUtf8(Constants.LINE_NUMBER_TABLE)).putInt(2 + lineNumberTable.length)
+                        .putShort(lineNumberTableLength).putByteArray(lineNumberTable.data, 0, lineNumberTable.length);
+            }
+            if (localVariableTable != null) {
+                output.putShort(symbolTable.addConstantUtf8(Constants.LOCAL_VARIABLE_TABLE)).putInt(2 + localVariableTable.length)
+                        .putShort(localVariableTableLength).putByteArray(localVariableTable.data, 0, localVariableTable.length);
+            }
+            if (localVariableTypeTable != null) {
+                output.putShort(symbolTable.addConstantUtf8(Constants.LOCAL_VARIABLE_TYPE_TABLE)).putInt(2 + localVariableTypeTable.length)
+                        .putShort(localVariableTypeTableLength).putByteArray(localVariableTypeTable.data, 0, localVariableTypeTable.length);
+            }
+            if (lastCodeRuntimeVisibleTypeAnnotation != null) {
+                lastCodeRuntimeVisibleTypeAnnotation.putAnnotations(symbolTable.addConstantUtf8(Constants.RUNTIME_VISIBLE_TYPE_ANNOTATIONS),
+                        output);
+            }
+            if (lastCodeRuntimeInvisibleTypeAnnotation != null) {
+                lastCodeRuntimeInvisibleTypeAnnotation
+                        .putAnnotations(symbolTable.addConstantUtf8(Constants.RUNTIME_INVISIBLE_TYPE_ANNOTATIONS), output);
+            }
+            if (firstCodeAttribute != null) {
+                firstCodeAttribute.putAttributes(symbolTable, code.data, code.length, maxStack, maxLocals, output);
+            }
+        }
+        if (numberOfExceptions > 0) {
+            output.putShort(symbolTable.addConstantUtf8(Constants.EXCEPTIONS)).putInt(2 + 2 * numberOfExceptions)
+                    .putShort(numberOfExceptions);
+            for (int exceptionIndex : exceptionIndexTable) {
+                output.putShort(exceptionIndex);
+            }
+        }
+        if ((accessFlags & Opcodes.ACC_SYNTHETIC) != 0 && useSyntheticAttribute) {
+            output.putShort(symbolTable.addConstantUtf8(Constants.SYNTHETIC)).putInt(0);
+        }
+        if (signatureIndex != 0) {
+            output.putShort(symbolTable.addConstantUtf8(Constants.SIGNATURE)).putInt(2).putShort(signatureIndex);
+        }
+        if ((accessFlags & Opcodes.ACC_DEPRECATED) != 0) {
+            output.putShort(symbolTable.addConstantUtf8(Constants.DEPRECATED)).putInt(0);
+        }
+        if (lastRuntimeVisibleAnnotation != null) {
+            lastRuntimeVisibleAnnotation.putAnnotations(symbolTable.addConstantUtf8(Constants.RUNTIME_VISIBLE_ANNOTATIONS), output);
+        }
+        if (lastRuntimeInvisibleAnnotation != null) {
+            lastRuntimeInvisibleAnnotation.putAnnotations(symbolTable.addConstantUtf8(Constants.RUNTIME_INVISIBLE_ANNOTATIONS), output);
+        }
+        if (lastRuntimeVisibleParameterAnnotations != null) {
+            AnnotationWriter.putParameterAnnotations(symbolTable.addConstantUtf8(Constants.RUNTIME_VISIBLE_PARAMETER_ANNOTATIONS),
+                    lastRuntimeVisibleParameterAnnotations,
+                    visibleAnnotableParameterCount == 0 ? lastRuntimeVisibleParameterAnnotations.length : visibleAnnotableParameterCount,
+                    output);
+        }
+        if (lastRuntimeInvisibleParameterAnnotations != null) {
+            AnnotationWriter.putParameterAnnotations(symbolTable.addConstantUtf8(Constants.RUNTIME_INVISIBLE_PARAMETER_ANNOTATIONS),
+                    lastRuntimeInvisibleParameterAnnotations,
+                    invisibleAnnotableParameterCount == 0 ? lastRuntimeInvisibleParameterAnnotations.length : invisibleAnnotableParameterCount,
+                    output);
+        }
+        if (lastRuntimeVisibleTypeAnnotation != null) {
+            lastRuntimeVisibleTypeAnnotation.putAnnotations(symbolTable.addConstantUtf8(Constants.RUNTIME_VISIBLE_TYPE_ANNOTATIONS),
+                    output);
+        }
+        if (lastRuntimeInvisibleTypeAnnotation != null) {
+            lastRuntimeInvisibleTypeAnnotation.putAnnotations(symbolTable.addConstantUtf8(Constants.RUNTIME_INVISIBLE_TYPE_ANNOTATIONS),
+                    output);
+        }
+        if (defaultValue != null) {
+            output.putShort(symbolTable.addConstantUtf8(Constants.ANNOTATION_DEFAULT)).putInt(defaultValue.length)
+                    .putByteArray(defaultValue.data, 0, defaultValue.length);
+        }
+        if (parameters != null) {
+            output.putShort(symbolTable.addConstantUtf8(Constants.METHOD_PARAMETERS)).putInt(1 + parameters.length).putByte(parametersCount)
+                    .putByteArray(parameters.data, 0, parameters.length);
+        }
+        if (firstAttribute != null) {
+            firstAttribute.putAttributes(symbolTable, output);
+        }
+    }
+
+    /**
+     * Collects the attributes of this method into the given set of attribute prototypes.
+     *
+     * @param attributePrototypes a set of attribute prototypes.
+     */
+    final void collectAttributePrototypes(final Attribute.Set attributePrototypes) {
+        attributePrototypes.addAttributes(firstAttribute);
+        attributePrototypes.addAttributes(firstCodeAttribute);
+    }
+}

--- a/core/src/main/java/org/mvel2/asm/ModuleVisitor.java
+++ b/core/src/main/java/org/mvel2/asm/ModuleVisitor.java
@@ -1,0 +1,175 @@
+// ASM: a very small and fast Java bytecode manipulation framework
+// Copyright (c) 2000-2011 INRIA, France Telecom
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+// 1. Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+// 2. Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+// 3. Neither the name of the copyright holders nor the names of its
+//    contributors may be used to endorse or promote products derived from
+//    this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+// THE POSSIBILITY OF SUCH DAMAGE.
+package org.mvel2.asm;
+
+/**
+ * A visitor to visit a Java module. The methods of this class must be called in the following
+ * order: ( {@code visitMainClass} | ( {@code visitPackage} | {@code visitRequire} | {@code
+ * visitExport} | {@code visitOpen} | {@code visitUse} | {@code visitProvide} )* ) {@code visitEnd}.
+ *
+ * @author Remi Forax
+ * @author Eric Bruneton
+ */
+public abstract class ModuleVisitor {
+
+    /**
+     * The ASM API version implemented by this visitor. The value of this field must be one of {@link
+     * Opcodes#ASM6} or {@link Opcodes#ASM7}.
+     */
+    protected final int api;
+
+    /** The module visitor to which this visitor must delegate method calls. May be null. */
+    protected ModuleVisitor mv;
+
+    /**
+     * Constructs a new {@link ModuleVisitor}.
+     *
+     * @param api the ASM API version implemented by this visitor. Must be one of {@link Opcodes#ASM6}
+     *     or {@link Opcodes#ASM7}.
+     */
+    public ModuleVisitor(final int api) {
+        this(api, null);
+    }
+
+    /**
+     * Constructs a new {@link ModuleVisitor}.
+     *
+     * @param api the ASM API version implemented by this visitor. Must be one of {@link Opcodes#ASM6}
+     *     or {@link Opcodes#ASM7}.
+     * @param moduleVisitor the module visitor to which this visitor must delegate method calls. May
+     *     be null.
+     */
+    public ModuleVisitor(final int api, final ModuleVisitor moduleVisitor) {
+        if (api != Opcodes.ASM6 && api != Opcodes.ASM7) {
+            throw new IllegalArgumentException();
+        }
+        this.api = api;
+        this.mv = moduleVisitor;
+    }
+
+    /**
+     * Visit the main class of the current module.
+     *
+     * @param mainClass the internal name of the main class of the current module.
+     */
+    public void visitMainClass(final String mainClass) {
+        if (mv != null) {
+            mv.visitMainClass(mainClass);
+        }
+    }
+
+    /**
+     * Visit a package of the current module.
+     *
+     * @param packaze the internal name of a package.
+     */
+    public void visitPackage(final String packaze) {
+        if (mv != null) {
+            mv.visitPackage(packaze);
+        }
+    }
+
+    /**
+     * Visits a dependence of the current module.
+     *
+     * @param module the fully qualified name (using dots) of the dependence.
+     * @param access the access flag of the dependence among {@code ACC_TRANSITIVE}, {@code
+     *     ACC_STATIC_PHASE}, {@code ACC_SYNTHETIC} and {@code ACC_MANDATED}.
+     * @param version the module version at compile time, or {@literal null}.
+     */
+    public void visitRequire(final String module, final int access, final String version) {
+        if (mv != null) {
+            mv.visitRequire(module, access, version);
+        }
+    }
+
+    /**
+     * Visit an exported package of the current module.
+     *
+     * @param packaze the internal name of the exported package.
+     * @param access the access flag of the exported package, valid values are among {@code
+     *     ACC_SYNTHETIC} and {@code ACC_MANDATED}.
+     * @param modules the fully qualified names (using dots) of the modules that can access the public
+     *     classes of the exported package, or {@literal null}.
+     */
+    public void visitExport(final String packaze, final int access, final String... modules) {
+        if (mv != null) {
+            mv.visitExport(packaze, access, modules);
+        }
+    }
+
+    /**
+     * Visit an open package of the current module.
+     *
+     * @param packaze the internal name of the opened package.
+     * @param access the access flag of the opened package, valid values are among {@code
+     *     ACC_SYNTHETIC} and {@code ACC_MANDATED}.
+     * @param modules the fully qualified names (using dots) of the modules that can use deep
+     *     reflection to the classes of the open package, or {@literal null}.
+     */
+    public void visitOpen(final String packaze, final int access, final String... modules) {
+        if (mv != null) {
+            mv.visitOpen(packaze, access, modules);
+        }
+    }
+
+    /**
+     * Visit a service used by the current module. The name must be the internal name of an interface
+     * or a class.
+     *
+     * @param service the internal name of the service.
+     */
+    public void visitUse(final String service) {
+        if (mv != null) {
+            mv.visitUse(service);
+        }
+    }
+
+    /**
+     * Visit an implementation of a service.
+     *
+     * @param service the internal name of the service.
+     * @param providers the internal names of the implementations of the service (there is at least
+     *     one provider).
+     */
+    public void visitProvide(final String service, final String... providers) {
+        if (mv != null) {
+            mv.visitProvide(service, providers);
+        }
+    }
+
+    /**
+     * Visits the end of the module. This method, which is the last one to be called, is used to
+     * inform the visitor that everything have been visited.
+     */
+    public void visitEnd() {
+        if (mv != null) {
+            mv.visitEnd();
+        }
+    }
+}

--- a/core/src/main/java/org/mvel2/asm/ModuleWriter.java
+++ b/core/src/main/java/org/mvel2/asm/ModuleWriter.java
@@ -1,0 +1,219 @@
+// ASM: a very small and fast Java bytecode manipulation framework
+// Copyright (c) 2000-2011 INRIA, France Telecom
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+// 1. Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+// 2. Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+// 3. Neither the name of the copyright holders nor the names of its
+//    contributors may be used to endorse or promote products derived from
+//    this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+// THE POSSIBILITY OF SUCH DAMAGE.
+package org.mvel2.asm;
+
+/**
+ * A {@link ModuleVisitor} that generates the corresponding Module, ModulePackages and
+ * ModuleMainClass attributes, as defined in the Java Virtual Machine Specification (JVMS).
+ *
+ * @see <a href="https://docs.oracle.com/javase/specs/jvms/se9/html/jvms-4.html#jvms-4.7.25">JVMS
+ *     4.7.25</a>
+ * @see <a href="https://docs.oracle.com/javase/specs/jvms/se9/html/jvms-4.html#jvms-4.7.26">JVMS
+ *     4.7.26</a>
+ * @see <a href="https://docs.oracle.com/javase/specs/jvms/se9/html/jvms-4.html#jvms-4.7.27">JVMS
+ *     4.7.27</a>
+ * @author Remi Forax
+ * @author Eric Bruneton
+ */
+final class ModuleWriter extends ModuleVisitor {
+
+    /** Where the constants used in this AnnotationWriter must be stored. */
+    private final SymbolTable symbolTable;
+
+    /** The module_name_index field of the JVMS Module attribute. */
+    private final int moduleNameIndex;
+
+    /** The module_flags field of the JVMS Module attribute. */
+    private final int moduleFlags;
+
+    /** The module_version_index field of the JVMS Module attribute. */
+    private final int moduleVersionIndex;
+    /** The binary content of the 'requires' array of the JVMS Module attribute. */
+    private final ByteVector requires;
+    /** The binary content of the 'exports' array of the JVMS Module attribute. */
+    private final ByteVector exports;
+    /** The binary content of the 'opens' array of the JVMS Module attribute. */
+    private final ByteVector opens;
+    /** The binary content of the 'uses_index' array of the JVMS Module attribute. */
+    private final ByteVector usesIndex;
+    /** The binary content of the 'provides' array of the JVMS Module attribute. */
+    private final ByteVector provides;
+    /** The binary content of the 'package_index' array of the JVMS ModulePackages attribute. */
+    private final ByteVector packageIndex;
+    /** The requires_count field of the JVMS Module attribute. */
+    private int requiresCount;
+    /** The exports_count field of the JVMS Module attribute. */
+    private int exportsCount;
+    /** The opens_count field of the JVMS Module attribute. */
+    private int opensCount;
+    /** The uses_count field of the JVMS Module attribute. */
+    private int usesCount;
+    /** The provides_count field of the JVMS Module attribute. */
+    private int providesCount;
+    /** The provides_count field of the JVMS ModulePackages attribute. */
+    private int packageCount;
+    /** The main_class_index field of the JVMS ModuleMainClass attribute, or 0. */
+    private int mainClassIndex;
+
+    ModuleWriter(final SymbolTable symbolTable, final int name, final int access, final int version) {
+        super(Opcodes.ASM7);
+        this.symbolTable = symbolTable;
+        this.moduleNameIndex = name;
+        this.moduleFlags = access;
+        this.moduleVersionIndex = version;
+        this.requires = new ByteVector();
+        this.exports = new ByteVector();
+        this.opens = new ByteVector();
+        this.usesIndex = new ByteVector();
+        this.provides = new ByteVector();
+        this.packageIndex = new ByteVector();
+    }
+
+    @Override
+    public void visitMainClass(final String mainClass) {
+        this.mainClassIndex = symbolTable.addConstantClass(mainClass).index;
+    }
+
+    @Override
+    public void visitPackage(final String packaze) {
+        packageIndex.putShort(symbolTable.addConstantPackage(packaze).index);
+        packageCount++;
+    }
+
+    @Override
+    public void visitRequire(final String module, final int access, final String version) {
+        requires.putShort(symbolTable.addConstantModule(module).index).putShort(access)
+                .putShort(version == null ? 0 : symbolTable.addConstantUtf8(version));
+        requiresCount++;
+    }
+
+    @Override
+    public void visitExport(final String packaze, final int access, final String... modules) {
+        exports.putShort(symbolTable.addConstantPackage(packaze).index).putShort(access);
+        if (modules == null) {
+            exports.putShort(0);
+        } else {
+            exports.putShort(modules.length);
+            for (String module : modules) {
+                exports.putShort(symbolTable.addConstantModule(module).index);
+            }
+        }
+        exportsCount++;
+    }
+
+    @Override
+    public void visitOpen(final String packaze, final int access, final String... modules) {
+        opens.putShort(symbolTable.addConstantPackage(packaze).index).putShort(access);
+        if (modules == null) {
+            opens.putShort(0);
+        } else {
+            opens.putShort(modules.length);
+            for (String module : modules) {
+                opens.putShort(symbolTable.addConstantModule(module).index);
+            }
+        }
+        opensCount++;
+    }
+
+    @Override
+    public void visitUse(final String service) {
+        usesIndex.putShort(symbolTable.addConstantClass(service).index);
+        usesCount++;
+    }
+
+    @Override
+    public void visitProvide(final String service, final String... providers) {
+        provides.putShort(symbolTable.addConstantClass(service).index);
+        provides.putShort(providers.length);
+        for (String provider : providers) {
+            provides.putShort(symbolTable.addConstantClass(provider).index);
+        }
+        providesCount++;
+    }
+
+    @Override
+    public void visitEnd() {
+        // Nothing to do.
+    }
+
+    /**
+     * Returns the number of Module, ModulePackages and ModuleMainClass attributes generated by this
+     * ModuleWriter.
+     *
+     * @return the number of Module, ModulePackages and ModuleMainClass attributes (between 1 and 3).
+     */
+    int getAttributeCount() {
+        return 1 + (packageCount > 0 ? 1 : 0) + (mainClassIndex > 0 ? 1 : 0);
+    }
+
+    /**
+     * Returns the size of the Module, ModulePackages and ModuleMainClass attributes generated by this
+     * ModuleWriter. Also add the names of these attributes in the constant pool.
+     *
+     * @return the size in bytes of the Module, ModulePackages and ModuleMainClass attributes.
+     */
+    int computeAttributesSize() {
+        symbolTable.addConstantUtf8(Constants.MODULE);
+        // 6 attribute header bytes, 6 bytes for name, flags and version, and 5 * 2 bytes for counts.
+        int size = 22 + requires.length + exports.length + opens.length + usesIndex.length + provides.length;
+        if (packageCount > 0) {
+            symbolTable.addConstantUtf8(Constants.MODULE_PACKAGES);
+            // 6 attribute header bytes, and 2 bytes for package_count.
+            size += 8 + packageIndex.length;
+        }
+        if (mainClassIndex > 0) {
+            symbolTable.addConstantUtf8(Constants.MODULE_MAIN_CLASS);
+            // 6 attribute header bytes, and 2 bytes for main_class_index.
+            size += 8;
+        }
+        return size;
+    }
+
+    /**
+     * Puts the Module, ModulePackages and ModuleMainClass attributes generated by this ModuleWriter
+     * in the given ByteVector.
+     *
+     * @param output where the attributes must be put.
+     */
+    void putAttributes(final ByteVector output) {
+        // 6 bytes for name, flags and version, and 5 * 2 bytes for counts.
+        int moduleAttributeLength = 16 + requires.length + exports.length + opens.length + usesIndex.length + provides.length;
+        output.putShort(symbolTable.addConstantUtf8(Constants.MODULE)).putInt(moduleAttributeLength).putShort(moduleNameIndex)
+                .putShort(moduleFlags).putShort(moduleVersionIndex).putShort(requiresCount).putByteArray(requires.data, 0, requires.length)
+                .putShort(exportsCount).putByteArray(exports.data, 0, exports.length).putShort(opensCount)
+                .putByteArray(opens.data, 0, opens.length).putShort(usesCount).putByteArray(usesIndex.data, 0, usesIndex.length)
+                .putShort(providesCount).putByteArray(provides.data, 0, provides.length);
+        if (packageCount > 0) {
+            output.putShort(symbolTable.addConstantUtf8(Constants.MODULE_PACKAGES)).putInt(2 + packageIndex.length).putShort(packageCount)
+                    .putByteArray(packageIndex.data, 0, packageIndex.length);
+        }
+        if (mainClassIndex > 0) {
+            output.putShort(symbolTable.addConstantUtf8(Constants.MODULE_MAIN_CLASS)).putInt(2).putShort(mainClassIndex);
+        }
+    }
+}

--- a/core/src/main/java/org/mvel2/asm/Opcodes.java
+++ b/core/src/main/java/org/mvel2/asm/Opcodes.java
@@ -1,0 +1,340 @@
+// ASM: a very small and fast Java bytecode manipulation framework
+// Copyright (c) 2000-2011 INRIA, France Telecom
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+// 1. Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+// 2. Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+// 3. Neither the name of the copyright holders nor the names of its
+//    contributors may be used to endorse or promote products derived from
+//    this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+// THE POSSIBILITY OF SUCH DAMAGE.
+package org.mvel2.asm;
+
+/**
+ * The JVM opcodes, access flags and array type codes. This interface does not define all the JVM
+ * opcodes because some opcodes are automatically handled. For example, the xLOAD and xSTORE opcodes
+ * are automatically replaced by xLOAD_n and xSTORE_n opcodes when possible. The xLOAD_n and
+ * xSTORE_n opcodes are therefore not defined in this interface. Likewise for LDC, automatically
+ * replaced by LDC_W or LDC2_W when necessary, WIDE, GOTO_W and JSR_W.
+ *
+ * @see <a href="https://docs.oracle.com/javase/specs/jvms/se11/html/jvms-6.html">JVMS 6</a>
+ * @author Eric Bruneton
+ * @author Eugene Kuleshov
+ */
+// DontCheck(InterfaceIsType): can't be fixed (for backward binary compatibility).
+public interface Opcodes {
+
+    // ASM API versions.
+
+    int ASM4 = 4 << 16 | 0 << 8;
+    int ASM5 = 5 << 16 | 0 << 8;
+    int ASM6 = 6 << 16 | 0 << 8;
+    int ASM7 = 7 << 16 | 0 << 8;
+
+    // Java ClassFile versions (the minor version is stored in the 16 most
+    // significant bits, and the
+    // major version in the 16 least significant bits).
+
+    int V1_1 = 3 << 16 | 45;
+    int V1_2 = 0 << 16 | 46;
+    int V1_3 = 0 << 16 | 47;
+    int V1_4 = 0 << 16 | 48;
+    int V1_5 = 0 << 16 | 49;
+    int V1_6 = 0 << 16 | 50;
+    int V1_7 = 0 << 16 | 51;
+    int V1_8 = 0 << 16 | 52;
+    int V9 = 0 << 16 | 53;
+    int V10 = 0 << 16 | 54;
+    int V11 = 0 << 16 | 55;
+    int V12 = 0 << 16 | 56;
+
+    /**
+     * Version flag indicating that the class is using 'preview' features.
+     *
+     * <p>{@code version & V_PREVIEW == V_PREVIEW} tests if a version is flagged with {@code
+     * V_PREVIEW}.
+     */
+    int V_PREVIEW = 0xFFFF0000;
+
+    // Access flags values, defined in
+    // - https://docs.oracle.com/javase/specs/jvms/se9/html/jvms-4.html#jvms-4.1-200-E.1
+    // - https://docs.oracle.com/javase/specs/jvms/se9/html/jvms-4.html#jvms-4.5-200-A.1
+    // - https://docs.oracle.com/javase/specs/jvms/se9/html/jvms-4.html#jvms-4.6-200-A.1
+    // - https://docs.oracle.com/javase/specs/jvms/se9/html/jvms-4.html#jvms-4.7.25
+
+    int ACC_PUBLIC = 0x0001; // class, field, method
+    int ACC_PRIVATE = 0x0002; // class, field, method
+    int ACC_PROTECTED = 0x0004; // class, field, method
+    int ACC_STATIC = 0x0008; // field, method
+    int ACC_FINAL = 0x0010; // class, field, method, parameter
+    int ACC_SUPER = 0x0020; // class
+    int ACC_SYNCHRONIZED = 0x0020; // method
+    int ACC_OPEN = 0x0020; // module
+    int ACC_TRANSITIVE = 0x0020; // module requires
+    int ACC_VOLATILE = 0x0040; // field
+    int ACC_BRIDGE = 0x0040; // method
+    int ACC_STATIC_PHASE = 0x0040; // module requires
+    int ACC_VARARGS = 0x0080; // method
+    int ACC_TRANSIENT = 0x0080; // field
+    int ACC_NATIVE = 0x0100; // method
+    int ACC_INTERFACE = 0x0200; // class
+    int ACC_ABSTRACT = 0x0400; // class, method
+    int ACC_STRICT = 0x0800; // method
+    int ACC_SYNTHETIC = 0x1000; // class, field, method, parameter, module *
+    int ACC_ANNOTATION = 0x2000; // class
+    int ACC_ENUM = 0x4000; // class(?) field inner
+    int ACC_MANDATED = 0x8000; // parameter, module, module *
+    int ACC_MODULE = 0x8000; // class
+
+    // ASM specific access flags.
+    // WARNING: the 16 least significant bits must NOT be used, to avoid conflicts with standard
+    // access flags, and also to make sure that these flags are automatically filtered out when
+    // written in class files (because access flags are stored using 16 bits only).
+
+    int ACC_DEPRECATED = 0x20000; // class, field, method
+
+    // Possible values for the type operand of the NEWARRAY instruction.
+    // See https://docs.oracle.com/javase/specs/jvms/se9/html/jvms-6.html#jvms-6.5.newarray.
+
+    int T_BOOLEAN = 4;
+    int T_CHAR = 5;
+    int T_FLOAT = 6;
+    int T_DOUBLE = 7;
+    int T_BYTE = 8;
+    int T_SHORT = 9;
+    int T_INT = 10;
+    int T_LONG = 11;
+
+    // Possible values for the reference_kind field of CONSTANT_MethodHandle_info structures.
+    // See https://docs.oracle.com/javase/specs/jvms/se9/html/jvms-4.html#jvms-4.4.8.
+
+    int H_GETFIELD = 1;
+    int H_GETSTATIC = 2;
+    int H_PUTFIELD = 3;
+    int H_PUTSTATIC = 4;
+    int H_INVOKEVIRTUAL = 5;
+    int H_INVOKESTATIC = 6;
+    int H_INVOKESPECIAL = 7;
+    int H_NEWINVOKESPECIAL = 8;
+    int H_INVOKEINTERFACE = 9;
+
+    // ASM specific stack map frame types, used in {@link ClassVisitor#visitFrame}.
+
+    /** An expanded frame. See {@link ClassReader#EXPAND_FRAMES}. */
+    int F_NEW = -1;
+
+    /** A compressed frame with complete frame data. */
+    int F_FULL = 0;
+
+    /**
+     * A compressed frame where locals are the same as the locals in the previous frame, except that
+     * additional 1-3 locals are defined, and with an empty stack.
+     */
+    int F_APPEND = 1;
+
+    /**
+     * A compressed frame where locals are the same as the locals in the previous frame, except that
+     * the last 1-3 locals are absent and with an empty stack.
+     */
+    int F_CHOP = 2;
+
+    /**
+     * A compressed frame with exactly the same locals as the previous frame and with an empty stack.
+     */
+    int F_SAME = 3;
+
+    /**
+     * A compressed frame with exactly the same locals as the previous frame and with a single value
+     * on the stack.
+     */
+    int F_SAME1 = 4;
+
+    // Standard stack map frame element types, used in {@link ClassVisitor#visitFrame}.
+
+    Integer TOP = Frame.ITEM_TOP;
+    Integer INTEGER = Frame.ITEM_INTEGER;
+    Integer FLOAT = Frame.ITEM_FLOAT;
+    Integer DOUBLE = Frame.ITEM_DOUBLE;
+    Integer LONG = Frame.ITEM_LONG;
+    Integer NULL = Frame.ITEM_NULL;
+    Integer UNINITIALIZED_THIS = Frame.ITEM_UNINITIALIZED_THIS;
+
+    // The JVM opcode values (with the MethodVisitor method name used to visit them in comment, and
+    // where '-' means 'same method name as on the previous line').
+    // See https://docs.oracle.com/javase/specs/jvms/se9/html/jvms-6.html.
+
+    int NOP = 0; // visitInsn
+    int ACONST_NULL = 1; // -
+    int ICONST_M1 = 2; // -
+    int ICONST_0 = 3; // -
+    int ICONST_1 = 4; // -
+    int ICONST_2 = 5; // -
+    int ICONST_3 = 6; // -
+    int ICONST_4 = 7; // -
+    int ICONST_5 = 8; // -
+    int LCONST_0 = 9; // -
+    int LCONST_1 = 10; // -
+    int FCONST_0 = 11; // -
+    int FCONST_1 = 12; // -
+    int FCONST_2 = 13; // -
+    int DCONST_0 = 14; // -
+    int DCONST_1 = 15; // -
+    int BIPUSH = 16; // visitIntInsn
+    int SIPUSH = 17; // -
+    int LDC = 18; // visitLdcInsn
+    int ILOAD = 21; // visitVarInsn
+    int LLOAD = 22; // -
+    int FLOAD = 23; // -
+    int DLOAD = 24; // -
+    int ALOAD = 25; // -
+    int IALOAD = 46; // visitInsn
+    int LALOAD = 47; // -
+    int FALOAD = 48; // -
+    int DALOAD = 49; // -
+    int AALOAD = 50; // -
+    int BALOAD = 51; // -
+    int CALOAD = 52; // -
+    int SALOAD = 53; // -
+    int ISTORE = 54; // visitVarInsn
+    int LSTORE = 55; // -
+    int FSTORE = 56; // -
+    int DSTORE = 57; // -
+    int ASTORE = 58; // -
+    int IASTORE = 79; // visitInsn
+    int LASTORE = 80; // -
+    int FASTORE = 81; // -
+    int DASTORE = 82; // -
+    int AASTORE = 83; // -
+    int BASTORE = 84; // -
+    int CASTORE = 85; // -
+    int SASTORE = 86; // -
+    int POP = 87; // -
+    int POP2 = 88; // -
+    int DUP = 89; // -
+    int DUP_X1 = 90; // -
+    int DUP_X2 = 91; // -
+    int DUP2 = 92; // -
+    int DUP2_X1 = 93; // -
+    int DUP2_X2 = 94; // -
+    int SWAP = 95; // -
+    int IADD = 96; // -
+    int LADD = 97; // -
+    int FADD = 98; // -
+    int DADD = 99; // -
+    int ISUB = 100; // -
+    int LSUB = 101; // -
+    int FSUB = 102; // -
+    int DSUB = 103; // -
+    int IMUL = 104; // -
+    int LMUL = 105; // -
+    int FMUL = 106; // -
+    int DMUL = 107; // -
+    int IDIV = 108; // -
+    int LDIV = 109; // -
+    int FDIV = 110; // -
+    int DDIV = 111; // -
+    int IREM = 112; // -
+    int LREM = 113; // -
+    int FREM = 114; // -
+    int DREM = 115; // -
+    int INEG = 116; // -
+    int LNEG = 117; // -
+    int FNEG = 118; // -
+    int DNEG = 119; // -
+    int ISHL = 120; // -
+    int LSHL = 121; // -
+    int ISHR = 122; // -
+    int LSHR = 123; // -
+    int IUSHR = 124; // -
+    int LUSHR = 125; // -
+    int IAND = 126; // -
+    int LAND = 127; // -
+    int IOR = 128; // -
+    int LOR = 129; // -
+    int IXOR = 130; // -
+    int LXOR = 131; // -
+    int IINC = 132; // visitIincInsn
+    int I2L = 133; // visitInsn
+    int I2F = 134; // -
+    int I2D = 135; // -
+    int L2I = 136; // -
+    int L2F = 137; // -
+    int L2D = 138; // -
+    int F2I = 139; // -
+    int F2L = 140; // -
+    int F2D = 141; // -
+    int D2I = 142; // -
+    int D2L = 143; // -
+    int D2F = 144; // -
+    int I2B = 145; // -
+    int I2C = 146; // -
+    int I2S = 147; // -
+    int LCMP = 148; // -
+    int FCMPL = 149; // -
+    int FCMPG = 150; // -
+    int DCMPL = 151; // -
+    int DCMPG = 152; // -
+    int IFEQ = 153; // visitJumpInsn
+    int IFNE = 154; // -
+    int IFLT = 155; // -
+    int IFGE = 156; // -
+    int IFGT = 157; // -
+    int IFLE = 158; // -
+    int IF_ICMPEQ = 159; // -
+    int IF_ICMPNE = 160; // -
+    int IF_ICMPLT = 161; // -
+    int IF_ICMPGE = 162; // -
+    int IF_ICMPGT = 163; // -
+    int IF_ICMPLE = 164; // -
+    int IF_ACMPEQ = 165; // -
+    int IF_ACMPNE = 166; // -
+    int GOTO = 167; // -
+    int JSR = 168; // -
+    int RET = 169; // visitVarInsn
+    int TABLESWITCH = 170; // visiTableSwitchInsn
+    int LOOKUPSWITCH = 171; // visitLookupSwitch
+    int IRETURN = 172; // visitInsn
+    int LRETURN = 173; // -
+    int FRETURN = 174; // -
+    int DRETURN = 175; // -
+    int ARETURN = 176; // -
+    int RETURN = 177; // -
+    int GETSTATIC = 178; // visitFieldInsn
+    int PUTSTATIC = 179; // -
+    int GETFIELD = 180; // -
+    int PUTFIELD = 181; // -
+    int INVOKEVIRTUAL = 182; // visitMethodInsn
+    int INVOKESPECIAL = 183; // -
+    int INVOKESTATIC = 184; // -
+    int INVOKEINTERFACE = 185; // -
+    int INVOKEDYNAMIC = 186; // visitInvokeDynamicInsn
+    int NEW = 187; // visitTypeInsn
+    int NEWARRAY = 188; // visitIntInsn
+    int ANEWARRAY = 189; // visitTypeInsn
+    int ARRAYLENGTH = 190; // visitInsn
+    int ATHROW = 191; // -
+    int CHECKCAST = 192; // visitTypeInsn
+    int INSTANCEOF = 193; // -
+    int MONITORENTER = 194; // visitInsn
+    int MONITOREXIT = 195; // -
+    int MULTIANEWARRAY = 197; // visitMultiANewArrayInsn
+    int IFNULL = 198; // visitJumpInsn
+    int IFNONNULL = 199; // -
+}

--- a/core/src/main/java/org/mvel2/asm/Symbol.java
+++ b/core/src/main/java/org/mvel2/asm/Symbol.java
@@ -1,0 +1,237 @@
+// ASM: a very small and fast Java bytecode manipulation framework
+// Copyright (c) 2000-2011 INRIA, France Telecom
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+// 1. Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+// 2. Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+// 3. Neither the name of the copyright holders nor the names of its
+//    contributors may be used to endorse or promote products derived from
+//    this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+// THE POSSIBILITY OF SUCH DAMAGE.
+package org.mvel2.asm;
+
+/**
+ * An entry of the constant pool, of the BootstrapMethods attribute, or of the (ASM specific) type
+ * table of a class.
+ *
+ * @see <a href="https://docs.oracle.com/javase/specs/jvms/se9/html/jvms-4.html#jvms-4.4">JVMS
+ *     4.4</a>
+ * @see <a href="https://docs.oracle.com/javase/specs/jvms/se9/html/jvms-4.html#jvms-4.7.23">JVMS
+ *     4.7.23</a>
+ * @author Eric Bruneton
+ */
+abstract class Symbol {
+
+    // Tag values for the constant pool entries (using the same order as in the JVMS).
+
+    /** The tag value of CONSTANT_Class_info JVMS structures. */
+    static final int CONSTANT_CLASS_TAG = 7;
+
+    /** The tag value of CONSTANT_Fieldref_info JVMS structures. */
+    static final int CONSTANT_FIELDREF_TAG = 9;
+
+    /** The tag value of CONSTANT_Methodref_info JVMS structures. */
+    static final int CONSTANT_METHODREF_TAG = 10;
+
+    /** The tag value of CONSTANT_InterfaceMethodref_info JVMS structures. */
+    static final int CONSTANT_INTERFACE_METHODREF_TAG = 11;
+
+    /** The tag value of CONSTANT_String_info JVMS structures. */
+    static final int CONSTANT_STRING_TAG = 8;
+
+    /** The tag value of CONSTANT_Integer_info JVMS structures. */
+    static final int CONSTANT_INTEGER_TAG = 3;
+
+    /** The tag value of CONSTANT_Float_info JVMS structures. */
+    static final int CONSTANT_FLOAT_TAG = 4;
+
+    /** The tag value of CONSTANT_Long_info JVMS structures. */
+    static final int CONSTANT_LONG_TAG = 5;
+
+    /** The tag value of CONSTANT_Double_info JVMS structures. */
+    static final int CONSTANT_DOUBLE_TAG = 6;
+
+    /** The tag value of CONSTANT_NameAndType_info JVMS structures. */
+    static final int CONSTANT_NAME_AND_TYPE_TAG = 12;
+
+    /** The tag value of CONSTANT_Utf8_info JVMS structures. */
+    static final int CONSTANT_UTF8_TAG = 1;
+
+    /** The tag value of CONSTANT_MethodHandle_info JVMS structures. */
+    static final int CONSTANT_METHOD_HANDLE_TAG = 15;
+
+    /** The tag value of CONSTANT_MethodType_info JVMS structures. */
+    static final int CONSTANT_METHOD_TYPE_TAG = 16;
+
+    /** The tag value of CONSTANT_Dynamic_info JVMS structures. */
+    static final int CONSTANT_DYNAMIC_TAG = 17;
+
+    /** The tag value of CONSTANT_InvokeDynamic_info JVMS structures. */
+    static final int CONSTANT_INVOKE_DYNAMIC_TAG = 18;
+
+    /** The tag value of CONSTANT_Module_info JVMS structures. */
+    static final int CONSTANT_MODULE_TAG = 19;
+
+    /** The tag value of CONSTANT_Package_info JVMS structures. */
+    static final int CONSTANT_PACKAGE_TAG = 20;
+
+    // Tag values for the BootstrapMethods attribute entries (ASM specific tag).
+
+    /** The tag value of the BootstrapMethods attribute entries. */
+    static final int BOOTSTRAP_METHOD_TAG = 64;
+
+    // Tag values for the type table entries (ASM specific tags).
+
+    /** The tag value of a normal type entry in the (ASM specific) type table of a class. */
+    static final int TYPE_TAG = 128;
+
+    /**
+     * The tag value of an {@link Frame#ITEM_UNINITIALIZED} type entry in the type table of a class.
+     */
+    static final int UNINITIALIZED_TYPE_TAG = 129;
+
+    /** The tag value of a merged type entry in the (ASM specific) type table of a class. */
+    static final int MERGED_TYPE_TAG = 130;
+
+    // Instance fields.
+
+    /**
+     * The index of this symbol in the constant pool, in the BootstrapMethods attribute, or in the
+     * (ASM specific) type table of a class (depending on the {@link #tag} value).
+     */
+    final int index;
+
+    /**
+     * A tag indicating the type of this symbol. Must be one of the static tag values defined in this
+     * class.
+     */
+    final int tag;
+
+    /**
+     * The internal name of the owner class of this symbol. Only used for {@link
+     * #CONSTANT_FIELDREF_TAG}, {@link #CONSTANT_METHODREF_TAG}, {@link
+     * #CONSTANT_INTERFACE_METHODREF_TAG}, and {@link #CONSTANT_METHOD_HANDLE_TAG} symbols.
+     */
+    final String owner;
+
+    /**
+     * The name of the class field or method corresponding to this symbol. Only used for {@link
+     * #CONSTANT_FIELDREF_TAG}, {@link #CONSTANT_METHODREF_TAG}, {@link
+     * #CONSTANT_INTERFACE_METHODREF_TAG}, {@link #CONSTANT_NAME_AND_TYPE_TAG}, {@link
+     * #CONSTANT_METHOD_HANDLE_TAG}, {@link #CONSTANT_DYNAMIC_TAG} and {@link
+     * #CONSTANT_INVOKE_DYNAMIC_TAG} symbols.
+     */
+    final String name;
+
+    /**
+     * The string value of this symbol. This is:
+     *
+     * <ul>
+     *   <li>a field or method descriptor for {@link #CONSTANT_FIELDREF_TAG}, {@link
+     *       #CONSTANT_METHODREF_TAG}, {@link #CONSTANT_INTERFACE_METHODREF_TAG}, {@link
+     *       #CONSTANT_NAME_AND_TYPE_TAG}, {@link #CONSTANT_METHOD_HANDLE_TAG}, {@link
+     *       #CONSTANT_METHOD_TYPE_TAG}, {@link #CONSTANT_DYNAMIC_TAG} and {@link
+     *       #CONSTANT_INVOKE_DYNAMIC_TAG} symbols,
+     *   <li>an arbitrary string for {@link #CONSTANT_UTF8_TAG} and {@link #CONSTANT_STRING_TAG}
+     *       symbols,
+     *   <li>an internal class name for {@link #CONSTANT_CLASS_TAG}, {@link #TYPE_TAG} and {@link
+     *       #UNINITIALIZED_TYPE_TAG} symbols,
+     *   <li>{@literal null} for the other types of symbol.
+     * </ul>
+     */
+    final String value;
+
+    /**
+     * The numeric value of this symbol. This is:
+     *
+     * <ul>
+     *   <li>the symbol's value for {@link #CONSTANT_INTEGER_TAG},{@link #CONSTANT_FLOAT_TAG}, {@link
+     *       #CONSTANT_LONG_TAG}, {@link #CONSTANT_DOUBLE_TAG},
+     *   <li>the CONSTANT_MethodHandle_info reference_kind field value for {@link
+     *       #CONSTANT_METHOD_HANDLE_TAG} symbols,
+     *   <li>the CONSTANT_InvokeDynamic_info bootstrap_method_attr_index field value for {@link
+     *       #CONSTANT_INVOKE_DYNAMIC_TAG} symbols,
+     *   <li>the offset of a bootstrap method in the BootstrapMethods boostrap_methods array, for
+     *       {@link #CONSTANT_DYNAMIC_TAG} or {@link #BOOTSTRAP_METHOD_TAG} symbols,
+     *   <li>the bytecode offset of the NEW instruction that created an {@link
+     *       Frame#ITEM_UNINITIALIZED} type for {@link #UNINITIALIZED_TYPE_TAG} symbols,
+     *   <li>the indices (in the class' type table) of two {@link #TYPE_TAG} source types for {@link
+     *       #MERGED_TYPE_TAG} symbols,
+     *   <li>0 for the other types of symbol.
+     * </ul>
+     */
+    final long data;
+
+    /**
+     * Additional information about this symbol, generally computed lazily. <i>Warning: the value of
+     * this field is ignored when comparing Symbol instances</i> (to avoid duplicate entries in a
+     * SymbolTable). Therefore, this field should only contain data that can be computed from the
+     * other fields of this class. It contains:
+     *
+     * <ul>
+     *   <li>the {@link Type#getArgumentsAndReturnSizes} of the symbol's method descriptor for {@link
+     *       #CONSTANT_METHODREF_TAG}, {@link #CONSTANT_INTERFACE_METHODREF_TAG} and {@link
+     *       #CONSTANT_INVOKE_DYNAMIC_TAG} symbols,
+     *   <li>the index in the InnerClasses_attribute 'classes' array (plus one) corresponding to this
+     *       class, for {@link #CONSTANT_CLASS_TAG} symbols,
+     *   <li>the index (in the class' type table) of the merged type of the two source types for
+     *       {@link #MERGED_TYPE_TAG} symbols,
+     *   <li>0 for the other types of symbol, or if this field has not been computed yet.
+     * </ul>
+     */
+    int info;
+
+    /**
+     * Constructs a new Symbol. This constructor can't be used directly because the Symbol class is
+     * abstract. Instead, use the factory methods of the {@link SymbolTable} class.
+     *
+     * @param index the symbol index in the constant pool, in the BootstrapMethods attribute, or in
+     *     the (ASM specific) type table of a class (depending on 'tag').
+     * @param tag the symbol type. Must be one of the static tag values defined in this class.
+     * @param owner The internal name of the symbol's owner class. Maybe {@literal null}.
+     * @param name The name of the symbol's corresponding class field or method. Maybe {@literal
+     *     null}.
+     * @param value The string value of this symbol. Maybe {@literal null}.
+     * @param data The numeric value of this symbol.
+     */
+    Symbol(final int index, final int tag, final String owner, final String name, final String value, final long data) {
+        this.index = index;
+        this.tag = tag;
+        this.owner = owner;
+        this.name = name;
+        this.value = value;
+        this.data = data;
+    }
+
+    /**
+     * Returns the result {@link Type#getArgumentsAndReturnSizes} on {@link #value}.
+     *
+     * @return the result {@link Type#getArgumentsAndReturnSizes} on {@link #value} (memoized in
+     *     {@link #info} for efficiency). This should only be used for {@link
+     *     #CONSTANT_METHODREF_TAG}, {@link #CONSTANT_INTERFACE_METHODREF_TAG} and {@link
+     *     #CONSTANT_INVOKE_DYNAMIC_TAG} symbols.
+     */
+    int getArgumentsAndReturnSizes() {
+        if (info == 0) {
+            info = Type.getArgumentsAndReturnSizes(value);
+        }
+        return info;
+    }
+}

--- a/core/src/main/java/org/mvel2/asm/SymbolTable.java
+++ b/core/src/main/java/org/mvel2/asm/SymbolTable.java
@@ -1,0 +1,1219 @@
+// ASM: a very small and fast Java bytecode manipulation framework
+// Copyright (c) 2000-2011 INRIA, France Telecom
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+// 1. Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+// 2. Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+// 3. Neither the name of the copyright holders nor the names of its
+//    contributors may be used to endorse or promote products derived from
+//    this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+// THE POSSIBILITY OF SUCH DAMAGE.
+package org.mvel2.asm;
+
+/**
+ * The constant pool entries, the BootstrapMethods attribute entries and the (ASM specific) type
+ * table entries of a class.
+ *
+ * @see <a href="https://docs.oracle.com/javase/specs/jvms/se9/html/jvms-4.html#jvms-4.4">JVMS
+ *     4.4</a>
+ * @see <a href="https://docs.oracle.com/javase/specs/jvms/se9/html/jvms-4.html#jvms-4.7.23">JVMS
+ *     4.7.23</a>
+ * @author Eric Bruneton
+ */
+final class SymbolTable {
+
+    /**
+     * The ClassWriter to which this SymbolTable belongs. This is only used to get access to {@link
+     * ClassWriter#getCommonSuperClass} and to serialize custom attributes with {@link
+     * Attribute#write}.
+     */
+    final ClassWriter classWriter;
+
+    /**
+     * The ClassReader from which this SymbolTable was constructed, or {@literal null} if it was
+     * constructed from scratch.
+     */
+    private final ClassReader sourceClassReader;
+
+    /** The major version number of the class to which this symbol table belongs. */
+    private int majorVersion;
+
+    /** The internal name of the class to which this symbol table belongs. */
+    private String className;
+
+    /**
+     * The total number of {@link Entry} instances in {@link #entries}. This includes entries that are
+     * accessible (recursively) via {@link Entry#next}.
+     */
+    private int entryCount;
+
+    /**
+     * A hash set of all the entries in this SymbolTable (this includes the constant pool entries, the
+     * bootstrap method entries and the type table entries). Each {@link Entry} instance is stored at
+     * the array index given by its hash code modulo the array size. If several entries must be stored
+     * at the same array index, they are linked together via their {@link Entry#next} field. The
+     * factory methods of this class make sure that this table does not contain duplicated entries.
+     */
+    private Entry[] entries;
+
+    /**
+     * The number of constant pool items in {@link #constantPool}, plus 1. The first constant pool
+     * item has index 1, and long and double items count for two items.
+     */
+    private int constantPoolCount;
+
+    /**
+     * The content of the ClassFile's constant_pool JVMS structure corresponding to this SymbolTable.
+     * The ClassFile's constant_pool_count field is <i>not</i> included.
+     */
+    private ByteVector constantPool;
+
+    /**
+     * The number of bootstrap methods in {@link #bootstrapMethods}. Corresponds to the
+     * BootstrapMethods_attribute's num_bootstrap_methods field value.
+     */
+    private int bootstrapMethodCount;
+
+    /**
+     * The content of the BootstrapMethods attribute 'bootstrap_methods' array corresponding to this
+     * SymbolTable. Note that the first 6 bytes of the BootstrapMethods_attribute, and its
+     * num_bootstrap_methods field, are <i>not</i> included.
+     */
+    private ByteVector bootstrapMethods;
+
+    /**
+     * The actual number of elements in {@link #typeTable}. These elements are stored from index 0 to
+     * typeCount (excluded). The other array entries are empty.
+     */
+    private int typeCount;
+
+    /**
+     * An ASM specific type table used to temporarily store internal names that will not necessarily
+     * be stored in the constant pool. This type table is used by the control flow and data flow
+     * analysis algorithm used to compute stack map frames from scratch. This array stores {@link
+     * Symbol#TYPE_TAG} and {@link Symbol#UNINITIALIZED_TYPE_TAG}) Symbol. The type symbol at index
+     * {@code i} has its {@link Symbol#index} equal to {@code i} (and vice versa).
+     */
+    private Entry[] typeTable;
+
+    /**
+     * Constructs a new, empty SymbolTable for the given ClassWriter.
+     *
+     * @param classWriter a ClassWriter.
+     */
+    SymbolTable(final ClassWriter classWriter) {
+        this.classWriter = classWriter;
+        this.sourceClassReader = null;
+        this.entries = new Entry[256];
+        this.constantPoolCount = 1;
+        this.constantPool = new ByteVector();
+    }
+
+    /**
+     * Constructs a new SymbolTable for the given ClassWriter, initialized with the constant pool and
+     * bootstrap methods of the given ClassReader.
+     *
+     * @param classWriter a ClassWriter.
+     * @param classReader the ClassReader whose constant pool and bootstrap methods must be copied to
+     *     initialize the SymbolTable.
+     */
+    SymbolTable(final ClassWriter classWriter, final ClassReader classReader) {
+        this.classWriter = classWriter;
+        this.sourceClassReader = classReader;
+
+        // Copy the constant pool binary content.
+        byte[] inputBytes = classReader.b;
+        int constantPoolOffset = classReader.getItem(1) - 1;
+        int constantPoolLength = classReader.header - constantPoolOffset;
+        constantPoolCount = classReader.getItemCount();
+        constantPool = new ByteVector(constantPoolLength);
+        constantPool.putByteArray(inputBytes, constantPoolOffset, constantPoolLength);
+
+        // Add the constant pool items in the symbol table entries. Reserve enough space in 'entries' to
+        // avoid too many hash set collisions (entries is not dynamically resized by the addConstant*
+        // method calls below), and to account for bootstrap method entries.
+        entries = new Entry[constantPoolCount * 2];
+        char[] charBuffer = new char[classReader.getMaxStringLength()];
+        boolean hasBootstrapMethods = false;
+        int itemIndex = 1;
+        while (itemIndex < constantPoolCount) {
+            int itemOffset = classReader.getItem(itemIndex);
+            int itemTag = inputBytes[itemOffset - 1];
+            int nameAndTypeItemOffset;
+            switch (itemTag) {
+                case Symbol.CONSTANT_FIELDREF_TAG:
+                case Symbol.CONSTANT_METHODREF_TAG:
+                case Symbol.CONSTANT_INTERFACE_METHODREF_TAG:
+                    nameAndTypeItemOffset = classReader.getItem(classReader.readUnsignedShort(itemOffset + 2));
+                    addConstantMemberReference(itemIndex, itemTag, classReader.readClass(itemOffset, charBuffer),
+                            classReader.readUTF8(nameAndTypeItemOffset, charBuffer),
+                            classReader.readUTF8(nameAndTypeItemOffset + 2, charBuffer));
+                    break;
+                case Symbol.CONSTANT_INTEGER_TAG:
+                case Symbol.CONSTANT_FLOAT_TAG:
+                    addConstantIntegerOrFloat(itemIndex, itemTag, classReader.readInt(itemOffset));
+                    break;
+                case Symbol.CONSTANT_NAME_AND_TYPE_TAG:
+                    addConstantNameAndType(itemIndex, classReader.readUTF8(itemOffset, charBuffer),
+                            classReader.readUTF8(itemOffset + 2, charBuffer));
+                    break;
+                case Symbol.CONSTANT_LONG_TAG:
+                case Symbol.CONSTANT_DOUBLE_TAG:
+                    addConstantLongOrDouble(itemIndex, itemTag, classReader.readLong(itemOffset));
+                    break;
+                case Symbol.CONSTANT_UTF8_TAG:
+                    addConstantUtf8(itemIndex, classReader.readUtf(itemIndex, charBuffer));
+                    break;
+                case Symbol.CONSTANT_METHOD_HANDLE_TAG:
+                    int memberRefItemOffset = classReader.getItem(classReader.readUnsignedShort(itemOffset + 1));
+                    nameAndTypeItemOffset = classReader.getItem(classReader.readUnsignedShort(memberRefItemOffset + 2));
+                    addConstantMethodHandle(itemIndex, classReader.readByte(itemOffset),
+                            classReader.readClass(memberRefItemOffset, charBuffer), classReader.readUTF8(nameAndTypeItemOffset, charBuffer),
+                            classReader.readUTF8(nameAndTypeItemOffset + 2, charBuffer));
+                    break;
+                case Symbol.CONSTANT_DYNAMIC_TAG:
+                case Symbol.CONSTANT_INVOKE_DYNAMIC_TAG:
+                    hasBootstrapMethods = true;
+                    nameAndTypeItemOffset = classReader.getItem(classReader.readUnsignedShort(itemOffset + 2));
+                    addConstantDynamicOrInvokeDynamicReference(itemTag, itemIndex, classReader.readUTF8(nameAndTypeItemOffset, charBuffer),
+                            classReader.readUTF8(nameAndTypeItemOffset + 2, charBuffer), classReader.readUnsignedShort(itemOffset));
+                    break;
+                case Symbol.CONSTANT_STRING_TAG:
+                case Symbol.CONSTANT_CLASS_TAG:
+                case Symbol.CONSTANT_METHOD_TYPE_TAG:
+                case Symbol.CONSTANT_MODULE_TAG:
+                case Symbol.CONSTANT_PACKAGE_TAG:
+                    addConstantUtf8Reference(itemIndex, itemTag, classReader.readUTF8(itemOffset, charBuffer));
+                    break;
+                default:
+                    throw new IllegalArgumentException();
+            }
+            itemIndex += (itemTag == Symbol.CONSTANT_LONG_TAG || itemTag == Symbol.CONSTANT_DOUBLE_TAG) ? 2 : 1;
+        }
+
+        // Copy the BootstrapMethods, if any.
+        if (hasBootstrapMethods) {
+            copyBootstrapMethods(classReader, charBuffer);
+        }
+    }
+
+    private static int hash(final int tag, final int value) {
+        return 0x7FFFFFFF & (tag + value);
+    }
+
+    private static int hash(final int tag, final long value) {
+        return 0x7FFFFFFF & (tag + (int) value + (int) (value >>> 32));
+    }
+
+    private static int hash(final int tag, final String value) {
+        return 0x7FFFFFFF & (tag + value.hashCode());
+    }
+
+    private static int hash(final int tag, final String value1, final int value2) {
+        return 0x7FFFFFFF & (tag + value1.hashCode() + value2);
+    }
+
+    private static int hash(final int tag, final String value1, final String value2) {
+        return 0x7FFFFFFF & (tag + value1.hashCode() * value2.hashCode());
+    }
+
+    private static int hash(final int tag, final String value1, final String value2, final int value3) {
+        return 0x7FFFFFFF & (tag + value1.hashCode() * value2.hashCode() * (value3 + 1));
+    }
+
+    private static int hash(final int tag, final String value1, final String value2, final String value3) {
+        return 0x7FFFFFFF & (tag + value1.hashCode() * value2.hashCode() * value3.hashCode());
+    }
+
+    private static int hash(final int tag, final String value1, final String value2, final String value3, final int value4) {
+        return 0x7FFFFFFF & (tag + value1.hashCode() * value2.hashCode() * value3.hashCode() * value4);
+    }
+
+    /**
+     * Read the BootstrapMethods 'bootstrap_methods' array binary content and add them as entries of
+     * the SymbolTable.
+     *
+     * @param classReader the ClassReader whose bootstrap methods must be copied to initialize the
+     *     SymbolTable.
+     * @param charBuffer a buffer used to read strings in the constant pool.
+     */
+    private void copyBootstrapMethods(final ClassReader classReader, final char[] charBuffer) {
+        // Find attributOffset of the 'bootstrap_methods' array.
+        byte[] inputBytes = classReader.b;
+        int currentAttributeOffset = classReader.getFirstAttributeOffset();
+        for (int i = classReader.readUnsignedShort(currentAttributeOffset - 2); i > 0; --i) {
+            String attributeName = classReader.readUTF8(currentAttributeOffset, charBuffer);
+            if (Constants.BOOTSTRAP_METHODS.equals(attributeName)) {
+                bootstrapMethodCount = classReader.readUnsignedShort(currentAttributeOffset + 6);
+                break;
+            }
+            currentAttributeOffset += 6 + classReader.readInt(currentAttributeOffset + 2);
+        }
+        if (bootstrapMethodCount > 0) {
+            // Compute the offset and the length of the BootstrapMethods 'bootstrap_methods' array.
+            int bootstrapMethodsOffset = currentAttributeOffset + 8;
+            int bootstrapMethodsLength = classReader.readInt(currentAttributeOffset + 2) - 2;
+            bootstrapMethods = new ByteVector(bootstrapMethodsLength);
+            bootstrapMethods.putByteArray(inputBytes, bootstrapMethodsOffset, bootstrapMethodsLength);
+
+            // Add each bootstrap method in the symbol table entries.
+            int currentOffset = bootstrapMethodsOffset;
+            for (int i = 0; i < bootstrapMethodCount; i++) {
+                int offset = currentOffset - bootstrapMethodsOffset;
+                int bootstrapMethodRef = classReader.readUnsignedShort(currentOffset);
+                currentOffset += 2;
+                int numBootstrapArguments = classReader.readUnsignedShort(currentOffset);
+                currentOffset += 2;
+                int hashCode = classReader.readConst(bootstrapMethodRef, charBuffer).hashCode();
+                while (numBootstrapArguments-- > 0) {
+                    int bootstrapArgument = classReader.readUnsignedShort(currentOffset);
+                    currentOffset += 2;
+                    hashCode ^= classReader.readConst(bootstrapArgument, charBuffer).hashCode();
+                }
+                add(new Entry(i, Symbol.BOOTSTRAP_METHOD_TAG, offset, hashCode & 0x7FFFFFFF));
+            }
+        }
+    }
+
+    /**
+     * Returns the ClassReader from which this SymbolTable was constructed.
+     *
+     * @return the ClassReader from which this SymbolTable was constructed, or {@literal null} if it
+     *     was constructed from scratch.
+     */
+    ClassReader getSource() {
+        return sourceClassReader;
+    }
+
+    // -----------------------------------------------------------------------------------------------
+    // Generic symbol table entries management.
+    // -----------------------------------------------------------------------------------------------
+
+    /**
+     * Returns the major version of the class to which this symbol table belongs.
+     *
+     * @return the major version of the class to which this symbol table belongs.
+     */
+    int getMajorVersion() {
+        return majorVersion;
+    }
+
+    /**
+     * Returns the internal name of the class to which this symbol table belongs.
+     *
+     * @return the internal name of the class to which this symbol table belongs.
+     */
+    String getClassName() {
+        return className;
+    }
+
+    /**
+     * Sets the major version and the name of the class to which this symbol table belongs. Also adds
+     * the class name to the constant pool.
+     *
+     * @param majorVersion a major ClassFile version number.
+     * @param className an internal class name.
+     * @return the constant pool index of a new or already existing Symbol with the given class name.
+     */
+    int setMajorVersionAndClassName(final int majorVersion, final String className) {
+        this.majorVersion = majorVersion;
+        this.className = className;
+        return addConstantClass(className).index;
+    }
+
+    // -----------------------------------------------------------------------------------------------
+    // Constant pool entries management.
+    // -----------------------------------------------------------------------------------------------
+
+    /**
+     * Returns the number of items in this symbol table's constant_pool array (plus 1).
+     *
+     * @return the number of items in this symbol table's constant_pool array (plus 1).
+     */
+    int getConstantPoolCount() {
+        return constantPoolCount;
+    }
+
+    /**
+     * Returns the length in bytes of this symbol table's constant_pool array.
+     *
+     * @return the length in bytes of this symbol table's constant_pool array.
+     */
+    int getConstantPoolLength() {
+        return constantPool.length;
+    }
+
+    /**
+     * Puts this symbol table's constant_pool array in the given ByteVector, preceded by the
+     * constant_pool_count value.
+     *
+     * @param output where the JVMS ClassFile's constant_pool array must be put.
+     */
+    void putConstantPool(final ByteVector output) {
+        output.putShort(constantPoolCount).putByteArray(constantPool.data, 0, constantPool.length);
+    }
+
+    /**
+     * Returns the size in bytes of this symbol table's BootstrapMethods attribute. Also adds the
+     * attribute name in the constant pool.
+     *
+     * @return the size in bytes of this symbol table's BootstrapMethods attribute.
+     */
+    int computeBootstrapMethodsSize() {
+        if (bootstrapMethods != null) {
+            addConstantUtf8(Constants.BOOTSTRAP_METHODS);
+            return 8 + bootstrapMethods.length;
+        } else {
+            return 0;
+        }
+    }
+
+    /**
+     * Puts this symbol table's BootstrapMethods attribute in the given ByteVector. This includes the
+     * 6 attribute header bytes and the num_bootstrap_methods value.
+     *
+     * @param output where the JVMS BootstrapMethods attribute must be put.
+     */
+    void putBootstrapMethods(final ByteVector output) {
+        if (bootstrapMethods != null) {
+            output.putShort(addConstantUtf8(Constants.BOOTSTRAP_METHODS)).putInt(bootstrapMethods.length + 2).putShort(bootstrapMethodCount)
+                    .putByteArray(bootstrapMethods.data, 0, bootstrapMethods.length);
+        }
+    }
+
+    /**
+     * Returns the list of entries which can potentially have the given hash code.
+     *
+     * @param hashCode a {@link Entry#hashCode} value.
+     * @return the list of entries which can potentially have the given hash code. The list is stored
+     *     via the {@link Entry#next} field.
+     */
+    private Entry get(final int hashCode) {
+        return entries[hashCode % entries.length];
+    }
+
+    /**
+     * Puts the given entry in the {@link #entries} hash set. This method does <i>not</i> check
+     * whether {@link #entries} already contains a similar entry or not. {@link #entries} is resized
+     * if necessary to avoid hash collisions (multiple entries needing to be stored at the same {@link
+     * #entries} array index) as much as possible, with reasonable memory usage.
+     *
+     * @param entry an Entry (which must not already be contained in {@link #entries}).
+     * @return the given entry
+     */
+    private Entry put(final Entry entry) {
+        if (entryCount > (entries.length * 3) / 4) {
+            int currentCapacity = entries.length;
+            int newCapacity = currentCapacity * 2 + 1;
+            Entry[] newEntries = new Entry[newCapacity];
+            for (int i = currentCapacity - 1; i >= 0; --i) {
+                Entry currentEntry = entries[i];
+                while (currentEntry != null) {
+                    int newCurrentEntryIndex = currentEntry.hashCode % newCapacity;
+                    Entry nextEntry = currentEntry.next;
+                    currentEntry.next = newEntries[newCurrentEntryIndex];
+                    newEntries[newCurrentEntryIndex] = currentEntry;
+                    currentEntry = nextEntry;
+                }
+            }
+            entries = newEntries;
+        }
+        entryCount++;
+        int index = entry.hashCode % entries.length;
+        entry.next = entries[index];
+        return entries[index] = entry;
+    }
+
+    /**
+     * Adds the given entry in the {@link #entries} hash set. This method does <i>not</i> check
+     * whether {@link #entries} already contains a similar entry or not, and does <i>not</i> resize
+     * {@link #entries} if necessary.
+     *
+     * @param entry an Entry (which must not already be contained in {@link #entries}).
+     */
+    private void add(final Entry entry) {
+        entryCount++;
+        int index = entry.hashCode % entries.length;
+        entry.next = entries[index];
+        entries[index] = entry;
+    }
+
+    /**
+     * Adds a number or string constant to the constant pool of this symbol table. Does nothing if the
+     * constant pool already contains a similar item.
+     *
+     * @param value the value of the constant to be added to the constant pool. This parameter must be
+     *     an {@link Integer}, {@link Byte}, {@link Character}, {@link Short}, {@link Boolean}, {@link
+     *     Float}, {@link Long}, {@link Double}, {@link String}, {@link Type} or {@link Handle}.
+     * @return a new or already existing Symbol with the given value.
+     */
+    Symbol addConstant(final Object value) {
+        if (value instanceof Integer) {
+            return addConstantInteger(((Integer) value).intValue());
+        } else if (value instanceof Byte) {
+            return addConstantInteger(((Byte) value).intValue());
+        } else if (value instanceof Character) {
+            return addConstantInteger(((Character) value).charValue());
+        } else if (value instanceof Short) {
+            return addConstantInteger(((Short) value).intValue());
+        } else if (value instanceof Boolean) {
+            return addConstantInteger(((Boolean) value).booleanValue() ? 1 : 0);
+        } else if (value instanceof Float) {
+            return addConstantFloat(((Float) value).floatValue());
+        } else if (value instanceof Long) {
+            return addConstantLong(((Long) value).longValue());
+        } else if (value instanceof Double) {
+            return addConstantDouble(((Double) value).doubleValue());
+        } else if (value instanceof String) {
+            return addConstantString((String) value);
+        } else if (value instanceof Type) {
+            Type type = (Type) value;
+            int typeSort = type.getSort();
+            if (typeSort == Type.OBJECT) {
+                return addConstantClass(type.getInternalName());
+            } else if (typeSort == Type.METHOD) {
+                return addConstantMethodType(type.getDescriptor());
+            } else { // type is a primitive or array type.
+                return addConstantClass(type.getDescriptor());
+            }
+        } else if (value instanceof Handle) {
+            Handle handle = (Handle) value;
+            return addConstantMethodHandle(handle.getTag(), handle.getOwner(), handle.getName(), handle.getDesc(), handle.isInterface());
+        } else if (value instanceof ConstantDynamic) {
+            ConstantDynamic constantDynamic = (ConstantDynamic) value;
+            return addConstantDynamic(constantDynamic.getName(), constantDynamic.getDescriptor(), constantDynamic.getBootstrapMethod(),
+                    constantDynamic.getBootstrapMethodArgumentsUnsafe());
+        } else {
+            throw new IllegalArgumentException("value " + value);
+        }
+    }
+
+    /**
+     * Adds a CONSTANT_Class_info to the constant pool of this symbol table. Does nothing if the
+     * constant pool already contains a similar item.
+     *
+     * @param value the internal name of a class.
+     * @return a new or already existing Symbol with the given value.
+     */
+    Symbol addConstantClass(final String value) {
+        return addConstantUtf8Reference(Symbol.CONSTANT_CLASS_TAG, value);
+    }
+
+    /**
+     * Adds a CONSTANT_Fieldref_info to the constant pool of this symbol table. Does nothing if the
+     * constant pool already contains a similar item.
+     *
+     * @param owner the internal name of a class.
+     * @param name a field name.
+     * @param descriptor a field descriptor.
+     * @return a new or already existing Symbol with the given value.
+     */
+    Symbol addConstantFieldref(final String owner, final String name, final String descriptor) {
+        return addConstantMemberReference(Symbol.CONSTANT_FIELDREF_TAG, owner, name, descriptor);
+    }
+
+    /**
+     * Adds a CONSTANT_Methodref_info or CONSTANT_InterfaceMethodref_info to the constant pool of this
+     * symbol table. Does nothing if the constant pool already contains a similar item.
+     *
+     * @param owner the internal name of a class.
+     * @param name a method name.
+     * @param descriptor a method descriptor.
+     * @param isInterface whether owner is an interface or not.
+     * @return a new or already existing Symbol with the given value.
+     */
+    Symbol addConstantMethodref(final String owner, final String name, final String descriptor, final boolean isInterface) {
+        int tag = isInterface ? Symbol.CONSTANT_INTERFACE_METHODREF_TAG : Symbol.CONSTANT_METHODREF_TAG;
+        return addConstantMemberReference(tag, owner, name, descriptor);
+    }
+
+    /**
+     * Adds a CONSTANT_Fieldref_info, CONSTANT_Methodref_info or CONSTANT_InterfaceMethodref_info to
+     * the constant pool of this symbol table. Does nothing if the constant pool already contains a
+     * similar item.
+     *
+     * @param tag one of {@link Symbol#CONSTANT_FIELDREF_TAG}, {@link Symbol#CONSTANT_METHODREF_TAG}
+     *     or {@link Symbol#CONSTANT_INTERFACE_METHODREF_TAG}.
+     * @param owner the internal name of a class.
+     * @param name a field or method name.
+     * @param descriptor a field or method descriptor.
+     * @return a new or already existing Symbol with the given value.
+     */
+    private Entry addConstantMemberReference(final int tag, final String owner, final String name, final String descriptor) {
+        int hashCode = hash(tag, owner, name, descriptor);
+        Entry entry = get(hashCode);
+        while (entry != null) {
+            if (entry.tag == tag && entry.hashCode == hashCode && entry.owner.equals(owner) && entry.name.equals(name)
+                    && entry.value.equals(descriptor)) {
+                return entry;
+            }
+            entry = entry.next;
+        }
+        constantPool.put122(tag, addConstantClass(owner).index, addConstantNameAndType(name, descriptor));
+        return put(new Entry(constantPoolCount++, tag, owner, name, descriptor, 0, hashCode));
+    }
+
+    /**
+     * Adds a new CONSTANT_Fieldref_info, CONSTANT_Methodref_info or CONSTANT_InterfaceMethodref_info
+     * to the constant pool of this symbol table.
+     *
+     * @param index the constant pool index of the new Symbol.
+     * @param tag one of {@link Symbol#CONSTANT_FIELDREF_TAG}, {@link Symbol#CONSTANT_METHODREF_TAG}
+     *     or {@link Symbol#CONSTANT_INTERFACE_METHODREF_TAG}.
+     * @param owner the internal name of a class.
+     * @param name a field or method name.
+     * @param descriptor a field or method descriptor.
+     */
+    private void addConstantMemberReference(final int index, final int tag, final String owner, final String name,
+            final String descriptor) {
+        add(new Entry(index, tag, owner, name, descriptor, 0, hash(tag, owner, name, descriptor)));
+    }
+
+    /**
+     * Adds a CONSTANT_String_info to the constant pool of this symbol table. Does nothing if the
+     * constant pool already contains a similar item.
+     *
+     * @param value a string.
+     * @return a new or already existing Symbol with the given value.
+     */
+    Symbol addConstantString(final String value) {
+        return addConstantUtf8Reference(Symbol.CONSTANT_STRING_TAG, value);
+    }
+
+    /**
+     * Adds a CONSTANT_Integer_info to the constant pool of this symbol table. Does nothing if the
+     * constant pool already contains a similar item.
+     *
+     * @param value an int.
+     * @return a new or already existing Symbol with the given value.
+     */
+    Symbol addConstantInteger(final int value) {
+        return addConstantIntegerOrFloat(Symbol.CONSTANT_INTEGER_TAG, value);
+    }
+
+    /**
+     * Adds a CONSTANT_Float_info to the constant pool of this symbol table. Does nothing if the
+     * constant pool already contains a similar item.
+     *
+     * @param value a float.
+     * @return a new or already existing Symbol with the given value.
+     */
+    Symbol addConstantFloat(final float value) {
+        return addConstantIntegerOrFloat(Symbol.CONSTANT_FLOAT_TAG, Float.floatToRawIntBits(value));
+    }
+
+    /**
+     * Adds a CONSTANT_Integer_info or CONSTANT_Float_info to the constant pool of this symbol table.
+     * Does nothing if the constant pool already contains a similar item.
+     *
+     * @param tag one of {@link Symbol#CONSTANT_INTEGER_TAG} or {@link Symbol#CONSTANT_FLOAT_TAG}.
+     * @param value an int or float.
+     * @return a constant pool constant with the given tag and primitive values.
+     */
+    private Symbol addConstantIntegerOrFloat(final int tag, final int value) {
+        int hashCode = hash(tag, value);
+        Entry entry = get(hashCode);
+        while (entry != null) {
+            if (entry.tag == tag && entry.hashCode == hashCode && entry.data == value) {
+                return entry;
+            }
+            entry = entry.next;
+        }
+        constantPool.putByte(tag).putInt(value);
+        return put(new Entry(constantPoolCount++, tag, value, hashCode));
+    }
+
+    /**
+     * Adds a new CONSTANT_Integer_info or CONSTANT_Float_info to the constant pool of this symbol
+     * table.
+     *
+     * @param index the constant pool index of the new Symbol.
+     * @param tag one of {@link Symbol#CONSTANT_INTEGER_TAG} or {@link Symbol#CONSTANT_FLOAT_TAG}.
+     * @param value an int or float.
+     */
+    private void addConstantIntegerOrFloat(final int index, final int tag, final int value) {
+        add(new Entry(index, tag, value, hash(tag, value)));
+    }
+
+    /**
+     * Adds a CONSTANT_Long_info to the constant pool of this symbol table. Does nothing if the
+     * constant pool already contains a similar item.
+     *
+     * @param value a long.
+     * @return a new or already existing Symbol with the given value.
+     */
+    Symbol addConstantLong(final long value) {
+        return addConstantLongOrDouble(Symbol.CONSTANT_LONG_TAG, value);
+    }
+
+    /**
+     * Adds a CONSTANT_Double_info to the constant pool of this symbol table. Does nothing if the
+     * constant pool already contains a similar item.
+     *
+     * @param value a double.
+     * @return a new or already existing Symbol with the given value.
+     */
+    Symbol addConstantDouble(final double value) {
+        return addConstantLongOrDouble(Symbol.CONSTANT_DOUBLE_TAG, Double.doubleToRawLongBits(value));
+    }
+
+    /**
+     * Adds a CONSTANT_Long_info or CONSTANT_Double_info to the constant pool of this symbol table.
+     * Does nothing if the constant pool already contains a similar item.
+     *
+     * @param tag one of {@link Symbol#CONSTANT_LONG_TAG} or {@link Symbol#CONSTANT_DOUBLE_TAG}.
+     * @param value a long or double.
+     * @return a constant pool constant with the given tag and primitive values.
+     */
+    private Symbol addConstantLongOrDouble(final int tag, final long value) {
+        int hashCode = hash(tag, value);
+        Entry entry = get(hashCode);
+        while (entry != null) {
+            if (entry.tag == tag && entry.hashCode == hashCode && entry.data == value) {
+                return entry;
+            }
+            entry = entry.next;
+        }
+        int index = constantPoolCount;
+        constantPool.putByte(tag).putLong(value);
+        constantPoolCount += 2;
+        return put(new Entry(index, tag, value, hashCode));
+    }
+
+    /**
+     * Adds a new CONSTANT_Long_info or CONSTANT_Double_info to the constant pool of this symbol
+     * table.
+     *
+     * @param index the constant pool index of the new Symbol.
+     * @param tag one of {@link Symbol#CONSTANT_LONG_TAG} or {@link Symbol#CONSTANT_DOUBLE_TAG}.
+     * @param value a long or double.
+     */
+    private void addConstantLongOrDouble(final int index, final int tag, final long value) {
+        add(new Entry(index, tag, value, hash(tag, value)));
+    }
+
+    /**
+     * Adds a CONSTANT_NameAndType_info to the constant pool of this symbol table. Does nothing if the
+     * constant pool already contains a similar item.
+     *
+     * @param name a field or method name.
+     * @param descriptor a field or method descriptor.
+     * @return a new or already existing Symbol with the given value.
+     */
+    int addConstantNameAndType(final String name, final String descriptor) {
+        final int tag = Symbol.CONSTANT_NAME_AND_TYPE_TAG;
+        int hashCode = hash(tag, name, descriptor);
+        Entry entry = get(hashCode);
+        while (entry != null) {
+            if (entry.tag == tag && entry.hashCode == hashCode && entry.name.equals(name) && entry.value.equals(descriptor)) {
+                return entry.index;
+            }
+            entry = entry.next;
+        }
+        constantPool.put122(tag, addConstantUtf8(name), addConstantUtf8(descriptor));
+        return put(new Entry(constantPoolCount++, tag, name, descriptor, hashCode)).index;
+    }
+
+    /**
+     * Adds a new CONSTANT_NameAndType_info to the constant pool of this symbol table.
+     *
+     * @param index the constant pool index of the new Symbol.
+     * @param name a field or method name.
+     * @param descriptor a field or method descriptor.
+     */
+    private void addConstantNameAndType(final int index, final String name, final String descriptor) {
+        final int tag = Symbol.CONSTANT_NAME_AND_TYPE_TAG;
+        add(new Entry(index, tag, name, descriptor, hash(tag, name, descriptor)));
+    }
+
+    /**
+     * Adds a CONSTANT_Utf8_info to the constant pool of this symbol table. Does nothing if the
+     * constant pool already contains a similar item.
+     *
+     * @param value a string.
+     * @return a new or already existing Symbol with the given value.
+     */
+    int addConstantUtf8(final String value) {
+        int hashCode = hash(Symbol.CONSTANT_UTF8_TAG, value);
+        Entry entry = get(hashCode);
+        while (entry != null) {
+            if (entry.tag == Symbol.CONSTANT_UTF8_TAG && entry.hashCode == hashCode && entry.value.equals(value)) {
+                return entry.index;
+            }
+            entry = entry.next;
+        }
+        constantPool.putByte(Symbol.CONSTANT_UTF8_TAG).putUTF8(value);
+        return put(new Entry(constantPoolCount++, Symbol.CONSTANT_UTF8_TAG, value, hashCode)).index;
+    }
+
+    /**
+     * Adds a new CONSTANT_String_info to the constant pool of this symbol table.
+     *
+     * @param index the constant pool index of the new Symbol.
+     * @param value a string.
+     */
+    private void addConstantUtf8(final int index, final String value) {
+        add(new Entry(index, Symbol.CONSTANT_UTF8_TAG, value, hash(Symbol.CONSTANT_UTF8_TAG, value)));
+    }
+
+    /**
+     * Adds a CONSTANT_MethodHandle_info to the constant pool of this symbol table. Does nothing if
+     * the constant pool already contains a similar item.
+     *
+     * @param referenceKind one of {@link Opcodes#H_GETFIELD}, {@link Opcodes#H_GETSTATIC}, {@link
+     *     Opcodes#H_PUTFIELD}, {@link Opcodes#H_PUTSTATIC}, {@link Opcodes#H_INVOKEVIRTUAL}, {@link
+     *     Opcodes#H_INVOKESTATIC}, {@link Opcodes#H_INVOKESPECIAL}, {@link
+     *     Opcodes#H_NEWINVOKESPECIAL} or {@link Opcodes#H_INVOKEINTERFACE}.
+     * @param owner the internal name of a class of interface.
+     * @param name a field or method name.
+     * @param descriptor a field or method descriptor.
+     * @param isInterface whether owner is an interface or not.
+     * @return a new or already existing Symbol with the given value.
+     */
+    Symbol addConstantMethodHandle(final int referenceKind, final String owner, final String name, final String descriptor,
+            final boolean isInterface) {
+        final int tag = Symbol.CONSTANT_METHOD_HANDLE_TAG;
+        // Note that we don't need to include isInterface in the hash computation, because it is
+        // redundant with owner (we can't have the same owner with different isInterface values).
+        int hashCode = hash(tag, owner, name, descriptor, referenceKind);
+        Entry entry = get(hashCode);
+        while (entry != null) {
+            if (entry.tag == tag && entry.hashCode == hashCode && entry.data == referenceKind && entry.owner.equals(owner)
+                    && entry.name.equals(name) && entry.value.equals(descriptor)) {
+                return entry;
+            }
+            entry = entry.next;
+        }
+        if (referenceKind <= Opcodes.H_PUTSTATIC) {
+            constantPool.put112(tag, referenceKind, addConstantFieldref(owner, name, descriptor).index);
+        } else {
+            constantPool.put112(tag, referenceKind, addConstantMethodref(owner, name, descriptor, isInterface).index);
+        }
+        return put(new Entry(constantPoolCount++, tag, owner, name, descriptor, referenceKind, hashCode));
+    }
+
+    /**
+     * Adds a new CONSTANT_MethodHandle_info to the constant pool of this symbol table.
+     *
+     * @param index the constant pool index of the new Symbol.
+     * @param referenceKind one of {@link Opcodes#H_GETFIELD}, {@link Opcodes#H_GETSTATIC}, {@link
+     *     Opcodes#H_PUTFIELD}, {@link Opcodes#H_PUTSTATIC}, {@link Opcodes#H_INVOKEVIRTUAL}, {@link
+     *     Opcodes#H_INVOKESTATIC}, {@link Opcodes#H_INVOKESPECIAL}, {@link
+     *     Opcodes#H_NEWINVOKESPECIAL} or {@link Opcodes#H_INVOKEINTERFACE}.
+     * @param owner the internal name of a class of interface.
+     * @param name a field or method name.
+     * @param descriptor a field or method descriptor.
+     */
+    private void addConstantMethodHandle(final int index, final int referenceKind, final String owner, final String name,
+            final String descriptor) {
+        final int tag = Symbol.CONSTANT_METHOD_HANDLE_TAG;
+        int hashCode = hash(tag, owner, name, descriptor, referenceKind);
+        add(new Entry(index, tag, owner, name, descriptor, referenceKind, hashCode));
+    }
+
+    /**
+     * Adds a CONSTANT_MethodType_info to the constant pool of this symbol table. Does nothing if the
+     * constant pool already contains a similar item.
+     *
+     * @param methodDescriptor a method descriptor.
+     * @return a new or already existing Symbol with the given value.
+     */
+    Symbol addConstantMethodType(final String methodDescriptor) {
+        return addConstantUtf8Reference(Symbol.CONSTANT_METHOD_TYPE_TAG, methodDescriptor);
+    }
+
+    // -----------------------------------------------------------------------------------------------
+    // Bootstrap method entries management.
+    // -----------------------------------------------------------------------------------------------
+
+    /**
+     * Adds a CONSTANT_Dynamic_info to the constant pool of this symbol table. Also adds the related
+     * bootstrap method to the BootstrapMethods of this symbol table. Does nothing if the constant
+     * pool already contains a similar item.
+     *
+     * @param name a method name.
+     * @param descriptor a field descriptor.
+     * @param bootstrapMethodHandle a bootstrap method handle.
+     * @param bootstrapMethodArguments the bootstrap method arguments.
+     * @return a new or already existing Symbol with the given value.
+     */
+    Symbol addConstantDynamic(final String name, final String descriptor, final Handle bootstrapMethodHandle,
+            final Object... bootstrapMethodArguments) {
+        Symbol bootstrapMethod = addBootstrapMethod(bootstrapMethodHandle, bootstrapMethodArguments);
+        return addConstantDynamicOrInvokeDynamicReference(Symbol.CONSTANT_DYNAMIC_TAG, name, descriptor, bootstrapMethod.index);
+    }
+
+    /**
+     * Adds a CONSTANT_InvokeDynamic_info to the constant pool of this symbol table. Also adds the
+     * related bootstrap method to the BootstrapMethods of this symbol table. Does nothing if the
+     * constant pool already contains a similar item.
+     *
+     * @param name a method name.
+     * @param descriptor a method descriptor.
+     * @param bootstrapMethodHandle a bootstrap method handle.
+     * @param bootstrapMethodArguments the bootstrap method arguments.
+     * @return a new or already existing Symbol with the given value.
+     */
+    Symbol addConstantInvokeDynamic(final String name, final String descriptor, final Handle bootstrapMethodHandle,
+            final Object... bootstrapMethodArguments) {
+        Symbol bootstrapMethod = addBootstrapMethod(bootstrapMethodHandle, bootstrapMethodArguments);
+        return addConstantDynamicOrInvokeDynamicReference(Symbol.CONSTANT_INVOKE_DYNAMIC_TAG, name, descriptor, bootstrapMethod.index);
+    }
+
+    // -----------------------------------------------------------------------------------------------
+    // Type table entries management.
+    // -----------------------------------------------------------------------------------------------
+
+    /**
+     * Adds a CONSTANT_Dynamic or a CONSTANT_InvokeDynamic_info to the constant pool of this symbol
+     * table. Does nothing if the constant pool already contains a similar item.
+     *
+     * @param tag one of {@link Symbol#CONSTANT_DYNAMIC_TAG} or {@link
+     *     Symbol#CONSTANT_INVOKE_DYNAMIC_TAG}.
+     * @param name a method name.
+     * @param descriptor a field descriptor for CONSTANT_DYNAMIC_TAG) or a method descriptor for
+     *     CONSTANT_INVOKE_DYNAMIC_TAG.
+     * @param bootstrapMethodIndex the index of a bootstrap method in the BootstrapMethods attribute.
+     * @return a new or already existing Symbol with the given value.
+     */
+    private Symbol addConstantDynamicOrInvokeDynamicReference(final int tag, final String name, final String descriptor,
+            final int bootstrapMethodIndex) {
+        int hashCode = hash(tag, name, descriptor, bootstrapMethodIndex);
+        Entry entry = get(hashCode);
+        while (entry != null) {
+            if (entry.tag == tag && entry.hashCode == hashCode && entry.data == bootstrapMethodIndex && entry.name.equals(name)
+                    && entry.value.equals(descriptor)) {
+                return entry;
+            }
+            entry = entry.next;
+        }
+        constantPool.put122(tag, bootstrapMethodIndex, addConstantNameAndType(name, descriptor));
+        return put(new Entry(constantPoolCount++, tag, null, name, descriptor, bootstrapMethodIndex, hashCode));
+    }
+
+    /**
+     * Adds a new CONSTANT_Dynamic_info or CONSTANT_InvokeDynamic_info to the constant pool of this
+     * symbol table.
+     *
+     * @param tag one of {@link Symbol#CONSTANT_DYNAMIC_TAG} or {@link
+     *     Symbol#CONSTANT_INVOKE_DYNAMIC_TAG}.
+     * @param index the constant pool index of the new Symbol.
+     * @param name a method name.
+     * @param descriptor a field descriptor for CONSTANT_DYNAMIC_TAG or a method descriptor for
+     *     CONSTANT_INVOKE_DYNAMIC_TAG.
+     * @param bootstrapMethodIndex the index of a bootstrap method in the BootstrapMethods attribute.
+     */
+    private void addConstantDynamicOrInvokeDynamicReference(final int tag, final int index, final String name, final String descriptor,
+            final int bootstrapMethodIndex) {
+        int hashCode = hash(tag, name, descriptor, bootstrapMethodIndex);
+        add(new Entry(index, tag, null, name, descriptor, bootstrapMethodIndex, hashCode));
+    }
+
+    /**
+     * Adds a CONSTANT_Module_info to the constant pool of this symbol table. Does nothing if the
+     * constant pool already contains a similar item.
+     *
+     * @param moduleName a fully qualified name (using dots) of a module.
+     * @return a new or already existing Symbol with the given value.
+     */
+    Symbol addConstantModule(final String moduleName) {
+        return addConstantUtf8Reference(Symbol.CONSTANT_MODULE_TAG, moduleName);
+    }
+
+    /**
+     * Adds a CONSTANT_Package_info to the constant pool of this symbol table. Does nothing if the
+     * constant pool already contains a similar item.
+     *
+     * @param packageName the internal name of a package.
+     * @return a new or already existing Symbol with the given value.
+     */
+    Symbol addConstantPackage(final String packageName) {
+        return addConstantUtf8Reference(Symbol.CONSTANT_PACKAGE_TAG, packageName);
+    }
+
+    /**
+     * Adds a CONSTANT_Class_info, CONSTANT_String_info, CONSTANT_MethodType_info,
+     * CONSTANT_Module_info or CONSTANT_Package_info to the constant pool of this symbol table. Does
+     * nothing if the constant pool already contains a similar item.
+     *
+     * @param tag one of {@link Symbol#CONSTANT_CLASS_TAG}, {@link Symbol#CONSTANT_STRING_TAG}, {@link
+     *     Symbol#CONSTANT_METHOD_TYPE_TAG}, {@link Symbol#CONSTANT_MODULE_TAG} or {@link
+     *     Symbol#CONSTANT_PACKAGE_TAG}.
+     * @param value an internal class name, an arbitrary string, a method descriptor, a module or a
+     *     package name, depending on tag.
+     * @return a new or already existing Symbol with the given value.
+     */
+    private Symbol addConstantUtf8Reference(final int tag, final String value) {
+        int hashCode = hash(tag, value);
+        Entry entry = get(hashCode);
+        while (entry != null) {
+            if (entry.tag == tag && entry.hashCode == hashCode && entry.value.equals(value)) {
+                return entry;
+            }
+            entry = entry.next;
+        }
+        constantPool.put12(tag, addConstantUtf8(value));
+        return put(new Entry(constantPoolCount++, tag, value, hashCode));
+    }
+
+    // -----------------------------------------------------------------------------------------------
+    // Static helper methods to compute hash codes.
+    // -----------------------------------------------------------------------------------------------
+
+    /**
+     * Adds a new CONSTANT_Class_info, CONSTANT_String_info, CONSTANT_MethodType_info,
+     * CONSTANT_Module_info or CONSTANT_Package_info to the constant pool of this symbol table.
+     *
+     * @param index the constant pool index of the new Symbol.
+     * @param tag one of {@link Symbol#CONSTANT_CLASS_TAG}, {@link Symbol#CONSTANT_STRING_TAG}, {@link
+     *     Symbol#CONSTANT_METHOD_TYPE_TAG}, {@link Symbol#CONSTANT_MODULE_TAG} or {@link
+     *     Symbol#CONSTANT_PACKAGE_TAG}.
+     * @param value an internal class name, an arbitrary string, a method descriptor, a module or a
+     *     package name, depending on tag.
+     */
+    private void addConstantUtf8Reference(final int index, final int tag, final String value) {
+        add(new Entry(index, tag, value, hash(tag, value)));
+    }
+
+    /**
+     * Adds a bootstrap method to the BootstrapMethods attribute of this symbol table. Does nothing if
+     * the BootstrapMethods already contains a similar bootstrap method.
+     *
+     * @param bootstrapMethodHandle a bootstrap method handle.
+     * @param bootstrapMethodArguments the bootstrap method arguments.
+     * @return a new or already existing Symbol with the given value.
+     */
+    Symbol addBootstrapMethod(final Handle bootstrapMethodHandle, final Object... bootstrapMethodArguments) {
+        ByteVector bootstrapMethodsAttribute = bootstrapMethods;
+        if (bootstrapMethodsAttribute == null) {
+            bootstrapMethodsAttribute = bootstrapMethods = new ByteVector();
+        }
+
+        // The bootstrap method arguments can be Constant_Dynamic values, which reference other
+        // bootstrap methods. We must therefore add the bootstrap method arguments to the constant pool
+        // and BootstrapMethods attribute first, so that the BootstrapMethods attribute is not modified
+        // while adding the given bootstrap method to it, in the rest of this method.
+        for (Object bootstrapMethodArgument : bootstrapMethodArguments) {
+            addConstant(bootstrapMethodArgument);
+        }
+
+        // Write the bootstrap method in the BootstrapMethods table. This is necessary to be able to
+        // compare it with existing ones, and will be reverted below if there is already a similar
+        // bootstrap method.
+        int bootstrapMethodOffset = bootstrapMethodsAttribute.length;
+        bootstrapMethodsAttribute.putShort(addConstantMethodHandle(bootstrapMethodHandle.getTag(), bootstrapMethodHandle.getOwner(),
+                bootstrapMethodHandle.getName(), bootstrapMethodHandle.getDesc(), bootstrapMethodHandle.isInterface()).index);
+        int numBootstrapArguments = bootstrapMethodArguments.length;
+        bootstrapMethodsAttribute.putShort(numBootstrapArguments);
+        for (Object bootstrapMethodArgument : bootstrapMethodArguments) {
+            bootstrapMethodsAttribute.putShort(addConstant(bootstrapMethodArgument).index);
+        }
+
+        // Compute the length and the hash code of the bootstrap method.
+        int bootstrapMethodlength = bootstrapMethodsAttribute.length - bootstrapMethodOffset;
+        int hashCode = bootstrapMethodHandle.hashCode();
+        for (Object bootstrapMethodArgument : bootstrapMethodArguments) {
+            hashCode ^= bootstrapMethodArgument.hashCode();
+        }
+        hashCode &= 0x7FFFFFFF;
+
+        // Add the bootstrap method to the symbol table or revert the above changes.
+        return addBootstrapMethod(bootstrapMethodOffset, bootstrapMethodlength, hashCode);
+    }
+
+    /**
+     * Adds a bootstrap method to the BootstrapMethods attribute of this symbol table. Does nothing if
+     * the BootstrapMethods already contains a similar bootstrap method (more precisely, reverts the
+     * content of {@link #bootstrapMethods} to remove the last, duplicate bootstrap method).
+     *
+     * @param offset the offset of the last bootstrap method in {@link #bootstrapMethods}, in bytes.
+     * @param length the length of this bootstrap method in {@link #bootstrapMethods}, in bytes.
+     * @param hashCode the hash code of this bootstrap method.
+     * @return a new or already existing Symbol with the given value.
+     */
+    private Symbol addBootstrapMethod(final int offset, final int length, final int hashCode) {
+        final byte[] bootstrapMethodsData = bootstrapMethods.data;
+        Entry entry = get(hashCode);
+        while (entry != null) {
+            if (entry.tag == Symbol.BOOTSTRAP_METHOD_TAG && entry.hashCode == hashCode) {
+                int otherOffset = (int) entry.data;
+                boolean isSameBootstrapMethod = true;
+                for (int i = 0; i < length; ++i) {
+                    if (bootstrapMethodsData[offset + i] != bootstrapMethodsData[otherOffset + i]) {
+                        isSameBootstrapMethod = false;
+                        break;
+                    }
+                }
+                if (isSameBootstrapMethod) {
+                    bootstrapMethods.length = offset; // Revert to old position.
+                    return entry;
+                }
+            }
+            entry = entry.next;
+        }
+        return put(new Entry(bootstrapMethodCount++, Symbol.BOOTSTRAP_METHOD_TAG, offset, hashCode));
+    }
+
+    /**
+     * Returns the type table element whose index is given.
+     *
+     * @param typeIndex a type table index.
+     * @return the type table element whose index is given.
+     */
+    Symbol getType(final int typeIndex) {
+        return typeTable[typeIndex];
+    }
+
+    /**
+     * Adds a type in the type table of this symbol table. Does nothing if the type table already
+     * contains a similar type.
+     *
+     * @param value an internal class name.
+     * @return the index of a new or already existing type Symbol with the given value.
+     */
+    int addType(final String value) {
+        int hashCode = hash(Symbol.TYPE_TAG, value);
+        Entry entry = get(hashCode);
+        while (entry != null) {
+            if (entry.tag == Symbol.TYPE_TAG && entry.hashCode == hashCode && entry.value.equals(value)) {
+                return entry.index;
+            }
+            entry = entry.next;
+        }
+        return addTypeInternal(new Entry(typeCount, Symbol.TYPE_TAG, value, hashCode));
+    }
+
+    /**
+     * Adds an {@link Frame#ITEM_UNINITIALIZED} type in the type table of this symbol table. Does
+     * nothing if the type table already contains a similar type.
+     *
+     * @param value an internal class name.
+     * @param bytecodeOffset the bytecode offset of the NEW instruction that created this {@link
+     *     Frame#ITEM_UNINITIALIZED} type value.
+     * @return the index of a new or already existing type Symbol with the given value.
+     */
+    int addUninitializedType(final String value, final int bytecodeOffset) {
+        int hashCode = hash(Symbol.UNINITIALIZED_TYPE_TAG, value, bytecodeOffset);
+        Entry entry = get(hashCode);
+        while (entry != null) {
+            if (entry.tag == Symbol.UNINITIALIZED_TYPE_TAG && entry.hashCode == hashCode && entry.data == bytecodeOffset
+                    && entry.value.equals(value)) {
+                return entry.index;
+            }
+            entry = entry.next;
+        }
+        return addTypeInternal(new Entry(typeCount, Symbol.UNINITIALIZED_TYPE_TAG, value, bytecodeOffset, hashCode));
+    }
+
+    /**
+     * Adds a merged type in the type table of this symbol table. Does nothing if the type table
+     * already contains a similar type.
+     *
+     * @param typeTableIndex1 a {@link Symbol#TYPE_TAG} type, specified by its index in the type
+     *     table.
+     * @param typeTableIndex2 another {@link Symbol#TYPE_TAG} type, specified by its index in the type
+     *     table.
+     * @return the index of a new or already existing {@link Symbol#TYPE_TAG} type Symbol,
+     *     corresponding to the common super class of the given types.
+     */
+    int addMergedType(final int typeTableIndex1, final int typeTableIndex2) {
+        // TODO sort the arguments? The merge result should be independent of their order.
+        long data = typeTableIndex1 | (((long) typeTableIndex2) << 32);
+        int hashCode = hash(Symbol.MERGED_TYPE_TAG, typeTableIndex1 + typeTableIndex2);
+        Entry entry = get(hashCode);
+        while (entry != null) {
+            if (entry.tag == Symbol.MERGED_TYPE_TAG && entry.hashCode == hashCode && entry.data == data) {
+                return entry.info;
+            }
+            entry = entry.next;
+        }
+        String type1 = typeTable[typeTableIndex1].value;
+        String type2 = typeTable[typeTableIndex2].value;
+        int commonSuperTypeIndex = addType(classWriter.getCommonSuperClass(type1, type2));
+        put(new Entry(typeCount, Symbol.MERGED_TYPE_TAG, data, hashCode)).info = commonSuperTypeIndex;
+        return commonSuperTypeIndex;
+    }
+
+    /**
+     * Adds the given type Symbol to {@link #typeTable}.
+     *
+     * @param entry a {@link Symbol#TYPE_TAG} or {@link Symbol#UNINITIALIZED_TYPE_TAG} type symbol.
+     *     The index of this Symbol must be equal to the current value of {@link #typeCount}.
+     * @return the index in {@link #typeTable} where the given type was added, which is also equal to
+     *     entry's index by hypothesis.
+     */
+    private int addTypeInternal(final Entry entry) {
+        if (typeTable == null) {
+            typeTable = new Entry[16];
+        }
+        if (typeCount == typeTable.length) {
+            Entry[] newTypeTable = new Entry[2 * typeTable.length];
+            System.arraycopy(typeTable, 0, newTypeTable, 0, typeTable.length);
+            typeTable = newTypeTable;
+        }
+        typeTable[typeCount++] = entry;
+        return put(entry).index;
+    }
+
+    /**
+     * An entry of a SymbolTable. This concrete and private subclass of {@link Symbol} adds two fields
+     * which are only used inside SymbolTable, to implement hash sets of symbols (in order to avoid
+     * duplicate symbols). See {@link #entries}.
+     *
+     * @author Eric Bruneton
+     */
+    private static class Entry extends Symbol {
+
+        /** The hash code of this entry. */
+        final int hashCode;
+
+        /**
+         * Another entry (and so on recursively) having the same hash code (modulo the size of {@link
+         * #entries}) as this one.
+         */
+        Entry next;
+
+        Entry(final int index, final int tag, final String owner, final String name, final String value, final long data,
+                final int hashCode) {
+            super(index, tag, owner, name, value, data);
+            this.hashCode = hashCode;
+        }
+
+        Entry(final int index, final int tag, final String value, final int hashCode) {
+            super(index, tag, /* owner = */ null, /* name = */ null, value, /* data = */ 0);
+            this.hashCode = hashCode;
+        }
+
+        Entry(final int index, final int tag, final String value, final long data, final int hashCode) {
+            super(index, tag, /* owner = */ null, /* name = */ null, value, data);
+            this.hashCode = hashCode;
+        }
+
+        Entry(final int index, final int tag, final String name, final String value, final int hashCode) {
+            super(index, tag, /* owner = */ null, name, value, /* data = */ 0);
+            this.hashCode = hashCode;
+        }
+
+        Entry(final int index, final int tag, final long data, final int hashCode) {
+            super(index, tag, /* owner = */ null, /* name = */ null, /* value = */ null, data);
+            this.hashCode = hashCode;
+        }
+    }
+}

--- a/core/src/main/java/org/mvel2/asm/Type.java
+++ b/core/src/main/java/org/mvel2/asm/Type.java
@@ -1,0 +1,882 @@
+// ASM: a very small and fast Java bytecode manipulation framework
+// Copyright (c) 2000-2011 INRIA, France Telecom
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+// 1. Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+// 2. Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+// 3. Neither the name of the copyright holders nor the names of its
+//    contributors may be used to endorse or promote products derived from
+//    this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+// THE POSSIBILITY OF SUCH DAMAGE.
+package org.mvel2.asm;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Method;
+
+/**
+ * A Java field or method type. This class can be used to make it easier to manipulate type and
+ * method descriptors.
+ *
+ * @author Eric Bruneton
+ * @author Chris Nokleberg
+ */
+public final class Type {
+
+    /** The sort of the {@code void} type. See {@link #getSort}. */
+    public static final int VOID = 0;
+
+    /** The sort of the {@code boolean} type. See {@link #getSort}. */
+    public static final int BOOLEAN = 1;
+
+    /** The sort of the {@code char} type. See {@link #getSort}. */
+    public static final int CHAR = 2;
+
+    /** The sort of the {@code byte} type. See {@link #getSort}. */
+    public static final int BYTE = 3;
+
+    /** The sort of the {@code short} type. See {@link #getSort}. */
+    public static final int SHORT = 4;
+
+    /** The sort of the {@code int} type. See {@link #getSort}. */
+    public static final int INT = 5;
+
+    /** The sort of the {@code float} type. See {@link #getSort}. */
+    public static final int FLOAT = 6;
+
+    /** The sort of the {@code long} type. See {@link #getSort}. */
+    public static final int LONG = 7;
+
+    /** The sort of the {@code double} type. See {@link #getSort}. */
+    public static final int DOUBLE = 8;
+
+    /** The sort of array reference types. See {@link #getSort}. */
+    public static final int ARRAY = 9;
+
+    /** The sort of object reference types. See {@link #getSort}. */
+    public static final int OBJECT = 10;
+
+    /** The sort of method types. See {@link #getSort}. */
+    public static final int METHOD = 11;
+
+    /** The (private) sort of object reference types represented with an internal name. */
+    private static final int INTERNAL = 12;
+
+    /** The descriptors of the primitive types. */
+    private static final String PRIMITIVE_DESCRIPTORS = "VZCBSIFJD";
+
+    /** The {@code void} type. */
+    public static final Type VOID_TYPE = new Type(VOID, PRIMITIVE_DESCRIPTORS, VOID, VOID + 1);
+
+    /** The {@code boolean} type. */
+    public static final Type BOOLEAN_TYPE = new Type(BOOLEAN, PRIMITIVE_DESCRIPTORS, BOOLEAN, BOOLEAN + 1);
+
+    /** The {@code char} type. */
+    public static final Type CHAR_TYPE = new Type(CHAR, PRIMITIVE_DESCRIPTORS, CHAR, CHAR + 1);
+
+    /** The {@code byte} type. */
+    public static final Type BYTE_TYPE = new Type(BYTE, PRIMITIVE_DESCRIPTORS, BYTE, BYTE + 1);
+
+    /** The {@code short} type. */
+    public static final Type SHORT_TYPE = new Type(SHORT, PRIMITIVE_DESCRIPTORS, SHORT, SHORT + 1);
+
+    /** The {@code int} type. */
+    public static final Type INT_TYPE = new Type(INT, PRIMITIVE_DESCRIPTORS, INT, INT + 1);
+
+    /** The {@code float} type. */
+    public static final Type FLOAT_TYPE = new Type(FLOAT, PRIMITIVE_DESCRIPTORS, FLOAT, FLOAT + 1);
+
+    /** The {@code long} type. */
+    public static final Type LONG_TYPE = new Type(LONG, PRIMITIVE_DESCRIPTORS, LONG, LONG + 1);
+
+    /** The {@code double} type. */
+    public static final Type DOUBLE_TYPE = new Type(DOUBLE, PRIMITIVE_DESCRIPTORS, DOUBLE, DOUBLE + 1);
+
+    // -----------------------------------------------------------------------------------------------
+    // Fields
+    // -----------------------------------------------------------------------------------------------
+
+    /**
+     * The sort of this type. Either {@link #VOID}, {@link #BOOLEAN}, {@link #CHAR}, {@link #BYTE},
+     * {@link #SHORT}, {@link #INT}, {@link #FLOAT}, {@link #LONG}, {@link #DOUBLE}, {@link #ARRAY},
+     * {@link #OBJECT}, {@link #METHOD} or {@link #INTERNAL}.
+     */
+    private final int sort;
+
+    /**
+     * A buffer containing the value of this field or method type. This value is an internal name for
+     * {@link #OBJECT} and {@link #INTERNAL} types, and a field or method descriptor in the other
+     * cases.
+     *
+     * <p>For {@link #OBJECT} types, this field also contains the descriptor: the characters in
+     * [{@link #valueBegin},{@link #valueEnd}) contain the internal name, and those in [{@link
+     * #valueBegin} - 1, {@link #valueEnd} + 1) contain the descriptor.
+     */
+    private final String valueBuffer;
+
+    /**
+     * The beginning index, inclusive, of the value of this Java field or method type in {@link
+     * #valueBuffer}. This value is an internal name for {@link #OBJECT} and {@link #INTERNAL} types,
+     * and a field or method descriptor in the other cases.
+     */
+    private final int valueBegin;
+
+    /**
+     * The end index, exclusive, of the value of this Java field or method type in {@link
+     * #valueBuffer}. This value is an internal name for {@link #OBJECT} and {@link #INTERNAL} types,
+     * and a field or method descriptor in the other cases.
+     */
+    private final int valueEnd;
+
+    /**
+     * Constructs a reference type.
+     *
+     * @param sort the sort of this type, see {@link #sort}.
+     * @param valueBuffer a buffer containing the value of this field or method type.
+     * @param valueBegin the beginning index, inclusive, of the value of this field or method type in
+     *     valueBuffer.
+     * @param valueEnd the end index, exclusive, of the value of this field or method type in
+     *     valueBuffer.
+     */
+    private Type(final int sort, final String valueBuffer, final int valueBegin, final int valueEnd) {
+        this.sort = sort;
+        this.valueBuffer = valueBuffer;
+        this.valueBegin = valueBegin;
+        this.valueEnd = valueEnd;
+    }
+
+    // -----------------------------------------------------------------------------------------------
+    // Methods to get Type(s) from a descriptor, a reflected Method or Constructor, other types, etc.
+    // -----------------------------------------------------------------------------------------------
+
+    /**
+     * Returns the {@link Type} corresponding to the given type descriptor.
+     *
+     * @param typeDescriptor a field or method type descriptor.
+     * @return the {@link Type} corresponding to the given type descriptor.
+     */
+    public static Type getType(final String typeDescriptor) {
+        return getTypeInternal(typeDescriptor, 0, typeDescriptor.length());
+    }
+
+    /**
+     * Returns the {@link Type} corresponding to the given class.
+     *
+     * @param clazz a class.
+     * @return the {@link Type} corresponding to the given class.
+     */
+    public static Type getType(final Class<?> clazz) {
+        if (clazz.isPrimitive()) {
+            if (clazz == Integer.TYPE) {
+                return INT_TYPE;
+            } else if (clazz == Void.TYPE) {
+                return VOID_TYPE;
+            } else if (clazz == Boolean.TYPE) {
+                return BOOLEAN_TYPE;
+            } else if (clazz == Byte.TYPE) {
+                return BYTE_TYPE;
+            } else if (clazz == Character.TYPE) {
+                return CHAR_TYPE;
+            } else if (clazz == Short.TYPE) {
+                return SHORT_TYPE;
+            } else if (clazz == Double.TYPE) {
+                return DOUBLE_TYPE;
+            } else if (clazz == Float.TYPE) {
+                return FLOAT_TYPE;
+            } else if (clazz == Long.TYPE) {
+                return LONG_TYPE;
+            } else {
+                throw new AssertionError();
+            }
+        } else {
+            return getType(getDescriptor(clazz));
+        }
+    }
+
+    /**
+     * Returns the method {@link Type} corresponding to the given constructor.
+     *
+     * @param constructor a {@link Constructor} object.
+     * @return the method {@link Type} corresponding to the given constructor.
+     */
+    public static Type getType(final Constructor<?> constructor) {
+        return getType(getConstructorDescriptor(constructor));
+    }
+
+    /**
+     * Returns the method {@link Type} corresponding to the given method.
+     *
+     * @param method a {@link Method} object.
+     * @return the method {@link Type} corresponding to the given method.
+     */
+    public static Type getType(final Method method) {
+        return getType(getMethodDescriptor(method));
+    }
+
+    /**
+     * Returns the {@link Type} corresponding to the given internal name.
+     *
+     * @param internalName an internal name.
+     * @return the {@link Type} corresponding to the given internal name.
+     */
+    public static Type getObjectType(final String internalName) {
+        return new Type(internalName.charAt(0) == '[' ? ARRAY : INTERNAL, internalName, 0, internalName.length());
+    }
+
+    /**
+     * Returns the {@link Type} corresponding to the given method descriptor. Equivalent to <code>
+     * Type.getType(methodDescriptor)</code>.
+     *
+     * @param methodDescriptor a method descriptor.
+     * @return the {@link Type} corresponding to the given method descriptor.
+     */
+    public static Type getMethodType(final String methodDescriptor) {
+        return new Type(METHOD, methodDescriptor, 0, methodDescriptor.length());
+    }
+
+    /**
+     * Returns the method {@link Type} corresponding to the given argument and return types.
+     *
+     * @param returnType the return type of the method.
+     * @param argumentTypes the argument types of the method.
+     * @return the method {@link Type} corresponding to the given argument and return types.
+     */
+    public static Type getMethodType(final Type returnType, final Type... argumentTypes) {
+        return getType(getMethodDescriptor(returnType, argumentTypes));
+    }
+
+    /**
+     * Returns the {@link Type} values corresponding to the argument types of the given method
+     * descriptor.
+     *
+     * @param methodDescriptor a method descriptor.
+     * @return the {@link Type} values corresponding to the argument types of the given method
+     *     descriptor.
+     */
+    public static Type[] getArgumentTypes(final String methodDescriptor) {
+        // First step: compute the number of argument types in methodDescriptor.
+        int numArgumentTypes = 0;
+        // Skip the first character, which is always a '('.
+        int currentOffset = 1;
+        // Parse the argument types, one at a each loop iteration.
+        while (methodDescriptor.charAt(currentOffset) != ')') {
+            while (methodDescriptor.charAt(currentOffset) == '[') {
+                currentOffset++;
+            }
+            if (methodDescriptor.charAt(currentOffset++) == 'L') {
+                // Skip the argument descriptor content.
+                currentOffset = methodDescriptor.indexOf(';', currentOffset) + 1;
+            }
+            ++numArgumentTypes;
+        }
+
+        // Second step: create a Type instance for each argument type.
+        Type[] argumentTypes = new Type[numArgumentTypes];
+        // Skip the first character, which is always a '('.
+        currentOffset = 1;
+        // Parse and create the argument types, one at each loop iteration.
+        int currentArgumentTypeIndex = 0;
+        while (methodDescriptor.charAt(currentOffset) != ')') {
+            final int currentArgumentTypeOffset = currentOffset;
+            while (methodDescriptor.charAt(currentOffset) == '[') {
+                currentOffset++;
+            }
+            if (methodDescriptor.charAt(currentOffset++) == 'L') {
+                // Skip the argument descriptor content.
+                currentOffset = methodDescriptor.indexOf(';', currentOffset) + 1;
+            }
+            argumentTypes[currentArgumentTypeIndex++] = getTypeInternal(methodDescriptor, currentArgumentTypeOffset, currentOffset);
+        }
+        return argumentTypes;
+    }
+
+    /**
+     * Returns the {@link Type} values corresponding to the argument types of the given method.
+     *
+     * @param method a method.
+     * @return the {@link Type} values corresponding to the argument types of the given method.
+     */
+    public static Type[] getArgumentTypes(final Method method) {
+        Class<?>[] classes = method.getParameterTypes();
+        Type[] types = new Type[classes.length];
+        for (int i = classes.length - 1; i >= 0; --i) {
+            types[i] = getType(classes[i]);
+        }
+        return types;
+    }
+
+    /**
+     * Returns the {@link Type} corresponding to the return type of the given method descriptor.
+     *
+     * @param methodDescriptor a method descriptor.
+     * @return the {@link Type} corresponding to the return type of the given method descriptor.
+     */
+    public static Type getReturnType(final String methodDescriptor) {
+        // Skip the first character, which is always a '('.
+        int currentOffset = 1;
+        // Skip the argument types, one at a each loop iteration.
+        while (methodDescriptor.charAt(currentOffset) != ')') {
+            while (methodDescriptor.charAt(currentOffset) == '[') {
+                currentOffset++;
+            }
+            if (methodDescriptor.charAt(currentOffset++) == 'L') {
+                // Skip the argument descriptor content.
+                currentOffset = methodDescriptor.indexOf(';', currentOffset) + 1;
+            }
+        }
+        return getTypeInternal(methodDescriptor, currentOffset + 1, methodDescriptor.length());
+    }
+
+    /**
+     * Returns the {@link Type} corresponding to the return type of the given method.
+     *
+     * @param method a method.
+     * @return the {@link Type} corresponding to the return type of the given method.
+     */
+    public static Type getReturnType(final Method method) {
+        return getType(method.getReturnType());
+    }
+
+    /**
+     * Returns the {@link Type} corresponding to the given field or method descriptor.
+     *
+     * @param descriptorBuffer a buffer containing the field or method descriptor.
+     * @param descriptorBegin the beginning index, inclusive, of the field or method descriptor in
+     *     descriptorBuffer.
+     * @param descriptorEnd the end index, exclusive, of the field or method descriptor in
+     *     descriptorBuffer.
+     * @return the {@link Type} corresponding to the given type descriptor.
+     */
+    private static Type getTypeInternal(final String descriptorBuffer, final int descriptorBegin, final int descriptorEnd) {
+        switch (descriptorBuffer.charAt(descriptorBegin)) {
+            case 'V':
+                return VOID_TYPE;
+            case 'Z':
+                return BOOLEAN_TYPE;
+            case 'C':
+                return CHAR_TYPE;
+            case 'B':
+                return BYTE_TYPE;
+            case 'S':
+                return SHORT_TYPE;
+            case 'I':
+                return INT_TYPE;
+            case 'F':
+                return FLOAT_TYPE;
+            case 'J':
+                return LONG_TYPE;
+            case 'D':
+                return DOUBLE_TYPE;
+            case '[':
+                return new Type(ARRAY, descriptorBuffer, descriptorBegin, descriptorEnd);
+            case 'L':
+                return new Type(OBJECT, descriptorBuffer, descriptorBegin + 1, descriptorEnd - 1);
+            case '(':
+                return new Type(METHOD, descriptorBuffer, descriptorBegin, descriptorEnd);
+            default:
+                throw new IllegalArgumentException();
+        }
+    }
+
+    /**
+     * Returns the internal name of the given class. The internal name of a class is its fully
+     * qualified name, as returned by Class.getName(), where '.' are replaced by '/'.
+     *
+     * @param clazz an object or array class.
+     * @return the internal name of the given class.
+     */
+    public static String getInternalName(final Class<?> clazz) {
+        return clazz.getName().replace('.', '/');
+    }
+
+    /**
+     * Returns the descriptor corresponding to the given class.
+     *
+     * @param clazz an object class, a primitive class or an array class.
+     * @return the descriptor corresponding to the given class.
+     */
+    public static String getDescriptor(final Class<?> clazz) {
+        StringBuilder stringBuilder = new StringBuilder();
+        appendDescriptor(clazz, stringBuilder);
+        return stringBuilder.toString();
+    }
+
+    /**
+     * Returns the descriptor corresponding to the given constructor.
+     *
+     * @param constructor a {@link Constructor} object.
+     * @return the descriptor of the given constructor.
+     */
+    public static String getConstructorDescriptor(final Constructor<?> constructor) {
+        StringBuilder stringBuilder = new StringBuilder();
+        stringBuilder.append('(');
+        Class<?>[] parameters = constructor.getParameterTypes();
+        for (Class<?> parameter : parameters) {
+            appendDescriptor(parameter, stringBuilder);
+        }
+        return stringBuilder.append(")V").toString();
+    }
+
+    // -----------------------------------------------------------------------------------------------
+    // Methods to get class names, internal names or descriptors.
+    // -----------------------------------------------------------------------------------------------
+
+    /**
+     * Returns the descriptor corresponding to the given argument and return types.
+     *
+     * @param returnType the return type of the method.
+     * @param argumentTypes the argument types of the method.
+     * @return the descriptor corresponding to the given argument and return types.
+     */
+    public static String getMethodDescriptor(final Type returnType, final Type... argumentTypes) {
+        StringBuilder stringBuilder = new StringBuilder();
+        stringBuilder.append('(');
+        for (Type argumentType : argumentTypes) {
+            argumentType.appendDescriptor(stringBuilder);
+        }
+        stringBuilder.append(')');
+        returnType.appendDescriptor(stringBuilder);
+        return stringBuilder.toString();
+    }
+
+    /**
+     * Returns the descriptor corresponding to the given method.
+     *
+     * @param method a {@link Method} object.
+     * @return the descriptor of the given method.
+     */
+    public static String getMethodDescriptor(final Method method) {
+        StringBuilder stringBuilder = new StringBuilder();
+        stringBuilder.append('(');
+        Class<?>[] parameters = method.getParameterTypes();
+        for (Class<?> parameter : parameters) {
+            appendDescriptor(parameter, stringBuilder);
+        }
+        stringBuilder.append(')');
+        appendDescriptor(method.getReturnType(), stringBuilder);
+        return stringBuilder.toString();
+    }
+
+    /**
+     * Appends the descriptor of the given class to the given string builder.
+     *
+     * @param clazz the class whose descriptor must be computed.
+     * @param stringBuilder the string builder to which the descriptor must be appended.
+     */
+    private static void appendDescriptor(final Class<?> clazz, final StringBuilder stringBuilder) {
+        Class<?> currentClass = clazz;
+        while (currentClass.isArray()) {
+            stringBuilder.append('[');
+            currentClass = currentClass.getComponentType();
+        }
+        if (currentClass.isPrimitive()) {
+            char descriptor;
+            if (currentClass == Integer.TYPE) {
+                descriptor = 'I';
+            } else if (currentClass == Void.TYPE) {
+                descriptor = 'V';
+            } else if (currentClass == Boolean.TYPE) {
+                descriptor = 'Z';
+            } else if (currentClass == Byte.TYPE) {
+                descriptor = 'B';
+            } else if (currentClass == Character.TYPE) {
+                descriptor = 'C';
+            } else if (currentClass == Short.TYPE) {
+                descriptor = 'S';
+            } else if (currentClass == Double.TYPE) {
+                descriptor = 'D';
+            } else if (currentClass == Float.TYPE) {
+                descriptor = 'F';
+            } else if (currentClass == Long.TYPE) {
+                descriptor = 'J';
+            } else {
+                throw new AssertionError();
+            }
+            stringBuilder.append(descriptor);
+        } else {
+            stringBuilder.append('L');
+            String name = currentClass.getName();
+            int nameLength = name.length();
+            for (int i = 0; i < nameLength; ++i) {
+                char car = name.charAt(i);
+                stringBuilder.append(car == '.' ? '/' : car);
+            }
+            stringBuilder.append(';');
+        }
+    }
+
+    /**
+     * Computes the size of the arguments and of the return value of a method.
+     *
+     * @param methodDescriptor a method descriptor.
+     * @return the size of the arguments of the method (plus one for the implicit this argument),
+     *     argumentsSize, and the size of its return value, returnSize, packed into a single int i =
+     *     {@code (argumentsSize &lt;&lt; 2) | returnSize} (argumentsSize is therefore equal to {@code
+     *     i &gt;&gt; 2}, and returnSize to {@code i &amp; 0x03}).
+     */
+    public static int getArgumentsAndReturnSizes(final String methodDescriptor) {
+        int argumentsSize = 1;
+        // Skip the first character, which is always a '('.
+        int currentOffset = 1;
+        int currentChar = methodDescriptor.charAt(currentOffset);
+        // Parse the argument types and compute their size, one at a each loop iteration.
+        while (currentChar != ')') {
+            if (currentChar == 'J' || currentChar == 'D') {
+                currentOffset++;
+                argumentsSize += 2;
+            } else {
+                while (methodDescriptor.charAt(currentOffset) == '[') {
+                    currentOffset++;
+                }
+                if (methodDescriptor.charAt(currentOffset++) == 'L') {
+                    // Skip the argument descriptor content.
+                    currentOffset = methodDescriptor.indexOf(';', currentOffset) + 1;
+                }
+                argumentsSize += 1;
+            }
+            currentChar = methodDescriptor.charAt(currentOffset);
+        }
+        currentChar = methodDescriptor.charAt(currentOffset + 1);
+        if (currentChar == 'V') {
+            return argumentsSize << 2;
+        } else {
+            int returnSize = (currentChar == 'J' || currentChar == 'D') ? 2 : 1;
+            return argumentsSize << 2 | returnSize;
+        }
+    }
+
+    /**
+     * Returns the type of the elements of this array type. This method should only be used for an
+     * array type.
+     *
+     * @return Returns the type of the elements of this array type.
+     */
+    public Type getElementType() {
+        final int numDimensions = getDimensions();
+        return getTypeInternal(valueBuffer, valueBegin + numDimensions, valueEnd);
+    }
+
+    /**
+     * Returns the argument types of methods of this type. This method should only be used for method
+     * types.
+     *
+     * @return the argument types of methods of this type.
+     */
+    public Type[] getArgumentTypes() {
+        return getArgumentTypes(getDescriptor());
+    }
+
+    /**
+     * Returns the return type of methods of this type. This method should only be used for method
+     * types.
+     *
+     * @return the return type of methods of this type.
+     */
+    public Type getReturnType() {
+        return getReturnType(getDescriptor());
+    }
+
+    /**
+     * Returns the binary name of the class corresponding to this type. This method must not be used
+     * on method types.
+     *
+     * @return the binary name of the class corresponding to this type.
+     */
+    public String getClassName() {
+        switch (sort) {
+            case VOID:
+                return "void";
+            case BOOLEAN:
+                return "boolean";
+            case CHAR:
+                return "char";
+            case BYTE:
+                return "byte";
+            case SHORT:
+                return "short";
+            case INT:
+                return "int";
+            case FLOAT:
+                return "float";
+            case LONG:
+                return "long";
+            case DOUBLE:
+                return "double";
+            case ARRAY:
+                StringBuilder stringBuilder = new StringBuilder(getElementType().getClassName());
+                for (int i = getDimensions(); i > 0; --i) {
+                    stringBuilder.append("[]");
+                }
+                return stringBuilder.toString();
+            case OBJECT:
+            case INTERNAL:
+                return valueBuffer.substring(valueBegin, valueEnd).replace('/', '.');
+            default:
+                throw new AssertionError();
+        }
+    }
+
+    /**
+     * Returns the internal name of the class corresponding to this object or array type. The internal
+     * name of a class is its fully qualified name (as returned by Class.getName(), where '.' are
+     * replaced by '/'). This method should only be used for an object or array type.
+     *
+     * @return the internal name of the class corresponding to this object type.
+     */
+    public String getInternalName() {
+        return valueBuffer.substring(valueBegin, valueEnd);
+    }
+
+    /**
+     * Returns the descriptor corresponding to this type.
+     *
+     * @return the descriptor corresponding to this type.
+     */
+    public String getDescriptor() {
+        if (sort == OBJECT) {
+            return valueBuffer.substring(valueBegin - 1, valueEnd + 1);
+        } else if (sort == INTERNAL) {
+            return new StringBuilder().append('L').append(valueBuffer, valueBegin, valueEnd).append(';').toString();
+        } else {
+            return valueBuffer.substring(valueBegin, valueEnd);
+        }
+    }
+
+    // -----------------------------------------------------------------------------------------------
+    // Methods to get the sort, dimension, size, and opcodes corresponding to a Type or descriptor.
+    // -----------------------------------------------------------------------------------------------
+
+    /**
+     * Appends the descriptor corresponding to this type to the given string buffer.
+     *
+     * @param stringBuilder the string builder to which the descriptor must be appended.
+     */
+    private void appendDescriptor(final StringBuilder stringBuilder) {
+        if (sort == OBJECT) {
+            stringBuilder.append(valueBuffer, valueBegin - 1, valueEnd + 1);
+        } else if (sort == INTERNAL) {
+            stringBuilder.append('L').append(valueBuffer, valueBegin, valueEnd).append(';');
+        } else {
+            stringBuilder.append(valueBuffer, valueBegin, valueEnd);
+        }
+    }
+
+    /**
+     * Returns the sort of this type.
+     *
+     * @return {@link #VOID}, {@link #BOOLEAN}, {@link #CHAR}, {@link #BYTE}, {@link #SHORT}, {@link
+     *     #INT}, {@link #FLOAT}, {@link #LONG}, {@link #DOUBLE}, {@link #ARRAY}, {@link #OBJECT} or
+     *     {@link #METHOD}.
+     */
+    public int getSort() {
+        return sort == INTERNAL ? OBJECT : sort;
+    }
+
+    /**
+     * Returns the number of dimensions of this array type. This method should only be used for an
+     * array type.
+     *
+     * @return the number of dimensions of this array type.
+     */
+    public int getDimensions() {
+        int numDimensions = 1;
+        while (valueBuffer.charAt(valueBegin + numDimensions) == '[') {
+            numDimensions++;
+        }
+        return numDimensions;
+    }
+
+    /**
+     * Returns the size of values of this type. This method must not be used for method types.
+     *
+     * @return the size of values of this type, i.e., 2 for {@code long} and {@code double}, 0 for
+     *     {@code void} and 1 otherwise.
+     */
+    public int getSize() {
+        switch (sort) {
+            case VOID:
+                return 0;
+            case BOOLEAN:
+            case CHAR:
+            case BYTE:
+            case SHORT:
+            case INT:
+            case FLOAT:
+            case ARRAY:
+            case OBJECT:
+            case INTERNAL:
+                return 1;
+            case LONG:
+            case DOUBLE:
+                return 2;
+            default:
+                throw new AssertionError();
+        }
+    }
+
+    /**
+     * Returns the size of the arguments and of the return value of methods of this type. This method
+     * should only be used for method types.
+     *
+     * @return the size of the arguments of the method (plus one for the implicit this argument),
+     *     argumentsSize, and the size of its return value, returnSize, packed into a single int i =
+     *     {@code (argumentsSize &lt;&lt; 2) | returnSize} (argumentsSize is therefore equal to {@code
+     *     i &gt;&gt; 2}, and returnSize to {@code i &amp; 0x03}).
+     */
+    public int getArgumentsAndReturnSizes() {
+        return getArgumentsAndReturnSizes(getDescriptor());
+    }
+
+    /**
+     * Returns a JVM instruction opcode adapted to this {@link Type}. This method must not be used for
+     * method types.
+     *
+     * @param opcode a JVM instruction opcode. This opcode must be one of ILOAD, ISTORE, IALOAD,
+     *     IASTORE, IADD, ISUB, IMUL, IDIV, IREM, INEG, ISHL, ISHR, IUSHR, IAND, IOR, IXOR and
+     *     IRETURN.
+     * @return an opcode that is similar to the given opcode, but adapted to this {@link Type}. For
+     *     example, if this type is {@code float} and {@code opcode} is IRETURN, this method returns
+     *     FRETURN.
+     */
+    public int getOpcode(final int opcode) {
+        if (opcode == Opcodes.IALOAD || opcode == Opcodes.IASTORE) {
+            switch (sort) {
+                case BOOLEAN:
+                case BYTE:
+                    return opcode + (Opcodes.BALOAD - Opcodes.IALOAD);
+                case CHAR:
+                    return opcode + (Opcodes.CALOAD - Opcodes.IALOAD);
+                case SHORT:
+                    return opcode + (Opcodes.SALOAD - Opcodes.IALOAD);
+                case INT:
+                    return opcode;
+                case FLOAT:
+                    return opcode + (Opcodes.FALOAD - Opcodes.IALOAD);
+                case LONG:
+                    return opcode + (Opcodes.LALOAD - Opcodes.IALOAD);
+                case DOUBLE:
+                    return opcode + (Opcodes.DALOAD - Opcodes.IALOAD);
+                case ARRAY:
+                case OBJECT:
+                case INTERNAL:
+                    return opcode + (Opcodes.AALOAD - Opcodes.IALOAD);
+                case METHOD:
+                case VOID:
+                    throw new UnsupportedOperationException();
+                default:
+                    throw new AssertionError();
+            }
+        } else {
+            switch (sort) {
+                case VOID:
+                    if (opcode != Opcodes.IRETURN) {
+                        throw new UnsupportedOperationException();
+                    }
+                    return Opcodes.RETURN;
+                case BOOLEAN:
+                case BYTE:
+                case CHAR:
+                case SHORT:
+                case INT:
+                    return opcode;
+                case FLOAT:
+                    return opcode + (Opcodes.FRETURN - Opcodes.IRETURN);
+                case LONG:
+                    return opcode + (Opcodes.LRETURN - Opcodes.IRETURN);
+                case DOUBLE:
+                    return opcode + (Opcodes.DRETURN - Opcodes.IRETURN);
+                case ARRAY:
+                case OBJECT:
+                case INTERNAL:
+                    if (opcode != Opcodes.ILOAD && opcode != Opcodes.ISTORE && opcode != Opcodes.IRETURN) {
+                        throw new UnsupportedOperationException();
+                    }
+                    return opcode + (Opcodes.ARETURN - Opcodes.IRETURN);
+                case METHOD:
+                    throw new UnsupportedOperationException();
+                default:
+                    throw new AssertionError();
+            }
+        }
+    }
+
+    // -----------------------------------------------------------------------------------------------
+    // Equals, hashCode and toString.
+    // -----------------------------------------------------------------------------------------------
+
+    /**
+     * Tests if the given object is equal to this type.
+     *
+     * @param object the object to be compared to this type.
+     * @return {@literal true} if the given object is equal to this type.
+     */
+    @Override
+    public boolean equals(final Object object) {
+        if (this == object) {
+            return true;
+        }
+        if (!(object instanceof Type)) {
+            return false;
+        }
+        Type other = (Type) object;
+        if ((sort == INTERNAL ? OBJECT : sort) != (other.sort == INTERNAL ? OBJECT : other.sort)) {
+            return false;
+        }
+        int begin = valueBegin;
+        int end = valueEnd;
+        int otherBegin = other.valueBegin;
+        int otherEnd = other.valueEnd;
+        // Compare the values.
+        if (end - begin != otherEnd - otherBegin) {
+            return false;
+        }
+        for (int i = begin, j = otherBegin; i < end; i++, j++) {
+            if (valueBuffer.charAt(i) != other.valueBuffer.charAt(j)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    /**
+     * Returns a hash code value for this type.
+     *
+     * @return a hash code value for this type.
+     */
+    @Override
+    public int hashCode() {
+        int hashCode = 13 * (sort == INTERNAL ? OBJECT : sort);
+        if (sort >= ARRAY) {
+            for (int i = valueBegin, end = valueEnd; i < end; i++) {
+                hashCode = 17 * (hashCode + valueBuffer.charAt(i));
+            }
+        }
+        return hashCode;
+    }
+
+    /**
+     * Returns a string representation of this type.
+     *
+     * @return the descriptor of this type.
+     */
+    @Override
+    public String toString() {
+        return getDescriptor();
+    }
+}

--- a/core/src/main/java/org/mvel2/asm/TypePath.java
+++ b/core/src/main/java/org/mvel2/asm/TypePath.java
@@ -1,0 +1,201 @@
+// ASM: a very small and fast Java bytecode manipulation framework
+// Copyright (c) 2000-2011 INRIA, France Telecom
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+// 1. Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+// 2. Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+// 3. Neither the name of the copyright holders nor the names of its
+//    contributors may be used to endorse or promote products derived from
+//    this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+// THE POSSIBILITY OF SUCH DAMAGE.
+
+package org.mvel2.asm;
+
+/**
+ * The path to a type argument, wildcard bound, array element type, or static inner type within an
+ * enclosing type.
+ *
+ * @author Eric Bruneton
+ */
+public final class TypePath {
+
+    /** A type path step that steps into the element type of an array type. See {@link #getStep}. */
+    public static final int ARRAY_ELEMENT = 0;
+
+    /** A type path step that steps into the nested type of a class type. See {@link #getStep}. */
+    public static final int INNER_TYPE = 1;
+
+    /** A type path step that steps into the bound of a wildcard type. See {@link #getStep}. */
+    public static final int WILDCARD_BOUND = 2;
+
+    /** A type path step that steps into a type argument of a generic type. See {@link #getStep}. */
+    public static final int TYPE_ARGUMENT = 3;
+
+    /**
+     * The byte array where the 'type_path' structure - as defined in the Java Virtual Machine
+     * Specification (JVMS) - corresponding to this TypePath is stored. The first byte of the
+     * structure in this array is given by {@link #typePathOffset}.
+     *
+     * @see <a
+     *     href="https://docs.oracle.com/javase/specs/jvms/se9/html/jvms-4.html#jvms-4.7.20.2">JVMS
+     *     4.7.20.2</a>
+     */
+    private final byte[] typePathContainer;
+
+    /** The offset of the first byte of the type_path JVMS structure in {@link #typePathContainer}. */
+    private final int typePathOffset;
+
+    /**
+     * Constructs a new TypePath.
+     *
+     * @param typePathContainer a byte array containing a type_path JVMS structure.
+     * @param typePathOffset the offset of the first byte of the type_path structure in
+     *     typePathContainer.
+     */
+    TypePath(final byte[] typePathContainer, final int typePathOffset) {
+        this.typePathContainer = typePathContainer;
+        this.typePathOffset = typePathOffset;
+    }
+
+    /**
+     * Converts a type path in string form, in the format used by {@link #toString()}, into a TypePath
+     * object.
+     *
+     * @param typePath a type path in string form, in the format used by {@link #toString()}. May be
+     *     {@literal null} or empty.
+     * @return the corresponding TypePath object, or {@literal null} if the path is empty.
+     */
+    public static TypePath fromString(final String typePath) {
+        if (typePath == null || typePath.length() == 0) {
+            return null;
+        }
+        int typePathLength = typePath.length();
+        ByteVector output = new ByteVector(typePathLength);
+        output.putByte(0);
+        int typePathIndex = 0;
+        while (typePathIndex < typePathLength) {
+            char c = typePath.charAt(typePathIndex++);
+            if (c == '[') {
+                output.put11(ARRAY_ELEMENT, 0);
+            } else if (c == '.') {
+                output.put11(INNER_TYPE, 0);
+            } else if (c == '*') {
+                output.put11(WILDCARD_BOUND, 0);
+            } else if (c >= '0' && c <= '9') {
+                int typeArg = c - '0';
+                while (typePathIndex < typePathLength) {
+                    c = typePath.charAt(typePathIndex++);
+                    if (c >= '0' && c <= '9') {
+                        typeArg = typeArg * 10 + c - '0';
+                    } else if (c == ';') {
+                        break;
+                    } else {
+                        throw new IllegalArgumentException();
+                    }
+                }
+                output.put11(TYPE_ARGUMENT, typeArg);
+            } else {
+                throw new IllegalArgumentException();
+            }
+        }
+        output.data[0] = (byte) (output.length / 2);
+        return new TypePath(output.data, 0);
+    }
+
+    /**
+     * Puts the type_path JVMS structure corresponding to the given TypePath into the given
+     * ByteVector.
+     *
+     * @param typePath a TypePath instance, or {@literal null} for empty paths.
+     * @param output where the type path must be put.
+     */
+    static void put(final TypePath typePath, final ByteVector output) {
+        if (typePath == null) {
+            output.putByte(0);
+        } else {
+            int length = typePath.typePathContainer[typePath.typePathOffset] * 2 + 1;
+            output.putByteArray(typePath.typePathContainer, typePath.typePathOffset, length);
+        }
+    }
+
+    /**
+     * Returns the length of this path, i.e. its number of steps.
+     *
+     * @return the length of this path.
+     */
+    public int getLength() {
+        // path_length is stored in the first byte of a type_path.
+        return typePathContainer[typePathOffset];
+    }
+
+    /**
+     * Returns the value of the given step of this path.
+     *
+     * @param index an index between 0 and {@link #getLength()}, exclusive.
+     * @return one of {@link #ARRAY_ELEMENT}, {@link #INNER_TYPE}, {@link #WILDCARD_BOUND}, or {@link
+     *     #TYPE_ARGUMENT}.
+     */
+    public int getStep(final int index) {
+        // Returns the type_path_kind of the path element of the given index.
+        return typePathContainer[typePathOffset + 2 * index + 1];
+    }
+
+    /**
+     * Returns the index of the type argument that the given step is stepping into. This method should
+     * only be used for steps whose value is {@link #TYPE_ARGUMENT}.
+     *
+     * @param index an index between 0 and {@link #getLength()}, exclusive.
+     * @return the index of the type argument that the given step is stepping into.
+     */
+    public int getStepArgument(final int index) {
+        // Returns the type_argument_index of the path element of the given index.
+        return typePathContainer[typePathOffset + 2 * index + 2];
+    }
+
+    /**
+     * Returns a string representation of this type path. {@link #ARRAY_ELEMENT} steps are represented
+     * with '[', {@link #INNER_TYPE} steps with '.', {@link #WILDCARD_BOUND} steps with '*' and {@link
+     * #TYPE_ARGUMENT} steps with their type argument index in decimal form followed by ';'.
+     */
+    @Override
+    public String toString() {
+        int length = getLength();
+        StringBuilder result = new StringBuilder(length * 2);
+        for (int i = 0; i < length; ++i) {
+            switch (getStep(i)) {
+                case ARRAY_ELEMENT:
+                    result.append('[');
+                    break;
+                case INNER_TYPE:
+                    result.append('.');
+                    break;
+                case WILDCARD_BOUND:
+                    result.append('*');
+                    break;
+                case TYPE_ARGUMENT:
+                    result.append(getStepArgument(i)).append(';');
+                    break;
+                default:
+                    throw new AssertionError();
+            }
+        }
+        return result.toString();
+    }
+}

--- a/core/src/main/java/org/mvel2/asm/TypeReference.java
+++ b/core/src/main/java/org/mvel2/asm/TypeReference.java
@@ -1,0 +1,435 @@
+// ASM: a very small and fast Java bytecode manipulation framework
+// Copyright (c) 2000-2011 INRIA, France Telecom
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+// 1. Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+// 2. Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+// 3. Neither the name of the copyright holders nor the names of its
+//    contributors may be used to endorse or promote products derived from
+//    this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+// THE POSSIBILITY OF SUCH DAMAGE.
+
+package org.mvel2.asm;
+
+/**
+ * A reference to a type appearing in a class, field or method declaration, or on an instruction.
+ * Such a reference designates the part of the class where the referenced type is appearing (e.g. an
+ * 'extends', 'implements' or 'throws' clause, a 'new' instruction, a 'catch' clause, a type cast, a
+ * local variable declaration, etc).
+ *
+ * @author Eric Bruneton
+ */
+public class TypeReference {
+
+    /**
+     * The sort of type references that target a type parameter of a generic class. See {@link
+     * #getSort}.
+     */
+    public static final int CLASS_TYPE_PARAMETER = 0x00;
+
+    /**
+     * The sort of type references that target a type parameter of a generic method. See {@link
+     * #getSort}.
+     */
+    public static final int METHOD_TYPE_PARAMETER = 0x01;
+
+    /**
+     * The sort of type references that target the super class of a class or one of the interfaces it
+     * implements. See {@link #getSort}.
+     */
+    public static final int CLASS_EXTENDS = 0x10;
+
+    /**
+     * The sort of type references that target a bound of a type parameter of a generic class. See
+     * {@link #getSort}.
+     */
+    public static final int CLASS_TYPE_PARAMETER_BOUND = 0x11;
+
+    /**
+     * The sort of type references that target a bound of a type parameter of a generic method. See
+     * {@link #getSort}.
+     */
+    public static final int METHOD_TYPE_PARAMETER_BOUND = 0x12;
+
+    /** The sort of type references that target the type of a field. See {@link #getSort}. */
+    public static final int FIELD = 0x13;
+
+    /** The sort of type references that target the return type of a method. See {@link #getSort}. */
+    public static final int METHOD_RETURN = 0x14;
+
+    /**
+     * The sort of type references that target the receiver type of a method. See {@link #getSort}.
+     */
+    public static final int METHOD_RECEIVER = 0x15;
+
+    /**
+     * The sort of type references that target the type of a formal parameter of a method. See {@link
+     * #getSort}.
+     */
+    public static final int METHOD_FORMAL_PARAMETER = 0x16;
+
+    /**
+     * The sort of type references that target the type of an exception declared in the throws clause
+     * of a method. See {@link #getSort}.
+     */
+    public static final int THROWS = 0x17;
+
+    /**
+     * The sort of type references that target the type of a local variable in a method. See {@link
+     * #getSort}.
+     */
+    public static final int LOCAL_VARIABLE = 0x40;
+
+    /**
+     * The sort of type references that target the type of a resource variable in a method. See {@link
+     * #getSort}.
+     */
+    public static final int RESOURCE_VARIABLE = 0x41;
+
+    /**
+     * The sort of type references that target the type of the exception of a 'catch' clause in a
+     * method. See {@link #getSort}.
+     */
+    public static final int EXCEPTION_PARAMETER = 0x42;
+
+    /**
+     * The sort of type references that target the type declared in an 'instanceof' instruction. See
+     * {@link #getSort}.
+     */
+    public static final int INSTANCEOF = 0x43;
+
+    /**
+     * The sort of type references that target the type of the object created by a 'new' instruction.
+     * See {@link #getSort}.
+     */
+    public static final int NEW = 0x44;
+
+    /**
+     * The sort of type references that target the receiver type of a constructor reference. See
+     * {@link #getSort}.
+     */
+    public static final int CONSTRUCTOR_REFERENCE = 0x45;
+
+    /**
+     * The sort of type references that target the receiver type of a method reference. See {@link
+     * #getSort}.
+     */
+    public static final int METHOD_REFERENCE = 0x46;
+
+    /**
+     * The sort of type references that target the type declared in an explicit or implicit cast
+     * instruction. See {@link #getSort}.
+     */
+    public static final int CAST = 0x47;
+
+    /**
+     * The sort of type references that target a type parameter of a generic constructor in a
+     * constructor call. See {@link #getSort}.
+     */
+    public static final int CONSTRUCTOR_INVOCATION_TYPE_ARGUMENT = 0x48;
+
+    /**
+     * The sort of type references that target a type parameter of a generic method in a method call.
+     * See {@link #getSort}.
+     */
+    public static final int METHOD_INVOCATION_TYPE_ARGUMENT = 0x49;
+
+    /**
+     * The sort of type references that target a type parameter of a generic constructor in a
+     * constructor reference. See {@link #getSort}.
+     */
+    public static final int CONSTRUCTOR_REFERENCE_TYPE_ARGUMENT = 0x4A;
+
+    /**
+     * The sort of type references that target a type parameter of a generic method in a method
+     * reference. See {@link #getSort}.
+     */
+    public static final int METHOD_REFERENCE_TYPE_ARGUMENT = 0x4B;
+
+    /**
+     * The target_type and target_info structures - as defined in the Java Virtual Machine
+     * Specification (JVMS) - corresponding to this type reference. target_type uses one byte, and all
+     * the target_info union fields use up to 3 bytes (except localvar_target, handled with the
+     * specific method {@link MethodVisitor#visitLocalVariableAnnotation}). Thus, both structures can
+     * be stored in an int.
+     *
+     * <p>This int field stores target_type (called the TypeReference 'sort' in the public API of this
+     * class) in its most significant byte, followed by the target_info fields. Depending on
+     * target_type, 1, 2 or even 3 least significant bytes of this field are unused. target_info
+     * fields which reference bytecode offsets are set to 0 (these offsets are ignored in ClassReader,
+     * and recomputed in MethodWriter).
+     *
+     * @see <a href="https://docs.oracle.com/javase/specs/jvms/se9/html/jvms-4.html#jvms-4.7.20">JVMS
+     *     4.7.20</a>
+     * @see <a
+     *     href="https://docs.oracle.com/javase/specs/jvms/se9/html/jvms-4.html#jvms-4.7.20.1">JVMS
+     *     4.7.20.1</a>
+     */
+    private final int targetTypeAndInfo;
+
+    /**
+     * Constructs a new TypeReference.
+     *
+     * @param typeRef the int encoded value of the type reference, as received in a visit method
+     *     related to type annotations, such as {@link ClassVisitor#visitTypeAnnotation}.
+     */
+    public TypeReference(final int typeRef) {
+        this.targetTypeAndInfo = typeRef;
+    }
+
+    /**
+     * Returns a type reference of the given sort.
+     *
+     * @param sort one of {@link #FIELD}, {@link #METHOD_RETURN}, {@link #METHOD_RECEIVER}, {@link
+     *     #LOCAL_VARIABLE}, {@link #RESOURCE_VARIABLE}, {@link #INSTANCEOF}, {@link #NEW}, {@link
+     *     #CONSTRUCTOR_REFERENCE}, or {@link #METHOD_REFERENCE}.
+     * @return a type reference of the given sort.
+     */
+    public static TypeReference newTypeReference(final int sort) {
+        return new TypeReference(sort << 24);
+    }
+
+    /**
+     * Returns a reference to a type parameter of a generic class or method.
+     *
+     * @param sort one of {@link #CLASS_TYPE_PARAMETER} or {@link #METHOD_TYPE_PARAMETER}.
+     * @param paramIndex the type parameter index.
+     * @return a reference to the given generic class or method type parameter.
+     */
+    public static TypeReference newTypeParameterReference(final int sort, final int paramIndex) {
+        return new TypeReference((sort << 24) | (paramIndex << 16));
+    }
+
+    /**
+     * Returns a reference to a type parameter bound of a generic class or method.
+     *
+     * @param sort one of {@link #CLASS_TYPE_PARAMETER} or {@link #METHOD_TYPE_PARAMETER}.
+     * @param paramIndex the type parameter index.
+     * @param boundIndex the type bound index within the above type parameters.
+     * @return a reference to the given generic class or method type parameter bound.
+     */
+    public static TypeReference newTypeParameterBoundReference(final int sort, final int paramIndex, final int boundIndex) {
+        return new TypeReference((sort << 24) | (paramIndex << 16) | (boundIndex << 8));
+    }
+
+    /**
+     * Returns a reference to the super class or to an interface of the 'implements' clause of a
+     * class.
+     *
+     * @param itfIndex the index of an interface in the 'implements' clause of a class, or -1 to
+     *     reference the super class of the class.
+     * @return a reference to the given super type of a class.
+     */
+    public static TypeReference newSuperTypeReference(final int itfIndex) {
+        return new TypeReference((CLASS_EXTENDS << 24) | ((itfIndex & 0xFFFF) << 8));
+    }
+
+    /**
+     * Returns a reference to the type of a formal parameter of a method.
+     *
+     * @param paramIndex the formal parameter index.
+     * @return a reference to the type of the given method formal parameter.
+     */
+    public static TypeReference newFormalParameterReference(final int paramIndex) {
+        return new TypeReference((METHOD_FORMAL_PARAMETER << 24) | (paramIndex << 16));
+    }
+
+    /**
+     * Returns a reference to the type of an exception, in a 'throws' clause of a method.
+     *
+     * @param exceptionIndex the index of an exception in a 'throws' clause of a method.
+     * @return a reference to the type of the given exception.
+     */
+    public static TypeReference newExceptionReference(final int exceptionIndex) {
+        return new TypeReference((THROWS << 24) | (exceptionIndex << 8));
+    }
+
+    /**
+     * Returns a reference to the type of the exception declared in a 'catch' clause of a method.
+     *
+     * @param tryCatchBlockIndex the index of a try catch block (using the order in which they are
+     *     visited with visitTryCatchBlock).
+     * @return a reference to the type of the given exception.
+     */
+    public static TypeReference newTryCatchReference(final int tryCatchBlockIndex) {
+        return new TypeReference((EXCEPTION_PARAMETER << 24) | (tryCatchBlockIndex << 8));
+    }
+
+    /**
+     * Returns a reference to the type of a type argument in a constructor or method call or
+     * reference.
+     *
+     * @param sort one of {@link #CAST}, {@link #CONSTRUCTOR_INVOCATION_TYPE_ARGUMENT}, {@link
+     *     #METHOD_INVOCATION_TYPE_ARGUMENT}, {@link #CONSTRUCTOR_REFERENCE_TYPE_ARGUMENT}, or {@link
+     *     #METHOD_REFERENCE_TYPE_ARGUMENT}.
+     * @param argIndex the type argument index.
+     * @return a reference to the type of the given type argument.
+     */
+    public static TypeReference newTypeArgumentReference(final int sort, final int argIndex) {
+        return new TypeReference((sort << 24) | argIndex);
+    }
+
+    /**
+     * Puts the given target_type and target_info JVMS structures into the given ByteVector.
+     *
+     * @param targetTypeAndInfo a target_type and a target_info structures encoded as in {@link
+     *     #targetTypeAndInfo}. LOCAL_VARIABLE and RESOURCE_VARIABLE target types are not supported.
+     * @param output where the type reference must be put.
+     */
+    static void putTarget(final int targetTypeAndInfo, final ByteVector output) {
+        switch (targetTypeAndInfo >>> 24) {
+            case CLASS_TYPE_PARAMETER:
+            case METHOD_TYPE_PARAMETER:
+            case METHOD_FORMAL_PARAMETER:
+                output.putShort(targetTypeAndInfo >>> 16);
+                break;
+            case FIELD:
+            case METHOD_RETURN:
+            case METHOD_RECEIVER:
+                output.putByte(targetTypeAndInfo >>> 24);
+                break;
+            case CAST:
+            case CONSTRUCTOR_INVOCATION_TYPE_ARGUMENT:
+            case METHOD_INVOCATION_TYPE_ARGUMENT:
+            case CONSTRUCTOR_REFERENCE_TYPE_ARGUMENT:
+            case METHOD_REFERENCE_TYPE_ARGUMENT:
+                output.putInt(targetTypeAndInfo);
+                break;
+            case CLASS_EXTENDS:
+            case CLASS_TYPE_PARAMETER_BOUND:
+            case METHOD_TYPE_PARAMETER_BOUND:
+            case THROWS:
+            case EXCEPTION_PARAMETER:
+            case INSTANCEOF:
+            case NEW:
+            case CONSTRUCTOR_REFERENCE:
+            case METHOD_REFERENCE:
+                output.put12(targetTypeAndInfo >>> 24, (targetTypeAndInfo & 0xFFFF00) >> 8);
+                break;
+            default:
+                throw new IllegalArgumentException();
+        }
+    }
+
+    /**
+     * Returns the sort of this type reference.
+     *
+     * @return one of {@link #CLASS_TYPE_PARAMETER}, {@link #METHOD_TYPE_PARAMETER}, {@link
+     *     #CLASS_EXTENDS}, {@link #CLASS_TYPE_PARAMETER_BOUND}, {@link #METHOD_TYPE_PARAMETER_BOUND},
+     *     {@link #FIELD}, {@link #METHOD_RETURN}, {@link #METHOD_RECEIVER}, {@link
+     *     #METHOD_FORMAL_PARAMETER}, {@link #THROWS}, {@link #LOCAL_VARIABLE}, {@link
+     *     #RESOURCE_VARIABLE}, {@link #EXCEPTION_PARAMETER}, {@link #INSTANCEOF}, {@link #NEW},
+     *     {@link #CONSTRUCTOR_REFERENCE}, {@link #METHOD_REFERENCE}, {@link #CAST}, {@link
+     *     #CONSTRUCTOR_INVOCATION_TYPE_ARGUMENT}, {@link #METHOD_INVOCATION_TYPE_ARGUMENT}, {@link
+     *     #CONSTRUCTOR_REFERENCE_TYPE_ARGUMENT}, or {@link #METHOD_REFERENCE_TYPE_ARGUMENT}.
+     */
+    public int getSort() {
+        return targetTypeAndInfo >>> 24;
+    }
+
+    /**
+     * Returns the index of the type parameter referenced by this type reference. This method must
+     * only be used for type references whose sort is {@link #CLASS_TYPE_PARAMETER}, {@link
+     * #METHOD_TYPE_PARAMETER}, {@link #CLASS_TYPE_PARAMETER_BOUND} or {@link
+     * #METHOD_TYPE_PARAMETER_BOUND}.
+     *
+     * @return a type parameter index.
+     */
+    public int getTypeParameterIndex() {
+        return (targetTypeAndInfo & 0x00FF0000) >> 16;
+    }
+
+    /**
+     * Returns the index of the type parameter bound, within the type parameter {@link
+     * #getTypeParameterIndex}, referenced by this type reference. This method must only be used for
+     * type references whose sort is {@link #CLASS_TYPE_PARAMETER_BOUND} or {@link
+     * #METHOD_TYPE_PARAMETER_BOUND}.
+     *
+     * @return a type parameter bound index.
+     */
+    public int getTypeParameterBoundIndex() {
+        return (targetTypeAndInfo & 0x0000FF00) >> 8;
+    }
+
+    /**
+     * Returns the index of the "super type" of a class that is referenced by this type reference.
+     * This method must only be used for type references whose sort is {@link #CLASS_EXTENDS}.
+     *
+     * @return the index of an interface in the 'implements' clause of a class, or -1 if this type
+     *     reference references the type of the super class.
+     */
+    public int getSuperTypeIndex() {
+        return (short) ((targetTypeAndInfo & 0x00FFFF00) >> 8);
+    }
+
+    /**
+     * Returns the index of the formal parameter whose type is referenced by this type reference. This
+     * method must only be used for type references whose sort is {@link #METHOD_FORMAL_PARAMETER}.
+     *
+     * @return a formal parameter index.
+     */
+    public int getFormalParameterIndex() {
+        return (targetTypeAndInfo & 0x00FF0000) >> 16;
+    }
+
+    /**
+     * Returns the index of the exception, in a 'throws' clause of a method, whose type is referenced
+     * by this type reference. This method must only be used for type references whose sort is {@link
+     * #THROWS}.
+     *
+     * @return the index of an exception in the 'throws' clause of a method.
+     */
+    public int getExceptionIndex() {
+        return (targetTypeAndInfo & 0x00FFFF00) >> 8;
+    }
+
+    /**
+     * Returns the index of the try catch block (using the order in which they are visited with
+     * visitTryCatchBlock), whose 'catch' type is referenced by this type reference. This method must
+     * only be used for type references whose sort is {@link #EXCEPTION_PARAMETER} .
+     *
+     * @return the index of an exception in the 'throws' clause of a method.
+     */
+    public int getTryCatchBlockIndex() {
+        return (targetTypeAndInfo & 0x00FFFF00) >> 8;
+    }
+
+    /**
+     * Returns the index of the type argument referenced by this type reference. This method must only
+     * be used for type references whose sort is {@link #CAST}, {@link
+     * #CONSTRUCTOR_INVOCATION_TYPE_ARGUMENT}, {@link #METHOD_INVOCATION_TYPE_ARGUMENT}, {@link
+     * #CONSTRUCTOR_REFERENCE_TYPE_ARGUMENT}, or {@link #METHOD_REFERENCE_TYPE_ARGUMENT}.
+     *
+     * @return a type parameter index.
+     */
+    public int getTypeArgumentIndex() {
+        return targetTypeAndInfo & 0xFF;
+    }
+
+    /**
+     * Returns the int encoded value of this type reference, suitable for use in visit methods related
+     * to type annotations, like visitTypeAnnotation.
+     *
+     * @return the int encoded value of this type reference.
+     */
+    public int getValue() {
+        return targetTypeAndInfo;
+    }
+}

--- a/core/src/main/java/org/mvel2/asm/package.html
+++ b/core/src/main/java/org/mvel2/asm/package.html
@@ -1,0 +1,74 @@
+<html>
+<!--
+ * ASM: a very small and fast Java bytecode manipulation framework
+ * Copyright (c) 2000-2011 INRIA, France Telecom
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the copyright holders nor the names of its
+ *    contributors may be used to endorse or promote products derived from
+ *    this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+-->
+<body>
+Provides a small and fast bytecode manipulation framework.
+
+<p>
+    The <a href="http://asm.ow2.org/">ASM</a> framework is organized
+    around the {@link org.mvel2.asm.ClassVisitor ClassVisitor},
+    {@link org.mvel2.asm.FieldVisitor FieldVisitor},
+    {@link org.mvel2.asm.MethodVisitor MethodVisitor} and
+    {@link org.mvel2.asm.AnnotationVisitor AnnotationVisitor} abstract classes,
+    which allow one to visit the fields, methods and annotations of a class,
+    including the bytecode instructions of each method.
+
+<p>
+    In addition to these main abstract classes, ASM provides a {@link
+    org.mvel2.asm.ClassReader ClassReader} class, that can parse an
+    existing class and make a given visitor visit it. ASM also provides
+    a {@link org.mvel2.asm.ClassWriter ClassWriter} class, which is
+    a visitor that generates Java class files.
+
+<p>
+    In order to generate a class from scratch, only the {@link
+    org.mvel2.asm.ClassWriter ClassWriter} class is necessary. Indeed,
+    in order to generate a class, one must just call its visit<i>Xxx</i>
+    methods with the appropriate arguments to generate the desired fields
+    and methods.
+
+<p>
+    In order to modify existing classes, one must use a {@link
+    org.mvel2.asm.ClassReader ClassReader} class to analyze
+    the original class, a class modifier, and a {@link org.mvel2.asm.ClassWriter
+    ClassWriter} to construct the modified class. The class modifier
+    is just a {@link org.mvel2.asm.ClassVisitor ClassVisitor}
+    that delegates most of the work to another {@link org.mvel2.asm.ClassVisitor
+    ClassVisitor}, but that sometimes changes some parameter values,
+    or call additional methods, in order to implement the desired
+    modification process. In order to make it easier to implement such
+    class modifiers, the {@link org.mvel2.asm.ClassVisitor
+    ClassVisitor} and {@link org.mvel2.asm.MethodVisitor MethodVisitor}
+    classes delegate by default all the method calls they receive to an
+    optional visitor.
+
+    @since ASM 1.3
+</body>
+</html>

--- a/core/src/main/java/org/mvel2/asm/signature/SignatureReader.java
+++ b/core/src/main/java/org/mvel2/asm/signature/SignatureReader.java
@@ -1,0 +1,248 @@
+// ASM: a very small and fast Java bytecode manipulation framework
+// Copyright (c) 2000-2011 INRIA, France Telecom
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+// 1. Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+// 2. Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+// 3. Neither the name of the copyright holders nor the names of its
+//    contributors may be used to endorse or promote products derived from
+//    this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+// THE POSSIBILITY OF SUCH DAMAGE.
+package org.mvel2.asm.signature;
+
+/**
+ * A parser for signature literals, as defined in the Java Virtual Machine Specification (JVMS), to
+ * visit them with a SignatureVisitor.
+ *
+ * @see <a href="https://docs.oracle.com/javase/specs/jvms/se9/html/jvms-4.html#jvms-4.7.9.1">JVMS
+ *     4.7.9.1</a>
+ * @author Thomas Hallgren
+ * @author Eric Bruneton
+ */
+public class SignatureReader {
+
+    /** The JVMS signature to be read. */
+    private final String signatureValue;
+
+    /**
+     * Constructs a {@link SignatureReader} for the given signature.
+     *
+     * @param signature A <i>JavaTypeSignature</i>, <i>ClassSignature</i> or <i>MethodSignature</i>.
+     */
+    public SignatureReader(final String signature) {
+        this.signatureValue = signature;
+    }
+
+    /**
+     * Parses a JavaTypeSignature and makes the given visitor visit it.
+     *
+     * @param signature a string containing the signature that must be parsed.
+     * @param startOffset index of the first character of the signature to parsed.
+     * @param signatureVisitor the visitor that must visit this signature.
+     * @return the index of the first character after the parsed signature.
+     */
+    private static int parseType(final String signature, final int startOffset, final SignatureVisitor signatureVisitor) {
+        int offset = startOffset; // Current offset in the parsed signature.
+        char currentChar = signature.charAt(offset++); // The signature character at 'offset'.
+
+        // Switch based on the first character of the JavaTypeSignature, which indicates its kind.
+        switch (currentChar) {
+            case 'Z':
+            case 'C':
+            case 'B':
+            case 'S':
+            case 'I':
+            case 'F':
+            case 'J':
+            case 'D':
+            case 'V':
+                // Case of a BaseType or a VoidDescriptor.
+                signatureVisitor.visitBaseType(currentChar);
+                return offset;
+
+            case '[':
+                // Case of an ArrayTypeSignature, a '[' followed by a JavaTypeSignature.
+                return parseType(signature, offset, signatureVisitor.visitArrayType());
+
+            case 'T':
+                // Case of TypeVariableSignature, an identifier between 'T' and ';'.
+                int endOffset = signature.indexOf(';', offset);
+                signatureVisitor.visitTypeVariable(signature.substring(offset, endOffset));
+                return endOffset + 1;
+
+            case 'L':
+                // Case of a ClassTypeSignature, which ends with ';'.
+                // These signatures have a main class type followed by zero or more inner class types
+                // (separated by '.'). Each can have type arguments, inside '<' and '>'.
+                int start = offset; // The start offset of the currently parsed main or inner class name.
+                boolean visited = false; // Whether the currently parsed class name has been visited.
+                boolean inner = false; // Whether we are currently parsing an inner class type.
+                // Parses the signature, one character at a time.
+                while (true) {
+                    currentChar = signature.charAt(offset++);
+                    if (currentChar == '.' || currentChar == ';') {
+                        // If a '.' or ';' is encountered, this means we have fully parsed the main class name
+                        // or an inner class name. This name may already have been visited it is was followed by
+                        // type arguments between '<' and '>'. If not, we need to visit it here.
+                        if (!visited) {
+                            String name = signature.substring(start, offset - 1);
+                            if (inner) {
+                                signatureVisitor.visitInnerClassType(name);
+                            } else {
+                                signatureVisitor.visitClassType(name);
+                            }
+                        }
+                        // If we reached the end of the ClassTypeSignature return, otherwise start the parsing
+                        // of a new class name, which is necessarily an inner class name.
+                        if (currentChar == ';') {
+                            signatureVisitor.visitEnd();
+                            break;
+                        }
+                        start = offset;
+                        visited = false;
+                        inner = true;
+                    } else if (currentChar == '<') {
+                        // If a '<' is encountered, this means we have fully parsed the main class name or an
+                        // inner class name, and that we now need to parse TypeArguments. First, we need to
+                        // visit the parsed class name.
+                        String name = signature.substring(start, offset - 1);
+                        if (inner) {
+                            signatureVisitor.visitInnerClassType(name);
+                        } else {
+                            signatureVisitor.visitClassType(name);
+                        }
+                        visited = true;
+                        // Now, parse the TypeArgument(s), one at a time.
+                        while ((currentChar = signature.charAt(offset)) != '>') {
+                            switch (currentChar) {
+                                case '*':
+                                    // Unbounded TypeArgument.
+                                    ++offset;
+                                    signatureVisitor.visitTypeArgument();
+                                    break;
+                                case '+':
+                                case '-':
+                                    // Extends or Super TypeArgument. Use offset + 1 to skip the '+' or '-'.
+                                    offset = parseType(signature, offset + 1, signatureVisitor.visitTypeArgument(currentChar));
+                                    break;
+                                default:
+                                    // Instanceof TypeArgument. The '=' is implicit.
+                                    offset = parseType(signature, offset, signatureVisitor.visitTypeArgument('='));
+                                    break;
+                            }
+                        }
+                    }
+                }
+                return offset;
+
+            default:
+                throw new IllegalArgumentException();
+        }
+    }
+
+    /**
+     * Makes the given visitor visit the signature of this {@link SignatureReader}. This signature is
+     * the one specified in the constructor (see {@link #SignatureReader}). This method is intended to
+     * be called on a {@link SignatureReader} that was created using a <i>ClassSignature</i> (such as
+     * the <code>signature</code> parameter of the {@link org.mvel2.asm.ClassVisitor#visit}
+     * method) or a <i>MethodSignature</i> (such as the <code>signature</code> parameter of the {@link
+     * org.mvel2.asm.ClassVisitor#visitMethod} method).
+     *
+     * @param signatureVistor the visitor that must visit this signature.
+     */
+    public void accept(final SignatureVisitor signatureVistor) {
+        String signature = this.signatureValue;
+        int length = signature.length();
+        int offset; // Current offset in the parsed signature (parsed from left to right).
+        char currentChar; // The signature character at 'offset', or just before.
+
+        // If the signature starts with '<', it starts with TypeParameters, i.e. a formal type parameter
+        // identifier, followed by one or more pair ':',ReferenceTypeSignature (for its class bound and
+        // interface bounds).
+        if (signature.charAt(0) == '<') {
+            // Invariant: offset points to the second character of a formal type parameter name at the
+            // beginning of each iteration of the loop below.
+            offset = 2;
+            do {
+                // The formal type parameter name is everything between offset - 1 and the first ':'.
+                int classBoundStartOffset = signature.indexOf(':', offset);
+                signatureVistor.visitFormalTypeParameter(signature.substring(offset - 1, classBoundStartOffset));
+
+                // If the character after the ':' class bound marker is not the start of a
+                // ReferenceTypeSignature, it means the class bound is empty (which is a valid case).
+                offset = classBoundStartOffset + 1;
+                currentChar = signature.charAt(offset);
+                if (currentChar == 'L' || currentChar == '[' || currentChar == 'T') {
+                    offset = parseType(signature, offset, signatureVistor.visitClassBound());
+                }
+
+                // While the character after the class bound or after the last parsed interface bound
+                // is ':', we need to parse another interface bound.
+                while ((currentChar = signature.charAt(offset++)) == ':') {
+                    offset = parseType(signature, offset, signatureVistor.visitInterfaceBound());
+                }
+
+                // At this point a TypeParameter has been fully parsed, and we need to parse the next one
+                // (note that currentChar is now the first character of the next TypeParameter, and that
+                // offset points to the second character), unless the character just after this
+                // TypeParameter signals the end of the TypeParameters.
+            } while (currentChar != '>');
+        } else {
+            offset = 0;
+        }
+
+        // If the (optional) TypeParameters is followed by '(' this means we are parsing a
+        // MethodSignature, which has JavaTypeSignature type inside parentheses, followed by a Result
+        // type and optional ThrowsSignature types.
+        if (signature.charAt(offset) == '(') {
+            offset++;
+            while (signature.charAt(offset) != ')') {
+                offset = parseType(signature, offset, signatureVistor.visitParameterType());
+            }
+            // Use offset + 1 to skip ')'.
+            offset = parseType(signature, offset + 1, signatureVistor.visitReturnType());
+            while (offset < length) {
+                // Use offset + 1 to skip the first character of a ThrowsSignature, i.e. '^'.
+                offset = parseType(signature, offset + 1, signatureVistor.visitExceptionType());
+            }
+        } else {
+            // Otherwise we are parsing a ClassSignature (by hypothesis on the method input), which has
+            // one or more ClassTypeSignature for the super class and the implemented interfaces.
+            offset = parseType(signature, offset, signatureVistor.visitSuperclass());
+            while (offset < length) {
+                offset = parseType(signature, offset, signatureVistor.visitInterface());
+            }
+        }
+    }
+
+    /**
+     * Makes the given visitor visit the signature of this {@link SignatureReader}. This signature is
+     * the one specified in the constructor (see {@link #SignatureReader}). This method is intended to
+     * be called on a {@link SignatureReader} that was created using a <i>JavaTypeSignature</i>, such
+     * as the <code>signature</code> parameter of the {@link
+     * org.mvel2.asm.ClassVisitor#visitField} or {@link
+     * org.mvel2.asm.MethodVisitor#visitLocalVariable} methods.
+     *
+     * @param signatureVisitor the visitor that must visit this signature.
+     */
+    public void acceptType(final SignatureVisitor signatureVisitor) {
+        parseType(signatureValue, 0, signatureVisitor);
+    }
+}

--- a/core/src/main/java/org/mvel2/asm/signature/SignatureVisitor.java
+++ b/core/src/main/java/org/mvel2/asm/signature/SignatureVisitor.java
@@ -1,0 +1,210 @@
+// ASM: a very small and fast Java bytecode manipulation framework
+// Copyright (c) 2000-2011 INRIA, France Telecom
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+// 1. Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+// 2. Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+// 3. Neither the name of the copyright holders nor the names of its
+//    contributors may be used to endorse or promote products derived from
+//    this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+// THE POSSIBILITY OF SUCH DAMAGE.
+package org.mvel2.asm.signature;
+
+import org.mvel2.asm.Opcodes;
+
+/**
+ * A visitor to visit a generic signature. The methods of this interface must be called in one of
+ * the three following orders (the last one is the only valid order for a {@link SignatureVisitor}
+ * that is returned by a method of this interface):
+ *
+ * <ul>
+ *   <li><i>ClassSignature</i> = ( {@code visitFormalTypeParameter} {@code visitClassBound}? {@code
+ *       visitInterfaceBound}* )* ({@code visitSuperclass} {@code visitInterface}* )
+ *   <li><i>MethodSignature</i> = ( {@code visitFormalTypeParameter} {@code visitClassBound}? {@code
+ *       visitInterfaceBound}* )* ({@code visitParameterType}* {@code visitReturnType} {@code
+ *       visitExceptionType}* )
+ *   <li><i>TypeSignature</i> = {@code visitBaseType} | {@code visitTypeVariable} | {@code
+ *       visitArrayType} | ( {@code visitClassType} {@code visitTypeArgument}* ( {@code
+ *       visitInnerClassType} {@code visitTypeArgument}* )* {@code visitEnd} ) )
+ * </ul>
+ *
+ * @author Thomas Hallgren
+ * @author Eric Bruneton
+ */
+public abstract class SignatureVisitor {
+
+    /** Wildcard for an "extends" type argument. */
+    public static final char EXTENDS = '+';
+
+    /** Wildcard for a "super" type argument. */
+    public static final char SUPER = '-';
+
+    /** Wildcard for a normal type argument. */
+    public static final char INSTANCEOF = '=';
+
+    /**
+     * The ASM API version implemented by this visitor. The value of this field must be one of {@link
+     * Opcodes#ASM4}, {@link Opcodes#ASM5}, {@link Opcodes#ASM6} or {@link Opcodes#ASM7}.
+     */
+    protected final int api;
+
+    /**
+     * Constructs a new {@link SignatureVisitor}.
+     *
+     * @param api the ASM API version implemented by this visitor. Must be one of {@link
+     *     Opcodes#ASM4}, {@link Opcodes#ASM5}, {@link Opcodes#ASM6} or {@link Opcodes#ASM7}.
+     */
+    public SignatureVisitor(final int api) {
+        if (api != Opcodes.ASM6 && api != Opcodes.ASM5 && api != Opcodes.ASM4 && api != Opcodes.ASM7) {
+            throw new IllegalArgumentException();
+        }
+        this.api = api;
+    }
+
+    /**
+     * Visits a formal type parameter.
+     *
+     * @param name the name of the formal parameter.
+     */
+    public void visitFormalTypeParameter(final String name) {
+    }
+
+    /**
+     * Visits the class bound of the last visited formal type parameter.
+     *
+     * @return a non null visitor to visit the signature of the class bound.
+     */
+    public SignatureVisitor visitClassBound() {
+        return this;
+    }
+
+    /**
+     * Visits an interface bound of the last visited formal type parameter.
+     *
+     * @return a non null visitor to visit the signature of the interface bound.
+     */
+    public SignatureVisitor visitInterfaceBound() {
+        return this;
+    }
+
+    /**
+     * Visits the type of the super class.
+     *
+     * @return a non null visitor to visit the signature of the super class type.
+     */
+    public SignatureVisitor visitSuperclass() {
+        return this;
+    }
+
+    /**
+     * Visits the type of an interface implemented by the class.
+     *
+     * @return a non null visitor to visit the signature of the interface type.
+     */
+    public SignatureVisitor visitInterface() {
+        return this;
+    }
+
+    /**
+     * Visits the type of a method parameter.
+     *
+     * @return a non null visitor to visit the signature of the parameter type.
+     */
+    public SignatureVisitor visitParameterType() {
+        return this;
+    }
+
+    /**
+     * Visits the return type of the method.
+     *
+     * @return a non null visitor to visit the signature of the return type.
+     */
+    public SignatureVisitor visitReturnType() {
+        return this;
+    }
+
+    /**
+     * Visits the type of a method exception.
+     *
+     * @return a non null visitor to visit the signature of the exception type.
+     */
+    public SignatureVisitor visitExceptionType() {
+        return this;
+    }
+
+    /**
+     * Visits a signature corresponding to a primitive type.
+     *
+     * @param descriptor the descriptor of the primitive type, or 'V' for {@code void} .
+     */
+    public void visitBaseType(final char descriptor) {
+    }
+
+    /**
+     * Visits a signature corresponding to a type variable.
+     *
+     * @param name the name of the type variable.
+     */
+    public void visitTypeVariable(final String name) {
+    }
+
+    /**
+     * Visits a signature corresponding to an array type.
+     *
+     * @return a non null visitor to visit the signature of the array element type.
+     */
+    public SignatureVisitor visitArrayType() {
+        return this;
+    }
+
+    /**
+     * Starts the visit of a signature corresponding to a class or interface type.
+     *
+     * @param name the internal name of the class or interface.
+     */
+    public void visitClassType(final String name) {
+    }
+
+    /**
+     * Visits an inner class.
+     *
+     * @param name the local name of the inner class in its enclosing class.
+     */
+    public void visitInnerClassType(final String name) {
+    }
+
+    /** Visits an unbounded type argument of the last visited class or inner class type. */
+    public void visitTypeArgument() {
+    }
+
+    /**
+     * Visits a type argument of the last visited class or inner class type.
+     *
+     * @param wildcard '+', '-' or '='.
+     * @return a non null visitor to visit the signature of the type argument.
+     */
+    public SignatureVisitor visitTypeArgument(final char wildcard) {
+        return this;
+    }
+
+    /** Ends the visit of a signature corresponding to a class or interface type. */
+    public void visitEnd() {
+    }
+}

--- a/core/src/main/java/org/mvel2/asm/signature/SignatureWriter.java
+++ b/core/src/main/java/org/mvel2/asm/signature/SignatureWriter.java
@@ -1,0 +1,240 @@
+// ASM: a very small and fast Java bytecode manipulation framework
+// Copyright (c) 2000-2011 INRIA, France Telecom
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+// 1. Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+// 2. Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+// 3. Neither the name of the copyright holders nor the names of its
+//    contributors may be used to endorse or promote products derived from
+//    this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+// THE POSSIBILITY OF SUCH DAMAGE.
+package org.mvel2.asm.signature;
+
+import org.mvel2.asm.Opcodes;
+
+/**
+ * A SignatureVisitor that generates signature literals, as defined in the Java Virtual Machine
+ * Specification (JVMS).
+ *
+ * @see <a href="https://docs.oracle.com/javase/specs/jvms/se9/html/jvms-4.html#jvms-4.7.9.1">JVMS
+ *     4.7.9.1</a>
+ * @author Thomas Hallgren
+ * @author Eric Bruneton
+ */
+public class SignatureWriter extends SignatureVisitor {
+
+    /** The builder used to construct the visited signature. */
+    private final StringBuilder stringBuilder = new StringBuilder();
+
+    /** Whether the visited signature contains formal type parameters. */
+    private boolean hasFormals;
+
+    /** Whether the visited signature contains method parameter types. */
+    private boolean hasParameters;
+
+    /**
+     * The stack used to keep track of class types that have arguments. Each element of this stack is
+     * a boolean encoded in one bit. The top of the stack is the least significant bit. Pushing false
+     * = *2, pushing true = *2+1, popping = /2.
+     *
+     * <p>Class type arguments must be surrounded with '&lt;' and '&gt;' and, because
+     *
+     * <ol>
+     *   <li>class types can be nested (because type arguments can themselves be class types),
+     *   <li>SignatureWriter always returns 'this' in each visit* method (to avoid allocating new
+     *       SignatureWriter instances),
+     * </ol>
+     *
+     * <p>we need a stack to properly balance these 'parentheses'. A new element is pushed on this
+     * stack for each new visited type, and popped when the visit of this type ends (either is
+     * visitEnd, or because visitInnerClassType is called).
+     */
+    private int argumentStack;
+
+    /** Constructs a new {@link SignatureWriter}. */
+    public SignatureWriter() {
+        super(Opcodes.ASM7);
+    }
+
+    // -----------------------------------------------------------------------------------------------
+    // Implementation of the SignatureVisitor interface
+    // -----------------------------------------------------------------------------------------------
+
+    @Override
+    public void visitFormalTypeParameter(final String name) {
+        if (!hasFormals) {
+            hasFormals = true;
+            stringBuilder.append('<');
+        }
+        stringBuilder.append(name);
+        stringBuilder.append(':');
+    }
+
+    @Override
+    public SignatureVisitor visitClassBound() {
+        return this;
+    }
+
+    @Override
+    public SignatureVisitor visitInterfaceBound() {
+        stringBuilder.append(':');
+        return this;
+    }
+
+    @Override
+    public SignatureVisitor visitSuperclass() {
+        endFormals();
+        return this;
+    }
+
+    @Override
+    public SignatureVisitor visitInterface() {
+        return this;
+    }
+
+    @Override
+    public SignatureVisitor visitParameterType() {
+        endFormals();
+        if (!hasParameters) {
+            hasParameters = true;
+            stringBuilder.append('(');
+        }
+        return this;
+    }
+
+    @Override
+    public SignatureVisitor visitReturnType() {
+        endFormals();
+        if (!hasParameters) {
+            stringBuilder.append('(');
+        }
+        stringBuilder.append(')');
+        return this;
+    }
+
+    @Override
+    public SignatureVisitor visitExceptionType() {
+        stringBuilder.append('^');
+        return this;
+    }
+
+    @Override
+    public void visitBaseType(final char descriptor) {
+        stringBuilder.append(descriptor);
+    }
+
+    @Override
+    public void visitTypeVariable(final String name) {
+        stringBuilder.append('T');
+        stringBuilder.append(name);
+        stringBuilder.append(';');
+    }
+
+    @Override
+    public SignatureVisitor visitArrayType() {
+        stringBuilder.append('[');
+        return this;
+    }
+
+    @Override
+    public void visitClassType(final String name) {
+        stringBuilder.append('L');
+        stringBuilder.append(name);
+        // Pushes 'false' on the stack, meaning that this type does not have type arguments (as far as
+        // we can tell at this point).
+        argumentStack *= 2;
+    }
+
+    @Override
+    public void visitInnerClassType(final String name) {
+        endArguments();
+        stringBuilder.append('.');
+        stringBuilder.append(name);
+        // Pushes 'false' on the stack, meaning that this type does not have type arguments (as far as
+        // we can tell at this point).
+        argumentStack *= 2;
+    }
+
+    @Override
+    public void visitTypeArgument() {
+        // If the top of the stack is 'false', this means we are visiting the first type argument of the
+        // currently visited type. We therefore need to append a '<', and to replace the top stack
+        // element with 'true' (meaning that the current type does have type arguments).
+        if (argumentStack % 2 == 0) {
+            argumentStack |= 1;
+            stringBuilder.append('<');
+        }
+        stringBuilder.append('*');
+    }
+
+    @Override
+    public SignatureVisitor visitTypeArgument(final char wildcard) {
+        // If the top of the stack is 'false', this means we are visiting the first type argument of the
+        // currently visited type. We therefore need to append a '<', and to replace the top stack
+        // element with 'true' (meaning that the current type does have type arguments).
+        if (argumentStack % 2 == 0) {
+            argumentStack |= 1;
+            stringBuilder.append('<');
+        }
+        if (wildcard != '=') {
+            stringBuilder.append(wildcard);
+        }
+        return this;
+    }
+
+    @Override
+    public void visitEnd() {
+        endArguments();
+        stringBuilder.append(';');
+    }
+
+    /**
+     * Returns the signature that was built by this signature writer.
+     *
+     * @return the signature that was built by this signature writer.
+     */
+    @Override
+    public String toString() {
+        return stringBuilder.toString();
+    }
+
+    // -----------------------------------------------------------------------------------------------
+    // Utility methods
+    // -----------------------------------------------------------------------------------------------
+
+    /** Ends the formal type parameters section of the signature. */
+    private void endFormals() {
+        if (hasFormals) {
+            hasFormals = false;
+            stringBuilder.append('>');
+        }
+    }
+
+    /** Ends the type arguments of a class or inner class type. */
+    private void endArguments() {
+        // If the top of the stack is 'true', this means that some type arguments have been visited for
+        // the type whose visit is now ending. We therefore need to append a '>', and to pop one element
+        // from the stack.
+        if (argumentStack % 2 == 1) {
+            stringBuilder.append('>');
+        }
+        argumentStack /= 2;
+    }
+}

--- a/core/src/main/java/org/mvel2/asm/signature/package.html
+++ b/core/src/main/java/org/mvel2/asm/signature/package.html
@@ -1,0 +1,36 @@
+<html>
+<!--
+ * ASM: a very small and fast Java bytecode manipulation framework
+ * Copyright (c) 2000-2011 INRIA, France Telecom
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the copyright holders nor the names of its
+ *    contributors may be used to endorse or promote products derived from
+ *    this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+-->
+<body>
+Provides support for type signatures.
+
+@since ASM 2.0
+</body>
+</html>

--- a/core/src/main/java/org/mvel2/ast/ASTNode.java
+++ b/core/src/main/java/org/mvel2/ast/ASTNode.java
@@ -1,0 +1,414 @@
+/**
+ * MVEL 2.0
+ * Copyright (C) 2007 The Codehaus
+ * Mike Brock, Dhanji Prasanna, John Graham, Mark Proctor
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mvel2.ast;
+
+import static java.lang.Thread.currentThread;
+import static org.mvel2.Operator.NOOP;
+import static org.mvel2.PropertyAccessor.get;
+import static org.mvel2.optimizers.OptimizerFactory.SAFE_REFLECTIVE;
+import static org.mvel2.optimizers.OptimizerFactory.getAccessorCompiler;
+import static org.mvel2.optimizers.OptimizerFactory.getDefaultAccessorCompiler;
+import static org.mvel2.util.CompilerTools.getInjectedImports;
+import static org.mvel2.util.ParseTools.handleNumericConversion;
+import static org.mvel2.util.ParseTools.isNumber;
+import static org.mvel2.util.ParseTools.subArray;
+
+import java.io.Serializable;
+
+import org.mvel2.CompileException;
+import org.mvel2.ParserConfiguration;
+import org.mvel2.ParserContext;
+import org.mvel2.compiler.Accessor;
+import org.mvel2.debug.DebugTools;
+import org.mvel2.integration.VariableResolverFactory;
+import org.mvel2.optimizers.AccessorOptimizer;
+import org.mvel2.optimizers.OptimizationNotSupported;
+
+@SuppressWarnings({ "ManualArrayCopy", "CaughtExceptionImmediatelyRethrown" })
+public class ASTNode implements Cloneable, Serializable {
+
+    public static final int LITERAL = 1;
+    public static final int DEEP_PROPERTY = 1 << 1;
+    public static final int OPERATOR = 1 << 2;
+    public static final int IDENTIFIER = 1 << 3;
+    public static final int COMPILE_IMMEDIATE = 1 << 4;
+    public static final int NUMERIC = 1 << 5;
+
+    public static final int INVERT = 1 << 6;
+    public static final int ASSIGN = 1 << 7;
+
+    public static final int COLLECTION = 1 << 8;
+    public static final int THISREF = 1 << 9;
+    public static final int INLINE_COLLECTION = 1 << 10;
+
+    public static final int BLOCK_IF = 1 << 11;
+    public static final int BLOCK_FOREACH = 1 << 12;
+    public static final int BLOCK_WITH = 1 << 13;
+    public static final int BLOCK_UNTIL = 1 << 14;
+    public static final int BLOCK_WHILE = 1 << 15;
+    public static final int BLOCK_DO = 1 << 16;
+    public static final int BLOCK_DO_UNTIL = 1 << 17;
+    public static final int BLOCK_FOR = 1 << 18;
+
+    public static final int OPT_SUBTR = 1 << 19;
+
+    public static final int FQCN = 1 << 20;
+
+    public static final int STACKLANG = 1 << 22;
+
+    public static final int DEFERRED_TYPE_RES = 1 << 23;
+    public static final int STRONG_TYPING = 1 << 24;
+    public static final int PCTX_STORED = 1 << 25;
+    public static final int ARRAY_TYPE_LITERAL = 1 << 26;
+
+    public static final int NOJIT = 1 << 27;
+    public static final int DEOP = 1 << 28;
+
+    public static final int DISCARD = 1 << 29;
+
+    // *** //
+    public int fields = 0;
+    public ASTNode nextASTNode;
+    protected int firstUnion;
+    protected int endOfName;
+    protected Class egressType;
+    protected char[] expr;
+    protected int start;
+    protected int offset;
+    protected String nameCache;
+    protected Object literal;
+    protected transient volatile Accessor accessor;
+    protected volatile Accessor safeAccessor;
+    protected int cursorPosition;
+    protected ParserContext pCtx;
+
+    protected ASTNode(ParserContext pCtx) {
+        this.pCtx = pCtx;
+    }
+
+    public ASTNode(char[] expr, int start, int offset, int fields, ParserContext pCtx) {
+        this(pCtx);
+        this.fields = fields;
+        this.expr = expr;
+        this.start = start;
+        this.offset = offset;
+
+        setName(expr);
+    }
+
+    public Object getReducedValueAccelerated(Object ctx, Object thisValue, VariableResolverFactory factory) {
+        if (accessor != null) {
+            try {
+                return accessor.getValue(ctx, thisValue, factory);
+            } catch (ClassCastException ce) {
+                return deop(ctx, thisValue, factory, ce);
+            }
+        } else {
+            return optimize(ctx, thisValue, factory);
+        }
+    }
+
+    private Object deop(Object ctx, Object thisValue, VariableResolverFactory factory, RuntimeException e) {
+        if ((fields & DEOP) == 0) {
+            accessor = null;
+            fields |= DEOP | NOJIT;
+
+            synchronized (this) {
+                return getReducedValueAccelerated(ctx, thisValue, factory);
+            }
+        } else {
+            throw e;
+        }
+    }
+
+    private Object optimize(Object ctx, Object thisValue, VariableResolverFactory factory) {
+        if ((fields & DEOP) != 0) {
+            fields ^= DEOP;
+        }
+
+        AccessorOptimizer optimizer;
+        Object retVal = null;
+
+        if ((fields & NOJIT) != 0 || factory != null && factory.isResolveable(nameCache)) {
+            optimizer = getAccessorCompiler(SAFE_REFLECTIVE);
+        } else {
+            optimizer = getDefaultAccessorCompiler();
+        }
+
+        ParserContext pCtx;
+
+        if ((fields & PCTX_STORED) != 0) {
+            pCtx = (ParserContext) literal;
+        } else {
+            pCtx = new ParserContext(new ParserConfiguration(getInjectedImports(factory), null));
+        }
+
+        try {
+            pCtx.optimizationNotify();
+            setAccessor(optimizer.optimizeAccessor(pCtx, expr, start, offset, ctx, thisValue, factory, true, egressType));
+        } catch (OptimizationNotSupported ne) {
+            setAccessor((optimizer = getAccessorCompiler(SAFE_REFLECTIVE)).optimizeAccessor(pCtx, expr, start, offset, ctx, thisValue,
+                    factory, true, null));
+        }
+
+        if (accessor == null) {
+            return get(expr, start, offset, ctx, factory, thisValue, pCtx);
+        }
+
+        if (retVal == null) {
+            retVal = optimizer.getResultOptPass();
+        }
+
+        if (egressType == null) {
+            egressType = optimizer.getEgressType();
+        }
+
+        return retVal;
+    }
+
+    public Object getReducedValue(Object ctx, Object thisValue, VariableResolverFactory factory) {
+        if ((fields & (LITERAL)) != 0) {
+            return literal;
+        } else {
+            return get(expr, start, offset, ctx, factory, thisValue, pCtx);
+        }
+    }
+
+    protected String getAbsoluteRootElement() {
+        if ((fields & (DEEP_PROPERTY | COLLECTION)) != 0) {
+            return new String(expr, start, getAbsoluteFirstPart());
+        }
+        return nameCache;
+    }
+
+    public Class getEgressType() {
+        return egressType;
+    }
+
+    public void setEgressType(Class egressType) {
+        this.egressType = egressType;
+    }
+
+    public char[] getNameAsArray() {
+        return subArray(expr, start, start + offset);
+    }
+
+    private int getAbsoluteFirstPart() {
+        if ((fields & COLLECTION) != 0) {
+            if (firstUnion < 0 || endOfName < firstUnion) return endOfName;
+            else return firstUnion;
+        } else if ((fields & DEEP_PROPERTY) != 0) {
+            return firstUnion;
+        } else {
+            return -1;
+        }
+    }
+
+    public String getAbsoluteName() {
+        if (firstUnion > start) {
+            return new String(expr, start, getAbsoluteFirstPart() - start);
+        } else {
+            return getName();
+        }
+    }
+
+    public String getName() {
+        if (nameCache != null) {
+            return nameCache;
+        } else if (expr != null) {
+            return nameCache = new String(expr, start, offset);
+        }
+        return "";
+    }
+
+    @SuppressWarnings({ "SuspiciousMethodCalls" })
+    protected void setName(char[] name) {
+        if (isNumber(name, start, offset)) {
+            egressType = (literal = handleNumericConversion(name, start, offset)).getClass();
+            if (((fields |= NUMERIC | LITERAL | IDENTIFIER) & INVERT) != 0) {
+                try {
+                    literal = ~((Integer) literal);
+                } catch (ClassCastException e) {
+                    throw new CompileException("bitwise (~) operator can only be applied to integers", expr, start);
+                }
+            }
+            return;
+        }
+
+        this.literal = new String(name, start, offset);
+
+        int end = start + offset;
+
+        Scan: for (int i = start; i < end; i++) {
+            switch (name[i]) {
+                case '.':
+                    if (firstUnion == 0) {
+                        firstUnion = i;
+                    }
+                    break;
+                case '[':
+                case '(':
+                    if (firstUnion == 0) {
+                        firstUnion = i;
+                    }
+                    if (endOfName == 0) {
+                        endOfName = i;
+                        if (i < name.length && name[i + 1] == ']') fields |= ARRAY_TYPE_LITERAL;
+                        break Scan;
+                    }
+            }
+        }
+
+        if ((fields & INLINE_COLLECTION) != 0) {
+            return;
+        }
+
+        if (firstUnion > start) {
+            fields |= DEEP_PROPERTY | IDENTIFIER;
+        } else {
+            fields |= IDENTIFIER;
+        }
+    }
+
+    public Object getLiteralValue() {
+        return literal;
+    }
+
+    public void setLiteralValue(Object literal) {
+        this.literal = literal;
+        this.fields |= LITERAL;
+    }
+
+    public void storeInLiteralRegister(Object o) {
+        this.literal = o;
+    }
+
+    public Accessor setAccessor(Accessor accessor) {
+        return this.accessor = accessor;
+    }
+
+    public boolean isIdentifier() {
+        return (fields & IDENTIFIER) != 0;
+    }
+
+    public boolean isLiteral() {
+        return (fields & LITERAL) != 0;
+    }
+
+    public boolean isThisVal() {
+        return (fields & THISREF) != 0;
+    }
+
+    public boolean isOperator() {
+        return (fields & OPERATOR) != 0;
+    }
+
+    public boolean isOperator(Integer operator) {
+        return (fields & OPERATOR) != 0 && operator.equals(literal);
+    }
+
+    public Integer getOperator() {
+        return NOOP;
+    }
+
+    protected boolean isCollection() {
+        return (fields & COLLECTION) != 0;
+    }
+
+    public boolean isAssignment() {
+        return ((fields & ASSIGN) != 0);
+    }
+
+    public boolean isDeepProperty() {
+        return ((fields & DEEP_PROPERTY) != 0);
+    }
+
+    public boolean isFQCN() {
+        return ((fields & FQCN) != 0);
+    }
+
+    public void setAsLiteral() {
+        fields |= LITERAL;
+    }
+
+    public void setAsFQCNReference() {
+        fields |= FQCN;
+    }
+
+    public int getCursorPosition() {
+        return cursorPosition;
+    }
+
+    public void setCursorPosition(int cursorPosition) {
+        this.cursorPosition = cursorPosition;
+    }
+
+    public boolean isDiscard() {
+        return fields != -1 && (fields & DISCARD) != 0;
+    }
+
+    public void discard() {
+        this.fields |= DISCARD;
+    }
+
+    public void strongTyping() {
+        this.fields |= STRONG_TYPING;
+    }
+
+    public void storePctx() {
+        this.fields |= PCTX_STORED;
+    }
+
+    public boolean isDebuggingSymbol() {
+        return this.fields == -1;
+    }
+
+    public int getFields() {
+        return fields;
+    }
+
+    public Accessor getAccessor() {
+        return accessor;
+    }
+
+    public boolean canSerializeAccessor() {
+        return safeAccessor != null;
+    }
+
+    public int getStart() {
+        return start;
+    }
+
+    public int getOffset() {
+        return offset;
+    }
+
+    public char[] getExpr() {
+        return expr;
+    }
+
+    public String toString() {
+        return isOperator() ? "<<" + DebugTools.getOperatorName(getOperator())
+                + ">>" : (PCTX_STORED & fields) != 0 ? nameCache : new String(expr, start, offset);
+    }
+
+    protected ClassLoader getClassLoader() {
+        return pCtx != null ? pCtx.getClassLoader() : currentThread().getContextClassLoader();
+    }
+}

--- a/core/src/main/java/org/mvel2/ast/And.java
+++ b/core/src/main/java/org/mvel2/ast/And.java
@@ -1,0 +1,65 @@
+/**
+ * MVEL 2.0
+ * Copyright (C) 2007 The Codehaus
+ * Mike Brock, Dhanji Prasanna, John Graham, Mark Proctor
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.mvel2.ast;
+
+import static org.mvel2.util.CompilerTools.expectType;
+
+import org.mvel2.ParserContext;
+import org.mvel2.integration.VariableResolverFactory;
+
+public class And extends BooleanNode {
+
+    public And(ASTNode left, ASTNode right, boolean strongTyping, ParserContext pCtx) {
+        super(pCtx);
+        expectType(pCtx, this.left = left, Boolean.class, strongTyping);
+        expectType(pCtx, this.right = right, Boolean.class, strongTyping);
+    }
+
+    public Object getReducedValueAccelerated(Object ctx, Object thisValue, VariableResolverFactory factory) {
+        return (((Boolean) left.getReducedValueAccelerated(ctx, thisValue, factory))
+                && ((Boolean) right.getReducedValueAccelerated(ctx, thisValue, factory)));
+    }
+
+    public Object getReducedValue(Object ctx, Object thisValue, VariableResolverFactory factory) {
+        throw new RuntimeException("improper use of AST element");
+    }
+
+    public String toString() {
+        return "(" + left.toString() + " && " + right.toString() + ")";
+    }
+
+    public ASTNode getRightMost() {
+        And n = this;
+        while (n.right != null && n.right instanceof And) {
+            n = (And) n.right;
+        }
+        return n.right;
+    }
+
+    public void setRightMost(ASTNode right) {
+        And n = this;
+        while (n.right != null && n.right instanceof And) {
+            n = (And) n.right;
+        }
+        n.right = right;
+    }
+
+    public Class getEgressType() {
+        return Boolean.class;
+    }
+}

--- a/core/src/main/java/org/mvel2/ast/ArraySize.java
+++ b/core/src/main/java/org/mvel2/ast/ArraySize.java
@@ -1,0 +1,30 @@
+/**
+ * MVEL 2.0
+ * Copyright (C) 2007 The Codehaus
+ * Mike Brock, Dhanji Prasanna, John Graham, Mark Proctor
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mvel2.ast;
+
+import java.io.Serializable;
+
+public class ArraySize implements Serializable {
+
+    public char[] value;
+
+    public ArraySize(char[] value) {
+        this.value = value;
+    }
+}

--- a/core/src/main/java/org/mvel2/ast/AssertNode.java
+++ b/core/src/main/java/org/mvel2/ast/AssertNode.java
@@ -1,0 +1,71 @@
+/**
+ * MVEL 2.0
+ * Copyright (C) 2007 The Codehaus
+ * Mike Brock, Dhanji Prasanna, John Graham, Mark Proctor
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mvel2.ast;
+
+import static org.mvel2.util.ParseTools.subCompileExpression;
+
+import org.mvel2.CompileException;
+import org.mvel2.MVEL;
+import org.mvel2.ParserContext;
+import org.mvel2.compiler.ExecutableStatement;
+import org.mvel2.integration.VariableResolverFactory;
+
+/**
+ * @author Christopher Brock
+ */
+public class AssertNode extends ASTNode {
+
+    public ExecutableStatement assertion;
+    public ExecutableStatement fail;
+
+    public AssertNode(char[] expr, int start, int offset, int fields, ParserContext pCtx) {
+        super(pCtx);
+        this.expr = expr;
+        this.start = start;
+        this.offset = offset;
+
+        if ((fields & COMPILE_IMMEDIATE) != 0) {
+            assertion = (ExecutableStatement) subCompileExpression(expr, start, offset, pCtx);
+        }
+    }
+
+    public Object getReducedValueAccelerated(Object ctx, Object thisValue, VariableResolverFactory factory) {
+        try {
+            if (!((Boolean) assertion.getValue(ctx, thisValue, factory))) {
+                throw new AssertionError("assertion failed in expression: " + new String(this.expr, start, offset));
+            } else {
+                return true;
+            }
+        } catch (ClassCastException e) {
+            throw new CompileException("assertion does not contain a boolean statement", expr, start);
+        }
+    }
+
+    public Object getReducedValue(Object ctx, Object thisValue, VariableResolverFactory factory) {
+        try {
+            if (!((Boolean) MVEL.eval(this.expr, ctx, factory))) {
+                throw new AssertionError("assertion failed in expression: " + new String(this.expr, start, offset));
+            } else {
+                return true;
+            }
+        } catch (ClassCastException e) {
+            throw new CompileException("assertion does not contain a boolean statement", expr, start);
+        }
+    }
+}

--- a/core/src/main/java/org/mvel2/ast/Assignment.java
+++ b/core/src/main/java/org/mvel2/ast/Assignment.java
@@ -1,0 +1,32 @@
+/**
+ * MVEL 2.0
+ * Copyright (C) 2007 The Codehaus
+ * Mike Brock, Dhanji Prasanna, John Graham, Mark Proctor
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mvel2.ast;
+
+import org.mvel2.compiler.ExecutableStatement;
+
+public interface Assignment {
+
+    public String getAssignmentVar();
+
+    public char[] getExpression();
+
+    public boolean isNewDeclaration();
+
+    public void setValueStatement(ExecutableStatement stmt);
+}

--- a/core/src/main/java/org/mvel2/ast/AssignmentNode.java
+++ b/core/src/main/java/org/mvel2/ast/AssignmentNode.java
@@ -1,0 +1,157 @@
+/**
+ * MVEL 2.0
+ * Copyright (C) 2007 The Codehaus
+ * Mike Brock, Dhanji Prasanna, John Graham, Mark Proctor
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mvel2.ast;
+
+import static org.mvel2.MVEL.compileSetExpression;
+import static org.mvel2.util.ArrayTools.findFirst;
+import static org.mvel2.util.ParseTools.checkNameSafety;
+import static org.mvel2.util.ParseTools.createStringTrimmed;
+import static org.mvel2.util.ParseTools.find;
+import static org.mvel2.util.ParseTools.skipWhitespace;
+import static org.mvel2.util.ParseTools.subCompileExpression;
+import static org.mvel2.util.ParseTools.subset;
+
+import org.mvel2.CompileException;
+import org.mvel2.MVELInterpretedRuntime;
+import org.mvel2.ParserContext;
+import org.mvel2.PropertyAccessor;
+import org.mvel2.compiler.CompiledAccExpression;
+import org.mvel2.compiler.ExecutableStatement;
+import org.mvel2.integration.VariableResolverFactory;
+
+/**
+ * @author Christopher Brock
+ */
+public class AssignmentNode extends ASTNode implements Assignment {
+
+    private String assignmentVar;
+    private String varName;
+    private transient CompiledAccExpression accExpr;
+
+    private char[] indexTarget;
+    private String index;
+
+    // private char[] stmt;
+    private ExecutableStatement statement;
+    private boolean col = false;
+
+    public AssignmentNode(char[] expr, int start, int offset, int fields, ParserContext pCtx) {
+        super(pCtx);
+        this.expr = expr;
+        this.start = start;
+        this.offset = offset;
+
+        int assignStart;
+
+        if ((assignStart = find(expr, start, offset, '=')) != -1) {
+            this.varName = createStringTrimmed(expr, start, assignStart - start);
+            this.assignmentVar = varName;
+
+            this.start = skipWhitespace(expr, assignStart + 1);
+            if (this.start >= start + offset) {
+                throw new CompileException("unexpected end of statement", expr, assignStart + 1);
+            }
+
+            this.offset = offset - (this.start - start);
+
+            if ((fields & COMPILE_IMMEDIATE) != 0) {
+                this.egressType = (statement = (ExecutableStatement) subCompileExpression(expr, this.start, this.offset, pCtx))
+                        .getKnownEgressType();
+            }
+
+            if (col = ((endOfName = findFirst('[', 0, this.varName.length(), indexTarget = this.varName.toCharArray())) > 0)) {
+                if (((this.fields |= COLLECTION) & COMPILE_IMMEDIATE) != 0) {
+                    accExpr = (CompiledAccExpression) compileSetExpression(indexTarget, pCtx);
+                }
+
+                this.varName = new String(expr, start, endOfName);
+                index = new String(indexTarget, endOfName, indexTarget.length - endOfName);
+            }
+
+            try {
+                checkNameSafety(this.varName);
+            } catch (RuntimeException e) {
+                throw new CompileException(e.getMessage(), expr, start);
+            }
+        } else {
+            try {
+                checkNameSafety(this.varName = new String(expr, start, offset));
+                this.assignmentVar = varName;
+            } catch (RuntimeException e) {
+                throw new CompileException(e.getMessage(), expr, start);
+            }
+        }
+
+        if ((fields & COMPILE_IMMEDIATE) != 0) {
+            pCtx.addVariable(this.varName, egressType);
+        }
+    }
+
+    public Object getReducedValueAccelerated(Object ctx, Object thisValue, VariableResolverFactory factory) {
+        if (accExpr == null && indexTarget != null) {
+            accExpr = (CompiledAccExpression) compileSetExpression(indexTarget);
+        }
+
+        if (col) {
+            return accExpr.setValue(ctx, thisValue, factory, statement.getValue(ctx, thisValue, factory));
+        } else if (statement != null) {
+            if (factory == null) throw new CompileException("cannot assign variables; no variable resolver factory available", expr, start);
+            return factory.createVariable(varName, statement.getValue(ctx, thisValue, factory)).getValue();
+        } else {
+            if (factory == null) throw new CompileException("cannot assign variables; no variable resolver factory available", expr, start);
+            factory.createVariable(varName, null);
+            return null;
+        }
+    }
+
+    public Object getReducedValue(Object ctx, Object thisValue, VariableResolverFactory factory) {
+        checkNameSafety(varName);
+
+        MVELInterpretedRuntime runtime = new MVELInterpretedRuntime(expr, start, offset, ctx, factory, pCtx);
+
+        if (col) {
+            PropertyAccessor.set(factory.getVariableResolver(varName).getValue(), factory, index, ctx = runtime.parse(), pCtx);
+        } else {
+            return factory.createVariable(varName, runtime.parse()).getValue();
+        }
+
+        return ctx;
+    }
+
+    public String getAssignmentVar() {
+        return assignmentVar;
+    }
+
+    public char[] getExpression() {
+        return subset(expr, start, offset);
+    }
+
+    public boolean isNewDeclaration() {
+        return false;
+    }
+
+    public void setValueStatement(ExecutableStatement stmt) {
+        this.statement = stmt;
+    }
+
+    @Override
+    public String toString() {
+        return assignmentVar + " = " + new String(expr, start, offset);
+    }
+}

--- a/core/src/main/java/org/mvel2/ast/BinaryOperation.java
+++ b/core/src/main/java/org/mvel2/ast/BinaryOperation.java
@@ -1,0 +1,177 @@
+/**
+ * MVEL 2.0
+ * Copyright (C) 2007 The Codehaus
+ * Mike Brock, Dhanji Prasanna, John Graham, Mark Proctor
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mvel2.ast;
+
+import static org.mvel2.DataConversion.canConvert;
+import static org.mvel2.DataConversion.convert;
+import static org.mvel2.Operator.PTABLE;
+import static org.mvel2.debug.DebugTools.getOperatorSymbol;
+import static org.mvel2.math.MathProcessor.doOperations;
+import static org.mvel2.util.CompilerTools.getReturnTypeFromOp;
+import static org.mvel2.util.ParseTools.boxPrimitive;
+
+import org.mvel2.CompileException;
+import org.mvel2.Operator;
+import org.mvel2.ParserContext;
+import org.mvel2.ScriptRuntimeException;
+import org.mvel2.integration.VariableResolverFactory;
+import org.mvel2.util.CompatibilityStrategy;
+import org.mvel2.util.NullType;
+import org.mvel2.util.ParseTools;
+
+public class BinaryOperation extends BooleanNode {
+
+    private final int operation;
+    private int lType = -1;
+    private int rType = -1;
+
+    public BinaryOperation(int operation, ParserContext ctx) {
+        super(ctx);
+        this.operation = operation;
+    }
+
+    public BinaryOperation(int operation, ASTNode left, ASTNode right, ParserContext ctx) {
+        super(ctx);
+        this.operation = operation;
+        if ((this.left = left) == null) {
+            throw new ScriptRuntimeException("not a statement");
+        }
+        if ((this.right = right) == null) {
+            throw new ScriptRuntimeException("not a statement");
+        }
+
+        //    if (ctx.isStrongTyping()) {
+        switch (operation) {
+            case Operator.ADD:
+                /**
+                 * In the special case of Strings, the return type may leftward propogate.
+                 */
+                if (left.getEgressType() == String.class || right.getEgressType() == String.class) {
+                    egressType = String.class;
+                    lType = ParseTools.__resolveType(left.egressType);
+                    rType = ParseTools.__resolveType(right.egressType);
+
+                    return;
+                }
+
+            default:
+                egressType = getReturnTypeFromOp(operation, this.left.egressType, this.right.egressType);
+                if (!ctx.isStrongTyping()) break;
+
+                final boolean leftIsAssignableFromRight = left.getEgressType().isAssignableFrom(right.getEgressType());
+                final boolean rightIsAssignableFromLeft = right.getEgressType().isAssignableFrom(left.getEgressType());
+
+                if (!leftIsAssignableFromRight && !rightIsAssignableFromLeft) {
+
+                    // Convert literals only when passing from String to Character or from Float to Double
+                    final boolean requiresConversion = right.getEgressType() == String.class || (right.getEgressType() == Double.class
+                            && (left.getEgressType() == Float.class || left.getEgressType() == float.class));
+
+                    if (right.isLiteral() && requiresConversion && canConvert(left.getEgressType(), right.getEgressType())) {
+                        Class targetType = isAritmeticOperation(operation) ? egressType : left.getEgressType();
+                        this.right = new LiteralNode(convert(right.getReducedValueAccelerated(null, null, null), targetType), pCtx);
+                    } else if (!(areCompatible(left.getEgressType(), right.getEgressType())
+                            || ((operation == Operator.EQUAL || operation == Operator.NEQUAL)
+                                    && CompatibilityStrategy.areEqualityCompatible(left.getEgressType(), right.getEgressType())))) {
+
+                        throw new CompileException(
+                                "incompatible types in statement: " + right.getEgressType() + " (compared from: " + left.getEgressType()
+                                        + ")",
+                                left.getExpr() != null ? left.getExpr() : right.getExpr(),
+                                left.getExpr() != null ? left.getStart() : right.getStart());
+                    }
+                }
+        }
+
+        // }
+
+        if (this.left.isLiteral() && this.right.isLiteral()) {
+            if (this.left.egressType == this.right.egressType) {
+                lType = rType = ParseTools.__resolveType(left.egressType);
+            } else {
+                lType = ParseTools.__resolveType(this.left.egressType);
+                rType = ParseTools.__resolveType(this.right.egressType);
+            }
+        }
+    }
+
+    private boolean isAritmeticOperation(int operation) {
+        return operation <= Operator.POWER;
+    }
+
+    private boolean areCompatible(Class<?> leftClass, Class<?> rightClass) {
+        return leftClass.equals(NullType.class) || rightClass.equals(NullType.class)
+                || (Number.class.isAssignableFrom(rightClass) && Number.class.isAssignableFrom(leftClass))
+                || ((rightClass.isPrimitive() || leftClass.isPrimitive()) && canConvert(boxPrimitive(leftClass), boxPrimitive(rightClass)));
+    }
+
+    public Object getReducedValueAccelerated(Object ctx, Object thisValue, VariableResolverFactory factory) {
+        return doOperations(lType, left.getReducedValueAccelerated(ctx, thisValue, factory), operation, rType,
+                right.getReducedValueAccelerated(ctx, thisValue, factory));
+    }
+
+    public Object getReducedValue(Object ctx, Object thisValue, VariableResolverFactory factory) {
+        throw new RuntimeException("unsupported AST operation");
+    }
+
+    public int getOperation() {
+        return operation;
+    }
+
+    public BinaryOperation getRightBinary() {
+        return right != null && right instanceof BinaryOperation ? (BinaryOperation) right : null;
+    }
+
+    public ASTNode getRightMost() {
+        BinaryOperation n = this;
+        while (n.right != null && n.right instanceof BinaryOperation) {
+            n = (BinaryOperation) n.right;
+        }
+        return n.right;
+    }
+
+    public void setRightMost(ASTNode right) {
+        BinaryOperation n = this;
+        while (n.right != null && n.right instanceof BinaryOperation) {
+            n = (BinaryOperation) n.right;
+        }
+        n.right = right;
+
+        if (n == this) {
+            if ((rType = ParseTools.__resolveType(n.right.getEgressType())) == 0) rType = -1;
+        }
+    }
+
+    public int getPrecedence() {
+        return PTABLE[operation];
+    }
+
+    public boolean isGreaterPrecedence(BinaryOperation o) {
+        return o.getPrecedence() > PTABLE[operation];
+    }
+
+    @Override
+    public boolean isLiteral() {
+        return false;
+    }
+
+    public String toString() {
+        return "(" + left + " " + getOperatorSymbol(operation) + " " + right + ")";
+    }
+}

--- a/core/src/main/java/org/mvel2/ast/BlockNode.java
+++ b/core/src/main/java/org/mvel2/ast/BlockNode.java
@@ -1,0 +1,49 @@
+/**
+ * MVEL 2.0
+ * Copyright (C) 2007 The Codehaus
+ * Mike Brock, Dhanji Prasanna, John Graham, Mark Proctor
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mvel2.ast;
+
+import org.mvel2.ParserContext;
+import org.mvel2.compiler.ExecutableStatement;
+
+/**
+ * @author Christopher Brock
+ */
+public class BlockNode extends ASTNode {
+
+    protected int blockStart;
+    protected int blockOffset;
+
+    protected ExecutableStatement compiledBlock;
+
+    public BlockNode(ParserContext pCtx) {
+        super(pCtx);
+    }
+
+    public ExecutableStatement getCompiledBlock() {
+        return compiledBlock;
+    }
+
+    public int getBlockStart() {
+        return blockStart;
+    }
+
+    public int getBlockOffset() {
+        return blockOffset;
+    }
+}

--- a/core/src/main/java/org/mvel2/ast/BooleanNode.java
+++ b/core/src/main/java/org/mvel2/ast/BooleanNode.java
@@ -1,0 +1,33 @@
+package org.mvel2.ast;
+
+import org.mvel2.ParserContext;
+
+public abstract class BooleanNode extends ASTNode {
+
+    protected ASTNode left;
+    protected ASTNode right;
+
+    protected BooleanNode(ParserContext pCtx) {
+        super(pCtx);
+    }
+
+    public ASTNode getLeft() {
+        return this.left;
+    }
+
+    public void setLeft(ASTNode node) {
+        this.left = node;
+    }
+
+    public ASTNode getRight() {
+        return this.right;
+    }
+
+    public void setRight(ASTNode node) {
+        this.right = node;
+    }
+
+    public abstract ASTNode getRightMost();
+
+    public abstract void setRightMost(ASTNode right);
+}

--- a/core/src/main/java/org/mvel2/ast/Contains.java
+++ b/core/src/main/java/org/mvel2/ast/Contains.java
@@ -1,0 +1,57 @@
+/**
+ * MVEL 2.0
+ * Copyright (C) 2007 The Codehaus
+ * Mike Brock, Dhanji Prasanna, John Graham, Mark Proctor
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mvel2.ast;
+
+import static org.mvel2.util.ParseTools.containsCheck;
+
+import org.mvel2.ParserContext;
+import org.mvel2.integration.VariableResolverFactory;
+
+public class Contains extends ASTNode {
+
+    private ASTNode stmt;
+    private ASTNode stmt2;
+
+    public Contains(ASTNode stmt, ASTNode stmt2, ParserContext pCtx) {
+        super(pCtx);
+        this.stmt = stmt;
+        this.stmt2 = stmt2;
+    }
+
+    public Object getReducedValueAccelerated(Object ctx, Object thisValue, VariableResolverFactory factory) {
+        return containsCheck(stmt.getReducedValueAccelerated(ctx, thisValue, factory),
+                stmt2.getReducedValueAccelerated(ctx, thisValue, factory));
+    }
+
+    public Object getReducedValue(Object ctx, Object thisValue, VariableResolverFactory factory) {
+        throw new RuntimeException("operation not supported");
+    }
+
+    public Class getEgressType() {
+        return Boolean.class;
+    }
+
+    public ASTNode getFirstStatement() {
+        return stmt;
+    }
+
+    public ASTNode getSecondStatement() {
+        return stmt2;
+    }
+}

--- a/core/src/main/java/org/mvel2/ast/Convertable.java
+++ b/core/src/main/java/org/mvel2/ast/Convertable.java
@@ -1,0 +1,45 @@
+package org.mvel2.ast;
+
+import org.mvel2.DataConversion;
+import org.mvel2.ParserContext;
+import org.mvel2.integration.VariableResolverFactory;
+import org.mvel2.util.CompilerTools;
+
+public class Convertable extends ASTNode {
+
+    private ASTNode stmt;
+    private ASTNode clsStmt;
+
+    public Convertable(ASTNode stmt, ASTNode clsStmt, ParserContext pCtx) {
+        super(pCtx);
+        this.stmt = stmt;
+        this.clsStmt = clsStmt;
+        CompilerTools.expectType(pCtx, clsStmt, Class.class, true);
+    }
+
+    public Object getReducedValueAccelerated(Object ctx, Object thisValue, VariableResolverFactory factory) {
+        Object o = stmt.getReducedValueAccelerated(ctx, thisValue, factory);
+        return o != null && DataConversion.canConvert((Class) clsStmt.getReducedValueAccelerated(ctx, thisValue, factory), o.getClass());
+
+    }
+
+    public Object getReducedValue(Object ctx, Object thisValue, VariableResolverFactory factory) {
+        try {
+
+            Object o = stmt.getReducedValue(ctx, thisValue, factory);
+            if (o == null) return false;
+
+            Class i = (Class) clsStmt.getReducedValue(ctx, thisValue, factory);
+            if (i == null) throw new ClassCastException();
+
+            return DataConversion.canConvert(i, o.getClass());
+        } catch (ClassCastException e) {
+            throw new RuntimeException("not a class reference: " + clsStmt.getName());
+        }
+
+    }
+
+    public Class getEgressType() {
+        return Boolean.class;
+    }
+}

--- a/core/src/main/java/org/mvel2/ast/DeclProtoVarNode.java
+++ b/core/src/main/java/org/mvel2/ast/DeclProtoVarNode.java
@@ -1,0 +1,84 @@
+/**
+ * MVEL 2.0
+ * Copyright (C) 2007 The Codehaus
+ * Mike Brock, Dhanji Prasanna, John Graham, Mark Proctor
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mvel2.ast;
+
+import static org.mvel2.util.ParseTools.checkNameSafety;
+
+import org.mvel2.ParserContext;
+import org.mvel2.compiler.ExecutableStatement;
+import org.mvel2.integration.VariableResolverFactory;
+
+/**
+ * @author Christopher Brock
+ */
+public class DeclProtoVarNode extends ASTNode implements Assignment {
+
+    private String name;
+
+    public DeclProtoVarNode(String name, Proto type, int fields, ParserContext pCtx) {
+        super(pCtx);
+        this.egressType = Proto.ProtoInstance.class;
+        checkNameSafety(this.name = name);
+
+        if ((fields & COMPILE_IMMEDIATE) != 0) {
+            pCtx.addVariable(name, egressType, true);
+        }
+    }
+
+    public Object getReducedValueAccelerated(Object ctx, Object thisValue, VariableResolverFactory factory) {
+        if (!factory.isResolveable(name)) factory.createVariable(name, null, egressType);
+        else throw new RuntimeException("variable defined within scope: " + name);
+        return null;
+    }
+
+    public Object getReducedValue(Object ctx, Object thisValue, VariableResolverFactory factory) {
+        if (!factory.isResolveable(name)) factory.createVariable(name, null, egressType);
+        else throw new RuntimeException("variable defined within scope: " + name);
+
+        return null;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getAssignmentVar() {
+        return name;
+    }
+
+    public char[] getExpression() {
+        return new char[0];
+    }
+
+    public boolean isAssignment() {
+        return true;
+    }
+
+    public boolean isNewDeclaration() {
+        return true;
+    }
+
+    public void setValueStatement(ExecutableStatement stmt) {
+        throw new RuntimeException("illegal operation");
+    }
+
+    public String toString() {
+        return "var:" + name;
+    }
+}

--- a/core/src/main/java/org/mvel2/ast/DeclTypedVarNode.java
+++ b/core/src/main/java/org/mvel2/ast/DeclTypedVarNode.java
@@ -1,0 +1,88 @@
+/**
+ * MVEL 2.0
+ * Copyright (C) 2007 The Codehaus
+ * Mike Brock, Dhanji Prasanna, John Graham, Mark Proctor
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mvel2.ast;
+
+import static org.mvel2.util.ParseTools.checkNameSafety;
+
+import org.mvel2.CompileException;
+import org.mvel2.ParserContext;
+import org.mvel2.compiler.ExecutableStatement;
+import org.mvel2.integration.VariableResolverFactory;
+
+/**
+ * @author Christopher Brock
+ */
+public class DeclTypedVarNode extends ASTNode implements Assignment {
+
+    private String name;
+
+    public DeclTypedVarNode(String name, char[] expr, int start, int offset, Class type, int fields, ParserContext pCtx) {
+        super(pCtx);
+        this.egressType = type;
+        checkNameSafety(this.name = name);
+        this.expr = expr;
+        this.start = start;
+        this.offset = offset;
+
+        if ((fields & COMPILE_IMMEDIATE) != 0) {
+            pCtx.addVariable(name, egressType, true);
+        }
+    }
+
+    public Object getReducedValueAccelerated(Object ctx, Object thisValue, VariableResolverFactory factory) {
+        if (!factory.isResolveable(name)) factory.createVariable(name, null, egressType);
+        else throw new CompileException("variable defined within scope: " + name, expr, start);
+        return null;
+    }
+
+    public Object getReducedValue(Object ctx, Object thisValue, VariableResolverFactory factory) {
+        if (!factory.isResolveable(name)) factory.createVariable(name, null, egressType);
+        else throw new CompileException("variable defined within scope: " + name, expr, start);
+
+        return null;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getAssignmentVar() {
+        return name;
+    }
+
+    public char[] getExpression() {
+        return new char[0];
+    }
+
+    public boolean isAssignment() {
+        return true;
+    }
+
+    public boolean isNewDeclaration() {
+        return true;
+    }
+
+    public void setValueStatement(ExecutableStatement stmt) {
+        throw new RuntimeException("illegal operation");
+    }
+
+    public String toString() {
+        return "var:" + name;
+    }
+}

--- a/core/src/main/java/org/mvel2/ast/DeepAssignmentNode.java
+++ b/core/src/main/java/org/mvel2/ast/DeepAssignmentNode.java
@@ -1,0 +1,126 @@
+/**
+ * MVEL 2.0
+ * Copyright (C) 2007 The Codehaus
+ * Mike Brock, Dhanji Prasanna, John Graham, Mark Proctor
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mvel2.ast;
+
+import static org.mvel2.MVEL.compileSetExpression;
+import static org.mvel2.MVEL.eval;
+import static org.mvel2.PropertyAccessor.set;
+import static org.mvel2.util.ParseTools.createShortFormOperativeAssignment;
+import static org.mvel2.util.ParseTools.createStringTrimmed;
+import static org.mvel2.util.ParseTools.find;
+import static org.mvel2.util.ParseTools.skipWhitespace;
+import static org.mvel2.util.ParseTools.subArray;
+import static org.mvel2.util.ParseTools.subCompileExpression;
+
+import org.mvel2.CompileException;
+import org.mvel2.ParserContext;
+import org.mvel2.compiler.CompiledAccExpression;
+import org.mvel2.compiler.ExecutableStatement;
+import org.mvel2.integration.VariableResolverFactory;
+
+/**
+ * @author Christopher Brock
+ */
+public class DeepAssignmentNode extends ASTNode implements Assignment {
+
+    private String property;
+    // private char[] stmt;
+
+    private CompiledAccExpression acc;
+    private ExecutableStatement statement;
+
+    public DeepAssignmentNode(char[] expr, int start, int offset, int fields, int operation, String name, ParserContext pCtx) {
+        super(pCtx);
+        this.fields |= DEEP_PROPERTY | fields;
+
+        this.expr = expr;
+        this.start = start;
+        this.offset = offset;
+        int mark;
+
+        if (operation != -1) {
+            this.egressType = ((statement = (ExecutableStatement) subCompileExpression(
+                    createShortFormOperativeAssignment(this.property = name, expr, start, offset, operation), pCtx))).getKnownEgressType();
+        } else if ((mark = find(expr, start, offset, '=')) != -1) {
+            property = createStringTrimmed(expr, start, mark - start);
+
+            // this.start = mark + 1;
+            this.start = skipWhitespace(expr, mark + 1);
+
+            if (this.start >= start + offset) {
+                throw new CompileException("unexpected end of statement", expr, mark + 1);
+            }
+
+            this.offset = offset - (this.start - start);
+
+            if ((fields & COMPILE_IMMEDIATE) != 0) {
+                statement = (ExecutableStatement) subCompileExpression(expr, this.start, this.offset, pCtx);
+            }
+        } else {
+            property = new String(expr);
+        }
+
+        if ((fields & COMPILE_IMMEDIATE) != 0) {
+            acc = (CompiledAccExpression) compileSetExpression(property.toCharArray(), start, offset, pCtx);
+        }
+    }
+
+    public DeepAssignmentNode(char[] expr, int start, int offset, int fields, ParserContext pCtx) {
+        this(expr, start, offset, fields, -1, null, pCtx);
+    }
+
+    public Object getReducedValueAccelerated(Object ctx, Object thisValue, VariableResolverFactory factory) {
+        if (statement == null) {
+            statement = (ExecutableStatement) subCompileExpression(expr, this.start, this.offset, pCtx);
+            acc = (CompiledAccExpression) compileSetExpression(property.toCharArray(), statement.getKnownEgressType(), pCtx);
+        }
+        acc.setValue(ctx, thisValue, factory, ctx = statement.getValue(ctx, thisValue, factory));
+        return ctx;
+    }
+
+    public Object getReducedValue(Object ctx, Object thisValue, VariableResolverFactory factory) {
+        set(ctx, factory, property, ctx = eval(expr, this.start, this.offset, ctx, factory), pCtx);
+        return ctx;
+    }
+
+    @Override
+    public String getAbsoluteName() {
+        return property.substring(0, property.indexOf('.'));
+    }
+
+    public String getAssignmentVar() {
+        return property;
+    }
+
+    public char[] getExpression() {
+        return subArray(expr, start, offset);
+    }
+
+    public boolean isNewDeclaration() {
+        return false;
+    }
+
+    public boolean isAssignment() {
+        return true;
+    }
+
+    public void setValueStatement(ExecutableStatement stmt) {
+        this.statement = stmt;
+    }
+}

--- a/core/src/main/java/org/mvel2/ast/DoNode.java
+++ b/core/src/main/java/org/mvel2/ast/DoNode.java
@@ -1,0 +1,82 @@
+/**
+ * MVEL 2.0
+ * Copyright (C) 2007 The Codehaus
+ * Mike Brock, Dhanji Prasanna, John Graham, Mark Proctor
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mvel2.ast;
+
+import static org.mvel2.util.CompilerTools.expectType;
+import static org.mvel2.util.ParseTools.subCompileExpression;
+
+import java.util.HashMap;
+
+import org.mvel2.ParserContext;
+import org.mvel2.compiler.ExecutableStatement;
+import org.mvel2.integration.VariableResolverFactory;
+import org.mvel2.integration.impl.MapVariableResolverFactory;
+
+/**
+ * @author Christopher Brock
+ */
+public class DoNode extends BlockNode {
+
+    protected String item;
+    protected ExecutableStatement condition;
+
+    public DoNode(char[] expr, int start, int offset, int blockStart, int blockOffset, int fields, ParserContext pCtx) {
+        super(pCtx);
+        this.expr = expr;
+        this.start = start;
+        this.offset = offset;
+        this.blockStart = blockStart;
+        this.blockOffset = blockOffset;
+
+        this.condition = (ExecutableStatement) subCompileExpression(expr, start, offset, pCtx);
+
+        expectType(pCtx, this.condition, Boolean.class, ((fields & COMPILE_IMMEDIATE) != 0));
+
+        if (pCtx != null) {
+            pCtx.pushVariableScope();
+        }
+
+        this.compiledBlock = (ExecutableStatement) subCompileExpression(expr, blockStart, blockOffset, pCtx);
+
+        if (pCtx != null) {
+            pCtx.popVariableScope();
+        }
+    }
+
+    public Object getReducedValueAccelerated(Object ctx, Object thisValue, VariableResolverFactory factory) {
+        VariableResolverFactory ctxFactory = new MapVariableResolverFactory(new HashMap<String, Object>(0), factory);
+
+        do {
+            compiledBlock.getValue(ctx, thisValue, ctxFactory);
+        } while ((Boolean) condition.getValue(ctx, thisValue, factory));
+
+        return null;
+    }
+
+    public Object getReducedValue(Object ctx, Object thisValue, VariableResolverFactory factory) {
+        VariableResolverFactory ctxFactory = new MapVariableResolverFactory(new HashMap<String, Object>(0), factory);
+
+        do {
+            compiledBlock.getValue(ctx, thisValue, ctxFactory);
+        } while ((Boolean) condition.getValue(ctx, thisValue, factory));
+
+        return null;
+    }
+
+}

--- a/core/src/main/java/org/mvel2/ast/DoUntilNode.java
+++ b/core/src/main/java/org/mvel2/ast/DoUntilNode.java
@@ -1,0 +1,79 @@
+/**
+ * MVEL 2.0
+ * Copyright (C) 2007 The Codehaus
+ * Mike Brock, Dhanji Prasanna, John Graham, Mark Proctor
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mvel2.ast;
+
+import static org.mvel2.util.CompilerTools.expectType;
+import static org.mvel2.util.ParseTools.subCompileExpression;
+
+import java.util.HashMap;
+
+import org.mvel2.ParserContext;
+import org.mvel2.compiler.ExecutableStatement;
+import org.mvel2.integration.VariableResolverFactory;
+import org.mvel2.integration.impl.MapVariableResolverFactory;
+
+/**
+ * @author Christopher Brock
+ */
+public class DoUntilNode extends BlockNode {
+
+    protected String item;
+    protected ExecutableStatement condition;
+
+    public DoUntilNode(char[] expr, int start, int offset, int blockStart, int blockOffset, ParserContext pCtx) {
+        super(pCtx);
+        this.expr = expr;
+        this.start = start;
+        this.offset = offset;
+
+        expectType(pCtx, this.condition = (ExecutableStatement) subCompileExpression(expr, start, offset, pCtx), Boolean.class,
+                ((fields & COMPILE_IMMEDIATE) != 0));
+
+        if (pCtx != null) {
+            pCtx.pushVariableScope();
+        }
+
+        this.compiledBlock = (ExecutableStatement) subCompileExpression(expr, blockStart, blockOffset, pCtx);
+
+        if (pCtx != null) {
+            pCtx.popVariableScope();
+        }
+    }
+
+    public Object getReducedValueAccelerated(Object ctx, Object thisValue, VariableResolverFactory factory) {
+        VariableResolverFactory lc = new MapVariableResolverFactory(new HashMap(0), factory);
+
+        do {
+            compiledBlock.getValue(ctx, thisValue, lc);
+        } while (!(Boolean) condition.getValue(ctx, thisValue, lc));
+
+        return null;
+    }
+
+    public Object getReducedValue(Object ctx, Object thisValue, VariableResolverFactory factory) {
+        VariableResolverFactory lc = new MapVariableResolverFactory(new HashMap(0), factory);
+
+        do {
+            compiledBlock.getValue(ctx, thisValue, lc);
+        } while (!(Boolean) condition.getValue(ctx, thisValue, lc));
+
+        return null;
+    }
+
+}

--- a/core/src/main/java/org/mvel2/ast/EndOfStatement.java
+++ b/core/src/main/java/org/mvel2/ast/EndOfStatement.java
@@ -1,0 +1,54 @@
+/**
+ * MVEL 2.0
+ * Copyright (C) 2007 The Codehaus
+ * Mike Brock, Dhanji Prasanna, John Graham, Mark Proctor
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mvel2.ast;
+
+import org.mvel2.Operator;
+import org.mvel2.ParserContext;
+import org.mvel2.integration.VariableResolverFactory;
+
+/**
+ * @author Christopher Brock
+ */
+public class EndOfStatement extends ASTNode {
+
+    public EndOfStatement(ParserContext pCtx) {
+        super(pCtx);
+        this.literal = getOperator();
+    }
+
+    public boolean isOperator() {
+        return true;
+    }
+
+    public boolean isOperator(Integer operator) {
+        return operator == Operator.END_OF_STMT;
+    }
+
+    public Object getReducedValueAccelerated(Object ctx, Object thisValue, VariableResolverFactory factory) {
+        return null;
+    }
+
+    public Object getReducedValue(Object ctx, Object thisValue, VariableResolverFactory factory) {
+        return null;
+    }
+
+    public Integer getOperator() {
+        return Operator.END_OF_STMT;
+    }
+}

--- a/core/src/main/java/org/mvel2/ast/Fold.java
+++ b/core/src/main/java/org/mvel2/ast/Fold.java
@@ -1,0 +1,149 @@
+/**
+ * MVEL 2.0
+ * Copyright (C) 2007 The Codehaus
+ * Mike Brock, Dhanji Prasanna, John Graham, Mark Proctor
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mvel2.ast;
+
+import static org.mvel2.util.CompilerTools.expectType;
+import static org.mvel2.util.ParseTools.isJunct;
+import static org.mvel2.util.ParseTools.isWhitespace;
+import static org.mvel2.util.ParseTools.subCompileExpression;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+import org.mvel2.CompileException;
+import org.mvel2.ParserContext;
+import org.mvel2.compiler.ExecutableStatement;
+import org.mvel2.integration.VariableResolverFactory;
+import org.mvel2.integration.impl.DefaultLocalVariableResolverFactory;
+import org.mvel2.integration.impl.ItemResolverFactory;
+
+public class Fold extends ASTNode {
+
+    private ExecutableStatement subEx;
+    private ExecutableStatement dataEx;
+    private ExecutableStatement constraintEx;
+
+    public Fold(char[] expr, int start, int offset, int fields, ParserContext pCtx) {
+        super(pCtx);
+        this.expr = expr;
+        this.start = start;
+        this.offset = offset;
+
+        int cursor = start;
+        int end = start + offset;
+        for (; cursor < end; cursor++) {
+            if (isWhitespace(expr[cursor])) {
+                while (cursor < end && isWhitespace(expr[cursor]))
+                    cursor++;
+
+                if (expr[cursor] == 'i' && expr[cursor + 1] == 'n' && isJunct(expr[cursor + 2])) {
+                    break;
+                }
+            }
+        }
+
+        subEx = (ExecutableStatement) subCompileExpression(expr, start, cursor - start - 1, pCtx);
+        int st = cursor += 2; // skip 'in'
+
+        for (; cursor < end; cursor++) {
+            if (isWhitespace(expr[cursor])) {
+                while (cursor < end && isWhitespace(expr[cursor]))
+                    cursor++;
+
+                if (expr[cursor] == 'i' && expr[cursor + 1] == 'f' && isJunct(expr[cursor + 2])) {
+                    int s = cursor + 2;
+                    constraintEx = (ExecutableStatement) subCompileExpression(expr, s, end - s, pCtx);
+                    break;
+                }
+            }
+        }
+
+        while (isWhitespace(expr[cursor]))
+            cursor--;
+
+        expectType(pCtx, dataEx = (ExecutableStatement) subCompileExpression(expr, st, cursor - st, pCtx), Collection.class,
+                ((fields & COMPILE_IMMEDIATE) != 0));
+    }
+
+    public Object getReducedValueAccelerated(Object ctx, Object thisValue, VariableResolverFactory factory) {
+        ItemResolverFactory.ItemResolver itemR = new ItemResolverFactory.ItemResolver("$");
+        ItemResolverFactory itemFactory = new ItemResolverFactory(itemR, new DefaultLocalVariableResolverFactory(factory));
+
+        List list;
+
+        if (constraintEx != null) {
+            Collection col = ((Collection) dataEx.getValue(ctx, thisValue, factory));
+            list = new ArrayList(col.size());
+
+            for (Object o : col) {
+                itemR.value = o;
+                if ((Boolean) constraintEx.getValue(ctx, thisValue, itemFactory)) {
+                    list.add(subEx.getValue(o, thisValue, itemFactory));
+                }
+            }
+
+        } else {
+            Collection col = ((Collection) dataEx.getValue(ctx, thisValue, factory));
+            list = new ArrayList(col.size());
+            for (Object o : col) {
+                list.add(subEx.getValue(itemR.value = o, thisValue, itemFactory));
+            }
+        }
+        return list;
+    }
+
+    public Object getReducedValue(Object ctx, Object thisValue, VariableResolverFactory factory) {
+        ItemResolverFactory.ItemResolver itemR = new ItemResolverFactory.ItemResolver("$");
+        ItemResolverFactory itemFactory = new ItemResolverFactory(itemR, new DefaultLocalVariableResolverFactory(factory));
+
+        List list;
+
+        if (constraintEx != null) {
+            Object x = dataEx.getValue(ctx, thisValue, factory);
+
+            if (!(x instanceof Collection)) throw new CompileException(
+                    "was expecting type: Collection; but found type: " + (x == null ? "null" : x.getClass().getName()), expr, start);
+
+            list = new ArrayList(((Collection) x).size());
+            for (Object o : (Collection) x) {
+                itemR.value = o;
+                if ((Boolean) constraintEx.getValue(ctx, thisValue, itemFactory)) {
+                    list.add(subEx.getValue(o, thisValue, itemFactory));
+                }
+            }
+        } else {
+            Object x = dataEx.getValue(ctx, thisValue, factory);
+
+            if (!(x instanceof Collection)) throw new CompileException(
+                    "was expecting type: Collection; but found type: " + (x == null ? "null" : x.getClass().getName()), expr, start);
+
+            list = new ArrayList(((Collection) x).size());
+            for (Object o : (Collection) x) {
+                list.add(subEx.getValue(itemR.value = o, thisValue, itemFactory));
+            }
+        }
+
+        return list;
+    }
+
+    public Class getEgressType() {
+        return Collection.class;
+    }
+}

--- a/core/src/main/java/org/mvel2/ast/ForEachNode.java
+++ b/core/src/main/java/org/mvel2/ast/ForEachNode.java
@@ -1,0 +1,223 @@
+/**
+ * MVEL 2.0
+ * Copyright (C) 2007 The Codehaus
+ * Mike Brock, Dhanji Prasanna, John Graham, Mark Proctor
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.mvel2.ast;
+
+import static org.mvel2.util.ParseTools.createStringTrimmed;
+import static org.mvel2.util.ParseTools.getBaseComponentType;
+import static org.mvel2.util.ParseTools.subCompileExpression;
+
+import java.lang.reflect.Array;
+
+import org.mvel2.CompileException;
+import org.mvel2.DataConversion;
+import org.mvel2.MVEL;
+import org.mvel2.ParserContext;
+import org.mvel2.compiler.ExecutableStatement;
+import org.mvel2.integration.VariableResolverFactory;
+import org.mvel2.integration.impl.DefaultLocalVariableResolverFactory;
+import org.mvel2.integration.impl.ItemResolverFactory;
+import org.mvel2.util.ParseTools;
+
+/**
+ * @author Christopher Brock
+ */
+public class ForEachNode extends BlockNode {
+
+    private static final int ITERABLE = 0;
+    private static final int ARRAY = 1;
+    private static final int CHARSEQUENCE = 2;
+    private static final int INTEGER = 3;
+    protected String item;
+    protected Class itemType;
+    protected ExecutableStatement condition;
+    private int type = -1;
+
+    public ForEachNode(char[] expr, int start, int offset, int blockStart, int blockOffset, int fields, ParserContext pCtx) {
+        super(pCtx);
+
+        handleCond(this.expr = expr, this.start = start, this.offset = offset, this.fields = fields, pCtx);
+        this.blockStart = blockStart;
+        this.blockOffset = blockOffset;
+
+        if ((fields & COMPILE_IMMEDIATE) != 0) {
+            if (pCtx.isStrictTypeEnforcement() && itemType != null) {
+                pCtx = pCtx.createSubcontext();
+                pCtx.addInput(item, itemType);
+            }
+
+            pCtx.pushVariableScope();
+            pCtx.makeVisible(item);
+
+            this.compiledBlock = (ExecutableStatement) subCompileExpression(expr, blockStart, blockOffset, pCtx);
+
+            pCtx.popVariableScope();
+        }
+    }
+
+    public Object getReducedValueAccelerated(Object ctx, Object thisValue, VariableResolverFactory factory) {
+        ItemResolverFactory.ItemResolver itemR = new ItemResolverFactory.ItemResolver(item);
+        ItemResolverFactory itemFactory = new ItemResolverFactory(itemR, new DefaultLocalVariableResolverFactory(factory));
+
+        Object iterCond = condition.getValue(ctx, thisValue, factory);
+
+        if (type == -1) {
+            determineIterType(iterCond.getClass());
+        }
+
+        Object v;
+        switch (type) {
+            case ARRAY:
+                int len = Array.getLength(iterCond);
+                for (int i = 0; i < len; i++) {
+                    itemR.setValue(Array.get(iterCond, i));
+                    v = compiledBlock.getValue(ctx, thisValue, itemFactory);
+                    if (itemFactory.tiltFlag()) return v;
+                }
+                break;
+            case CHARSEQUENCE:
+                for (Object o : iterCond.toString().toCharArray()) {
+                    itemR.setValue(o);
+                    v = compiledBlock.getValue(ctx, thisValue, itemFactory);
+                    if (itemFactory.tiltFlag()) return v;
+                }
+                break;
+            case INTEGER:
+                int max = (Integer) iterCond + 1;
+                for (int i = 1; i != max; i++) {
+                    itemR.setValue(i);
+                    v = compiledBlock.getValue(ctx, thisValue, itemFactory);
+                    if (itemFactory.tiltFlag()) return v;
+                }
+                break;
+
+            case ITERABLE:
+                for (Object o : (Iterable) iterCond) {
+                    itemR.setValue(o);
+                    v = compiledBlock.getValue(ctx, thisValue, itemFactory);
+                    if (itemFactory.tiltFlag()) return v;
+                }
+
+                break;
+        }
+
+        return null;
+    }
+
+    public Object getReducedValue(Object ctx, Object thisValue, VariableResolverFactory factory) {
+        ItemResolverFactory.ItemResolver itemR = new ItemResolverFactory.ItemResolver(item);
+        ItemResolverFactory itemFactory = new ItemResolverFactory(itemR, new DefaultLocalVariableResolverFactory(factory));
+
+        Object iterCond = MVEL.eval(expr, start, offset, thisValue, factory);
+
+        if (itemType != null && itemType.isArray()) enforceTypeSafety(itemType, getBaseComponentType(iterCond.getClass()));
+
+        this.compiledBlock = (ExecutableStatement) subCompileExpression(expr, blockStart, blockOffset, pCtx);
+
+        Object v;
+        if (iterCond instanceof Iterable) {
+            for (Object o : (Iterable) iterCond) {
+                itemR.setValue(o);
+                v = compiledBlock.getValue(ctx, thisValue, itemFactory);
+                if (itemFactory.tiltFlag()) return v;
+            }
+        } else if (iterCond != null && iterCond.getClass().isArray()) {
+            int len = Array.getLength(iterCond);
+            for (int i = 0; i < len; i++) {
+                itemR.setValue(Array.get(iterCond, i));
+                v = compiledBlock.getValue(ctx, thisValue, itemFactory);
+                if (itemFactory.tiltFlag()) return v;
+            }
+        } else if (iterCond instanceof CharSequence) {
+            for (Object o : iterCond.toString().toCharArray()) {
+                itemR.setValue(o);
+                v = compiledBlock.getValue(ctx, thisValue, itemFactory);
+                if (itemFactory.tiltFlag()) return v;
+            }
+        } else if (iterCond instanceof Integer) {
+            int max = (Integer) iterCond + 1;
+            for (int i = 1; i != max; i++) {
+                itemR.setValue(i);
+                v = compiledBlock.getValue(ctx, thisValue, itemFactory);
+                if (itemFactory.tiltFlag()) return v;
+            }
+        } else {
+            throw new CompileException("non-iterable type: " + (iterCond != null ? iterCond.getClass().getName() : "null"), expr, start);
+        }
+
+        return null;
+    }
+
+    private void handleCond(char[] condition, int start, int offset, int fields, ParserContext pCtx) {
+        int cursor = start;
+        int end = start + offset;
+        while (cursor < end && condition[cursor] != ':')
+            cursor++;
+
+        if (cursor == end || condition[cursor] != ':') throw new CompileException("expected : in foreach", condition, cursor);
+
+        int x;
+        if ((x = (item = createStringTrimmed(condition, start, cursor - start)).indexOf(' ')) != -1) {
+            String tk = new String(condition, start, x).trim();
+            try {
+                itemType = ParseTools.findClass(null, tk, pCtx);
+                item = new String(condition, start + x, (cursor - start) - x).trim();
+
+            } catch (ClassNotFoundException e) {
+                throw new CompileException("cannot resolve identifier: " + tk, condition, start);
+            }
+        }
+
+        // this.start = ++cursor;
+
+        this.start = cursor + 1;
+        this.offset = offset - (cursor - start) - 1;
+
+        if ((fields & COMPILE_IMMEDIATE) != 0) {
+            Class egress = (this.condition = (ExecutableStatement) subCompileExpression(expr, this.start, this.offset, pCtx))
+                    .getKnownEgressType();
+
+            if (itemType != null && egress.isArray()) {
+                enforceTypeSafety(itemType, getBaseComponentType(this.condition.getKnownEgressType()));
+            } else if (pCtx.isStrongTyping()) {
+                determineIterType(egress);
+            }
+        }
+    }
+
+    private void determineIterType(Class t) {
+        if (Iterable.class.isAssignableFrom(t)) {
+            type = ITERABLE;
+        } else if (t.isArray()) {
+            type = ARRAY;
+        } else if (CharSequence.class.isAssignableFrom(t)) {
+            type = CHARSEQUENCE;
+        } else if (Integer.class.isAssignableFrom(t)) {
+            type = INTEGER;
+        } else {
+            throw new CompileException("non-iterable type: " + t.getName(), expr, start);
+        }
+    }
+
+    private void enforceTypeSafety(Class required, Class actual) {
+        if (!required.isAssignableFrom(actual) && !DataConversion.canConvert(actual, required)) {
+            throw new CompileException(
+                    "type mismatch in foreach: expected: " + required.getName() + "; but found: " + getBaseComponentType(actual), expr,
+                    start);
+        }
+    }
+}

--- a/core/src/main/java/org/mvel2/ast/ForNode.java
+++ b/core/src/main/java/org/mvel2/ast/ForNode.java
@@ -1,0 +1,152 @@
+/**
+ * MVEL 2.0
+ * Copyright (C) 2007 The Codehaus
+ * Mike Brock, Dhanji Prasanna, John Graham, Mark Proctor
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mvel2.ast;
+
+import static org.mvel2.util.CompilerTools.expectType;
+import static org.mvel2.util.ParseTools.subCompileExpression;
+
+import java.util.HashMap;
+
+import org.mvel2.CompileException;
+import org.mvel2.ParserContext;
+import org.mvel2.compiler.ExecutableStatement;
+import org.mvel2.integration.VariableResolverFactory;
+import org.mvel2.integration.impl.MapVariableResolverFactory;
+import org.mvel2.util.ParseTools;
+
+/**
+ * @author Christopher Brock
+ */
+public class ForNode extends BlockNode {
+
+    protected String item;
+
+    protected ExecutableStatement initializer;
+    protected ExecutableStatement condition;
+
+    protected ExecutableStatement after;
+
+    protected boolean indexAlloc = false;
+
+    public ForNode(char[] expr, int start, int offset, int blockStart, int blockEnd, int fields, ParserContext pCtx) {
+        super(pCtx);
+
+        boolean varsEscape = buildForEach(this.expr = expr, this.start = start, this.offset = offset, this.blockStart = blockStart,
+                this.blockOffset = blockEnd, fields, pCtx);
+
+        this.indexAlloc = pCtx != null && pCtx.isIndexAllocation();
+
+        if ((fields & COMPILE_IMMEDIATE) != 0 && compiledBlock.isEmptyStatement() && !varsEscape) {
+            throw new RedundantCodeException();
+        }
+
+        if (pCtx != null) {
+            pCtx.popVariableScope();
+        }
+    }
+
+    private static int nextCondPart(char[] condition, int cursor, int end, boolean allowEnd) {
+        for (; cursor < end; cursor++) {
+            if (condition[cursor] == ';') return ++cursor;
+        }
+        if (!allowEnd) throw new CompileException("expected ;", condition, cursor);
+        return cursor;
+    }
+
+    public Object getReducedValueAccelerated(Object ctx, Object thisValue, VariableResolverFactory factory) {
+        VariableResolverFactory ctxFactory = indexAlloc ? factory : new MapVariableResolverFactory(new HashMap<String, Object>(1), factory);
+        Object v;
+        for (initializer.getValue(ctx, thisValue, ctxFactory); (Boolean) condition.getValue(ctx, thisValue, ctxFactory); after.getValue(ctx,
+                thisValue, ctxFactory)) {
+            v = compiledBlock.getValue(ctx, thisValue, ctxFactory);
+            if (ctxFactory.tiltFlag()) return v;
+        }
+        return null;
+    }
+
+    public Object getReducedValue(Object ctx, Object thisValue, VariableResolverFactory factory) {
+        Object v;
+        for (initializer.getValue(ctx, thisValue,
+                factory = new MapVariableResolverFactory(new HashMap<String, Object>(1), factory)); (Boolean) condition.getValue(ctx,
+                        thisValue, factory); after.getValue(ctx, thisValue, factory)) {
+            v = compiledBlock.getValue(ctx, thisValue, factory);
+            if (factory.tiltFlag()) return v;
+        }
+
+        return null;
+    }
+
+    private boolean buildForEach(char[] condition, int start, int offset, int blockStart, int blockEnd, int fields, ParserContext pCtx) {
+        int end = start + offset;
+        int cursor = nextCondPart(condition, start, end, false);
+
+        boolean varsEscape = false;
+
+        try {
+            ParserContext spCtx;
+            if (pCtx != null) {
+                spCtx = pCtx.createSubcontext().createColoringSubcontext();
+            } else {
+                spCtx = new ParserContext();
+            }
+
+            this.initializer = (ExecutableStatement) subCompileExpression(condition, start, cursor - start - 1, spCtx);
+
+            if (pCtx != null) {
+                pCtx.pushVariableScope();
+            }
+
+            try {
+                expectType(pCtx,
+                        this.condition = (ExecutableStatement) subCompileExpression(condition, start = cursor,
+                                (cursor = nextCondPart(condition, start, end, false)) - start - 1, spCtx),
+                        Boolean.class, ((fields & COMPILE_IMMEDIATE) != 0));
+            } catch (CompileException e) {
+                if (e.getExpr().length == 0) {
+                    e.setExpr(expr);
+
+                    while (start < expr.length && ParseTools.isWhitespace(expr[start])) {
+                        start++;
+                    }
+
+                    e.setCursor(start);
+                }
+                throw e;
+            }
+
+            this.after = (ExecutableStatement) subCompileExpression(condition, start = cursor,
+                    (nextCondPart(condition, start, end, true)) - start, spCtx);
+
+            if (spCtx != null && (fields & COMPILE_IMMEDIATE) != 0 && spCtx.isVariablesEscape()) {
+                if (pCtx != spCtx) pCtx.addVariables(spCtx.getVariables());
+                varsEscape = true;
+            } else if (spCtx != null && pCtx != null) {
+                pCtx.addVariables(spCtx.getVariables());
+            }
+
+            this.compiledBlock = (ExecutableStatement) subCompileExpression(expr, blockStart, blockEnd, spCtx);
+            if (pCtx != null) {
+                pCtx.setInputs(spCtx.getInputs());
+            }
+        } catch (NegativeArraySizeException e) {
+            throw new CompileException("wrong syntax; did you mean to use 'foreach'?", expr, start);
+        }
+        return varsEscape;
+    }
+}

--- a/core/src/main/java/org/mvel2/ast/Function.java
+++ b/core/src/main/java/org/mvel2/ast/Function.java
@@ -1,0 +1,199 @@
+/**
+ * MVEL 2.0
+ * Copyright (C) 2007 The Codehaus
+ * Mike Brock, Dhanji Prasanna, John Graham, Mark Proctor
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mvel2.ast;
+
+import static org.mvel2.util.ParseTools.parseParameterDefList;
+import static org.mvel2.util.ParseTools.subCompileExpression;
+
+import java.util.Map;
+
+import org.mvel2.CompileException;
+import org.mvel2.ParserContext;
+import org.mvel2.compiler.ExecutableStatement;
+import org.mvel2.compiler.ExpressionCompiler;
+import org.mvel2.integration.VariableResolver;
+import org.mvel2.integration.VariableResolverFactory;
+import org.mvel2.integration.impl.DefaultLocalVariableResolverFactory;
+import org.mvel2.integration.impl.FunctionVariableResolverFactory;
+import org.mvel2.integration.impl.MapVariableResolverFactory;
+import org.mvel2.integration.impl.StackDemarcResolverFactory;
+
+@SuppressWarnings({ "unchecked" })
+public class Function extends ASTNode implements Safe {
+
+    protected String name;
+    protected ExecutableStatement compiledBlock;
+
+    protected String[] parameters;
+    protected int parmNum;
+    protected boolean compiledMode = false;
+    protected boolean singleton;
+
+    public Function(String name, char[] expr, int start, int offset, int blockStart, int blockOffset, int fields, ParserContext pCtx) {
+
+        super(pCtx);
+        if ((this.name = name) == null || name.length() == 0) {
+            this.name = null;
+        }
+        this.expr = expr;
+
+        parmNum = (this.parameters = parseParameterDefList(expr, start, offset)).length;
+
+        //pCtx.declareFunction(this);
+
+        ParserContext ctx = new ParserContext(pCtx.getParserConfiguration(), pCtx, true);
+
+        if (!pCtx.isFunctionContext()) {
+            singleton = true;
+            pCtx.declareFunction(this);
+        } else {
+            ctx.declareFunction(this);
+        }
+
+        /**
+         * To prevent the function parameters from being counted as
+         * external inputs, we must add them explicitly here.
+         */
+        for (String s : this.parameters) {
+            ctx.addVariable(s, Object.class);
+            ctx.addIndexedInput(s);
+        }
+
+        /**
+         * Compile the expression so we can determine the input-output delta.
+         */
+        ctx.setIndexAllocation(false);
+        ExpressionCompiler compiler = new ExpressionCompiler(expr, blockStart, blockOffset, ctx);
+        compiler.setVerifyOnly(true);
+        compiler.compile();
+
+        ctx.setIndexAllocation(true);
+
+        /**
+         * Add globals as inputs
+         */
+        if (pCtx.getVariables() != null) {
+            for (Map.Entry<String, Class> e : pCtx.getVariables().entrySet()) {
+                ctx.getVariables().remove(e.getKey());
+                ctx.addInput(e.getKey(), e.getValue());
+            }
+
+            ctx.processTables();
+        }
+
+        ctx.addIndexedInputs(ctx.getVariables().keySet());
+        ctx.getVariables().clear();
+
+        this.compiledBlock = (ExecutableStatement) subCompileExpression(expr, blockStart, blockOffset, ctx);
+
+        this.parameters = new String[ctx.getIndexedInputs().size()];
+
+        int i = 0;
+        for (String s : ctx.getIndexedInputs()) {
+            this.parameters[i++] = s;
+        }
+
+        compiledMode = (fields & COMPILE_IMMEDIATE) != 0;
+
+        this.egressType = this.compiledBlock.getKnownEgressType();
+
+        pCtx.addVariable(name, Function.class);
+    }
+
+    public Object getReducedValueAccelerated(Object ctx, Object thisValue, VariableResolverFactory factory) {
+        PrototypalFunctionInstance instance = new PrototypalFunctionInstance(this, new MapVariableResolverFactory());
+        if (name != null) {
+            if (!factory.isIndexedFactory() && factory.isResolveable(name))
+                throw new CompileException("duplicate function: " + name, expr, start);
+
+            factory.createVariable(name, instance);
+        }
+        return instance;
+    }
+
+    public Object getReducedValue(Object ctx, Object thisValue, VariableResolverFactory factory) {
+        PrototypalFunctionInstance instance = new PrototypalFunctionInstance(this, new MapVariableResolverFactory());
+        if (name != null) {
+            if (!factory.isIndexedFactory() && factory.isResolveable(name))
+                throw new CompileException("duplicate function: " + name, expr, start);
+            factory.createVariable(name, instance);
+        }
+        return instance;
+    }
+
+    public Object call(Object ctx, Object thisValue, VariableResolverFactory factory, Object[] parms) {
+        if (parms != null && parms.length != 0) {
+            // detect tail recursion
+            if (factory instanceof FunctionVariableResolverFactory
+                    && ((FunctionVariableResolverFactory) factory).getIndexedVariableResolvers().length == parms.length) {
+                FunctionVariableResolverFactory fvrf = (FunctionVariableResolverFactory) factory;
+                if (fvrf.getFunction().equals(this)) {
+                    VariableResolver[] swapVR = fvrf.getIndexedVariableResolvers();
+                    fvrf.updateParameters(parms);
+                    try {
+                        return compiledBlock.getValue(ctx, thisValue, fvrf);
+                    } finally {
+                        fvrf.setIndexedVariableResolvers(swapVR);
+                    }
+                }
+            }
+            return compiledBlock.getValue(thisValue,
+                    new StackDemarcResolverFactory(new FunctionVariableResolverFactory(this, factory, parameters, parms)));
+        } else if (compiledMode) {
+            return compiledBlock.getValue(thisValue,
+                    new StackDemarcResolverFactory(new DefaultLocalVariableResolverFactory(factory, parameters)));
+        } else {
+            return compiledBlock.getValue(thisValue,
+                    new StackDemarcResolverFactory(new DefaultLocalVariableResolverFactory(factory, parameters)));
+        }
+
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String[] getParameters() {
+        return parameters;
+    }
+
+    public boolean hasParameters() {
+        return this.parameters != null && this.parameters.length != 0;
+    }
+
+    public void checkArgumentCount(int passing) {
+        if (passing != parmNum) {
+            throw new CompileException(
+                    "bad number of arguments in function call: " + passing + " (expected: " + (parmNum == 0 ? "none" : parmNum) + ")", expr,
+                    start);
+        }
+    }
+
+    public ExecutableStatement getCompiledBlock() {
+        return compiledBlock;
+    }
+
+    public String toString() {
+        return "FunctionDef:" + (name == null ? "Anonymous" : name);
+    }
+}

--- a/core/src/main/java/org/mvel2/ast/FunctionInstance.java
+++ b/core/src/main/java/org/mvel2/ast/FunctionInstance.java
@@ -1,0 +1,23 @@
+package org.mvel2.ast;
+
+import org.mvel2.integration.VariableResolverFactory;
+
+/**
+ * @author Mike Brock
+ */
+public class FunctionInstance {
+
+    protected final Function function;
+
+    public FunctionInstance(Function function) {
+        this.function = function;
+    }
+
+    public Function getFunction() {
+        return function;
+    }
+
+    public Object call(Object ctx, Object thisValue, VariableResolverFactory factory, Object[] parms) {
+        return function.call(ctx, thisValue, factory, parms);
+    }
+}

--- a/core/src/main/java/org/mvel2/ast/IfNode.java
+++ b/core/src/main/java/org/mvel2/ast/IfNode.java
@@ -1,0 +1,117 @@
+/**
+ * MVEL 2.0
+ * Copyright (C) 2007 The Codehaus
+ * Mike Brock, Dhanji Prasanna, John Graham, Mark Proctor
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mvel2.ast;
+
+import static org.mvel2.MVEL.eval;
+import static org.mvel2.util.CompilerTools.expectType;
+import static org.mvel2.util.ParseTools.subCompileExpression;
+
+import java.util.HashMap;
+
+import org.mvel2.CompileException;
+import org.mvel2.ParserContext;
+import org.mvel2.compiler.ExecutableStatement;
+import org.mvel2.integration.VariableResolverFactory;
+import org.mvel2.integration.impl.MapVariableResolverFactory;
+
+/**
+ * @author Christopher Brock
+ */
+public class IfNode extends BlockNode implements NestedStatement {
+
+    protected ExecutableStatement condition;
+    protected ExecutableStatement nestedStatement;
+
+    protected IfNode elseIf;
+    protected ExecutableStatement elseBlock;
+
+    protected boolean idxAlloc = false;
+
+    public IfNode(char[] expr, int start, int offset, int blockStart, int blockOffset, int fields, ParserContext pCtx) {
+        super(pCtx);
+        if ((this.expr = expr) == null || offset == 0) {
+            throw new CompileException("statement expected", expr, start);
+        }
+        this.start = start;
+        this.offset = offset;
+        this.blockStart = blockStart;
+        this.blockOffset = blockOffset;
+
+        idxAlloc = pCtx != null && pCtx.isIndexAllocation();
+
+        if ((fields & COMPILE_IMMEDIATE) != 0) {
+            expectType(pCtx, this.condition = (ExecutableStatement) subCompileExpression(expr, start, offset, pCtx), Boolean.class, true);
+
+            if (pCtx != null) {
+                pCtx.pushVariableScope();
+            }
+            this.nestedStatement = (ExecutableStatement) subCompileExpression(expr, blockStart, blockOffset, pCtx);
+
+            if (pCtx != null) {
+                pCtx.popVariableScope();
+            }
+        }
+    }
+
+    public Object getReducedValueAccelerated(Object ctx, Object thisValue, VariableResolverFactory factory) {
+        if ((Boolean) condition.getValue(ctx, thisValue, factory)) {
+            return nestedStatement.getValue(ctx, thisValue, idxAlloc ? factory : new MapVariableResolverFactory(new HashMap(0), factory));
+        } else if (elseIf != null) {
+            return elseIf.getReducedValueAccelerated(ctx, thisValue,
+                    idxAlloc ? factory : new MapVariableResolverFactory(new HashMap(0), factory));
+        } else if (elseBlock != null) {
+            return elseBlock.getValue(ctx, thisValue, idxAlloc ? factory : new MapVariableResolverFactory(new HashMap(0), factory));
+        } else {
+            return null;
+        }
+    }
+
+    public Object getReducedValue(Object ctx, Object thisValue, VariableResolverFactory factory) {
+        if ((Boolean) eval(expr, start, offset, ctx, factory)) {
+            return eval(expr, blockStart, blockOffset, ctx, new MapVariableResolverFactory(new HashMap(0), factory));
+        } else if (elseIf != null) {
+            return elseIf.getReducedValue(ctx, thisValue, new MapVariableResolverFactory(new HashMap(0), factory));
+        } else if (elseBlock != null) {
+            return elseBlock.getValue(ctx, thisValue, new MapVariableResolverFactory(new HashMap(0), factory));
+        } else {
+            return null;
+        }
+    }
+
+    public ExecutableStatement getNestedStatement() {
+        return nestedStatement;
+    }
+
+    public IfNode setElseIf(IfNode elseIf) {
+        return this.elseIf = elseIf;
+    }
+
+    public ExecutableStatement getElseBlock() {
+        return elseBlock;
+    }
+
+    public IfNode setElseBlock(char[] block, int cursor, int offset, ParserContext ctx) {
+        elseBlock = (ExecutableStatement) subCompileExpression(block, cursor, offset, ctx);
+        return this;
+    }
+
+    public String toString() {
+        return new String(expr, start, offset);
+    }
+}

--- a/core/src/main/java/org/mvel2/ast/ImportNode.java
+++ b/core/src/main/java/org/mvel2/ast/ImportNode.java
@@ -1,0 +1,110 @@
+/**
+ * MVEL 2.0
+ * Copyright (C) 2007 The Codehaus
+ * Mike Brock, Dhanji Prasanna, John Graham, Mark Proctor
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mvel2.ast;
+
+import static org.mvel2.util.ParseTools.findClassImportResolverFactory;
+
+import org.mvel2.CompileException;
+import org.mvel2.MVEL;
+import org.mvel2.ParserContext;
+import org.mvel2.integration.VariableResolverFactory;
+import org.mvel2.integration.impl.ImmutableDefaultFactory;
+import org.mvel2.integration.impl.StackResetResolverFactory;
+import org.mvel2.util.ParseTools;
+
+/**
+ * @author Christopher Brock
+ */
+public class ImportNode extends ASTNode {
+
+    private static final char[] WC_TEST = new char[] { '.', '*' };
+    private Class importClass;
+    private boolean packageImport;
+    private int _offset;
+
+    public ImportNode(char[] expr, int start, int offset, ParserContext pCtx) {
+        super(pCtx);
+        this.expr = expr;
+        this.start = start;
+        this.offset = offset;
+        this.pCtx = pCtx;
+
+        if (ParseTools.endsWith(expr, start, offset, WC_TEST)) {
+            packageImport = true;
+            _offset = (short) ParseTools.findLast(expr, start, offset, '.');
+            if (_offset == -1) {
+                _offset = 0;
+            }
+        } else {
+            String clsName = new String(expr, start, offset);
+
+            ClassLoader classLoader = getClassLoader();
+
+            try {
+                this.importClass = Class.forName(clsName, true, classLoader);
+            } catch (ClassNotFoundException e) {
+                int idx;
+                clsName = (clsName.substring(0, idx = clsName.lastIndexOf('.')) + "$" + clsName.substring(idx + 1)).trim();
+
+                try {
+                    this.importClass = Class.forName(clsName, true, classLoader);
+                } catch (ClassNotFoundException e2) {
+                    throw new CompileException("class not found: " + new String(expr), expr, start);
+                }
+            }
+        }
+    }
+
+    public Object getReducedValueAccelerated(Object ctx, Object thisValue, VariableResolverFactory factory) {
+        if (!packageImport) {
+            if (MVEL.COMPILER_OPT_ALLOCATE_TYPE_LITERALS_TO_SHARED_SYMBOL_TABLE) {
+                factory.createVariable(importClass.getSimpleName(), importClass);
+                return importClass;
+            }
+            return findClassImportResolverFactory(factory, pCtx).addClass(importClass);
+        }
+
+        // if the factory is an ImmutableDefaultFactory it means this import is unused so we can skip it safely
+        if (!(factory instanceof ImmutableDefaultFactory) && !(factory instanceof StackResetResolverFactory
+                && ((StackResetResolverFactory) factory).getDelegate() instanceof ImmutableDefaultFactory)) {
+            findClassImportResolverFactory(factory, pCtx).addPackageImport(new String(expr, start, _offset - start));
+        }
+        return null;
+    }
+
+    public Object getReducedValue(Object ctx, Object thisValue, VariableResolverFactory factory) {
+        return getReducedValueAccelerated(ctx, thisValue, factory);
+    }
+
+    public Class getImportClass() {
+        return importClass;
+    }
+
+    public boolean isPackageImport() {
+        return packageImport;
+    }
+
+    public String getPackageImport() {
+        return new String(expr, start, _offset - start);
+    }
+
+    public void setPackageImport(boolean packageImport) {
+        this.packageImport = packageImport;
+    }
+}

--- a/core/src/main/java/org/mvel2/ast/IndexedAssignmentNode.java
+++ b/core/src/main/java/org/mvel2/ast/IndexedAssignmentNode.java
@@ -1,0 +1,186 @@
+/**
+ * MVEL 2.0
+ * Copyright (C) 2007 The Codehaus
+ * Mike Brock, Dhanji Prasanna, John Graham, Mark Proctor
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mvel2.ast;
+
+import static org.mvel2.MVEL.compileSetExpression;
+import static org.mvel2.util.ArrayTools.findFirst;
+import static org.mvel2.util.ParseTools.checkNameSafety;
+import static org.mvel2.util.ParseTools.createShortFormOperativeAssignment;
+import static org.mvel2.util.ParseTools.createStringTrimmed;
+import static org.mvel2.util.ParseTools.find;
+import static org.mvel2.util.ParseTools.skipWhitespace;
+import static org.mvel2.util.ParseTools.subCompileExpression;
+import static org.mvel2.util.ParseTools.subset;
+
+import org.mvel2.CompileException;
+import org.mvel2.MVEL;
+import org.mvel2.ParserContext;
+import org.mvel2.compiler.CompiledAccExpression;
+import org.mvel2.compiler.ExecutableStatement;
+import org.mvel2.integration.VariableResolverFactory;
+
+/**
+ * @author Christopher Brock
+ */
+public class IndexedAssignmentNode extends ASTNode implements Assignment {
+
+    private String assignmentVar;
+    private String name;
+    private int register;
+    private transient CompiledAccExpression accExpr;
+
+    private char[] indexTarget;
+    private char[] index;
+
+    private char[] stmt;
+    private ExecutableStatement statement;
+
+    private boolean col = false;
+
+    public IndexedAssignmentNode(char[] expr, int start, int offset, int fields, int operation, String name, int register,
+            ParserContext pCtx) {
+        super(pCtx);
+        this.expr = expr;
+        this.start = start;
+        this.offset = offset;
+
+        this.register = register;
+
+        int assignStart;
+
+        if (operation != -1) {
+            checkNameSafety(this.name = name);
+
+            this.egressType = (statement = (ExecutableStatement) subCompileExpression(
+                    stmt = createShortFormOperativeAssignment(name, expr, start, offset, operation), pCtx)).getKnownEgressType();
+        } else if ((assignStart = find(expr, start, offset, '=')) != -1) {
+            this.name = createStringTrimmed(expr, start, assignStart - start);
+            this.assignmentVar = name;
+
+            this.start = skipWhitespace(expr, assignStart + 1);
+
+            if (this.start >= start + offset) {
+                throw new CompileException("unexpected end of statement", expr, assignStart + 1);
+            }
+
+            this.offset = offset - (this.start - start);
+            stmt = subset(expr, this.start, this.offset);
+
+            this.egressType = (statement = (ExecutableStatement) subCompileExpression(expr, this.start, this.offset, pCtx))
+                    .getKnownEgressType();
+
+            if (col = ((endOfName = (short) findFirst('[', 0, this.name.length(), indexTarget = this.name.toCharArray())) > 0)) {
+                if (((this.fields |= COLLECTION) & COMPILE_IMMEDIATE) != 0) {
+                    accExpr = (CompiledAccExpression) compileSetExpression(indexTarget, pCtx);
+                }
+
+                this.name = this.name.substring(0, endOfName);
+                index = subset(indexTarget, endOfName, indexTarget.length - endOfName);
+            }
+
+            checkNameSafety(this.name);
+        } else {
+            checkNameSafety(this.name = new String(expr));
+            this.assignmentVar = name;
+        }
+
+        if ((fields & COMPILE_IMMEDIATE) != 0) {
+            pCtx.addVariable(name, egressType);
+        }
+    }
+
+    public IndexedAssignmentNode(char[] expr, int start, int offset, int fields, int register, ParserContext pCtx) {
+        this(expr, start, offset, fields, -1, null, register, pCtx);
+    }
+
+    public Object getReducedValueAccelerated(Object ctx, Object thisValue, VariableResolverFactory factory) {
+        if (accExpr == null && indexTarget != null) {
+            accExpr = (CompiledAccExpression) compileSetExpression(indexTarget);
+        }
+
+        if (col) {
+            accExpr.setValue(ctx, thisValue, factory, ctx = statement.getValue(ctx, thisValue, factory));
+        } else if (statement != null) {
+            if (factory.isIndexedFactory()) {
+                factory.createIndexedVariable(register, name, ctx = statement.getValue(ctx, thisValue, factory));
+            } else {
+                factory.createVariable(name, ctx = statement.getValue(ctx, thisValue, factory));
+            }
+        } else {
+            if (factory.isIndexedFactory()) {
+                factory.createIndexedVariable(register, name, null);
+            } else {
+                factory.createVariable(name, statement.getValue(ctx, thisValue, factory));
+            }
+            return Void.class;
+        }
+
+        return ctx;
+    }
+
+    public Object getReducedValue(Object ctx, Object thisValue, VariableResolverFactory factory) {
+        checkNameSafety(name);
+
+        if (col) {
+            MVEL.setProperty(factory.getIndexedVariableResolver(register).getValue(), new String(index),
+                    ctx = MVEL.eval(stmt, ctx, factory));
+        } else {
+            factory.createIndexedVariable(register, name, ctx = MVEL.eval(stmt, ctx, factory));
+        }
+
+        return ctx;
+    }
+
+    public String getAssignmentVar() {
+        return assignmentVar;
+    }
+
+    public String getVarName() {
+        return name;
+    }
+
+    public char[] getExpression() {
+        return stmt;
+    }
+
+    public int getRegister() {
+        return register;
+    }
+
+    public void setRegister(int register) {
+        this.register = register;
+    }
+
+    public boolean isAssignment() {
+        return true;
+    }
+
+    @Override
+    public String getAbsoluteName() {
+        return name;
+    }
+
+    public boolean isNewDeclaration() {
+        return false;
+    }
+
+    public void setValueStatement(ExecutableStatement stmt) {
+        this.statement = stmt;
+    }
+}

--- a/core/src/main/java/org/mvel2/ast/IndexedDeclTypedVarNode.java
+++ b/core/src/main/java/org/mvel2/ast/IndexedDeclTypedVarNode.java
@@ -1,0 +1,69 @@
+/**
+ * MVEL 2.0
+ * Copyright (C) 2007 The Codehaus
+ * Mike Brock, Dhanji Prasanna, John Graham, Mark Proctor
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mvel2.ast;
+
+import org.mvel2.ParserContext;
+import org.mvel2.compiler.ExecutableStatement;
+import org.mvel2.integration.VariableResolverFactory;
+
+/**
+ * @author Christopher Brock
+ */
+public class IndexedDeclTypedVarNode extends ASTNode implements Assignment {
+
+    private int register;
+
+    public IndexedDeclTypedVarNode(int register, int start, int offset, Class type, ParserContext pCtx) {
+        super(pCtx);
+        this.egressType = type;
+        this.start = start;
+        this.offset = offset;
+        this.register = register;
+    }
+
+    public Object getReducedValueAccelerated(Object ctx, Object thisValue, VariableResolverFactory factory) {
+        factory.createIndexedVariable(register, null, egressType);
+        return ctx;
+    }
+
+    public Object getReducedValue(Object ctx, Object thisValue, VariableResolverFactory factory) {
+        factory.createIndexedVariable(register, null, egressType);
+        return null;
+    }
+
+    public String getAssignmentVar() {
+        return null;
+    }
+
+    public char[] getExpression() {
+        return new char[0];
+    }
+
+    public boolean isAssignment() {
+        return true;
+    }
+
+    public boolean isNewDeclaration() {
+        return true;
+    }
+
+    public void setValueStatement(ExecutableStatement stmt) {
+        throw new RuntimeException("illegal operation");
+    }
+}

--- a/core/src/main/java/org/mvel2/ast/IndexedOperativeAssign.java
+++ b/core/src/main/java/org/mvel2/ast/IndexedOperativeAssign.java
@@ -1,0 +1,61 @@
+/**
+ * MVEL 2.0
+ * Copyright (C) 2007 The Codehaus
+ * Mike Brock, Dhanji Prasanna, John Graham, Mark Proctor
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mvel2.ast;
+
+import static org.mvel2.MVEL.eval;
+import static org.mvel2.util.ParseTools.subCompileExpression;
+
+import org.mvel2.ParserContext;
+import org.mvel2.compiler.ExecutableStatement;
+import org.mvel2.integration.VariableResolver;
+import org.mvel2.integration.VariableResolverFactory;
+import org.mvel2.math.MathProcessor;
+
+public class IndexedOperativeAssign extends ASTNode {
+
+    private final int register;
+    private final int operation;
+    private ExecutableStatement statement;
+
+    public IndexedOperativeAssign(char[] expr, int start, int offset, int operation, int register, int fields, ParserContext pCtx) {
+        super(pCtx);
+        this.operation = operation;
+        this.expr = expr;
+        this.start = start;
+        this.offset = offset;
+        this.register = register;
+
+        if ((fields & COMPILE_IMMEDIATE) != 0) {
+            statement = (ExecutableStatement) subCompileExpression(expr, start, offset, pCtx);
+            egressType = statement.getKnownEgressType();
+        }
+    }
+
+    public Object getReducedValueAccelerated(Object ctx, Object thisValue, VariableResolverFactory factory) {
+        VariableResolver resolver = factory.getIndexedVariableResolver(register);
+        resolver.setValue(ctx = MathProcessor.doOperations(resolver.getValue(), operation, statement.getValue(ctx, thisValue, factory)));
+        return ctx;
+    }
+
+    public Object getReducedValue(Object ctx, Object thisValue, VariableResolverFactory factory) {
+        VariableResolver resolver = factory.getIndexedVariableResolver(register);
+        resolver.setValue(ctx = MathProcessor.doOperations(resolver.getValue(), operation, eval(expr, start, offset, ctx, factory)));
+        return ctx;
+    }
+}

--- a/core/src/main/java/org/mvel2/ast/IndexedPostFixDecNode.java
+++ b/core/src/main/java/org/mvel2/ast/IndexedPostFixDecNode.java
@@ -1,0 +1,53 @@
+/**
+ * MVEL 2.0
+ * Copyright (C) 2007 The Codehaus
+ * Mike Brock, Dhanji Prasanna, John Graham, Mark Proctor
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mvel2.ast;
+
+import org.mvel2.DataTypes;
+import org.mvel2.Operator;
+import org.mvel2.ParserContext;
+import org.mvel2.integration.VariableResolver;
+import org.mvel2.integration.VariableResolverFactory;
+import org.mvel2.math.MathProcessor;
+import org.mvel2.util.ParseTools;
+
+/**
+ * @author Christopher Brock
+ */
+public class IndexedPostFixDecNode extends ASTNode {
+
+    private int register;
+
+    public IndexedPostFixDecNode(int register, ParserContext pCtx) {
+        super(pCtx);
+        this.register = register;
+        this.egressType = pCtx.getVarOrInputType(pCtx.getIndexedVarNames()[register]);
+    }
+
+    public Object getReducedValueAccelerated(Object ctx, Object thisValue, VariableResolverFactory factory) {
+        VariableResolver vResolver = factory.getIndexedVariableResolver(register);
+        //  ctx = vResolver.getValue();
+        vResolver.setValue(
+                MathProcessor.doOperations(ParseTools.resolveType(ctx = vResolver.getValue()), ctx, Operator.SUB, DataTypes.INTEGER, 1));
+        return ctx;
+    }
+
+    public Object getReducedValue(Object ctx, Object thisValue, VariableResolverFactory factory) {
+        return getReducedValueAccelerated(ctx, thisValue, factory);
+    }
+}

--- a/core/src/main/java/org/mvel2/ast/IndexedPostFixIncNode.java
+++ b/core/src/main/java/org/mvel2/ast/IndexedPostFixIncNode.java
@@ -1,0 +1,50 @@
+/**
+ * MVEL 2.0
+ * Copyright (C) 2007 The Codehaus
+ * Mike Brock, Dhanji Prasanna, John Graham, Mark Proctor
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mvel2.ast;
+
+import org.mvel2.DataTypes;
+import org.mvel2.Operator;
+import org.mvel2.ParserContext;
+import org.mvel2.integration.VariableResolver;
+import org.mvel2.integration.VariableResolverFactory;
+import org.mvel2.math.MathProcessor;
+
+/**
+ * @author Christopher Brock
+ */
+public class IndexedPostFixIncNode extends ASTNode {
+
+    private int register;
+
+    public IndexedPostFixIncNode(int register, ParserContext pCtx) {
+        super(pCtx);
+        this.register = register;
+        this.egressType = pCtx.getVarOrInputType(pCtx.getIndexedVarNames()[register]);
+    }
+
+    public Object getReducedValueAccelerated(Object ctx, Object thisValue, VariableResolverFactory factory) {
+        VariableResolver vResolver = factory.getIndexedVariableResolver(register);
+        vResolver.setValue(MathProcessor.doOperations(ctx = vResolver.getValue(), Operator.ADD, DataTypes.INTEGER, 1));
+        return ctx;
+    }
+
+    public Object getReducedValue(Object ctx, Object thisValue, VariableResolverFactory factory) {
+        return getReducedValueAccelerated(ctx, thisValue, factory);
+    }
+}

--- a/core/src/main/java/org/mvel2/ast/IndexedPreFixDecNode.java
+++ b/core/src/main/java/org/mvel2/ast/IndexedPreFixDecNode.java
@@ -1,0 +1,49 @@
+/**
+ * MVEL 2.0
+ * Copyright (C) 2007 The Codehaus
+ * Mike Brock, Dhanji Prasanna, John Graham, Mark Proctor
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.mvel2.ast;
+
+import org.mvel2.DataTypes;
+import org.mvel2.Operator;
+import org.mvel2.ParserContext;
+import org.mvel2.integration.VariableResolver;
+import org.mvel2.integration.VariableResolverFactory;
+import org.mvel2.math.MathProcessor;
+
+/**
+ * @author Christopher Brock
+ */
+public class IndexedPreFixDecNode extends ASTNode {
+
+    private int register;
+
+    public IndexedPreFixDecNode(int register, ParserContext pCtx) {
+        super(pCtx);
+        this.register = register;
+        this.egressType = pCtx.getVarOrInputType(pCtx.getIndexedVarNames()[register]);
+    }
+
+    public Object getReducedValueAccelerated(Object ctx, Object thisValue, VariableResolverFactory factory) {
+        VariableResolver vResolver = factory.getIndexedVariableResolver(register);
+        vResolver.setValue(ctx = MathProcessor.doOperations(vResolver.getValue(), Operator.SUB, DataTypes.INTEGER, 1));
+        return ctx;
+    }
+
+    public Object getReducedValue(Object ctx, Object thisValue, VariableResolverFactory factory) {
+        return getReducedValueAccelerated(ctx, thisValue, factory);
+    }
+}

--- a/core/src/main/java/org/mvel2/ast/IndexedPreFixIncNode.java
+++ b/core/src/main/java/org/mvel2/ast/IndexedPreFixIncNode.java
@@ -1,0 +1,50 @@
+/**
+ * MVEL 2.0
+ * Copyright (C) 2007 The Codehaus
+ * Mike Brock, Dhanji Prasanna, John Graham, Mark Proctor
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mvel2.ast;
+
+import org.mvel2.DataTypes;
+import org.mvel2.Operator;
+import org.mvel2.ParserContext;
+import org.mvel2.integration.VariableResolver;
+import org.mvel2.integration.VariableResolverFactory;
+import org.mvel2.math.MathProcessor;
+
+/**
+ * @author Christopher Brock
+ */
+public class IndexedPreFixIncNode extends ASTNode {
+
+    private int register;
+
+    public IndexedPreFixIncNode(int register, ParserContext pCtx) {
+        super(pCtx);
+        this.register = register;
+        this.egressType = pCtx.getVarOrInputType(pCtx.getIndexedVarNames()[register]);
+    }
+
+    public Object getReducedValueAccelerated(Object ctx, Object thisValue, VariableResolverFactory factory) {
+        VariableResolver vResolver = factory.getIndexedVariableResolver(register);
+        vResolver.setValue(ctx = MathProcessor.doOperations(vResolver.getValue(), Operator.ADD, DataTypes.INTEGER, 1));
+        return ctx;
+    }
+
+    public Object getReducedValue(Object ctx, Object thisValue, VariableResolverFactory factory) {
+        return getReducedValueAccelerated(ctx, thisValue, factory);
+    }
+}

--- a/core/src/main/java/org/mvel2/ast/InlineCollectionNode.java
+++ b/core/src/main/java/org/mvel2/ast/InlineCollectionNode.java
@@ -1,0 +1,177 @@
+/**
+ * MVEL 2.0
+ * Copyright (C) 2007 The Codehaus
+ * Mike Brock, Dhanji Prasanna, John Graham, Mark Proctor
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mvel2.ast;
+
+import static org.mvel2.util.ParseTools.findClass;
+import static org.mvel2.util.ParseTools.getBaseComponentType;
+import static org.mvel2.util.ParseTools.getSubComponentType;
+import static org.mvel2.util.ParseTools.repeatChar;
+
+import java.lang.reflect.Array;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.mvel2.CompileException;
+import org.mvel2.MVEL;
+import org.mvel2.ParserContext;
+import org.mvel2.integration.VariableResolverFactory;
+import org.mvel2.optimizers.AccessorOptimizer;
+import org.mvel2.optimizers.OptimizerFactory;
+import org.mvel2.util.CollectionParser;
+
+/**
+ * @author Christopher Brock
+ */
+public class InlineCollectionNode extends ASTNode {
+
+    int trailingStart;
+    int trailingOffset;
+    private Object collectionGraph;
+
+    public InlineCollectionNode(char[] expr, int start, int end, int fields, ParserContext pctx) {
+        super(expr, start, end, fields | INLINE_COLLECTION, pctx);
+
+        if ((fields & COMPILE_IMMEDIATE) != 0) {
+            parseGraph(true, null, pctx);
+            try {
+                AccessorOptimizer ao = OptimizerFactory.getThreadAccessorOptimizer();
+                accessor = ao.optimizeCollection(pctx, collectionGraph, egressType, expr, trailingStart, trailingOffset, null, null, null);
+                egressType = ao.getEgressType();
+            } finally {
+                OptimizerFactory.clearThreadAccessorOptimizer();
+            }
+        }
+    }
+
+    public InlineCollectionNode(char[] expr, int start, int end, int fields, Class type, ParserContext pctx) {
+        super(expr, start, end, fields | INLINE_COLLECTION, pctx);
+
+        this.egressType = type;
+
+        if ((fields & COMPILE_IMMEDIATE) != 0) {
+            try {
+                parseGraph(true, type, pctx);
+                AccessorOptimizer ao = OptimizerFactory.getThreadAccessorOptimizer();
+                accessor = ao.optimizeCollection(pctx, collectionGraph, egressType, expr, this.trailingStart, trailingOffset, null, null,
+                        null);
+                egressType = ao.getEgressType();
+            } finally {
+                OptimizerFactory.clearThreadAccessorOptimizer();
+            }
+        }
+    }
+
+    public Object getReducedValueAccelerated(Object ctx, Object thisValue, VariableResolverFactory factory) {
+        if (accessor != null) {
+            return accessor.getValue(ctx, thisValue, factory);
+        } else {
+            try {
+                AccessorOptimizer ao = OptimizerFactory.getThreadAccessorOptimizer();
+                if (collectionGraph == null) parseGraph(true, null, null);
+
+                accessor = ao.optimizeCollection(pCtx, collectionGraph, egressType, expr, trailingStart, trailingOffset, ctx, thisValue,
+                        factory);
+                egressType = ao.getEgressType();
+
+                return accessor.getValue(ctx, thisValue, factory);
+            } finally {
+                OptimizerFactory.clearThreadAccessorOptimizer();
+            }
+        }
+
+    }
+
+    public Object getReducedValue(Object ctx, Object thisValue, VariableResolverFactory factory) {
+        parseGraph(false, egressType, pCtx);
+
+        return execGraph(collectionGraph, egressType, ctx, factory);
+    }
+
+    private void parseGraph(boolean compile, Class type, ParserContext pCtx) {
+        CollectionParser parser = new CollectionParser();
+
+        if (type == null) {
+            collectionGraph = ((List) parser.parseCollection(expr, start, offset, compile, pCtx)).get(0);
+        } else {
+            collectionGraph = ((List) parser.parseCollection(expr, start, offset, compile, type, pCtx)).get(0);
+        }
+
+        trailingStart = parser.getCursor() + 2;
+        trailingOffset = offset - (trailingStart - start);
+
+        if (this.egressType == null) this.egressType = collectionGraph.getClass();
+    }
+
+    private Object execGraph(Object o, Class type, Object ctx, VariableResolverFactory factory) {
+        if (o instanceof List) {
+            ArrayList list = new ArrayList(((List) o).size());
+
+            for (Object item : (List) o) {
+                list.add(execGraph(item, type, ctx, factory));
+            }
+
+            return list;
+        } else if (o instanceof Map) {
+            HashMap map = new HashMap();
+
+            for (Object item : ((Map) o).keySet()) {
+                map.put(execGraph(item, type, ctx, factory), execGraph(((Map) o).get(item), type, ctx, factory));
+            }
+
+            return map;
+        } else if (o instanceof Object[]) {
+            int dim = 0;
+
+            if (type != null) {
+                String nm = type.getName();
+                while (nm.charAt(dim) == '[')
+                    dim++;
+            } else {
+                type = Object[].class;
+                dim = 1;
+            }
+
+            Object newArray = Array.newInstance(getSubComponentType(type), ((Object[]) o).length);
+
+            try {
+                Class cls = dim > 1 ? findClass(null, repeatChar('[', dim - 1) + "L" + getBaseComponentType(type).getName() + ";",
+                        pCtx) : type;
+
+                int c = 0;
+                for (Object item : (Object[]) o) {
+                    Array.set(newArray, c++, execGraph(item, cls, ctx, factory));
+                }
+
+                return newArray;
+            } catch (IllegalArgumentException e) {
+                throw new CompileException("type mismatch in array", expr, start, e);
+            } catch (ClassNotFoundException e) {
+                throw new RuntimeException("this error should never throw:" + getBaseComponentType(type).getName(), e);
+            }
+        } else {
+            if (type.isArray()) {
+                return MVEL.eval((String) o, ctx, factory, getBaseComponentType(type));
+            } else {
+                return MVEL.eval((String) o, ctx, factory);
+            }
+        }
+    }
+}

--- a/core/src/main/java/org/mvel2/ast/Instance.java
+++ b/core/src/main/java/org/mvel2/ast/Instance.java
@@ -1,0 +1,47 @@
+package org.mvel2.ast;
+
+import org.mvel2.ParserContext;
+import org.mvel2.integration.VariableResolverFactory;
+import org.mvel2.util.CompilerTools;
+
+public class Instance extends ASTNode {
+
+    private ASTNode stmt;
+    private ASTNode clsStmt;
+
+    public Instance(ASTNode stmt, ASTNode clsStmt, ParserContext pCtx) {
+        super(pCtx);
+        this.stmt = stmt;
+        this.clsStmt = clsStmt;
+        CompilerTools.expectType(pCtx, clsStmt, Class.class, true);
+    }
+
+    public Object getReducedValueAccelerated(Object ctx, Object thisValue, VariableResolverFactory factory) {
+        return ((Class) clsStmt.getReducedValueAccelerated(ctx, thisValue, factory))
+                .isInstance(stmt.getReducedValueAccelerated(ctx, thisValue, factory));
+    }
+
+    public Object getReducedValue(Object ctx, Object thisValue, VariableResolverFactory factory) {
+        try {
+            Class i = (Class) clsStmt.getReducedValue(ctx, thisValue, factory);
+            if (i == null) throw new ClassCastException();
+
+            return i.isInstance(stmt.getReducedValue(ctx, thisValue, factory));
+        } catch (ClassCastException e) {
+            throw new RuntimeException("not a class reference: " + clsStmt.getName());
+        }
+
+    }
+
+    public Class getEgressType() {
+        return Boolean.class;
+    }
+
+    public ASTNode getStatement() {
+        return stmt;
+    }
+
+    public ASTNode getClassStatement() {
+        return clsStmt;
+    }
+}

--- a/core/src/main/java/org/mvel2/ast/IntAdd.java
+++ b/core/src/main/java/org/mvel2/ast/IntAdd.java
@@ -1,0 +1,30 @@
+package org.mvel2.ast;
+
+import org.mvel2.Operator;
+import org.mvel2.ParserContext;
+import org.mvel2.integration.VariableResolverFactory;
+
+public class IntAdd extends BinaryOperation implements IntOptimized {
+
+    public IntAdd(ASTNode left, ASTNode right, ParserContext pCtx) {
+        super(Operator.ADD, pCtx);
+        this.left = left;
+        this.right = right;
+    }
+
+    @Override
+    public Object getReducedValueAccelerated(Object ctx, Object thisValue, VariableResolverFactory factory) {
+        return ((Integer) left.getReducedValueAccelerated(ctx, thisValue, factory))
+                + ((Integer) right.getReducedValueAccelerated(ctx, thisValue, factory));
+    }
+
+    @Override
+    public Object getReducedValue(Object ctx, Object thisValue, VariableResolverFactory factory) {
+        return ((Integer) left.getReducedValue(ctx, thisValue, factory)) + ((Integer) right.getReducedValue(ctx, thisValue, factory));
+    }
+
+    @Override
+    public Class getEgressType() {
+        return Integer.class;
+    }
+}

--- a/core/src/main/java/org/mvel2/ast/IntDiv.java
+++ b/core/src/main/java/org/mvel2/ast/IntDiv.java
@@ -1,0 +1,35 @@
+package org.mvel2.ast;
+
+import org.mvel2.Operator;
+import org.mvel2.ParserContext;
+import org.mvel2.integration.VariableResolverFactory;
+
+public class IntDiv extends BinaryOperation implements IntOptimized {
+
+    public IntDiv(ASTNode left, ASTNode right, ParserContext pCtx) {
+        super(Operator.MULT, pCtx);
+        this.left = left;
+        this.right = right;
+    }
+
+    @Override
+    public Object getReducedValueAccelerated(Object ctx, Object thisValue, VariableResolverFactory factory) {
+        return ((Integer) left.getReducedValueAccelerated(ctx, thisValue, factory))
+                / ((Integer) right.getReducedValueAccelerated(ctx, thisValue, factory));
+    }
+
+    @Override
+    public Object getReducedValue(Object ctx, Object thisValue, VariableResolverFactory factory) {
+        return ((Integer) left.getReducedValue(ctx, thisValue, factory)) / ((Integer) right.getReducedValue(ctx, thisValue, factory));
+    }
+
+    @Override
+    public void setRight(ASTNode node) {
+        super.setRight(node);
+    }
+
+    @Override
+    public Class getEgressType() {
+        return Integer.class;
+    }
+}

--- a/core/src/main/java/org/mvel2/ast/IntMult.java
+++ b/core/src/main/java/org/mvel2/ast/IntMult.java
@@ -1,0 +1,30 @@
+package org.mvel2.ast;
+
+import org.mvel2.Operator;
+import org.mvel2.ParserContext;
+import org.mvel2.integration.VariableResolverFactory;
+
+public class IntMult extends BinaryOperation implements IntOptimized {
+
+    public IntMult(ASTNode left, ASTNode right, ParserContext pCtx) {
+        super(Operator.MULT, pCtx);
+        this.left = left;
+        this.right = right;
+    }
+
+    @Override
+    public Object getReducedValueAccelerated(Object ctx, Object thisValue, VariableResolverFactory factory) {
+        return ((Integer) left.getReducedValueAccelerated(ctx, thisValue, factory))
+                * ((Integer) right.getReducedValueAccelerated(ctx, thisValue, factory));
+    }
+
+    @Override
+    public Object getReducedValue(Object ctx, Object thisValue, VariableResolverFactory factory) {
+        return ((Integer) left.getReducedValue(ctx, thisValue, factory)) * ((Integer) right.getReducedValue(ctx, thisValue, factory));
+    }
+
+    @Override
+    public Class getEgressType() {
+        return Integer.class;
+    }
+}

--- a/core/src/main/java/org/mvel2/ast/IntOptimized.java
+++ b/core/src/main/java/org/mvel2/ast/IntOptimized.java
@@ -1,0 +1,4 @@
+package org.mvel2.ast;
+
+public interface IntOptimized {
+}

--- a/core/src/main/java/org/mvel2/ast/IntSub.java
+++ b/core/src/main/java/org/mvel2/ast/IntSub.java
@@ -1,0 +1,30 @@
+package org.mvel2.ast;
+
+import org.mvel2.Operator;
+import org.mvel2.ParserContext;
+import org.mvel2.integration.VariableResolverFactory;
+
+public class IntSub extends BinaryOperation implements IntOptimized {
+
+    public IntSub(ASTNode left, ASTNode right, ParserContext pCtx) {
+        super(Operator.SUB, pCtx);
+        this.left = left;
+        this.right = right;
+    }
+
+    @Override
+    public Object getReducedValueAccelerated(Object ctx, Object thisValue, VariableResolverFactory factory) {
+        return ((Integer) left.getReducedValueAccelerated(ctx, thisValue, factory))
+                - ((Integer) right.getReducedValueAccelerated(ctx, thisValue, factory));
+    }
+
+    @Override
+    public Object getReducedValue(Object ctx, Object thisValue, VariableResolverFactory factory) {
+        return ((Integer) left.getReducedValue(ctx, thisValue, factory)) - ((Integer) right.getReducedValue(ctx, thisValue, factory));
+    }
+
+    @Override
+    public Class getEgressType() {
+        return Integer.class;
+    }
+}

--- a/core/src/main/java/org/mvel2/ast/InterceptorWrapper.java
+++ b/core/src/main/java/org/mvel2/ast/InterceptorWrapper.java
@@ -1,0 +1,50 @@
+/**
+ * MVEL 2.0
+ * Copyright (C) 2007 The Codehaus
+ * Mike Brock, Dhanji Prasanna, John Graham, Mark Proctor
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mvel2.ast;
+
+import org.mvel2.ParserContext;
+import org.mvel2.integration.Interceptor;
+import org.mvel2.integration.VariableResolverFactory;
+
+/**
+ * @author Christopher Brock
+ */
+public class InterceptorWrapper extends ASTNode {
+
+    private Interceptor interceptor;
+    private ASTNode node;
+
+    public InterceptorWrapper(Interceptor interceptor, ASTNode node, ParserContext pCtx) {
+        super(pCtx);
+        this.interceptor = interceptor;
+        this.node = node;
+    }
+
+    public Object getReducedValueAccelerated(Object ctx, Object thisValue, VariableResolverFactory factory) {
+        interceptor.doBefore(node, factory);
+        interceptor.doAfter(ctx = node.getReducedValueAccelerated(ctx, thisValue, factory), node, factory);
+        return ctx;
+    }
+
+    public Object getReducedValue(Object ctx, Object thisValue, VariableResolverFactory factory) {
+        interceptor.doBefore(node, factory);
+        interceptor.doAfter(ctx = node.getReducedValue(ctx, thisValue, factory), node, factory);
+        return ctx;
+    }
+}

--- a/core/src/main/java/org/mvel2/ast/Invert.java
+++ b/core/src/main/java/org/mvel2/ast/Invert.java
@@ -1,0 +1,58 @@
+/**
+ * MVEL 2.0
+ * Copyright (C) 2007 The Codehaus
+ * Mike Brock, Dhanji Prasanna, John Graham, Mark Proctor
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mvel2.ast;
+
+import static org.mvel2.util.CompilerTools.expectType;
+import static org.mvel2.util.ParseTools.subCompileExpression;
+
+import org.mvel2.CompileException;
+import org.mvel2.MVEL;
+import org.mvel2.ParserContext;
+import org.mvel2.compiler.ExecutableStatement;
+import org.mvel2.integration.VariableResolverFactory;
+
+public class Invert extends ASTNode {
+
+    private ExecutableStatement stmt;
+
+    public Invert(char[] expr, int start, int offset, int fields, ParserContext pCtx) {
+        super(pCtx);
+        this.expr = expr;
+        this.start = start;
+        this.offset = offset;
+
+        if ((fields & COMPILE_IMMEDIATE) != 0) {
+            expectType(pCtx, this.stmt = (ExecutableStatement) subCompileExpression(expr, start, offset, pCtx), Integer.class, true);
+        }
+    }
+
+    public Object getReducedValueAccelerated(Object ctx, Object thisValue, VariableResolverFactory factory) {
+        return ~((Integer) stmt.getValue(ctx, thisValue, factory));
+    }
+
+    public Object getReducedValue(Object ctx, Object thisValue, VariableResolverFactory factory) {
+        Object o = MVEL.eval(expr, start, offset, ctx, factory);
+        if (o instanceof Integer) {
+            return ~((Integer) o);
+        } else {
+            throw new CompileException("was expecting type: Integer; but found type: " + (o == null ? "null" : o.getClass().getName()),
+                    expr, start);
+        }
+    }
+}

--- a/core/src/main/java/org/mvel2/ast/InvokationContextFactory.java
+++ b/core/src/main/java/org/mvel2/ast/InvokationContextFactory.java
@@ -1,0 +1,60 @@
+package org.mvel2.ast;
+
+import org.mvel2.integration.VariableResolver;
+import org.mvel2.integration.VariableResolverFactory;
+import org.mvel2.integration.impl.MapVariableResolverFactory;
+
+/**
+* @author Mike Brock
+*/
+public class InvokationContextFactory extends MapVariableResolverFactory {
+
+    private VariableResolverFactory protoContext;
+
+    public InvokationContextFactory(VariableResolverFactory next, VariableResolverFactory protoContext) {
+        this.nextFactory = next;
+        this.protoContext = protoContext;
+    }
+
+    @Override
+    public VariableResolver createVariable(String name, Object value) {
+        if (isResolveable(name) && !protoContext.isResolveable(name)) {
+            return nextFactory.createVariable(name, value);
+        } else {
+            return protoContext.createVariable(name, value);
+        }
+    }
+
+    @Override
+    public VariableResolver createVariable(String name, Object value, Class<?> type) {
+        if (isResolveable(name) && !protoContext.isResolveable(name)) {
+            return nextFactory.createVariable(name, value, type);
+        } else {
+            return protoContext.createVariable(name, value, type);
+        }
+    }
+
+    @Override
+    public VariableResolver getVariableResolver(String name) {
+        if (isResolveable(name) && !protoContext.isResolveable(name)) {
+            return nextFactory.getVariableResolver(name);
+        } else {
+            return protoContext.getVariableResolver(name);
+        }
+    }
+
+    @Override
+    public boolean isTarget(String name) {
+        return protoContext.isTarget(name);
+    }
+
+    @Override
+    public boolean isResolveable(String name) {
+        return protoContext.isResolveable(name) || nextFactory.isResolveable(name);
+    }
+
+    @Override
+    public boolean isIndexedFactory() {
+        return true;
+    }
+}

--- a/core/src/main/java/org/mvel2/ast/IsDef.java
+++ b/core/src/main/java/org/mvel2/ast/IsDef.java
@@ -1,0 +1,45 @@
+/**
+ * MVEL 2.0
+ * Copyright (C) 2007 The Codehaus
+ * Mike Brock, Dhanji Prasanna, John Graham, Mark Proctor
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mvel2.ast;
+
+import static org.mvel2.util.PropertyTools.getFieldOrAccessor;
+
+import org.mvel2.ParserContext;
+import org.mvel2.integration.VariableResolverFactory;
+
+public class IsDef extends ASTNode {
+
+    public IsDef(char[] expr, int start, int offset, ParserContext pCtx) {
+        super(pCtx);
+        this.nameCache = new String(this.expr = expr, this.start = start, this.offset = offset);
+    }
+
+    public Object getReducedValueAccelerated(Object ctx, Object thisValue, VariableResolverFactory factory) {
+        return factory.isResolveable(nameCache) || (thisValue != null && getFieldOrAccessor(thisValue.getClass(), nameCache) != null);
+    }
+
+    public Object getReducedValue(Object ctx, Object thisValue, VariableResolverFactory factory) {
+        return factory.isResolveable(nameCache) || (thisValue != null && getFieldOrAccessor(thisValue.getClass(), nameCache) != null);
+
+    }
+
+    public Class getEgressType() {
+        return Boolean.class;
+    }
+}

--- a/core/src/main/java/org/mvel2/ast/LineLabel.java
+++ b/core/src/main/java/org/mvel2/ast/LineLabel.java
@@ -1,0 +1,65 @@
+/**
+ * MVEL 2.0
+ * Copyright (C) 2007 The Codehaus
+ * Mike Brock, Dhanji Prasanna, John Graham, Mark Proctor
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.mvel2.ast;
+
+import org.mvel2.ParserContext;
+import org.mvel2.integration.VariableResolverFactory;
+
+/**
+ * @author Christopher Brock
+ */
+public class LineLabel extends ASTNode {
+
+    private String sourceFile;
+    private int lineNumber;
+
+    public LineLabel(String sourceFile, int lineNumber, ParserContext pCtx) {
+        super(pCtx);
+        this.lineNumber = lineNumber;
+        this.sourceFile = sourceFile;
+        this.fields = -1;
+    }
+
+    public String getSourceFile() {
+        return sourceFile;
+    }
+
+    public void setSourceFile(String sourceFile) {
+        this.sourceFile = sourceFile;
+    }
+
+    public int getLineNumber() {
+        return lineNumber;
+    }
+
+    public void setLineNumber(int lineNumber) {
+        this.lineNumber = lineNumber;
+    }
+
+    public Object getReducedValueAccelerated(Object ctx, Object thisValue, VariableResolverFactory factory) {
+        return null;
+    }
+
+    public Object getReducedValue(Object ctx, Object thisValue, VariableResolverFactory factory) {
+        return null;
+    }
+
+    public String toString() {
+        return "[SourceLine:" + lineNumber + "]";
+    }
+}

--- a/core/src/main/java/org/mvel2/ast/LiteralDeepPropertyNode.java
+++ b/core/src/main/java/org/mvel2/ast/LiteralDeepPropertyNode.java
@@ -1,0 +1,63 @@
+/**
+ * MVEL 2.0
+ * Copyright (C) 2007 The Codehaus
+ * Mike Brock, Dhanji Prasanna, John Graham, Mark Proctor
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.mvel2.ast;
+
+import static org.mvel2.PropertyAccessor.get;
+import static org.mvel2.optimizers.OptimizerFactory.getThreadAccessorOptimizer;
+
+import org.mvel2.ParserContext;
+import org.mvel2.integration.VariableResolverFactory;
+import org.mvel2.optimizers.AccessorOptimizer;
+import org.mvel2.optimizers.OptimizerFactory;
+
+/**
+ * @author Christopher Brock
+ */
+@SuppressWarnings({ "CaughtExceptionImmediatelyRethrown" })
+public class LiteralDeepPropertyNode extends ASTNode {
+
+    private Object literal;
+
+    public LiteralDeepPropertyNode(char[] expr, int start, int offset, int fields, Object literal, ParserContext pCtx) {
+        super(pCtx);
+        this.fields = fields;
+        this.expr = expr;
+        this.start = start;
+        this.offset = offset;
+
+        this.literal = literal;
+    }
+
+    public Object getReducedValueAccelerated(Object ctx, Object thisValue, VariableResolverFactory factory) {
+        if (accessor != null) {
+            return accessor.getValue(literal, thisValue, factory);
+        } else {
+            try {
+                AccessorOptimizer aO = getThreadAccessorOptimizer();
+                accessor = aO.optimizeAccessor(pCtx, expr, start, offset, literal, thisValue, factory, false, null);
+                return aO.getResultOptPass();
+            } finally {
+                OptimizerFactory.clearThreadAccessorOptimizer();
+            }
+        }
+    }
+
+    public Object getReducedValue(Object ctx, Object thisValue, VariableResolverFactory factory) {
+        return get(expr, start, offset, literal, factory, thisValue, pCtx);
+    }
+}

--- a/core/src/main/java/org/mvel2/ast/LiteralNode.java
+++ b/core/src/main/java/org/mvel2/ast/LiteralNode.java
@@ -1,0 +1,68 @@
+/**
+ * MVEL 2.0
+ * Copyright (C) 2007 The Codehaus
+ * Mike Brock, Dhanji Prasanna, John Graham, Mark Proctor
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.mvel2.ast;
+
+import org.mvel2.ParserContext;
+import org.mvel2.compiler.BlankLiteral;
+import org.mvel2.integration.VariableResolverFactory;
+import org.mvel2.util.NullType;
+
+/**
+ * @author Christopher Brock
+ */
+public class LiteralNode extends ASTNode {
+
+    public LiteralNode(Object literal, Class type, ParserContext pCtx) {
+        this(literal, pCtx);
+        this.egressType = type;
+    }
+
+    public LiteralNode(Object literal, ParserContext pCtx) {
+        super(pCtx);
+        if ((this.literal = literal) != null) {
+            if ((this.egressType = literal.getClass()) == BlankLiteral.class) this.egressType = Object.class;
+        } else {
+            this.egressType = NullType.class;
+        }
+    }
+
+    public Object getReducedValueAccelerated(Object ctx, Object thisValue, VariableResolverFactory factory) {
+        return literal;
+    }
+
+    public Object getReducedValue(Object ctx, Object thisValue, VariableResolverFactory factory) {
+        return literal;
+    }
+
+    public Object getLiteralValue() {
+        return literal;
+    }
+
+    public void setLiteralValue(Object literal) {
+        this.literal = literal;
+    }
+
+    public boolean isLiteral() {
+        return true;
+    }
+
+    @Override
+    public String toString() {
+        return "Literal<" + literal + ">";
+    }
+}

--- a/core/src/main/java/org/mvel2/ast/Negation.java
+++ b/core/src/main/java/org/mvel2/ast/Negation.java
@@ -1,0 +1,69 @@
+/**
+ * MVEL 2.0
+ * Copyright (C) 2007 The Codehaus
+ * Mike Brock, Dhanji Prasanna, John Graham, Mark Proctor
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mvel2.ast;
+
+import static org.mvel2.util.ParseTools.subCompileExpression;
+
+import org.mvel2.CompileException;
+import org.mvel2.MVEL;
+import org.mvel2.ParserContext;
+import org.mvel2.compiler.ExecutableStatement;
+import org.mvel2.integration.VariableResolverFactory;
+import org.mvel2.util.ParseTools;
+
+public class Negation extends ASTNode {
+
+    private ExecutableStatement stmt;
+
+    public Negation(char[] expr, int start, int offset, int fields, ParserContext pCtx) {
+        super(pCtx);
+        this.expr = expr;
+        this.start = start;
+        this.offset = offset;
+
+        if ((fields & COMPILE_IMMEDIATE) != 0) {
+            if (((this.stmt = (ExecutableStatement) subCompileExpression(expr, start, offset, pCtx)).getKnownEgressType() != null)
+                    && (!ParseTools.boxPrimitive(stmt.getKnownEgressType()).isAssignableFrom(Boolean.class))) {
+                throw new CompileException("negation operator cannot be applied to non-boolean type", expr, start);
+            }
+        }
+    }
+
+    public Object getReducedValueAccelerated(Object ctx, Object thisValue, VariableResolverFactory factory) {
+        return !((Boolean) stmt.getValue(ctx, thisValue, factory));
+    }
+
+    public Object getReducedValue(Object ctx, Object thisValue, VariableResolverFactory factory) {
+        try {
+            return !((Boolean) MVEL.eval(expr, start, offset, ctx, factory));
+        } catch (NullPointerException e) {
+            throw new CompileException("negation operator applied to a null value", expr, start, e);
+        } catch (ClassCastException e) {
+            throw new CompileException("negation operator applied to non-boolean expression", expr, start, e);
+        }
+    }
+
+    public Class getEgressType() {
+        return Boolean.class;
+    }
+
+    public ExecutableStatement getStatement() {
+        return stmt;
+    }
+}

--- a/core/src/main/java/org/mvel2/ast/NestedStatement.java
+++ b/core/src/main/java/org/mvel2/ast/NestedStatement.java
@@ -1,0 +1,28 @@
+/**
+ * MVEL 2.0
+ * Copyright (C) 2007 The Codehaus
+ * Mike Brock, Dhanji Prasanna, John Graham, Mark Proctor
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.mvel2.ast;
+
+import org.mvel2.compiler.ExecutableStatement;
+
+/**
+ * @author Christopher Brock
+ */
+public interface NestedStatement {
+
+    public ExecutableStatement getNestedStatement();
+}

--- a/core/src/main/java/org/mvel2/ast/NewObjectNode.java
+++ b/core/src/main/java/org/mvel2/ast/NewObjectNode.java
@@ -1,0 +1,343 @@
+/**
+ * MVEL 2.0
+ * Copyright (C) 2007 The Codehaus
+ * Mike Brock, Dhanji Prasanna, John Graham, Mark Proctor
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.mvel2.ast;
+
+import static java.lang.reflect.Array.newInstance;
+import static org.mvel2.DataConversion.convert;
+import static org.mvel2.MVEL.analyze;
+import static org.mvel2.MVEL.eval;
+import static org.mvel2.optimizers.OptimizerFactory.getThreadAccessorOptimizer;
+import static org.mvel2.util.ArrayTools.findFirst;
+import static org.mvel2.util.CompilerTools.getInjectedImports;
+import static org.mvel2.util.ParseTools.captureContructorAndResidual;
+import static org.mvel2.util.ParseTools.findClass;
+import static org.mvel2.util.ParseTools.getBaseComponentType;
+import static org.mvel2.util.ParseTools.getBestConstructorCandidate;
+import static org.mvel2.util.ParseTools.parseMethodOrConstructor;
+import static org.mvel2.util.ParseTools.repeatChar;
+import static org.mvel2.util.ParseTools.subArray;
+import static org.mvel2.util.ParseTools.subset;
+import static org.mvel2.util.ReflectionUtil.toPrimitiveArrayType;
+
+import java.io.Serializable;
+import java.lang.reflect.Constructor;
+import java.util.Arrays;
+import java.util.List;
+
+import org.mvel2.CompileException;
+import org.mvel2.ErrorDetail;
+import org.mvel2.ParserContext;
+import org.mvel2.PropertyAccessor;
+import org.mvel2.compiler.Accessor;
+import org.mvel2.compiler.ExecutableStatement;
+import org.mvel2.compiler.PropertyVerifier;
+import org.mvel2.integration.VariableResolverFactory;
+import org.mvel2.optimizers.AccessorOptimizer;
+import org.mvel2.optimizers.OptimizerFactory;
+import org.mvel2.util.ArrayTools;
+import org.mvel2.util.ErrorUtil;
+
+/**
+ * @author Christopher Brock
+ */
+@SuppressWarnings({ "ManualArrayCopy" })
+public class NewObjectNode extends ASTNode {
+
+    private static final Class[] EMPTYCLS = new Class[0];
+    private transient Accessor newObjectOptimizer;
+    private TypeDescriptor typeDescr;
+    private char[] name;
+
+    public NewObjectNode(TypeDescriptor typeDescr, int fields, ParserContext pCtx) {
+        super(pCtx);
+        this.typeDescr = typeDescr;
+        this.fields = fields;
+        this.expr = typeDescr.getExpr();
+        this.start = typeDescr.getStart();
+        this.offset = typeDescr.getOffset();
+
+        if (offset < expr.length) {
+            this.name = subArray(expr, start, start + offset);
+        } else {
+            this.name = expr;
+        }
+
+        if ((fields & COMPILE_IMMEDIATE) != 0) {
+            if (pCtx != null && pCtx.hasImport(typeDescr.getClassName())) {
+                pCtx.setAllowBootstrapBypass(false);
+                egressType = pCtx.getImport(typeDescr.getClassName());
+            } else {
+                try {
+                    egressType = Class.forName(typeDescr.getClassName(), true, getClassLoader());
+                } catch (ClassNotFoundException e) {
+                    if (pCtx.isStrongTyping())
+                        pCtx.addError(new ErrorDetail(expr, start, true, "could not resolve class: " + typeDescr.getClassName()));
+                    return;
+                    // do nothing.
+                }
+            }
+
+            if (egressType != null) {
+                rewriteClassReferenceToFQCN(fields);
+                if (typeDescr.isArray()) {
+                    try {
+                        egressType = egressType.isPrimitive() ? toPrimitiveArrayType(egressType) : findClass(null,
+                                repeatChar('[', typeDescr.getArrayLength()) + "L" + egressType.getName() + ";", pCtx);
+                    } catch (Exception e) {
+                        e.printStackTrace();
+                        // for now, don't handle this.
+                    }
+                }
+            }
+
+            if (pCtx != null) {
+                if (egressType == null) {
+                    pCtx.addError(new ErrorDetail(expr, start, true, "could not resolve class: " + typeDescr.getClassName()));
+                    return;
+                }
+
+                if (!typeDescr.isArray()) {
+                    String[] cnsResid = captureContructorAndResidual(expr, start, offset);
+
+                    final List<char[]> constructorParms = parseMethodOrConstructor(cnsResid[0].toCharArray());
+
+                    final Class[] parms = new Class[constructorParms.size()];
+                    for (int i = 0; i < parms.length; i++) {
+                        parms[i] = analyze(constructorParms.get(i), pCtx);
+                    }
+
+                    if (getBestConstructorCandidate(parms, egressType, true) == null) {
+                        if (pCtx.isStrongTyping()) pCtx.addError(new ErrorDetail(expr, start, pCtx.isStrongTyping(),
+                                "could not resolve constructor " + typeDescr.getClassName() + Arrays.toString(parms)));
+                    }
+
+                    if (cnsResid.length == 2) {
+                        String residualProperty = cnsResid[1].trim();
+
+                        if (residualProperty.length() == 0) return;
+
+                        this.egressType = new PropertyVerifier(residualProperty, pCtx, egressType).analyze();
+                    }
+                }
+            }
+        }
+    }
+
+    private void rewriteClassReferenceToFQCN(int fields) {
+        String FQCN = egressType.getName();
+
+        if (typeDescr.getClassName().indexOf('.') == -1) {
+            int idx = ArrayTools.findFirst('(', 0, name.length, name);
+
+            char[] fqcn = FQCN.toCharArray();
+
+            if (idx == -1) {
+                this.name = new char[idx = fqcn.length];
+                for (int i = 0; i < idx; i++)
+                    this.name[i] = fqcn[i];
+            } else {
+                char[] newName = new char[fqcn.length + (name.length - idx)];
+
+                for (int i = 0; i < fqcn.length; i++)
+                    newName[i] = fqcn[i];
+
+                int i0 = name.length - idx;
+                int i1 = fqcn.length;
+                for (int i = 0; i < i0; i++)
+                    newName[i + i1] = name[i + idx];
+
+                this.name = newName;
+            }
+
+            this.typeDescr.updateClassName(name, 0, name.length, fields);
+        }
+    }
+
+    public Object getReducedValueAccelerated(Object ctx, Object thisValue, VariableResolverFactory factory) {
+        if (newObjectOptimizer == null) {
+            if (egressType == null) {
+                /**
+                 * This means we couldn't resolve the type at the time this AST node was created, which means
+                 * we have to attempt runtime resolution.
+                 */
+
+                if (factory != null && factory.isResolveable(typeDescr.getClassName())) {
+                    try {
+                        egressType = (Class) factory.getVariableResolver(typeDescr.getClassName()).getValue();
+                        rewriteClassReferenceToFQCN(COMPILE_IMMEDIATE);
+
+                        if (typeDescr.isArray()) {
+                            try {
+                                egressType = findClass(factory,
+                                        repeatChar('[', typeDescr.getArrayLength()) + "L" + egressType.getName() + ";", pCtx);
+                            } catch (Exception e) {
+                                // for now, don't handle this.
+                            }
+                        }
+
+                    } catch (ClassCastException e) {
+                        throw new CompileException("cannot construct object: " + typeDescr.getClassName() + " is not a class reference",
+                                expr, start, e);
+                    }
+                }
+            }
+
+            if (typeDescr.isArray()) {
+                return (newObjectOptimizer = new NewObjectArray(getBaseComponentType(egressType.getComponentType()),
+                        typeDescr.getCompiledArraySize())).getValue(ctx, thisValue, factory);
+            }
+
+            try {
+                AccessorOptimizer optimizer = getThreadAccessorOptimizer();
+
+                ParserContext pCtx = this.pCtx;
+                if (pCtx == null) {
+                    pCtx = new ParserContext();
+                    pCtx.getParserConfiguration().setAllImports(getInjectedImports(factory));
+                }
+
+                newObjectOptimizer = optimizer.optimizeObjectCreation(pCtx, name, 0, name.length, ctx, thisValue, factory);
+
+                /**
+                 * Check to see if the optimizer actually produced the object during optimization.  If so,
+                 * we return that value now.
+                 */
+                if (optimizer.getResultOptPass() != null) {
+                    egressType = optimizer.getEgressType();
+                    return optimizer.getResultOptPass();
+                }
+            } catch (CompileException e) {
+                throw ErrorUtil.rewriteIfNeeded(e, expr, start);
+            } finally {
+                OptimizerFactory.clearThreadAccessorOptimizer();
+            }
+        }
+
+        return newObjectOptimizer.getValue(ctx, thisValue, factory);
+    }
+
+    public Object getReducedValue(Object ctx, Object thisValue, VariableResolverFactory factory) {
+        try {
+            if (typeDescr.isArray()) {
+                Class cls = findClass(factory, typeDescr.getClassName(), pCtx);
+
+                int[] s = new int[typeDescr.getArrayLength()];
+                ArraySize[] arraySize = typeDescr.getArraySize();
+
+                for (int i = 0; i < s.length; i++) {
+                    s[i] = convert(eval(arraySize[i].value, ctx, factory), Integer.class);
+                }
+
+                return newInstance(cls, s);
+            } else {
+                String[] cnsRes = captureContructorAndResidual(name, 0, name.length);
+                List<char[]> constructorParms = parseMethodOrConstructor(cnsRes[0].toCharArray());
+
+                if (constructorParms != null) {
+                    Class cls = findClass(factory, new String(subset(name, 0, findFirst('(', 0, name.length, name))).trim(), pCtx);
+
+                    Object[] parms = new Object[constructorParms.size()];
+                    for (int i = 0; i < constructorParms.size(); i++) {
+                        parms[i] = eval(constructorParms.get(i), ctx, factory);
+                    }
+
+                    Constructor cns = getBestConstructorCandidate(parms, cls, false);
+
+                    if (cns == null) throw new CompileException("unable to find constructor for: " + cls.getName(), expr, start);
+
+                    for (int i = 0; i < parms.length; i++) {
+                        //noinspection unchecked
+                        parms[i] = convert(parms[i], cns.getParameterTypes()[i]);
+                    }
+
+                    if (cnsRes.length > 1) {
+                        return PropertyAccessor.get(cnsRes[1], cns.newInstance(parms), factory, thisValue, pCtx);
+                    } else {
+                        return cns.newInstance(parms);
+                    }
+                } else {
+                    Constructor<?> cns = Class.forName(typeDescr.getClassName(), true, pCtx.getParserConfiguration().getClassLoader())
+                            .getConstructor(EMPTYCLS);
+
+                    if (cnsRes.length > 1) {
+                        return PropertyAccessor.get(cnsRes[1], cns.newInstance(), factory, thisValue, pCtx);
+                    } else {
+                        return cns.newInstance();
+                    }
+                }
+            }
+        } catch (CompileException e) {
+            throw e;
+        } catch (ClassNotFoundException e) {
+            throw new CompileException("unable to resolve class: " + e.getMessage(), expr, start, e);
+        } catch (NoSuchMethodException e) {
+            throw new CompileException("cannot resolve constructor: " + e.getMessage(), expr, start, e);
+        } catch (Exception e) {
+            throw new CompileException("could not instantiate class: " + e.getMessage(), expr, start, e);
+        }
+    }
+
+    private boolean isPrototypeFunction() {
+        return pCtx.getFunctions().containsKey(typeDescr.getClassName());
+    }
+
+    private Object createPrototypalObject(Object ctx, Object thisRef, VariableResolverFactory factory) {
+        final Function function = pCtx.getFunction(typeDescr.getClassName());
+        return function.getReducedValueAccelerated(ctx, thisRef, factory);
+    }
+
+    public TypeDescriptor getTypeDescr() {
+        return typeDescr;
+    }
+
+    public Accessor getNewObjectOptimizer() {
+        return newObjectOptimizer;
+    }
+
+    public static class NewObjectArray implements Accessor, Serializable {
+
+        private ExecutableStatement[] sizes;
+        private Class arrayType;
+
+        public NewObjectArray(Class arrayType, ExecutableStatement[] sizes) {
+            this.arrayType = arrayType;
+            this.sizes = sizes;
+        }
+
+        public Object getValue(Object ctx, Object elCtx, VariableResolverFactory variableFactory) {
+            int[] s = new int[sizes.length];
+            for (int i = 0; i < s.length; i++) {
+                s[i] = convert(sizes[i].getValue(ctx, elCtx, variableFactory), Integer.class);
+            }
+
+            return newInstance(arrayType, s);
+        }
+
+        public Object setValue(Object ctx, Object elCtx, VariableResolverFactory variableFactory, Object value) {
+            return null;
+        }
+
+        public Class getKnownEgressType() {
+            try {
+                return Class.forName("[L" + arrayType.getName() + ";");
+            } catch (ClassNotFoundException cne) {
+                return null;
+            }
+        }
+    }
+}

--- a/core/src/main/java/org/mvel2/ast/NewObjectPrototype.java
+++ b/core/src/main/java/org/mvel2/ast/NewObjectPrototype.java
@@ -1,0 +1,32 @@
+package org.mvel2.ast;
+
+import java.util.HashMap;
+
+import org.mvel2.ParserContext;
+import org.mvel2.integration.VariableResolverFactory;
+import org.mvel2.integration.impl.MapVariableResolverFactory;
+
+/**
+ * @author Mike Brock
+ */
+public class NewObjectPrototype extends ASTNode {
+
+    private Function function;
+
+    public NewObjectPrototype(ParserContext pCtx, Function function) {
+        super(pCtx);
+        this.function = function;
+    }
+
+    @Override
+    public Object getReducedValue(Object ctx, Object thisValue, VariableResolverFactory factory) {
+        final MapVariableResolverFactory resolverFactory = new MapVariableResolverFactory(new HashMap<String, Object>(), factory);
+        function.getCompiledBlock().getValue(ctx, thisValue, resolverFactory);
+        return new PrototypalFunctionInstance(function, resolverFactory);
+    }
+
+    @Override
+    public Object getReducedValueAccelerated(Object ctx, Object thisValue, VariableResolverFactory factory) {
+        return getReducedValue(ctx, thisValue, factory);
+    }
+}

--- a/core/src/main/java/org/mvel2/ast/NewPrototypeNode.java
+++ b/core/src/main/java/org/mvel2/ast/NewPrototypeNode.java
@@ -1,0 +1,24 @@
+package org.mvel2.ast;
+
+import org.mvel2.ParserContext;
+import org.mvel2.integration.VariableResolverFactory;
+
+public class NewPrototypeNode extends ASTNode {
+
+    private String protoName;
+
+    public NewPrototypeNode(TypeDescriptor t, ParserContext pCtx) {
+        super(pCtx);
+        this.protoName = t.getClassName();
+    }
+
+    @Override
+    public Object getReducedValueAccelerated(Object ctx, Object thisValue, VariableResolverFactory factory) {
+        return ((Proto) factory.getVariableResolver(protoName).getValue()).newInstance(ctx, thisValue, factory);
+    }
+
+    @Override
+    public Object getReducedValue(Object ctx, Object thisValue, VariableResolverFactory factory) {
+        return ((Proto) factory.getVariableResolver(protoName).getValue()).newInstance(ctx, thisValue, factory);
+    }
+}

--- a/core/src/main/java/org/mvel2/ast/OperativeAssign.java
+++ b/core/src/main/java/org/mvel2/ast/OperativeAssign.java
@@ -1,0 +1,70 @@
+/**
+ * MVEL 2.0
+ * Copyright (C) 2007 The Codehaus
+ * Mike Brock, Dhanji Prasanna, John Graham, Mark Proctor
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.mvel2.ast;
+
+import static org.mvel2.MVEL.eval;
+import static org.mvel2.util.ParseTools.subCompileExpression;
+
+import org.mvel2.ParserContext;
+import org.mvel2.compiler.ExecutableStatement;
+import org.mvel2.integration.VariableResolver;
+import org.mvel2.integration.VariableResolverFactory;
+import org.mvel2.math.MathProcessor;
+import org.mvel2.util.ParseTools;
+
+public class OperativeAssign extends ASTNode {
+
+    private final int operation;
+    private String varName;
+    private ExecutableStatement statement;
+    private int knownInType = -1;
+
+    public OperativeAssign(String variableName, char[] expr, int start, int offset, int operation, int fields, ParserContext pCtx) {
+        super(pCtx);
+        this.varName = variableName;
+        this.operation = operation;
+        this.expr = expr;
+        this.start = start;
+        this.offset = offset;
+
+        if ((fields & COMPILE_IMMEDIATE) != 0) {
+            egressType = (statement = (ExecutableStatement) subCompileExpression(expr, start, offset, pCtx)).getKnownEgressType();
+
+            if (pCtx.isStrongTyping()) {
+                knownInType = ParseTools.__resolveType(egressType);
+            }
+
+            if (!pCtx.hasVarOrInput(varName)) {
+                pCtx.addInput(varName, egressType);
+            }
+        }
+    }
+
+    public Object getReducedValueAccelerated(Object ctx, Object thisValue, VariableResolverFactory factory) {
+        VariableResolver resolver = factory.getVariableResolver(varName);
+        resolver.setValue(
+                ctx = MathProcessor.doOperations(resolver.getValue(), operation, knownInType, statement.getValue(ctx, thisValue, factory)));
+        return ctx;
+    }
+
+    public Object getReducedValue(Object ctx, Object thisValue, VariableResolverFactory factory) {
+        VariableResolver resolver = factory.getVariableResolver(varName);
+        resolver.setValue(ctx = MathProcessor.doOperations(resolver.getValue(), operation, eval(expr, start, offset, ctx, factory)));
+        return ctx;
+    }
+}

--- a/core/src/main/java/org/mvel2/ast/OperatorNode.java
+++ b/core/src/main/java/org/mvel2/ast/OperatorNode.java
@@ -1,0 +1,58 @@
+/**
+ * MVEL 2.0
+ * Copyright (C) 2007 The Codehaus
+ * Mike Brock, Dhanji Prasanna, John Graham, Mark Proctor
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mvel2.ast;
+
+import static org.mvel2.debug.DebugTools.getOperatorSymbol;
+
+import org.mvel2.CompileException;
+import org.mvel2.ParserContext;
+import org.mvel2.integration.VariableResolverFactory;
+
+public class OperatorNode extends ASTNode {
+
+    private Integer operator;
+
+    public OperatorNode(Integer operator, char[] expr, int start, ParserContext pCtx) {
+        super(pCtx);
+        assert operator != null;
+        this.expr = expr;
+        this.literal = this.operator = operator;
+        this.start = start;
+    }
+
+    public boolean isOperator() {
+        return true;
+    }
+
+    public boolean isOperator(Integer operator) {
+        return operator.equals(this.operator);
+    }
+
+    public Integer getOperator() {
+        return operator;
+    }
+
+    public Object getReducedValueAccelerated(Object ctx, Object thisValue, VariableResolverFactory factory) {
+        throw new CompileException("illegal use of operator: " + getOperatorSymbol(operator), expr, start);
+    }
+
+    public Object getReducedValue(Object ctx, Object thisValue, VariableResolverFactory factory) {
+        throw new CompileException("illegal use of operator: " + getOperatorSymbol(operator), expr, start);
+    }
+}

--- a/core/src/main/java/org/mvel2/ast/Or.java
+++ b/core/src/main/java/org/mvel2/ast/Or.java
@@ -1,0 +1,65 @@
+/**
+ * MVEL 2.0
+ * Copyright (C) 2007 The Codehaus
+ * Mike Brock, Dhanji Prasanna, John Graham, Mark Proctor
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.mvel2.ast;
+
+import static org.mvel2.util.CompilerTools.expectType;
+
+import org.mvel2.ParserContext;
+import org.mvel2.integration.VariableResolverFactory;
+
+public class Or extends BooleanNode {
+
+    public Or(ASTNode left, ASTNode right, boolean strongTyping, ParserContext pCtx) {
+        super(pCtx);
+        expectType(pCtx, this.left = left, Boolean.class, strongTyping);
+        expectType(pCtx, this.right = right, Boolean.class, strongTyping);
+    }
+
+    public Object getReducedValueAccelerated(Object ctx, Object thisValue, VariableResolverFactory factory) {
+        return (((Boolean) left.getReducedValueAccelerated(ctx, thisValue, factory))
+                || ((Boolean) right.getReducedValueAccelerated(ctx, thisValue, factory)));
+    }
+
+    public Object getReducedValue(Object ctx, Object thisValue, VariableResolverFactory factory) {
+        throw new RuntimeException("improper use of AST element");
+    }
+
+    public ASTNode getRightMost() {
+        Or n = this;
+        while (n.right != null && n.right instanceof Or) {
+            n = (Or) n.right;
+        }
+        return n.right;
+    }
+
+    public void setRightMost(ASTNode right) {
+        Or n = this;
+        while (n.right != null && n.right instanceof Or) {
+            n = (Or) n.right;
+        }
+        n.right = right;
+    }
+
+    public String toString() {
+        return "(" + left.toString() + " || " + right.toString() + ")";
+    }
+
+    public Class getEgressType() {
+        return Boolean.class;
+    }
+}

--- a/core/src/main/java/org/mvel2/ast/PostFixDecNode.java
+++ b/core/src/main/java/org/mvel2/ast/PostFixDecNode.java
@@ -1,0 +1,52 @@
+/**
+ * MVEL 2.0
+ * Copyright (C) 2007 The Codehaus
+ * Mike Brock, Dhanji Prasanna, John Graham, Mark Proctor
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.mvel2.ast;
+
+import org.mvel2.DataTypes;
+import org.mvel2.Operator;
+import org.mvel2.ParserContext;
+import org.mvel2.integration.VariableResolver;
+import org.mvel2.integration.VariableResolverFactory;
+import org.mvel2.math.MathProcessor;
+
+/**
+ * @author Christopher Brock
+ */
+public class PostFixDecNode extends ASTNode {
+
+    private String name;
+
+    public PostFixDecNode(String name, ParserContext pCtx) {
+        super(pCtx);
+        this.name = name;
+        if (pCtx != null) {
+            this.egressType = pCtx.getVarOrInputType(name);
+        }
+    }
+
+    public Object getReducedValueAccelerated(Object ctx, Object thisValue, VariableResolverFactory factory) {
+        VariableResolver vResolver = factory.getVariableResolver(name);
+        vResolver.setValue(MathProcessor.doOperations(ctx = vResolver.getValue(), Operator.SUB, DataTypes.INTEGER, 1));
+        return ctx;
+    }
+
+    public Object getReducedValue(Object ctx, Object thisValue, VariableResolverFactory factory) {
+        return getReducedValueAccelerated(ctx, thisValue, factory);
+    }
+
+}

--- a/core/src/main/java/org/mvel2/ast/PostFixIncNode.java
+++ b/core/src/main/java/org/mvel2/ast/PostFixIncNode.java
@@ -1,0 +1,51 @@
+/**
+ * MVEL 2.0
+ * Copyright (C) 2007 The Codehaus
+ * Mike Brock, Dhanji Prasanna, John Graham, Mark Proctor
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.mvel2.ast;
+
+import org.mvel2.DataTypes;
+import org.mvel2.Operator;
+import org.mvel2.ParserContext;
+import org.mvel2.integration.VariableResolver;
+import org.mvel2.integration.VariableResolverFactory;
+import org.mvel2.math.MathProcessor;
+
+/**
+ * @author Christopher Brock
+ */
+public class PostFixIncNode extends ASTNode {
+
+    private String name;
+
+    public PostFixIncNode(String name, ParserContext pCtx) {
+        super(pCtx);
+        this.name = name;
+        if (pCtx != null) {
+            this.egressType = pCtx.getVarOrInputType(name);
+        }
+    }
+
+    public Object getReducedValueAccelerated(Object ctx, Object thisValue, VariableResolverFactory factory) {
+        VariableResolver vResolver = factory.getVariableResolver(name);
+        vResolver.setValue(MathProcessor.doOperations(ctx = vResolver.getValue(), Operator.ADD, DataTypes.INTEGER, 1));
+        return ctx;
+    }
+
+    public Object getReducedValue(Object ctx, Object thisValue, VariableResolverFactory factory) {
+        return getReducedValueAccelerated(ctx, thisValue, factory);
+    }
+}

--- a/core/src/main/java/org/mvel2/ast/PreFixDecNode.java
+++ b/core/src/main/java/org/mvel2/ast/PreFixDecNode.java
@@ -1,0 +1,51 @@
+/**
+ * MVEL 2.0
+ * Copyright (C) 2007 The Codehaus
+ * Mike Brock, Dhanji Prasanna, John Graham, Mark Proctor
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.mvel2.ast;
+
+import org.mvel2.DataTypes;
+import org.mvel2.Operator;
+import org.mvel2.ParserContext;
+import org.mvel2.integration.VariableResolver;
+import org.mvel2.integration.VariableResolverFactory;
+import org.mvel2.math.MathProcessor;
+
+/**
+ * @author Christopher Brock
+ */
+public class PreFixDecNode extends ASTNode {
+
+    private String name;
+
+    public PreFixDecNode(String name, ParserContext pCtx) {
+        super(pCtx);
+        this.name = name;
+        if (pCtx != null) {
+            this.egressType = pCtx.getVarOrInputType(name);
+        }
+    }
+
+    public Object getReducedValueAccelerated(Object ctx, Object thisValue, VariableResolverFactory factory) {
+        VariableResolver vResolver = factory.getVariableResolver(name);
+        vResolver.setValue(ctx = MathProcessor.doOperations(vResolver.getValue(), Operator.SUB, DataTypes.INTEGER, 1));
+        return ctx;
+    }
+
+    public Object getReducedValue(Object ctx, Object thisValue, VariableResolverFactory factory) {
+        return getReducedValueAccelerated(ctx, thisValue, factory);
+    }
+}

--- a/core/src/main/java/org/mvel2/ast/PreFixIncNode.java
+++ b/core/src/main/java/org/mvel2/ast/PreFixIncNode.java
@@ -1,0 +1,51 @@
+/**
+ * MVEL 2.0
+ * Copyright (C) 2007 The Codehaus
+ * Mike Brock, Dhanji Prasanna, John Graham, Mark Proctor
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.mvel2.ast;
+
+import org.mvel2.DataTypes;
+import org.mvel2.Operator;
+import org.mvel2.ParserContext;
+import org.mvel2.integration.VariableResolver;
+import org.mvel2.integration.VariableResolverFactory;
+import org.mvel2.math.MathProcessor;
+
+/**
+ * @author Christopher Brock
+ */
+public class PreFixIncNode extends ASTNode {
+
+    private String name;
+
+    public PreFixIncNode(String name, ParserContext pCtx) {
+        super(pCtx);
+        this.name = name;
+        if (pCtx != null) {
+            this.egressType = pCtx.getVarOrInputType(name);
+        }
+    }
+
+    public Object getReducedValueAccelerated(Object ctx, Object thisValue, VariableResolverFactory factory) {
+        VariableResolver vResolver = factory.getVariableResolver(name);
+        vResolver.setValue(ctx = MathProcessor.doOperations(vResolver.getValue(), Operator.ADD, DataTypes.INTEGER, 1));
+        return ctx;
+    }
+
+    public Object getReducedValue(Object ctx, Object thisValue, VariableResolverFactory factory) {
+        return getReducedValueAccelerated(ctx, thisValue, factory);
+    }
+}

--- a/core/src/main/java/org/mvel2/ast/Proto.java
+++ b/core/src/main/java/org/mvel2/ast/Proto.java
@@ -1,0 +1,371 @@
+package org.mvel2.ast;
+
+import static org.mvel2.DataConversion.canConvert;
+import static org.mvel2.DataConversion.convert;
+
+import java.util.Collection;
+import java.util.Map;
+import java.util.Set;
+
+import org.mvel2.CompileException;
+import org.mvel2.ParserContext;
+import org.mvel2.UnresolveablePropertyException;
+import org.mvel2.compiler.ExecutableStatement;
+import org.mvel2.integration.VariableResolver;
+import org.mvel2.integration.VariableResolverFactory;
+import org.mvel2.integration.impl.MapVariableResolverFactory;
+import org.mvel2.integration.impl.SimpleValueResolver;
+import org.mvel2.util.CallableProxy;
+import org.mvel2.util.SimpleIndexHashMapWrapper;
+
+public class Proto extends ASTNode {
+
+    private String name;
+    private Map<String, Receiver> receivers;
+    private int cursorStart;
+    private int cursorEnd;
+
+    public Proto(String name, ParserContext pCtx) {
+        super(pCtx);
+        this.name = name;
+        this.receivers = new SimpleIndexHashMapWrapper<String, Receiver>();
+    }
+
+    public Receiver declareReceiver(String name, Function function) {
+        Receiver r = new Receiver(null, ReceiverType.FUNCTION, function);
+        receivers.put(name, r);
+        return r;
+    }
+
+    public Receiver declareReceiver(String name, Class type, ExecutableStatement initCode) {
+        Receiver r = new Receiver(null, ReceiverType.PROPERTY, initCode);
+        receivers.put(name, r);
+        return r;
+    }
+
+    public Receiver declareReceiver(String name, ReceiverType type, ExecutableStatement initCode) {
+        Receiver r = new Receiver(null, type, initCode);
+        receivers.put(name, r);
+        return r;
+    }
+
+    public ProtoInstance newInstance(Object ctx, Object thisCtx, VariableResolverFactory factory) {
+        return new ProtoInstance(this, ctx, thisCtx, factory);
+    }
+
+    @Override
+    public Object getReducedValue(Object ctx, Object thisValue, VariableResolverFactory factory) {
+        factory.createVariable(name, this);
+        return this;
+    }
+
+    @Override
+    public Object getReducedValueAccelerated(Object ctx, Object thisValue, VariableResolverFactory factory) {
+        factory.createVariable(name, this);
+        return this;
+    }
+
+    @Override
+    public String getName() {
+        return name;
+    }
+
+    @Override
+    public String toString() {
+        return "proto " + name;
+    }
+
+    public void setCursorPosition(int start, int end) {
+        this.cursorStart = start;
+        this.cursorEnd = end;
+    }
+
+    public int getCursorStart() {
+        return cursorStart;
+    }
+
+    public int getCursorEnd() {
+        return cursorEnd;
+    }
+
+    public enum ReceiverType {
+        DEFERRED, FUNCTION, PROPERTY
+    }
+
+    public class Receiver implements CallableProxy {
+
+        private ReceiverType type;
+        private Object receiver;
+        private ExecutableStatement initValue;
+        private ProtoInstance instance;
+
+        public Receiver(ProtoInstance protoInstance, ReceiverType type, Object receiver) {
+            this.instance = protoInstance;
+            this.type = type;
+            this.receiver = receiver;
+        }
+
+        public Receiver(ProtoInstance protoInstance, ReceiverType type, ExecutableStatement stmt) {
+            this.instance = protoInstance;
+            this.type = type;
+            this.initValue = stmt;
+        }
+
+        public Object call(Object ctx, Object thisCtx, VariableResolverFactory factory, Object[] parms) {
+            switch (type) {
+                case FUNCTION:
+                    return ((Function) receiver).call(ctx, thisCtx, new InvokationContextFactory(factory, instance.instanceStates), parms);
+                case PROPERTY:
+                    return receiver;
+                case DEFERRED:
+                    throw new CompileException("unresolved prototype receiver", expr, start);
+            }
+            return null;
+        }
+
+        public Receiver init(ProtoInstance instance, Object ctx, Object thisCtx, VariableResolverFactory factory) {
+            return new Receiver(instance, type,
+                    type == ReceiverType.PROPERTY && initValue != null ? initValue.getValue(ctx, thisCtx, factory) : receiver);
+        }
+
+        public void setType(ReceiverType type) {
+            this.type = type;
+        }
+
+        public void setInitValue(ExecutableStatement initValue) {
+            this.initValue = initValue;
+        }
+    }
+
+    public class ProtoInstance implements Map<String, Receiver> {
+
+        private Proto protoType;
+        private VariableResolverFactory instanceStates;
+        private SimpleIndexHashMapWrapper<String, Receiver> receivers;
+
+        public ProtoInstance(Proto protoType, Object ctx, Object thisCtx, VariableResolverFactory factory) {
+            this.protoType = protoType;
+
+            receivers = new SimpleIndexHashMapWrapper<String, Receiver>();
+            for (Entry<String, Receiver> entry : protoType.receivers.entrySet()) {
+                receivers.put(entry.getKey(), entry.getValue().init(this, ctx, thisCtx, factory));
+            }
+
+            instanceStates = new ProtoContextFactory(receivers);
+        }
+
+        public Proto getProtoType() {
+            return protoType;
+        }
+
+        public int size() {
+            return receivers.size();
+        }
+
+        public boolean isEmpty() {
+            return receivers.isEmpty();
+        }
+
+        public boolean containsKey(Object key) {
+            return receivers.containsKey(key);
+        }
+
+        public boolean containsValue(Object value) {
+            return receivers.containsValue(value);
+        }
+
+        public Receiver get(Object key) {
+            return receivers.get(key);
+        }
+
+        public Receiver put(String key, Receiver value) {
+            return receivers.put(key, value);
+        }
+
+        public Receiver remove(Object key) {
+            return receivers.remove(key);
+        }
+
+        public void putAll(Map m) {
+        }
+
+        public void clear() {
+        }
+
+        public Set<String> keySet() {
+            return receivers.keySet();
+        }
+
+        public Collection<Receiver> values() {
+            return receivers.values();
+        }
+
+        public Set<Entry<String, Receiver>> entrySet() {
+            return receivers.entrySet();
+        }
+    }
+
+    public class ProtoContextFactory extends MapVariableResolverFactory {
+
+        private final SimpleIndexHashMapWrapper<String, VariableResolver> variableResolvers;
+
+        public ProtoContextFactory(SimpleIndexHashMapWrapper variables) {
+            super(variables);
+            variableResolvers = new SimpleIndexHashMapWrapper<String, VariableResolver>(variables, true);
+        }
+
+        @Override
+        public VariableResolver createVariable(String name, Object value) {
+            VariableResolver vr;
+
+            try {
+                (vr = getVariableResolver(name)).setValue(value);
+                return vr;
+            } catch (UnresolveablePropertyException e) {
+                addResolver(name, vr = new ProtoResolver(variables, name)).setValue(value);
+                return vr;
+            }
+        }
+
+        @Override
+        public VariableResolver createVariable(String name, Object value, Class<?> type) {
+            VariableResolver vr;
+            try {
+                vr = getVariableResolver(name);
+            } catch (UnresolveablePropertyException e) {
+                vr = null;
+            }
+
+            if (vr != null && vr.getType() != null) {
+                throw new CompileException("variable already defined within scope: " + vr.getType() + " " + name, expr, start);
+            } else {
+                addResolver(name, vr = new ProtoResolver(variables, name, type)).setValue(value);
+                return vr;
+            }
+        }
+
+        @Override
+        public String[] getIndexedVariableNames() {
+            //
+            return null;
+        }
+
+        @Override
+        public void setIndexedVariableNames(String[] indexedVariableNames) {
+            //
+        }
+
+        @Override
+        public VariableResolver createIndexedVariable(int index, String name, Object value, Class<?> type) {
+            VariableResolver vr = this.variableResolvers != null ? this.variableResolvers.getByIndex(index) : null;
+            if (vr != null && vr.getType() != null) {
+                throw new CompileException("variable already defined within scope: " + vr.getType() + " " + name, expr, start);
+            } else {
+                return createIndexedVariable(variableIndexOf(name), name, value);
+            }
+        }
+
+        @Override
+        public VariableResolver createIndexedVariable(int index, String name, Object value) {
+            VariableResolver vr = variableResolvers.getByIndex(index);
+
+            if (vr == null) {
+                vr = new SimpleValueResolver(value);
+                variableResolvers.putAtIndex(index, vr);
+            } else {
+                vr.setValue(value);
+            }
+
+            return indexedVariableResolvers[index];
+        }
+
+        @Override
+        public VariableResolver getIndexedVariableResolver(int index) {
+            return variableResolvers.getByIndex(index);
+        }
+
+        @Override
+        public VariableResolver setIndexedVariableResolver(int index, VariableResolver resolver) {
+            variableResolvers.putAtIndex(index, resolver);
+            return resolver;
+        }
+
+        @Override
+        public int variableIndexOf(String name) {
+            return variableResolvers.indexOf(name);
+        }
+
+        public VariableResolver getVariableResolver(String name) {
+            VariableResolver vr = variableResolvers.get(name);
+            if (vr != null) {
+                return vr;
+            } else if (variables.containsKey(name)) {
+                variableResolvers.put(name, vr = new ProtoResolver(variables, name));
+                return vr;
+            } else if (nextFactory != null) {
+                return nextFactory.getVariableResolver(name);
+            }
+
+            throw new UnresolveablePropertyException("unable to resolve variable '" + name + "'");
+        }
+    }
+
+    public class ProtoResolver implements VariableResolver {
+
+        private String name;
+        private Class<?> knownType;
+        private Map<String, Object> variableMap;
+
+        public ProtoResolver(Map<String, Object> variableMap, String name) {
+            this.variableMap = variableMap;
+            this.name = name;
+        }
+
+        public ProtoResolver(Map<String, Object> variableMap, String name, Class knownType) {
+            this.name = name;
+            this.knownType = knownType;
+            this.variableMap = variableMap;
+        }
+
+        public void setStaticType(Class knownType) {
+            this.knownType = knownType;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public void setName(String name) {
+            this.name = name;
+        }
+
+        public Class getType() {
+            return knownType;
+        }
+
+        public Object getValue() {
+            return ((Receiver) variableMap.get(name)).receiver;
+        }
+
+        public void setValue(Object value) {
+            if (knownType != null && value != null && value.getClass() != knownType) {
+                if (!canConvert(knownType, value.getClass())) {
+                    throw new CompileException("cannot assign " + value.getClass().getName() + " to type: " + knownType.getName(), expr,
+                            start);
+                }
+                try {
+                    value = convert(value, knownType);
+                } catch (Exception e) {
+                    throw new CompileException("cannot convert value of " + value.getClass().getName() + " to: " + knownType.getName(),
+                            expr, start);
+                }
+            }
+
+            ((Receiver) variableMap.get(name)).receiver = value;
+        }
+
+        public int getFlags() {
+            return 0;
+        }
+    }
+}

--- a/core/src/main/java/org/mvel2/ast/ProtoVarNode.java
+++ b/core/src/main/java/org/mvel2/ast/ProtoVarNode.java
@@ -1,0 +1,94 @@
+/**
+ * MVEL 2.0
+ * Copyright (C) 2007 The Codehaus
+ * Mike Brock, Dhanji Prasanna, John Graham, Mark Proctor
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mvel2.ast;
+
+import static org.mvel2.MVEL.eval;
+import static org.mvel2.util.ParseTools.checkNameSafety;
+import static org.mvel2.util.ParseTools.createStringTrimmed;
+import static org.mvel2.util.ParseTools.find;
+import static org.mvel2.util.ParseTools.subCompileExpression;
+
+import org.mvel2.ParserContext;
+import org.mvel2.compiler.ExecutableStatement;
+import org.mvel2.integration.VariableResolverFactory;
+
+/**
+ * @author Christopher Brock
+ */
+public class ProtoVarNode extends ASTNode implements Assignment {
+
+    private String name;
+
+    private ExecutableStatement statement;
+
+    public ProtoVarNode(char[] expr, int start, int offset, int fields, Proto type, ParserContext pCtx) {
+        super(pCtx);
+        this.egressType = Proto.ProtoInstance.class;
+        this.expr = expr;
+        this.start = start;
+        this.offset = offset;
+        this.fields = fields;
+
+        int assignStart;
+        if ((assignStart = find(super.expr = expr, start, offset, '=')) != -1) {
+            checkNameSafety(name = createStringTrimmed(expr, 0, assignStart));
+
+            if (((fields |= ASSIGN) & COMPILE_IMMEDIATE) != 0) {
+                statement = (ExecutableStatement) subCompileExpression(expr, assignStart + 1, offset, pCtx);
+            }
+        } else {
+            checkNameSafety(name = new String(expr, start, offset));
+        }
+
+        if ((fields & COMPILE_IMMEDIATE) != 0) {
+            pCtx.addVariable(name, egressType, true);
+        }
+    }
+
+    public Object getReducedValueAccelerated(Object ctx, Object thisValue, VariableResolverFactory factory) {
+        if (statement == null) statement = (ExecutableStatement) subCompileExpression(expr, start, offset, pCtx);
+        factory.createVariable(name, ctx = statement.getValue(ctx, thisValue, factory), egressType);
+        return ctx;
+    }
+
+    public Object getReducedValue(Object ctx, Object thisValue, VariableResolverFactory factory) {
+        factory.createVariable(name, ctx = eval(expr, start, offset, thisValue, factory), egressType);
+        return ctx;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getAssignmentVar() {
+        return name;
+    }
+
+    public char[] getExpression() {
+        return expr;
+    }
+
+    public boolean isNewDeclaration() {
+        return true;
+    }
+
+    public void setValueStatement(ExecutableStatement stmt) {
+        this.statement = stmt;
+    }
+}

--- a/core/src/main/java/org/mvel2/ast/PrototypalFunctionInstance.java
+++ b/core/src/main/java/org/mvel2/ast/PrototypalFunctionInstance.java
@@ -1,0 +1,30 @@
+package org.mvel2.ast;
+
+import org.mvel2.integration.VariableResolverFactory;
+
+/**
+ * @author Mike Brock
+ */
+public class PrototypalFunctionInstance extends FunctionInstance {
+
+    private final VariableResolverFactory resolverFactory;
+
+    public PrototypalFunctionInstance(Function function, VariableResolverFactory resolverFactory) {
+        super(function);
+        this.resolverFactory = resolverFactory;
+    }
+
+    @Override
+    public Object call(Object ctx, Object thisValue, VariableResolverFactory factory, Object[] parms) {
+        return function.call(ctx, thisValue, new InvokationContextFactory(factory, resolverFactory), parms);
+    }
+
+    public VariableResolverFactory getResolverFactory() {
+        return resolverFactory;
+    }
+
+    public String toString() {
+        return "function_prototype:" + function.getName();
+    }
+
+}

--- a/core/src/main/java/org/mvel2/ast/ReduceableCodeException.java
+++ b/core/src/main/java/org/mvel2/ast/ReduceableCodeException.java
@@ -1,0 +1,14 @@
+package org.mvel2.ast;
+
+public class ReduceableCodeException extends RuntimeException {
+
+    private Object literal;
+
+    public ReduceableCodeException(Object literal) {
+        this.literal = literal;
+    }
+
+    public Object getLiteral() {
+        return literal;
+    }
+}

--- a/core/src/main/java/org/mvel2/ast/RedundantCodeException.java
+++ b/core/src/main/java/org/mvel2/ast/RedundantCodeException.java
@@ -1,0 +1,4 @@
+package org.mvel2.ast;
+
+public class RedundantCodeException extends RuntimeException {
+}

--- a/core/src/main/java/org/mvel2/ast/RegExMatch.java
+++ b/core/src/main/java/org/mvel2/ast/RegExMatch.java
@@ -1,0 +1,98 @@
+/**
+ * MVEL 2.0
+ * Copyright (C) 2007 The Codehaus
+ * Mike Brock, Dhanji Prasanna, John Graham, Mark Proctor
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.mvel2.ast;
+
+import static java.lang.String.valueOf;
+import static java.util.regex.Pattern.compile;
+import static org.mvel2.MVEL.eval;
+import static org.mvel2.util.ParseTools.subCompileExpression;
+
+import java.util.regex.Pattern;
+import java.util.regex.PatternSyntaxException;
+
+import org.mvel2.CompileException;
+import org.mvel2.ParserContext;
+import org.mvel2.compiler.ExecutableLiteral;
+import org.mvel2.compiler.ExecutableStatement;
+import org.mvel2.integration.VariableResolverFactory;
+
+public class RegExMatch extends ASTNode {
+
+    private ExecutableStatement stmt;
+    private ExecutableStatement patternStmt;
+
+    private int patternStart;
+    private int patternOffset;
+    private Pattern p;
+
+    public RegExMatch(char[] expr, int start, int offset, int fields, int patternStart, int patternOffset, ParserContext pCtx) {
+        super(pCtx);
+        this.expr = expr;
+        this.start = start;
+        this.offset = offset;
+        this.patternStart = patternStart;
+        this.patternOffset = patternOffset;
+
+        if ((fields & COMPILE_IMMEDIATE) != 0) {
+            this.stmt = (ExecutableStatement) subCompileExpression(expr, start, offset, pCtx);
+            if ((this.patternStmt = (ExecutableStatement) subCompileExpression(expr, patternStart, patternOffset,
+                    pCtx)) instanceof ExecutableLiteral) {
+
+                try {
+                    p = compile(valueOf(patternStmt.getValue(null, null)));
+                } catch (PatternSyntaxException e) {
+                    throw new CompileException("bad regular expression", expr, patternStart, e);
+                }
+            }
+        }
+    }
+
+    public Object getReducedValueAccelerated(Object ctx, Object thisValue, VariableResolverFactory factory) {
+        if (p == null) {
+            return compile(valueOf(patternStmt.getValue(ctx, thisValue, factory))).matcher(valueOf(stmt.getValue(ctx, thisValue, factory)))
+                    .matches();
+        } else {
+            return p.matcher(valueOf(stmt.getValue(ctx, thisValue, factory))).matches();
+        }
+    }
+
+    public Object getReducedValue(Object ctx, Object thisValue, VariableResolverFactory factory) {
+        try {
+            return compile(valueOf(eval(expr, patternStart, patternOffset, ctx, factory)))
+                    .matcher(valueOf(eval(expr, start, offset, ctx, factory))).matches();
+        } catch (PatternSyntaxException e) {
+            throw new CompileException("bad regular expression", expr, patternStart, e);
+        }
+    }
+
+    public Class getEgressType() {
+        return Boolean.class;
+    }
+
+    public Pattern getPattern() {
+        return p;
+    }
+
+    public ExecutableStatement getStatement() {
+        return stmt;
+    }
+
+    public ExecutableStatement getPatternStatement() {
+        return patternStmt;
+    }
+}

--- a/core/src/main/java/org/mvel2/ast/RegExMatchNode.java
+++ b/core/src/main/java/org/mvel2/ast/RegExMatchNode.java
@@ -1,0 +1,52 @@
+/**
+ * MVEL 2.0
+ * Copyright (C) 2007 The Codehaus
+ * Mike Brock, Dhanji Prasanna, John Graham, Mark Proctor
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mvel2.ast;
+
+import static java.lang.String.valueOf;
+import static java.util.regex.Pattern.compile;
+import static org.mvel2.MVEL.eval;
+
+import org.mvel2.ParserContext;
+import org.mvel2.integration.VariableResolverFactory;
+
+public class RegExMatchNode extends ASTNode {
+
+    private ASTNode node;
+    private ASTNode patternNode;
+
+    public RegExMatchNode(ASTNode matchNode, ASTNode patternNode, ParserContext pCtx) {
+        super(pCtx);
+        this.node = matchNode;
+        this.patternNode = patternNode;
+    }
+
+    public Object getReducedValueAccelerated(Object ctx, Object thisValue, VariableResolverFactory factory) {
+        return compile(valueOf(patternNode.getReducedValueAccelerated(ctx, thisValue, factory)))
+                .matcher(valueOf(node.getReducedValueAccelerated(ctx, thisValue, factory))).matches();
+    }
+
+    public Object getReducedValue(Object ctx, Object thisValue, VariableResolverFactory factory) {
+        return compile(valueOf(eval(expr, patternNode.start, patternNode.offset, ctx, factory)))
+                .matcher(valueOf(eval(expr, node.start, node.offset, ctx, factory))).matches();
+    }
+
+    public Class getEgressType() {
+        return Boolean.class;
+    }
+}

--- a/core/src/main/java/org/mvel2/ast/ReturnNode.java
+++ b/core/src/main/java/org/mvel2/ast/ReturnNode.java
@@ -1,0 +1,74 @@
+/**
+ * MVEL 2.0
+ * Copyright (C) 2007 The Codehaus
+ * Mike Brock, Dhanji Prasanna, John Graham, Mark Proctor
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.mvel2.ast;
+
+import static org.mvel2.MVEL.eval;
+import static org.mvel2.util.ParseTools.subCompileExpression;
+
+import org.mvel2.Operator;
+import org.mvel2.ParserContext;
+import org.mvel2.compiler.Accessor;
+import org.mvel2.integration.VariableResolverFactory;
+import org.mvel2.integration.impl.StackDemarcResolverFactory;
+
+/**
+ * @author Christopher Brock
+ */
+public class ReturnNode extends ASTNode {
+
+    public ReturnNode(char[] expr, int start, int offset, int fields, ParserContext pCtx) {
+        super(pCtx);
+        this.expr = expr;
+        this.start = start;
+        this.offset = offset;
+
+        if ((fields & COMPILE_IMMEDIATE) != 0) {
+            setAccessor((Accessor) subCompileExpression(expr, start, offset, pCtx));
+        }
+    }
+
+    public Object getReducedValueAccelerated(Object ctx, Object thisValue, VariableResolverFactory factory) {
+        if (accessor == null) {
+            setAccessor((Accessor) subCompileExpression(expr, start, offset, pCtx));
+        }
+
+        factory.setTiltFlag(true);
+
+        return accessor.getValue(ctx, thisValue, new StackDemarcResolverFactory(factory));
+    }
+
+    public Object getReducedValue(Object ctx, Object thisValue, VariableResolverFactory factory) {
+        factory.setTiltFlag(true);
+        return eval(expr, start, offset, ctx, new StackDemarcResolverFactory(factory));
+    }
+
+    @Override
+    public boolean isOperator() {
+        return true;
+    }
+
+    @Override
+    public Integer getOperator() {
+        return Operator.RETURN;
+    }
+
+    @Override
+    public boolean isOperator(Integer operator) {
+        return Operator.RETURN == operator;
+    }
+}

--- a/core/src/main/java/org/mvel2/ast/Safe.java
+++ b/core/src/main/java/org/mvel2/ast/Safe.java
@@ -1,0 +1,24 @@
+/**
+ * MVEL 2.0
+ * Copyright (C) 2007 The Codehaus
+ * Mike Brock, Dhanji Prasanna, John Graham, Mark Proctor
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.mvel2.ast;
+
+/**
+ * Marker interface to tell MVEL it can safely hard-reference.
+ */
+public interface Safe {
+}

--- a/core/src/main/java/org/mvel2/ast/Sign.java
+++ b/core/src/main/java/org/mvel2/ast/Sign.java
@@ -1,0 +1,134 @@
+package org.mvel2.ast;
+
+import static org.mvel2.util.ParseTools.boxPrimitive;
+
+import java.io.Serializable;
+import java.math.BigDecimal;
+import java.math.BigInteger;
+
+import org.mvel2.CompileException;
+import org.mvel2.MVEL;
+import org.mvel2.ParserContext;
+import org.mvel2.compiler.ExecutableStatement;
+import org.mvel2.integration.VariableResolverFactory;
+import org.mvel2.util.ParseTools;
+
+public class Sign extends ASTNode {
+
+    private Signer signer;
+    private ExecutableStatement stmt;
+
+    public Sign(char[] expr, int start, int end, int fields, ParserContext pCtx) {
+        super(pCtx);
+        this.expr = expr;
+        this.start = start + 1;
+        this.offset = end - 1;
+        this.fields = fields;
+
+        if ((fields & COMPILE_IMMEDIATE) != 0) {
+            stmt = (ExecutableStatement) ParseTools.subCompileExpression(expr, this.start, this.offset, pCtx);
+
+            egressType = stmt.getKnownEgressType();
+
+            if (egressType != null && egressType != Object.class) {
+                initSigner(egressType);
+            }
+        }
+    }
+
+    public ExecutableStatement getStatement() {
+        return stmt;
+    }
+
+    @Override
+    public Object getReducedValueAccelerated(Object ctx, Object thisValue, VariableResolverFactory factory) {
+        return sign(stmt.getValue(ctx, thisValue, factory));
+    }
+
+    @Override
+    public Object getReducedValue(Object ctx, Object thisValue, VariableResolverFactory factory) {
+        return sign(MVEL.eval(expr, start, offset, thisValue, factory));
+    }
+
+    private Object sign(Object o) {
+        if (o == null) return null;
+        if (signer == null) {
+            if (egressType == null || egressType == Object.class) egressType = o.getClass();
+            initSigner(egressType);
+        }
+        return signer.sign(o);
+    }
+
+    private void initSigner(Class type) {
+        if (Integer.class.isAssignableFrom(type = boxPrimitive(type))) signer = new IntegerSigner();
+        else if (Double.class.isAssignableFrom(type)) signer = new DoubleSigner();
+        else if (Long.class.isAssignableFrom(type)) signer = new LongSigner();
+        else if (Float.class.isAssignableFrom(type)) signer = new FloatSigner();
+        else if (Short.class.isAssignableFrom(type)) signer = new ShortSigner();
+        else if (BigInteger.class.isAssignableFrom(type)) signer = new BigIntSigner();
+        else if (BigDecimal.class.isAssignableFrom(type)) signer = new BigDecSigner();
+        else {
+            throw new CompileException("illegal use of '-': cannot be applied to: " + type.getName(), expr, start);
+        }
+
+    }
+
+    @Override
+    public boolean isIdentifier() {
+        return false;
+    }
+
+    private interface Signer extends Serializable {
+
+        public Object sign(Object o);
+    }
+
+    private class IntegerSigner implements Signer {
+
+        public Object sign(Object o) {
+            return -((Integer) o);
+        }
+    }
+
+    private class ShortSigner implements Signer {
+
+        public Object sign(Object o) {
+            return -((Short) o);
+        }
+    }
+
+    private class LongSigner implements Signer {
+
+        public Object sign(Object o) {
+            return -((Long) o);
+        }
+    }
+
+    private class DoubleSigner implements Signer {
+
+        public Object sign(Object o) {
+            return -((Double) o);
+        }
+    }
+
+    private class FloatSigner implements Signer {
+
+        public Object sign(Object o) {
+            return -((Float) o);
+        }
+    }
+
+    private class BigIntSigner implements Signer {
+
+        public Object sign(Object o) {
+            return new BigInteger(String.valueOf(-(((BigInteger) o).longValue())));
+        }
+    }
+
+    private class BigDecSigner implements Signer {
+
+        public Object sign(Object o) {
+            return new BigDecimal(-((BigDecimal) o).doubleValue());
+        }
+    }
+}

--- a/core/src/main/java/org/mvel2/ast/Soundslike.java
+++ b/core/src/main/java/org/mvel2/ast/Soundslike.java
@@ -1,0 +1,54 @@
+package org.mvel2.ast;
+
+import static org.mvel2.util.Soundex.soundex;
+
+import org.mvel2.CompileException;
+import org.mvel2.ParserContext;
+import org.mvel2.integration.VariableResolverFactory;
+import org.mvel2.util.CompilerTools;
+
+public class Soundslike extends ASTNode {
+
+    private ASTNode stmt;
+    private ASTNode soundslike;
+
+    public Soundslike(ASTNode stmt, ASTNode clsStmt, ParserContext pCtx) {
+        super(pCtx);
+        this.stmt = stmt;
+        this.soundslike = clsStmt;
+        CompilerTools.expectType(pCtx, clsStmt, String.class, true);
+    }
+
+    public Object getReducedValueAccelerated(Object ctx, Object thisValue, VariableResolverFactory factory) {
+        String str1 = String.valueOf(soundslike.getReducedValueAccelerated(ctx, thisValue, factory));
+        String str2 = (String) stmt.getReducedValueAccelerated(ctx, thisValue, factory);
+        return str1 == null ? str2 == null : (str2 == null ? false : soundex(str1).equals(soundex(str2)));
+    }
+
+    public Object getReducedValue(Object ctx, Object thisValue, VariableResolverFactory factory) {
+        try {
+            String i = String.valueOf(soundslike.getReducedValue(ctx, thisValue, factory));
+            if (i == null) throw new ClassCastException();
+
+            String x = (String) stmt.getReducedValue(ctx, thisValue, factory);
+            if (x == null) throw new CompileException("not a string: " + stmt.getName(), stmt.getExpr(), stmt.getStart());
+
+            return soundex(i).equals(soundex(x));
+        } catch (ClassCastException e) {
+            throw new CompileException("not a string: " + soundslike.getName(), soundslike.getExpr(), soundslike.getStart());
+        }
+
+    }
+
+    public Class getEgressType() {
+        return Boolean.class;
+    }
+
+    public ASTNode getStatement() {
+        return stmt;
+    }
+
+    public ASTNode getSoundslike() {
+        return soundslike;
+    }
+}

--- a/core/src/main/java/org/mvel2/ast/Stacklang.java
+++ b/core/src/main/java/org/mvel2/ast/Stacklang.java
@@ -1,0 +1,278 @@
+package org.mvel2.ast;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.mvel2.CompileException;
+import org.mvel2.MVEL;
+import org.mvel2.Operator;
+import org.mvel2.ParserContext;
+import org.mvel2.integration.VariableResolver;
+import org.mvel2.integration.VariableResolverFactory;
+import org.mvel2.util.ExecutionStack;
+import org.mvel2.util.ParseTools;
+
+/**
+ * @author Mike Brock <cbrock@redhat.com>
+ */
+public class Stacklang extends BlockNode {
+
+    static final Map<String, Integer> opcodes = new HashMap<String, Integer>();
+
+    static {
+        opcodes.put("push", Operator.PUSH);
+        opcodes.put("pop", Operator.POP);
+        opcodes.put("load", Operator.LOAD);
+        opcodes.put("ldtype", Operator.LDTYPE);
+        opcodes.put("invoke", Operator.INVOKE);
+        opcodes.put("store", Operator.STORE);
+        opcodes.put("getfield", Operator.GETFIELD);
+        opcodes.put("storefield", Operator.STOREFIELD);
+        opcodes.put("dup", Operator.DUP);
+        opcodes.put("jump", Operator.JUMP);
+        opcodes.put("jumpif", Operator.JUMPIF);
+        opcodes.put("label", Operator.LABEL);
+        opcodes.put("eq", Operator.EQUAL);
+        opcodes.put("ne", Operator.NEQUAL);
+        opcodes.put("reduce", Operator.REDUCE);
+        opcodes.put("xswap", Operator.XSWAP);
+        opcodes.put("swap", Operator.SWAP);
+    }
+
+    List<Instruction> instructionList;
+    ParserContext pCtx;
+
+    public Stacklang(char[] expr, int blockStart, int blockOffset, int fields, ParserContext pCtx) {
+        super(pCtx);
+        this.expr = expr;
+        this.blockStart = blockStart;
+        this.blockOffset = blockOffset;
+        this.fields = fields | ASTNode.STACKLANG;
+
+        String[] instructions = new String(expr, blockStart, blockOffset).split(";");
+
+        instructionList = new ArrayList<Instruction>(instructions.length);
+        for (String s : instructions) {
+            instructionList.add(parseInstruction(s.trim()));
+        }
+
+        this.pCtx = pCtx;
+    }
+
+    private static Instruction parseInstruction(String s) {
+        int split = s.indexOf(' ');
+
+        Instruction instruction = new Instruction();
+
+        String keyword = split == -1 ? s : s.substring(0, split);
+
+        if (opcodes.containsKey(keyword)) {
+            instruction.opcode = opcodes.get(keyword);
+        }
+
+        //noinspection StringEquality
+        if (keyword != s) {
+            instruction.expr = s.substring(split + 1);
+        }
+
+        return instruction;
+    }
+
+    @Override
+    public Object getReducedValueAccelerated(Object ctx, Object thisValue, VariableResolverFactory factory) {
+        ExecutionStack stk = new ExecutionStack();
+        stk.push(getReducedValue(stk, thisValue, factory));
+        if (stk.isReduceable()) {
+            while (true) {
+                stk.op();
+                if (stk.isReduceable()) {
+                    stk.xswap();
+                } else {
+                    break;
+                }
+            }
+        }
+        return stk.peek();
+    }
+
+    @Override
+    public Object getReducedValue(Object ctx, Object thisValue, VariableResolverFactory factory) {
+        ExecutionStack stack = (ExecutionStack) ctx;
+
+        for (int i1 = 0, instructionListSize = instructionList.size(); i1 < instructionListSize; i1++) {
+            Instruction instruction = instructionList.get(i1);
+
+            System.out.println(stack.toString() + " >> " + instruction.opcode + ":" + instruction.expr);
+
+            switch (instruction.opcode) {
+                case Operator.STORE:
+                    if (instruction.cache == null) {
+                        instruction.cache = factory.createVariable(instruction.expr, stack.peek());
+                    } else {
+                        ((VariableResolver) instruction.cache).setValue(stack.peek());
+                    }
+                    break;
+                case Operator.LOAD:
+                    if (instruction.cache == null) {
+                        instruction.cache = factory.getVariableResolver(instruction.expr);
+                    }
+                    stack.push(((VariableResolver) instruction.cache).getValue());
+                    break;
+                case Operator.GETFIELD:
+                    try {
+                        if (stack.isEmpty() || !(stack.peek() instanceof Class)) {
+                            throw new CompileException("getfield without class", expr, blockStart);
+                        }
+
+                        Field field;
+                        if (instruction.cache == null) {
+                            instruction.cache = field = ((Class) stack.pop()).getField(instruction.expr);
+                        } else {
+                            stack.discard();
+                            field = (Field) instruction.cache;
+                        }
+
+                        stack.push(field.get(stack.pop()));
+                    } catch (Exception e) {
+                        throw new CompileException("field access error", expr, blockStart, e);
+                    }
+                    break;
+                case Operator.STOREFIELD:
+                    try {
+                        if (stack.isEmpty() || !(stack.peek() instanceof Class)) {
+                            throw new CompileException("storefield without class", expr, blockStart);
+                        }
+
+                        Class cls = (Class) stack.pop();
+                        Object val = stack.pop();
+                        cls.getField(instruction.expr).set(stack.pop(), val);
+                        stack.push(val);
+                    } catch (Exception e) {
+                        throw new CompileException("field access error", expr, blockStart, e);
+                    }
+                    break;
+
+                case Operator.LDTYPE:
+                    try {
+                        if (instruction.cache == null) {
+                            instruction.cache = ParseTools.createClass(instruction.expr, pCtx);
+                        }
+                        stack.push(instruction.cache);
+                    } catch (ClassNotFoundException e) {
+                        throw new CompileException("error", expr, blockStart, e);
+                    }
+                    break;
+
+                case Operator.INVOKE:
+                    Object[] parms;
+                    ExecutionStack call = new ExecutionStack();
+                    while (!stack.isEmpty() && !(stack.peek() instanceof Class)) {
+                        call.push(stack.pop());
+                    }
+                    if (stack.isEmpty()) {
+                        throw new CompileException("invoke without class", expr, blockStart);
+                    }
+
+                    parms = new Object[call.size()];
+                    for (int i = 0; !call.isEmpty(); i++)
+                        parms[i] = call.pop();
+
+                    if ("<init>".equals(instruction.expr)) {
+                        Constructor c;
+                        if (instruction.cache == null) {
+                            instruction.cache = c = ParseTools.getBestConstructorCandidate(parms, (Class) stack.pop(), false);
+                        } else {
+                            c = (Constructor) instruction.cache;
+                        }
+
+                        try {
+                            stack.push(c.newInstance(parms));
+                        } catch (Exception e) {
+                            throw new CompileException("instantiation error", expr, blockStart, e);
+                        }
+                    } else {
+                        Method m;
+                        if (instruction.cache == null) {
+                            Class cls = (Class) stack.pop();
+
+                            instruction.cache = m = ParseTools.getBestCandidate(parms, instruction.expr, cls, cls.getDeclaredMethods(),
+                                    false);
+                        } else {
+                            stack.discard();
+                            m = (Method) instruction.cache;
+                        }
+
+                        try {
+                            stack.push(m.invoke(stack.isEmpty() ? null : stack.pop(), parms));
+                        } catch (Exception e) {
+                            throw new CompileException("invokation error", expr, blockStart, e);
+                        }
+                    }
+                    break;
+                case Operator.PUSH:
+                    if (instruction.cache == null) {
+                        instruction.cache = MVEL.eval(instruction.expr, ctx, factory);
+                    }
+                    stack.push(instruction.cache);
+                    break;
+                case Operator.POP:
+                    stack.pop();
+                    break;
+                case Operator.DUP:
+                    stack.dup();
+                    break;
+                case Operator.LABEL:
+                    break;
+                case Operator.JUMPIF:
+                    if (!stack.popBoolean()) continue;
+
+                case Operator.JUMP:
+                    if (instruction.cache != null) {
+                        i1 = (Integer) instruction.cache;
+                    } else {
+                        for (int i2 = 0; i2 < instructionList.size(); i2++) {
+                            Instruction ins = instructionList.get(i2);
+                            if (ins.opcode == Operator.LABEL && instruction.expr.equals(ins.expr)) {
+                                instruction.cache = i1 = i2;
+                                break;
+                            }
+                        }
+                    }
+                    break;
+                case Operator.EQUAL:
+                    stack.push(stack.pop().equals(stack.pop()));
+                    break;
+                case Operator.NEQUAL:
+                    stack.push(!stack.pop().equals(stack.pop()));
+                    break;
+                case Operator.REDUCE:
+                    stack.op();
+                    break;
+                case Operator.XSWAP:
+                    stack.xswap2();
+                    break;
+                case Operator.SWAP:
+                    Object o = stack.pop();
+                    Object o2 = stack.pop();
+                    stack.push(o);
+                    stack.push(o2);
+                    break;
+
+            }
+        }
+
+        return stack.pop();
+    }
+
+    private static class Instruction {
+
+        int opcode;
+        String expr;
+        Object cache;
+    }
+}

--- a/core/src/main/java/org/mvel2/ast/StaticImportNode.java
+++ b/core/src/main/java/org/mvel2/ast/StaticImportNode.java
@@ -1,0 +1,85 @@
+/**
+ * MVEL 2.0
+ * Copyright (C) 2007 The Codehaus
+ * Mike Brock, Dhanji Prasanna, John Graham, Mark Proctor
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mvel2.ast;
+
+import static java.lang.reflect.Modifier.isStatic;
+import static org.mvel2.util.ArrayTools.findLast;
+
+import java.lang.reflect.Method;
+
+import org.mvel2.CompileException;
+import org.mvel2.ParserContext;
+import org.mvel2.integration.VariableResolverFactory;
+
+/**
+ * @author Christopher Brock
+ */
+public class StaticImportNode extends ASTNode {
+
+    private Class declaringClass;
+    private String methodName;
+    private transient Method method;
+
+    public StaticImportNode(char[] expr, int start, int offset, ParserContext pCtx) {
+        super(pCtx);
+        try {
+            this.expr = expr;
+            this.start = start;
+            this.offset = offset;
+
+            int mark;
+
+            ClassLoader classLoader = getClassLoader();
+
+            declaringClass = Class.forName(new String(expr, start, (mark = findLast('.', start, offset, this.expr = expr)) - start), true,
+                    classLoader);
+
+            methodName = new String(expr, ++mark, offset - (mark - start));
+
+            if (resolveMethod() == null) {
+                throw new CompileException("can not find method for static import: " + declaringClass.getName() + "." + methodName, expr,
+                        start);
+            }
+        } catch (Exception e) {
+            throw new CompileException("unable to import class", expr, start, e);
+        }
+    }
+
+    private Method resolveMethod() {
+        for (Method meth : declaringClass.getMethods()) {
+            if (isStatic(meth.getModifiers()) && methodName.equals(meth.getName())) {
+                return method = meth;
+            }
+        }
+        return null;
+    }
+
+    public Method getMethod() {
+        return method;
+    }
+
+    public Object getReducedValueAccelerated(Object ctx, Object thisValue, VariableResolverFactory factory) {
+        factory.createVariable(methodName, method == null ? method = resolveMethod() : method);
+        return null;
+    }
+
+    public Object getReducedValue(Object ctx, Object thisValue, VariableResolverFactory factory) {
+        return getReducedValueAccelerated(ctx, thisValue, factory);
+    }
+}

--- a/core/src/main/java/org/mvel2/ast/Strsim.java
+++ b/core/src/main/java/org/mvel2/ast/Strsim.java
@@ -1,0 +1,45 @@
+package org.mvel2.ast;
+
+import static org.mvel2.util.ParseTools.similarity;
+
+import org.mvel2.CompileException;
+import org.mvel2.ParserContext;
+import org.mvel2.integration.VariableResolverFactory;
+import org.mvel2.util.CompilerTools;
+
+public class Strsim extends ASTNode {
+
+    private ASTNode stmt;
+    private ASTNode soundslike;
+
+    public Strsim(ASTNode stmt, ASTNode clsStmt, ParserContext pCtx) {
+        super(pCtx);
+        this.stmt = stmt;
+        this.soundslike = clsStmt;
+        CompilerTools.expectType(pCtx, clsStmt, String.class, true);
+    }
+
+    public Object getReducedValueAccelerated(Object ctx, Object thisValue, VariableResolverFactory factory) {
+        return similarity(String.valueOf(soundslike.getReducedValueAccelerated(ctx, thisValue, factory)),
+                ((String) stmt.getReducedValueAccelerated(ctx, thisValue, factory)));
+    }
+
+    public Object getReducedValue(Object ctx, Object thisValue, VariableResolverFactory factory) {
+        try {
+            String i = String.valueOf(soundslike.getReducedValue(ctx, thisValue, factory));
+            if (i == null) throw new ClassCastException();
+
+            String x = (String) stmt.getReducedValue(ctx, thisValue, factory);
+            if (x == null) throw new CompileException("not a string: " + stmt.getName(), stmt.getExpr(), getStart());
+
+            return similarity(i, x);
+        } catch (ClassCastException e) {
+            throw new CompileException("not a string: " + soundslike.getName(), soundslike.getExpr(), soundslike.getStart());
+        }
+
+    }
+
+    public Class getEgressType() {
+        return Boolean.class;
+    }
+}

--- a/core/src/main/java/org/mvel2/ast/Substatement.java
+++ b/core/src/main/java/org/mvel2/ast/Substatement.java
@@ -1,0 +1,59 @@
+/**
+ * MVEL 2.0
+ * Copyright (C) 2007 The Codehaus
+ * Mike Brock, Dhanji Prasanna, John Graham, Mark Proctor
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mvel2.ast;
+
+import static org.mvel2.util.ParseTools.subCompileExpression;
+
+import org.mvel2.MVEL;
+import org.mvel2.ParserContext;
+import org.mvel2.compiler.ExecutableStatement;
+import org.mvel2.integration.VariableResolverFactory;
+
+public class Substatement extends ASTNode {
+
+    private ExecutableStatement statement;
+
+    public Substatement(char[] expr, int start, int offset, int fields, ParserContext pCtx) {
+        super(pCtx);
+        this.expr = expr;
+        this.start = start;
+        this.offset = offset;
+
+        if (((this.fields = fields) & COMPILE_IMMEDIATE) != 0) {
+            this.egressType = (this.statement = (ExecutableStatement) subCompileExpression(expr, start, offset, pCtx)).getKnownEgressType();
+        }
+    }
+
+    public Object getReducedValueAccelerated(Object ctx, Object thisValue, VariableResolverFactory factory) {
+        return statement.getValue(ctx, thisValue, factory);
+    }
+
+    public Object getReducedValue(Object ctx, Object thisValue, VariableResolverFactory factory) {
+        return MVEL.eval(this.expr, start, offset, ctx, factory);
+    }
+
+    public ExecutableStatement getStatement() {
+        return statement;
+    }
+
+    public String toString() {
+        return statement == null ? "(" + new String(expr, start, offset) + ")" : statement.toString();
+    }
+
+}

--- a/core/src/main/java/org/mvel2/ast/ThisWithNode.java
+++ b/core/src/main/java/org/mvel2/ast/ThisWithNode.java
@@ -1,0 +1,52 @@
+/**
+ * MVEL 2.0
+ * Copyright (C) 2007 The Codehaus
+ * Mike Brock, Dhanji Prasanna, John Graham, Mark Proctor
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mvel2.ast;
+
+import static org.mvel2.MVEL.executeSetExpression;
+
+import org.mvel2.CompileException;
+import org.mvel2.ParserContext;
+import org.mvel2.integration.VariableResolverFactory;
+
+/**
+ * @author Christopher Brock
+ */
+public class ThisWithNode extends WithNode {
+
+    public ThisWithNode(char[] expr, int start, int offset, int blockStart, int blockOffset, int fields, ParserContext pCtx) {
+        super(expr, start, offset, blockStart, blockOffset, fields, pCtx);
+    }
+
+    public Object getReducedValueAccelerated(Object ctx, Object thisValue, VariableResolverFactory factory) {
+        if (thisValue == null) throw new CompileException("with-block against null pointer (this)", expr, start);
+
+        for (ParmValuePair pvp : withExpressions) {
+            if (pvp.getSetExpression() != null) {
+                executeSetExpression(pvp.getSetExpression(), thisValue, factory, pvp.getStatement().getValue(ctx, thisValue, factory));
+            } else {
+                pvp.getStatement().getValue(thisValue, thisValue, factory);
+            }
+        }
+        return thisValue;
+    }
+
+    public Object getReducedValue(Object ctx, Object thisValue, VariableResolverFactory factory) {
+        return getReducedValueAccelerated(ctx, thisValue, factory);
+    }
+}

--- a/core/src/main/java/org/mvel2/ast/TypeCast.java
+++ b/core/src/main/java/org/mvel2/ast/TypeCast.java
@@ -1,0 +1,93 @@
+/**
+ * MVEL 2.0
+ * Copyright (C) 2007 The Codehaus
+ * Mike Brock, Dhanji Prasanna, John Graham, Mark Proctor
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mvel2.ast;
+
+import static org.mvel2.DataConversion.canConvert;
+import static org.mvel2.DataConversion.convert;
+import static org.mvel2.MVEL.eval;
+import static org.mvel2.util.ParseTools.subCompileExpression;
+import static org.mvel2.util.ReflectionUtil.isAssignableFrom;
+
+import org.mvel2.CompileException;
+import org.mvel2.ParserContext;
+import org.mvel2.compiler.ExecutableStatement;
+import org.mvel2.integration.VariableResolverFactory;
+
+public class TypeCast extends ASTNode {
+
+    private ExecutableStatement statement;
+    private boolean widen;
+
+    public TypeCast(char[] expr, int start, int offset, Class cast, int fields, ParserContext pCtx) {
+        super(pCtx);
+        this.egressType = cast;
+        this.expr = expr;
+        this.start = start;
+        this.offset = offset;
+
+        if ((fields & COMPILE_IMMEDIATE) != 0) {
+
+            if ((statement = (ExecutableStatement) subCompileExpression(expr, start, offset, pCtx)).getKnownEgressType() != Object.class
+                    && !canConvert(cast, statement.getKnownEgressType())) {
+
+                if (canCast(statement.getKnownEgressType(), cast)) {
+                    widen = true;
+                } else {
+                    throw new CompileException("unable to cast type: " + statement.getKnownEgressType() + "; to: " + cast, expr, start);
+                }
+            }
+        }
+    }
+
+    private static Object typeCheck(Object inst, Class type) {
+        if (inst == null) return null;
+        if (type.isInstance(inst)) {
+            return inst;
+        } else {
+            throw new ClassCastException(inst.getClass().getName() + " cannot be cast to: " + type.getClass().getName());
+        }
+    }
+
+    private boolean canCast(Class from, Class to) {
+        return isAssignableFrom(from, to) || (from.isInterface() && interfaceAssignable(from, to));
+    }
+
+    private boolean interfaceAssignable(Class from, Class to) {
+        for (Class c : from.getInterfaces()) {
+            if (c.isAssignableFrom(to)) return true;
+        }
+        return false;
+    }
+
+    public Object getReducedValueAccelerated(Object ctx, Object thisValue, VariableResolverFactory factory) {
+        //noinspection unchecked
+        return widen ? typeCheck(statement.getValue(ctx, thisValue, factory),
+                egressType) : convert(statement.getValue(ctx, thisValue, factory), egressType);
+    }
+
+    public Object getReducedValue(Object ctx, Object thisValue, VariableResolverFactory factory) {
+        //noinspection unchecked
+        return widen ? typeCheck(eval(expr, start, offset, ctx, factory), egressType) : convert(eval(expr, start, offset, ctx, factory),
+                egressType);
+    }
+
+    public ExecutableStatement getStatement() {
+        return statement;
+    }
+}

--- a/core/src/main/java/org/mvel2/ast/TypeDescriptor.java
+++ b/core/src/main/java/org/mvel2/ast/TypeDescriptor.java
@@ -1,0 +1,217 @@
+/**
+ * MVEL 2.0
+ * Copyright (C) 2007 The Codehaus
+ * Mike Brock, Dhanji Prasanna, John Graham, Mark Proctor
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mvel2.ast;
+
+import static java.lang.Character.isDigit;
+import static org.mvel2.ast.ASTNode.COMPILE_IMMEDIATE;
+import static org.mvel2.util.ArrayTools.findFirst;
+import static org.mvel2.util.ParseTools.balancedCapture;
+import static org.mvel2.util.ParseTools.createClass;
+import static org.mvel2.util.ParseTools.findClass;
+import static org.mvel2.util.ParseTools.isWhitespace;
+import static org.mvel2.util.ParseTools.repeatChar;
+import static org.mvel2.util.ParseTools.subCompileExpression;
+import static org.mvel2.util.ParseTools.subset;
+import static org.mvel2.util.ReflectionUtil.toPrimitiveArrayType;
+
+import java.io.Serializable;
+import java.util.Iterator;
+import java.util.LinkedList;
+
+import org.mvel2.CompileException;
+import org.mvel2.ParserContext;
+import org.mvel2.compiler.AbstractParser;
+import org.mvel2.compiler.ExecutableStatement;
+import org.mvel2.integration.VariableResolverFactory;
+import org.mvel2.util.ParseTools;
+
+public class TypeDescriptor implements Serializable {
+
+    int endRange;
+    private String className;
+    private char[] expr;
+    private int start;
+    private int offset;
+    private ArraySize[] arraySize;
+    private ExecutableStatement[] compiledArraySize;
+
+    public TypeDescriptor(char[] name, int start, int offset, int fields) {
+        updateClassName(this.expr = name, this.start = start, this.offset = offset, fields);
+    }
+
+    public static Class getClassReference(Class baseType, TypeDescriptor tDescr, VariableResolverFactory factory, ParserContext ctx)
+            throws ClassNotFoundException {
+        return findClass(factory, repeatChar('[', tDescr.arraySize.length) + "L" + baseType.getName() + ";", ctx);
+    }
+
+    public static Class getClassReference(ParserContext ctx, Class cls, TypeDescriptor tDescr) throws ClassNotFoundException {
+        if (tDescr.isArray()) {
+            cls = cls.isPrimitive() ? toPrimitiveArrayType(cls) : findClass(null,
+                    repeatChar('[', tDescr.arraySize.length) + "L" + cls.getName() + ";", ctx);
+        }
+        return cls;
+    }
+
+    public static Class getClassReference(ParserContext ctx, TypeDescriptor tDescr) throws ClassNotFoundException {
+        Class cls;
+        if (ctx != null && ctx.hasImport(tDescr.className)) {
+            cls = ctx.getImport(tDescr.className);
+            if (tDescr.isArray()) {
+                cls = cls.isPrimitive() ? toPrimitiveArrayType(cls) : findClass(null,
+                        repeatChar('[', tDescr.arraySize.length) + "L" + cls.getName() + ";", ctx);
+            }
+        } else if (ctx == null && hasContextFreeImport(tDescr.className)) {
+            cls = getContextFreeImport(tDescr.className);
+            if (tDescr.isArray()) {
+                cls = cls.isPrimitive() ? toPrimitiveArrayType(cls) : findClass(null,
+                        repeatChar('[', tDescr.arraySize.length) + "L" + cls.getName() + ";", ctx);
+            }
+        } else {
+            cls = createClass(tDescr.getClassName(), ctx);
+            if (tDescr.isArray()) {
+                cls = cls.isPrimitive() ? toPrimitiveArrayType(cls) : findClass(null,
+                        repeatChar('[', tDescr.arraySize.length) + "L" + cls.getName() + ";", ctx);
+            }
+        }
+
+        return cls;
+    }
+
+    public static boolean hasContextFreeImport(String name) {
+        return AbstractParser.LITERALS.containsKey(name) && AbstractParser.LITERALS.get(name) instanceof Class;
+    }
+
+    public static Class getContextFreeImport(String name) {
+        return (Class) AbstractParser.LITERALS.get(name);
+    }
+
+    public void updateClassName(char[] name, int start, int offset, int fields) {
+        this.expr = name;
+
+        if (offset == 0 || !ParseTools.isIdentifierPart(name[start]) || isDigit(name[start])) return;
+
+        if ((endRange = findFirst('(', start, offset, name)) == -1) {
+            if ((endRange = findFirst('[', start, offset, name)) != -1) {
+                className = new String(name, start, endRange - start).trim();
+                int to;
+
+                LinkedList<char[]> sizes = new LinkedList<char[]>();
+
+                int end = start + offset;
+                while (endRange < end) {
+                    while (endRange < end && isWhitespace(name[endRange]))
+                        endRange++;
+
+                    if (endRange == end || name[endRange] == '{') break;
+
+                    if (name[endRange] != '[') {
+                        throw new CompileException("unexpected token in constructor", name, endRange);
+                    }
+                    to = balancedCapture(name, endRange, start + offset, '[');
+                    sizes.add(subset(name, ++endRange, to - endRange));
+                    endRange = to + 1;
+                }
+
+                Iterator<char[]> iter = sizes.iterator();
+                arraySize = new ArraySize[sizes.size()];
+
+                for (int i = 0; i < arraySize.length; i++)
+                    arraySize[i] = new ArraySize(iter.next());
+
+                if ((fields & COMPILE_IMMEDIATE) != 0) {
+                    compiledArraySize = new ExecutableStatement[arraySize.length];
+                    for (int i = 0; i < compiledArraySize.length; i++)
+                        compiledArraySize[i] = (ExecutableStatement) subCompileExpression(arraySize[i].value);
+                }
+
+                return;
+            }
+
+            className = new String(name, start, offset).trim();
+        } else {
+            className = new String(name, start, endRange - start).trim();
+        }
+    }
+
+    public boolean isArray() {
+        return arraySize != null;
+    }
+
+    public int getArrayLength() {
+        return arraySize.length;
+    }
+
+    public ArraySize[] getArraySize() {
+        return arraySize;
+    }
+
+    public ExecutableStatement[] getCompiledArraySize() {
+        return compiledArraySize;
+    }
+
+    public String getClassName() {
+        return className;
+    }
+
+    public void setClassName(String className) {
+        this.className = className;
+    }
+
+    public boolean isClass() {
+        return className != null && className.length() != 0;
+    }
+
+    public int getEndRange() {
+        return endRange;
+    }
+
+    public void setEndRange(int endRange) {
+        this.endRange = endRange;
+    }
+
+    public Class<?> getClassReference() throws ClassNotFoundException {
+        return getClassReference(null, this);
+    }
+
+    public Class<?> getClassReference(ParserContext ctx) throws ClassNotFoundException {
+        return getClassReference(ctx, this);
+    }
+
+    public boolean isUndimensionedArray() {
+        if (arraySize != null) {
+            for (ArraySize anArraySize : arraySize) {
+                if (anArraySize.value.length == 0) return true;
+            }
+        }
+
+        return false;
+    }
+
+    public char[] getExpr() {
+        return expr;
+    }
+
+    public int getStart() {
+        return start;
+    }
+
+    public int getOffset() {
+        return offset;
+    }
+}

--- a/core/src/main/java/org/mvel2/ast/TypedVarNode.java
+++ b/core/src/main/java/org/mvel2/ast/TypedVarNode.java
@@ -1,0 +1,101 @@
+/**
+ * MVEL 2.0
+ * Copyright (C) 2007 The Codehaus
+ * Mike Brock, Dhanji Prasanna, John Graham, Mark Proctor
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mvel2.ast;
+
+import static org.mvel2.MVEL.eval;
+import static org.mvel2.util.ParseTools.checkNameSafety;
+import static org.mvel2.util.ParseTools.createStringTrimmed;
+import static org.mvel2.util.ParseTools.find;
+import static org.mvel2.util.ParseTools.subCompileExpression;
+
+import org.mvel2.ParserContext;
+import org.mvel2.compiler.ExecutableStatement;
+import org.mvel2.integration.VariableResolverFactory;
+
+/**
+ * @author Christopher Brock
+ */
+public class TypedVarNode extends ASTNode implements Assignment {
+
+    private String name;
+
+    private ExecutableStatement statement;
+
+    public TypedVarNode(char[] expr, int start, int offset, int fields, Class type, ParserContext pCtx) {
+        super(pCtx);
+        this.egressType = type;
+        this.fields = fields;
+
+        this.expr = expr;
+        this.start = start;
+        this.offset = offset;
+
+        int assignStart;
+        if ((assignStart = find(this.expr = expr, start, offset, '=')) != -1) {
+            checkNameSafety(name = createStringTrimmed(expr, start, assignStart - start));
+            this.offset -= (assignStart - start);
+            this.start = assignStart + 1;
+
+            if (((fields |= ASSIGN) & COMPILE_IMMEDIATE) != 0) {
+                statement = (ExecutableStatement) subCompileExpression(expr, this.start, this.offset, pCtx);
+            }
+        } else {
+            checkNameSafety(name = new String(expr, start, offset));
+        }
+
+        if ((fields & COMPILE_IMMEDIATE) != 0) {
+            Class x = pCtx.getVarOrInputType(name);
+            if (x != null && x != Object.class && !x.isAssignableFrom(egressType)) {
+                throw new RuntimeException("statically-typed variable already defined in scope: " + name);
+            }
+            pCtx.addVariable(name, egressType, false);
+        }
+    }
+
+    public Object getReducedValueAccelerated(Object ctx, Object thisValue, VariableResolverFactory factory) {
+        if (statement == null) statement = (ExecutableStatement) subCompileExpression(expr, start, offset, pCtx);
+        factory.createVariable(name, ctx = statement.getValue(ctx, thisValue, factory), egressType);
+        return ctx;
+    }
+
+    public Object getReducedValue(Object ctx, Object thisValue, VariableResolverFactory factory) {
+        factory.createVariable(name, ctx = eval(expr, start, offset, thisValue, factory), egressType);
+        return ctx;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getAssignmentVar() {
+        return name;
+    }
+
+    public char[] getExpression() {
+        return expr;
+    }
+
+    public boolean isNewDeclaration() {
+        return true;
+    }
+
+    public void setValueStatement(ExecutableStatement stmt) {
+        this.statement = stmt;
+    }
+}

--- a/core/src/main/java/org/mvel2/ast/Union.java
+++ b/core/src/main/java/org/mvel2/ast/Union.java
@@ -1,0 +1,72 @@
+/**
+ * MVEL 2.0
+ * Copyright (C) 2007 The Codehaus
+ * Mike Brock, Dhanji Prasanna, John Graham, Mark Proctor
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mvel2.ast;
+
+import org.mvel2.ParserContext;
+import org.mvel2.PropertyAccessor;
+import org.mvel2.compiler.Accessor;
+import org.mvel2.integration.VariableResolverFactory;
+import org.mvel2.optimizers.AccessorOptimizer;
+import org.mvel2.optimizers.OptimizerFactory;
+
+public class Union extends ASTNode {
+
+    private ASTNode main;
+    private transient Accessor accessor;
+
+    public Union(char[] expr, int start, int offset, int fields, ASTNode main, ParserContext pCtx) {
+        super(expr, start, offset, fields, pCtx);
+        this.main = main;
+    }
+
+    public Object getReducedValueAccelerated(Object ctx, Object thisValue, VariableResolverFactory factory) {
+        if (accessor != null) {
+            return accessor.getValue(main.getReducedValueAccelerated(ctx, thisValue, factory), thisValue, factory);
+        } else {
+            try {
+                AccessorOptimizer o = OptimizerFactory.getThreadAccessorOptimizer();
+                accessor = o.optimizeAccessor(pCtx, expr, start, offset, main.getReducedValueAccelerated(ctx, thisValue, factory),
+                        thisValue, factory, false, main.getEgressType());
+                return o.getResultOptPass();
+            } finally {
+                OptimizerFactory.clearThreadAccessorOptimizer();
+            }
+        }
+    }
+
+    public ASTNode getMain() {
+        return main;
+    }
+
+    public Accessor getAccessor() {
+        return accessor;
+    }
+
+    public Object getReducedValue(Object ctx, Object thisValue, VariableResolverFactory factory) {
+        return PropertyAccessor.get(expr, start, offset, main.getReducedValue(ctx, thisValue, factory), factory, thisValue, pCtx);
+    }
+
+    public Class getLeftEgressType() {
+        return main.getEgressType();
+    }
+
+    public String toString() {
+        return (main != null ? main.toString() : "") + "-[union]->" + (accessor != null ? accessor.toString() : "");
+    }
+}

--- a/core/src/main/java/org/mvel2/ast/UntilNode.java
+++ b/core/src/main/java/org/mvel2/ast/UntilNode.java
@@ -1,0 +1,73 @@
+/**
+ * MVEL 2.0
+ * Copyright (C) 2007 The Codehaus
+ * Mike Brock, Dhanji Prasanna, John Graham, Mark Proctor
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mvel2.ast;
+
+import static org.mvel2.util.CompilerTools.expectType;
+import static org.mvel2.util.ParseTools.subCompileExpression;
+
+import java.util.HashMap;
+
+import org.mvel2.ParserContext;
+import org.mvel2.compiler.ExecutableStatement;
+import org.mvel2.integration.VariableResolverFactory;
+import org.mvel2.integration.impl.MapVariableResolverFactory;
+
+/**
+ * @author Christopher Brock
+ */
+public class UntilNode extends BlockNode {
+
+    protected String item;
+    protected ExecutableStatement condition;
+
+    public UntilNode(char[] expr, int start, int offset, int blockStart, int blockOffset, int fields, ParserContext pCtx) {
+        super(pCtx);
+        expectType(pCtx, this.condition = (ExecutableStatement) subCompileExpression(expr, start, offset, pCtx), Boolean.class,
+                ((fields & COMPILE_IMMEDIATE) != 0));
+
+        if (pCtx != null) {
+            pCtx.pushVariableScope();
+        }
+
+        this.compiledBlock = (ExecutableStatement) subCompileExpression(expr, blockStart, blockOffset, pCtx);
+
+        if (pCtx != null) {
+            pCtx.popVariableScope();
+        }
+    }
+
+    public Object getReducedValueAccelerated(Object ctx, Object thisValue, VariableResolverFactory factory) {
+        VariableResolverFactory ctxFactory = new MapVariableResolverFactory(new HashMap(0), factory);
+        while (!(Boolean) condition.getValue(ctx, thisValue, factory)) {
+            compiledBlock.getValue(ctx, thisValue, ctxFactory);
+        }
+
+        return null;
+    }
+
+    public Object getReducedValue(Object ctx, Object thisValue, VariableResolverFactory factory) {
+        VariableResolverFactory ctxFactory = new MapVariableResolverFactory(new HashMap(0), factory);
+
+        while (!(Boolean) condition.getValue(ctx, thisValue, factory)) {
+            compiledBlock.getValue(ctx, thisValue, ctxFactory);
+        }
+        return null;
+    }
+
+}

--- a/core/src/main/java/org/mvel2/ast/WhileNode.java
+++ b/core/src/main/java/org/mvel2/ast/WhileNode.java
@@ -1,0 +1,73 @@
+/**
+ * MVEL 2.0
+ * Copyright (C) 2007 The Codehaus
+ * Mike Brock, Dhanji Prasanna, John Graham, Mark Proctor
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mvel2.ast;
+
+import static org.mvel2.util.CompilerTools.expectType;
+import static org.mvel2.util.ParseTools.subCompileExpression;
+
+import java.util.HashMap;
+
+import org.mvel2.ParserContext;
+import org.mvel2.compiler.ExecutableStatement;
+import org.mvel2.integration.VariableResolverFactory;
+import org.mvel2.integration.impl.MapVariableResolverFactory;
+
+/**
+ * @author Christopher Brock
+ */
+public class WhileNode extends BlockNode {
+
+    protected String item;
+    protected ExecutableStatement condition;
+
+    public WhileNode(char[] expr, int start, int offset, int blockStart, int blockEnd, int fields, ParserContext pCtx) {
+        super(pCtx);
+        expectType(pCtx, this.condition = (ExecutableStatement) subCompileExpression(expr, start, offset, pCtx), Boolean.class,
+                ((fields & COMPILE_IMMEDIATE) != 0));
+
+        if (pCtx != null) {
+            pCtx.pushVariableScope();
+        }
+        this.compiledBlock = (ExecutableStatement) subCompileExpression(expr, blockStart, blockEnd, pCtx);
+
+        if (pCtx != null) {
+            pCtx.popVariableScope();
+
+        }
+    }
+
+    public Object getReducedValueAccelerated(Object ctx, Object thisValue, VariableResolverFactory factory) {
+        VariableResolverFactory ctxFactory = new MapVariableResolverFactory(new HashMap<String, Object>(), factory);
+        while ((Boolean) condition.getValue(ctx, thisValue, factory)) {
+            compiledBlock.getValue(ctx, thisValue, ctxFactory);
+        }
+
+        return null;
+    }
+
+    public Object getReducedValue(Object ctx, Object thisValue, VariableResolverFactory factory) {
+        VariableResolverFactory ctxFactory = new MapVariableResolverFactory(new HashMap<String, Object>(), factory);
+
+        while ((Boolean) condition.getValue(ctx, thisValue, factory)) {
+            compiledBlock.getValue(ctx, thisValue, ctxFactory);
+        }
+        return null;
+    }
+
+}

--- a/core/src/main/java/org/mvel2/ast/WithNode.java
+++ b/core/src/main/java/org/mvel2/ast/WithNode.java
@@ -1,0 +1,264 @@
+/**
+ * MVEL 2.0
+ * Copyright (C) 2007 The Codehaus
+ * Mike Brock, Dhanji Prasanna, John Graham, Mark Proctor
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mvel2.ast;
+
+import static org.mvel2.util.ParseTools.balancedCapture;
+import static org.mvel2.util.ParseTools.createShortFormOperativeAssignment;
+import static org.mvel2.util.ParseTools.createStringTrimmed;
+import static org.mvel2.util.ParseTools.opLookup;
+import static org.mvel2.util.ParseTools.parseWithExpressions;
+import static org.mvel2.util.ParseTools.subCompileExpression;
+import static org.mvel2.util.PropertyTools.getReturnType;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.mvel2.CompileException;
+import org.mvel2.MVEL;
+import org.mvel2.Operator;
+import org.mvel2.ParserContext;
+import org.mvel2.compiler.ExecutableStatement;
+import org.mvel2.integration.VariableResolverFactory;
+import org.mvel2.util.ErrorUtil;
+
+/**
+ * @author Christopher Brock
+ */
+public class WithNode extends BlockNode implements NestedStatement {
+
+    protected String nestParm;
+    //   protected ExecutableStatement nestedStatement;
+    protected ParmValuePair[] withExpressions;
+
+    public WithNode(char[] expr, int start, int offset, int blockStart, int blockOffset, int fields, ParserContext pCtx) {
+        super(pCtx);
+        nestParm = createStringTrimmed(this.expr = expr, this.start = start, this.offset = offset);
+        this.blockStart = blockStart;
+        this.blockOffset = blockOffset;
+
+        if ((fields & COMPILE_IMMEDIATE) != 0) {
+            pCtx.setBlockSymbols(true);
+
+            egressType = (compiledBlock = (ExecutableStatement) subCompileExpression(expr, start, offset, pCtx)).getKnownEgressType();
+
+            withExpressions = compileWithExpressions(expr, blockStart, blockOffset, nestParm, egressType, pCtx);
+
+            pCtx.setBlockSymbols(false);
+        }
+    }
+
+    public static ParmValuePair[] compileWithExpressions(char[] block, int start, int offset, String nestParm, Class egressType,
+            ParserContext pCtx) {
+        /**
+         *
+         * MAINTENANCE NOTE: AN INTERPRETED MODE VERSION OF THIS CODE IS DUPLICATED IN: ParseTools
+         *
+         */
+
+        List<ParmValuePair> parms = new ArrayList<ParmValuePair>();
+        String parm = "";
+
+        int end = start + offset;
+
+        int _st = start;
+        int _end = -1;
+
+        int oper = -1;
+        for (int i = start; i < end; i++) {
+            switch (block[i]) {
+                case '{':
+                case '[':
+                case '(':
+                case '\'':
+                case '"':
+                    i = balancedCapture(block, i, end, block[i]);
+                    continue;
+
+                case '/':
+                    if (i < end && block[i + 1] == '/') {
+                        while (i < end && block[i] != '\n')
+                            block[i++] = ' ';
+                        if (parm == null) _st = i;
+                    } else if (i < end && block[i + 1] == '*') {
+                        int len = end - 1;
+                        while (i < len && !(block[i] == '*' && block[i + 1] == '/')) {
+                            block[i++] = ' ';
+                        }
+                        block[i++] = ' ';
+                        block[i++] = ' ';
+
+                        if (parm == null) _st = i;
+                    } else if (i < end && block[i + 1] == '=') {
+                        oper = Operator.DIV;
+                    }
+                    continue;
+
+                case '%':
+                case '*':
+                case '-':
+                case '+':
+                    if (i + 1 < end && block[i + 1] == '=') {
+                        oper = opLookup(block[i]);
+                    }
+                    continue;
+
+                case '=':
+                    parm = createStringTrimmed(block, _st, i - _st - (oper != -1 ? 1 : 0));
+                    _st = i + 1;
+                    continue;
+
+                case ',':
+                    if (_end == -1) _end = i;
+
+                    if (parm == null || parm.length() == 0) {
+                        try {
+                            String expr;
+                            if (nestParm == null) {
+                                expr = new String(block, _st, _end - _st);
+                            } else {
+                                expr = new StringBuilder(nestParm).append('.').append(new String(block, _st, _end - _st)).toString();
+                            }
+
+                            parms.add(new ParmValuePair(null, (ExecutableStatement) subCompileExpression(expr, pCtx), egressType, pCtx));
+
+                        } catch (CompileException e) {
+                            e.setCursor(_st + (e.getCursor() - (e.getExpr().length - offset)));
+                            e.setExpr(block);
+                            throw e;
+                        }
+
+                        oper = -1;
+                        _st = ++i;
+                    } else {
+                        if (nestParm == null) {
+                            throw new CompileException("operative assignment not possible here", block, start);
+                        }
+
+                        try {
+                            parms.add(
+                                    new ParmValuePair(parm,
+                                            oper != -1 ? (ExecutableStatement) subCompileExpression(
+                                                    createShortFormOperativeAssignment(nestParm + "." + parm, block, _st, _end - _st, oper),
+                                                    pCtx)
+                                                    //or
+                                                    : (ExecutableStatement) subCompileExpression(block, _st, _end - _st, pCtx),
+                                            egressType, pCtx));
+                        } catch (CompileException e) {
+                            e.setCursor(_st + (e.getCursor() - (e.getExpr().length - offset)));
+                            e.setExpr(block);
+                            throw e;
+                        }
+
+                        parm = null;
+                        oper = -1;
+                        _st = ++i;
+                    }
+
+                    _end = -1;
+
+                    break;
+            }
+        }
+
+        if (_st != (_end = end)) {
+            try {
+                if (parm == null || "".equals(parm)) {
+                    String expr;
+                    if (nestParm == null) {
+                        expr = new String(block, _st, _end - _st);
+                    } else {
+                        expr = new StringBuilder(nestParm).append('.').append(new String(block, _st, _end - _st)).toString();
+                    }
+
+                    parms.add(new ParmValuePair(null, (ExecutableStatement) subCompileExpression(expr, pCtx), egressType, pCtx));
+                } else {
+                    if (nestParm == null) {
+                        throw new CompileException("operative assignment not possible here", block, start);
+                    }
+
+                    parms.add(new ParmValuePair(parm, oper != -1 ? (ExecutableStatement) subCompileExpression(
+                            createShortFormOperativeAssignment(nestParm + "." + parm, block, _st, _end - _st, oper), pCtx)
+                            //or
+                            : (ExecutableStatement) subCompileExpression(block, _st, _end - _st, pCtx), egressType, pCtx));
+                }
+            } catch (CompileException e) {
+                throw ErrorUtil.rewriteIfNeeded(e, block, _st);
+            }
+        }
+
+        ParmValuePair[] withExpressions;
+        parms.toArray(withExpressions = new ParmValuePair[parms.size()]);
+        return withExpressions;
+    }
+
+    public Object getReducedValueAccelerated(Object ctx, Object thisValue, VariableResolverFactory factory) {
+        Object ctxObject = compiledBlock.getValue(ctx, thisValue, factory);
+        if (ctxObject == null) throw new CompileException("with-block against null pointer", expr, start);
+
+        for (ParmValuePair pvp : withExpressions) {
+            pvp.eval(ctxObject, factory);
+        }
+
+        return ctxObject;
+    }
+
+    public Object getReducedValue(Object ctx, Object thisValue, VariableResolverFactory factory) {
+        parseWithExpressions(nestParm, expr, blockStart, blockOffset, ctx = MVEL.eval(expr, start, offset, ctx, factory), factory);
+        return ctx;
+    }
+
+    public ExecutableStatement getNestedStatement() {
+        return compiledBlock;
+    }
+
+    public ParmValuePair[] getWithExpressions() {
+        return withExpressions;
+    }
+
+    public static final class ParmValuePair implements Serializable {
+
+        private Serializable setExpression;
+        private ExecutableStatement statement;
+
+        public ParmValuePair(String parameter, ExecutableStatement statement, Class ingressType, ParserContext pCtx) {
+            if (parameter != null && parameter.length() != 0) {
+                this.setExpression = MVEL.compileSetExpression(parameter,
+                        ingressType != null ? getReturnType(ingressType, parameter, pCtx) : Object.class, pCtx);
+            }
+            this.statement = statement;
+        }
+
+        public Serializable getSetExpression() {
+            return setExpression;
+        }
+
+        public ExecutableStatement getStatement() {
+            return statement;
+        }
+
+        public void eval(Object ctx, VariableResolverFactory factory) {
+            if (setExpression == null) {
+                this.statement.getValue(ctx, factory);
+            } else {
+                MVEL.executeSetExpression(setExpression, ctx, factory, this.statement.getValue(ctx, factory));
+            }
+        }
+    }
+}

--- a/core/src/main/java/org/mvel2/compiler/AbstractParser.java
+++ b/core/src/main/java/org/mvel2/compiler/AbstractParser.java
@@ -1,0 +1,2716 @@
+/**
+ * MVEL 2.0
+ * Copyright (C) 2007 The Codehaus
+ * Mike Brock, Dhanji Prasanna, John Graham, Mark Proctor
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.mvel2.compiler;
+
+import static java.lang.Boolean.FALSE;
+import static java.lang.Boolean.TRUE;
+import static org.mvel2.Operator.ADD;
+import static org.mvel2.Operator.AND;
+import static org.mvel2.Operator.ASSERT;
+import static org.mvel2.Operator.ASSIGN;
+import static org.mvel2.Operator.ASSIGN_ADD;
+import static org.mvel2.Operator.ASSIGN_DIV;
+import static org.mvel2.Operator.ASSIGN_MOD;
+import static org.mvel2.Operator.ASSIGN_SUB;
+import static org.mvel2.Operator.BW_AND;
+import static org.mvel2.Operator.BW_OR;
+import static org.mvel2.Operator.BW_SHIFT_LEFT;
+import static org.mvel2.Operator.BW_SHIFT_RIGHT;
+import static org.mvel2.Operator.BW_USHIFT_LEFT;
+import static org.mvel2.Operator.BW_USHIFT_RIGHT;
+import static org.mvel2.Operator.BW_XOR;
+import static org.mvel2.Operator.CHOR;
+import static org.mvel2.Operator.CONTAINS;
+import static org.mvel2.Operator.CONVERTABLE_TO;
+import static org.mvel2.Operator.DEC;
+import static org.mvel2.Operator.DIV;
+import static org.mvel2.Operator.DO;
+import static org.mvel2.Operator.ELSE;
+import static org.mvel2.Operator.END_OF_STMT;
+import static org.mvel2.Operator.EQUAL;
+import static org.mvel2.Operator.FOR;
+import static org.mvel2.Operator.FOREACH;
+import static org.mvel2.Operator.FUNCTION;
+import static org.mvel2.Operator.GETHAN;
+import static org.mvel2.Operator.GTHAN;
+import static org.mvel2.Operator.IF;
+import static org.mvel2.Operator.IMPORT;
+import static org.mvel2.Operator.IMPORT_STATIC;
+import static org.mvel2.Operator.INC;
+import static org.mvel2.Operator.INSTANCEOF;
+import static org.mvel2.Operator.ISDEF;
+import static org.mvel2.Operator.LETHAN;
+import static org.mvel2.Operator.LTHAN;
+import static org.mvel2.Operator.MOD;
+import static org.mvel2.Operator.MULT;
+import static org.mvel2.Operator.NEQUAL;
+import static org.mvel2.Operator.NEW;
+import static org.mvel2.Operator.OR;
+import static org.mvel2.Operator.POWER;
+import static org.mvel2.Operator.PROJECTION;
+import static org.mvel2.Operator.PROTO;
+import static org.mvel2.Operator.PTABLE;
+import static org.mvel2.Operator.REGEX;
+import static org.mvel2.Operator.RETURN;
+import static org.mvel2.Operator.SIMILARITY;
+import static org.mvel2.Operator.SOUNDEX;
+import static org.mvel2.Operator.STACKLANG;
+import static org.mvel2.Operator.STR_APPEND;
+import static org.mvel2.Operator.SUB;
+import static org.mvel2.Operator.SWITCH;
+import static org.mvel2.Operator.TERNARY;
+import static org.mvel2.Operator.TERNARY_ELSE;
+import static org.mvel2.Operator.UNTIL;
+import static org.mvel2.Operator.UNTYPED_VAR;
+import static org.mvel2.Operator.WHILE;
+import static org.mvel2.Operator.WITH;
+import static org.mvel2.ast.TypeDescriptor.getClassReference;
+import static org.mvel2.util.ArrayTools.findFirst;
+import static org.mvel2.util.ParseTools.balancedCaptureWithLineAccounting;
+import static org.mvel2.util.ParseTools.captureStringLiteral;
+import static org.mvel2.util.ParseTools.containsCheck;
+import static org.mvel2.util.ParseTools.createStringTrimmed;
+import static org.mvel2.util.ParseTools.handleStringEscapes;
+import static org.mvel2.util.ParseTools.isArrayType;
+import static org.mvel2.util.ParseTools.isDigit;
+import static org.mvel2.util.ParseTools.isIdentifierPart;
+import static org.mvel2.util.ParseTools.isNotValidNameorLabel;
+import static org.mvel2.util.ParseTools.isPropertyOnly;
+import static org.mvel2.util.ParseTools.isReservedWord;
+import static org.mvel2.util.ParseTools.isWhitespace;
+import static org.mvel2.util.ParseTools.opLookup;
+import static org.mvel2.util.ParseTools.similarity;
+import static org.mvel2.util.ParseTools.subset;
+import static org.mvel2.util.PropertyTools.isEmpty;
+import static org.mvel2.util.Soundex.soundex;
+
+import java.io.Serializable;
+import java.util.HashMap;
+import java.util.WeakHashMap;
+
+import org.mvel2.CompileException;
+import org.mvel2.ErrorDetail;
+import org.mvel2.Operator;
+import org.mvel2.ParserContext;
+import org.mvel2.ast.ASTNode;
+import org.mvel2.ast.AssertNode;
+import org.mvel2.ast.AssignmentNode;
+import org.mvel2.ast.BooleanNode;
+import org.mvel2.ast.DeclProtoVarNode;
+import org.mvel2.ast.DeclTypedVarNode;
+import org.mvel2.ast.DeepAssignmentNode;
+import org.mvel2.ast.DoNode;
+import org.mvel2.ast.DoUntilNode;
+import org.mvel2.ast.EndOfStatement;
+import org.mvel2.ast.Fold;
+import org.mvel2.ast.ForEachNode;
+import org.mvel2.ast.ForNode;
+import org.mvel2.ast.Function;
+import org.mvel2.ast.IfNode;
+import org.mvel2.ast.ImportNode;
+import org.mvel2.ast.IndexedAssignmentNode;
+import org.mvel2.ast.IndexedDeclTypedVarNode;
+import org.mvel2.ast.IndexedOperativeAssign;
+import org.mvel2.ast.IndexedPostFixDecNode;
+import org.mvel2.ast.IndexedPostFixIncNode;
+import org.mvel2.ast.IndexedPreFixDecNode;
+import org.mvel2.ast.IndexedPreFixIncNode;
+import org.mvel2.ast.InlineCollectionNode;
+import org.mvel2.ast.InterceptorWrapper;
+import org.mvel2.ast.Invert;
+import org.mvel2.ast.IsDef;
+import org.mvel2.ast.LineLabel;
+import org.mvel2.ast.LiteralDeepPropertyNode;
+import org.mvel2.ast.LiteralNode;
+import org.mvel2.ast.Negation;
+import org.mvel2.ast.NewObjectNode;
+import org.mvel2.ast.NewObjectPrototype;
+import org.mvel2.ast.NewPrototypeNode;
+import org.mvel2.ast.OperativeAssign;
+import org.mvel2.ast.OperatorNode;
+import org.mvel2.ast.PostFixDecNode;
+import org.mvel2.ast.PostFixIncNode;
+import org.mvel2.ast.PreFixDecNode;
+import org.mvel2.ast.PreFixIncNode;
+import org.mvel2.ast.Proto;
+import org.mvel2.ast.ProtoVarNode;
+import org.mvel2.ast.RedundantCodeException;
+import org.mvel2.ast.RegExMatch;
+import org.mvel2.ast.ReturnNode;
+import org.mvel2.ast.Sign;
+import org.mvel2.ast.Stacklang;
+import org.mvel2.ast.StaticImportNode;
+import org.mvel2.ast.Substatement;
+import org.mvel2.ast.ThisWithNode;
+import org.mvel2.ast.TypeCast;
+import org.mvel2.ast.TypeDescriptor;
+import org.mvel2.ast.TypedVarNode;
+import org.mvel2.ast.Union;
+import org.mvel2.ast.UntilNode;
+import org.mvel2.ast.WhileNode;
+import org.mvel2.ast.WithNode;
+import org.mvel2.integration.VariableResolverFactory;
+import org.mvel2.util.ErrorUtil;
+import org.mvel2.util.ExecutionStack;
+import org.mvel2.util.FunctionParser;
+import org.mvel2.util.ProtoParser;
+
+/**
+ * This is the core parser that the subparsers extend.
+ *
+ * @author Christopher Brock
+ */
+public class AbstractParser implements Parser, Serializable {
+
+    public static final int LEVEL_5_CONTROL_FLOW = 5;
+    public static final int LEVEL_4_ASSIGNMENT = 4;
+    public static final int LEVEL_3_ITERATION = 3;
+    public static final int LEVEL_2_MULTI_STATEMENT = 2;
+    public static final int LEVEL_1_BASIC_LANG = 1;
+    public static final int LEVEL_0_PROPERTY_ONLY = 0;
+    protected static final int OP_NOT_LITERAL = -3;
+    protected static final int OP_OVERFLOW = -2;
+    protected static final int OP_TERMINATE = -1;
+    protected static final int OP_RESET_FRAME = 0;
+    protected static final int OP_CONTINUE = 1;
+    protected static final int SET = 0;
+    protected static final int REMOVE = 1;
+    protected static final int GET = 2;
+    protected static final int GET_OR_CREATE = 3;
+    private static final WeakHashMap<String, char[]> EX_PRECACHE = new WeakHashMap<String, char[]>(15);
+    public static HashMap<String, Object> LITERALS;
+    public static HashMap<String, Object> CLASS_LITERALS;
+    public static HashMap<String, Integer> OPERATORS;
+
+    static {
+        setupParser();
+    }
+
+    protected char[] expr;
+    protected int cursor;
+    protected int start;
+    protected int length;
+    protected int end;
+    protected int st;
+    protected int fields;
+    protected boolean greedy = true;
+    protected boolean lastWasIdentifier = false;
+    protected boolean lastWasLineLabel = false;
+    protected boolean lastWasComment = false;
+    protected boolean compileMode = false;
+    protected int literalOnly = -1;
+    protected int lastLineStart = 0;
+    protected int line = 0;
+    protected ASTNode lastNode;
+    protected ExecutionStack stk;
+    protected ExecutionStack splitAccumulator = new ExecutionStack();
+    protected ParserContext pCtx;
+    protected ExecutionStack dStack;
+    protected Object ctx;
+    protected VariableResolverFactory variableFactory;
+    protected boolean debugSymbols = false;
+
+    protected AbstractParser() {
+        pCtx = new ParserContext();
+    }
+
+    protected AbstractParser(ParserContext pCtx) {
+        this.pCtx = pCtx != null ? pCtx : new ParserContext();
+    }
+
+    /**
+     * This method is internally called by the static initializer for AbstractParser in order to setup the parser.
+     * The static initialization populates the operator and literal tables for the parser.  In some situations, like
+     * OSGi, it may be necessary to utilize this manually.
+     */
+    public static void setupParser() {
+        if (LITERALS == null || LITERALS.isEmpty()) {
+            LITERALS = new HashMap<String, Object>();
+            CLASS_LITERALS = new HashMap<String, Object>();
+            OPERATORS = new HashMap<String, Integer>();
+
+            /**
+             * Add System and all the class wrappers from the JCL.
+             */
+            CLASS_LITERALS.put("System", System.class);
+            CLASS_LITERALS.put("String", String.class);
+            CLASS_LITERALS.put("CharSequence", CharSequence.class);
+
+            CLASS_LITERALS.put("Integer", Integer.class);
+            CLASS_LITERALS.put("int", int.class);
+
+            CLASS_LITERALS.put("Long", Long.class);
+            CLASS_LITERALS.put("long", long.class);
+
+            CLASS_LITERALS.put("Boolean", Boolean.class);
+            CLASS_LITERALS.put("boolean", boolean.class);
+
+            CLASS_LITERALS.put("Short", Short.class);
+            CLASS_LITERALS.put("short", short.class);
+
+            CLASS_LITERALS.put("Character", Character.class);
+            CLASS_LITERALS.put("char", char.class);
+
+            CLASS_LITERALS.put("Double", Double.class);
+            CLASS_LITERALS.put("double", double.class);
+
+            CLASS_LITERALS.put("Float", Float.class);
+            CLASS_LITERALS.put("float", float.class);
+
+            CLASS_LITERALS.put("Byte", Byte.class);
+            CLASS_LITERALS.put("byte", byte.class);
+
+            CLASS_LITERALS.put("Math", Math.class);
+            CLASS_LITERALS.put("Void", Void.class);
+            CLASS_LITERALS.put("Object", Object.class);
+            CLASS_LITERALS.put("Number", Number.class);
+
+            CLASS_LITERALS.put("Class", Class.class);
+            CLASS_LITERALS.put("ClassLoader", ClassLoader.class);
+            CLASS_LITERALS.put("Runtime", Runtime.class);
+            CLASS_LITERALS.put("Thread", Thread.class);
+            CLASS_LITERALS.put("Compiler", Compiler.class);
+            CLASS_LITERALS.put("StringBuffer", StringBuffer.class);
+            CLASS_LITERALS.put("ThreadLocal", ThreadLocal.class);
+            CLASS_LITERALS.put("SecurityManager", SecurityManager.class);
+            CLASS_LITERALS.put("StrictMath", StrictMath.class);
+
+            CLASS_LITERALS.put("Exception", Exception.class);
+
+            CLASS_LITERALS.put("Array", java.lang.reflect.Array.class);
+
+            CLASS_LITERALS.put("StringBuilder", StringBuilder.class);
+
+            // Setup LITERALS
+            LITERALS.putAll(CLASS_LITERALS);
+            LITERALS.put("true", TRUE);
+            LITERALS.put("false", FALSE);
+
+            LITERALS.put("null", null);
+            LITERALS.put("nil", null);
+
+            LITERALS.put("empty", BlankLiteral.INSTANCE);
+
+            setLanguageLevel(Boolean.getBoolean("mvel.future.lang.support") ? 6 : 5);
+        }
+    }
+
+    public static void setLanguageLevel(int level) {
+        OPERATORS.clear();
+        OPERATORS.putAll(loadLanguageFeaturesByLevel(level));
+    }
+
+    public static HashMap<String, Integer> loadLanguageFeaturesByLevel(int languageLevel) {
+        HashMap<String, Integer> operatorsTable = new HashMap<String, Integer>();
+        switch (languageLevel) {
+            case 6: // prototype definition
+                operatorsTable.put("proto", PROTO);
+
+            case 5: // control flow operations
+                operatorsTable.put("if", IF);
+                operatorsTable.put("else", ELSE);
+                operatorsTable.put("?", TERNARY);
+                operatorsTable.put("switch", SWITCH);
+                operatorsTable.put("function", FUNCTION);
+                operatorsTable.put("def", FUNCTION);
+                operatorsTable.put("stacklang", STACKLANG);
+
+            case 4: // assignment
+                operatorsTable.put("=", ASSIGN);
+                operatorsTable.put("var", UNTYPED_VAR);
+                operatorsTable.put("+=", ASSIGN_ADD);
+                operatorsTable.put("-=", ASSIGN_SUB);
+                operatorsTable.put("/=", ASSIGN_DIV);
+                operatorsTable.put("%=", ASSIGN_MOD);
+
+            case 3: // iteration
+                operatorsTable.put("foreach", FOREACH);
+                operatorsTable.put("while", WHILE);
+                operatorsTable.put("until", UNTIL);
+                operatorsTable.put("for", FOR);
+                operatorsTable.put("do", DO);
+
+            case 2: // multi-statement
+                operatorsTable.put("return", RETURN);
+                operatorsTable.put(";", END_OF_STMT);
+
+            case 1: // boolean, math ops, projection, assertion, objection creation, block setters, imports
+                operatorsTable.put("+", ADD);
+                operatorsTable.put("-", SUB);
+                operatorsTable.put("*", MULT);
+                operatorsTable.put("**", POWER);
+                operatorsTable.put("/", DIV);
+                operatorsTable.put("%", MOD);
+                operatorsTable.put("==", EQUAL);
+                operatorsTable.put("!=", NEQUAL);
+                operatorsTable.put(">", GTHAN);
+                operatorsTable.put(">=", GETHAN);
+                operatorsTable.put("<", LTHAN);
+                operatorsTable.put("<=", LETHAN);
+                operatorsTable.put("&&", AND);
+                operatorsTable.put("and", AND);
+                operatorsTable.put("||", OR);
+                operatorsTable.put("or", CHOR);
+                operatorsTable.put("~=", REGEX);
+                operatorsTable.put("instanceof", INSTANCEOF);
+                operatorsTable.put("is", INSTANCEOF);
+                operatorsTable.put("contains", CONTAINS);
+                operatorsTable.put("soundslike", SOUNDEX);
+                operatorsTable.put("strsim", SIMILARITY);
+                operatorsTable.put("convertable_to", CONVERTABLE_TO);
+                operatorsTable.put("isdef", ISDEF);
+
+                operatorsTable.put("#", STR_APPEND);
+
+                operatorsTable.put("&", BW_AND);
+                operatorsTable.put("|", BW_OR);
+                operatorsTable.put("^", BW_XOR);
+                operatorsTable.put("<<", BW_SHIFT_LEFT);
+                operatorsTable.put("<<<", BW_USHIFT_LEFT);
+                operatorsTable.put(">>", BW_SHIFT_RIGHT);
+                operatorsTable.put(">>>", BW_USHIFT_RIGHT);
+
+                operatorsTable.put("new", Operator.NEW);
+                operatorsTable.put("in", PROJECTION);
+
+                operatorsTable.put("with", WITH);
+
+                operatorsTable.put("assert", ASSERT);
+                operatorsTable.put("import", IMPORT);
+                operatorsTable.put("import_static", IMPORT_STATIC);
+
+                operatorsTable.put("++", INC);
+                operatorsTable.put("--", DEC);
+
+            case 0: // Property access and inline collections
+                operatorsTable.put(":", TERNARY_ELSE);
+        }
+        return operatorsTable;
+    }
+
+    protected static boolean isArithmeticOperator(int operator) {
+        return operator != -1 && operator < 6;
+    }
+
+    private static int asInt(final Object o) {
+        return (Integer) o;
+    }
+
+    protected ASTNode nextTokenSkipSymbols() {
+        ASTNode n = nextToken();
+        if (n != null && n.getFields() == -1) n = nextToken();
+        return n;
+    }
+
+    /**
+     * Retrieve the next token in the expression.
+     *
+     * @return -
+     */
+    protected ASTNode nextToken() {
+        try {
+            /**
+             * If the cursor is at the end of the expression, we have nothing more to do:
+             * return null.
+             */
+            if (!splitAccumulator.isEmpty()) {
+                lastNode = (ASTNode) splitAccumulator.pop();
+                if (cursor >= end && lastNode instanceof EndOfStatement) {
+                    return nextToken();
+                } else {
+                    return lastNode;
+                }
+            } else if (cursor >= end) {
+                return null;
+            }
+
+            int brace, idx;
+            int tmpStart;
+
+            String name;
+            /**
+             * Because of parser recursion for sub-expression parsing, we sometimes need to remain
+             * certain field states.  We do not reset for assignments, boolean mode, list creation or
+             * a capture only mode.
+             */
+
+            boolean capture = false, union = false;
+
+            if ((fields & ASTNode.COMPILE_IMMEDIATE) != 0) {
+                debugSymbols = pCtx.isDebugSymbols();
+            }
+
+            if (debugSymbols) {
+                if (!lastWasLineLabel) {
+                    if (pCtx.getSourceFile() == null) {
+                        throw new CompileException("unable to produce debugging symbols: source name must be provided.", expr, st);
+                    }
+
+                    if (!pCtx.isLineMapped(pCtx.getSourceFile())) {
+                        pCtx.initLineMapping(pCtx.getSourceFile(), expr);
+                    }
+
+                    skipWhitespace();
+
+                    if (cursor >= end) {
+                        return null;
+                    }
+
+                    int line = pCtx.getLineFor(pCtx.getSourceFile(), cursor);
+
+                    if (!pCtx.isVisitedLine(pCtx.getSourceFile(), pCtx.setLineCount(line)) && !pCtx.isBlockSymbols()) {
+                        lastWasLineLabel = true;
+                        pCtx.visitLine(pCtx.getSourceFile(), line);
+
+                        return lastNode = pCtx.setLastLineLabel(new LineLabel(pCtx.getSourceFile(), line, pCtx));
+                    }
+                } else {
+                    lastWasComment = lastWasLineLabel = false;
+                }
+            }
+
+            /**
+             * Skip any whitespace currently under the starting point.
+             */
+            skipWhitespace();
+
+            /**
+             * From here to the end of the method is the core MVEL parsing code.  Fiddling around here is asking for
+             * trouble unless you really know what you're doing.
+             */
+
+            st = cursor;
+
+            Mainloop: while (cursor != end) {
+                if (isIdentifierPart(expr[cursor])) {
+                    capture = true;
+                    cursor++;
+
+                    while (cursor != end && isIdentifierPart(expr[cursor]))
+                        cursor++;
+                }
+
+                /**
+                 * If the current character under the cursor is a valid
+                 * part of an identifier, we keep capturing.
+                 */
+
+                if (capture) {
+                    String t;
+                    if (OPERATORS.containsKey(t = new String(expr, st, cursor - st)) && !Character.isDigit(expr[st])) {
+                        switch (OPERATORS.get(t)) {
+                            case NEW:
+                                if (!isIdentifierPart(expr[st = cursor = trimRight(cursor)])) {
+                                    throw new CompileException("unexpected character (expected identifier): " + expr[cursor], expr, st);
+                                }
+
+                                /**
+                                 * Capture the beginning part of the token.
+                                 */
+                                do {
+                                    captureToNextTokenJunction();
+                                    skipWhitespace();
+                                } while (cursor < end && expr[cursor] == '[');
+
+                                /**
+                                 * If it's not a dimentioned array, continue capturing if necessary.
+                                 */
+                                if (cursor < end && !lastNonWhite(']')) captureToEOT();
+
+                                TypeDescriptor descr = new TypeDescriptor(expr, st, trimLeft(cursor) - st, fields);
+
+                                if (pCtx.getFunctions().containsKey(descr.getClassName())) {
+                                    return lastNode = new NewObjectPrototype(pCtx, pCtx.getFunction(descr.getClassName()));
+                                }
+
+                                if (pCtx.hasProtoImport(descr.getClassName())) {
+                                    return lastNode = new NewPrototypeNode(descr, pCtx);
+                                }
+
+                                lastNode = new NewObjectNode(descr, fields, pCtx);
+
+                                skipWhitespace();
+                                if (cursor != end && expr[cursor] == '{') {
+                                    if (!((NewObjectNode) lastNode).getTypeDescr().isUndimensionedArray()) {
+                                        throw new CompileException("conflicting syntax: dimensioned array with initializer block", expr,
+                                                st);
+                                    }
+
+                                    st = cursor;
+                                    Class egressType = lastNode.getEgressType();
+
+                                    if (egressType == null) {
+                                        try {
+                                            egressType = getClassReference(pCtx, descr);
+                                        } catch (ClassNotFoundException e) {
+                                            throw new CompileException("could not instantiate class", expr, st, e);
+                                        }
+                                    }
+
+                                    cursor = balancedCaptureWithLineAccounting(expr, st, end, expr[cursor], pCtx) + 1;
+                                    if (tokenContinues()) {
+                                        lastNode = new InlineCollectionNode(expr, st, cursor - st, fields, egressType, pCtx);
+                                        st = cursor;
+                                        captureToEOT();
+                                        return lastNode = new Union(expr, st + 1, cursor, fields, lastNode, pCtx);
+                                    } else {
+                                        return lastNode = new InlineCollectionNode(expr, st, cursor - st, fields, egressType, pCtx);
+                                    }
+                                } else if (((NewObjectNode) lastNode).getTypeDescr().isUndimensionedArray()) {
+                                    throw new CompileException("array initializer expected", expr, st);
+                                }
+                                st = cursor;
+
+                                return lastNode;
+
+                            case ASSERT:
+                                st = cursor = trimRight(cursor);
+                                captureToEOS();
+                                return lastNode = new AssertNode(expr, st, cursor-- - st, fields, pCtx);
+
+                            case RETURN:
+                                st = cursor = trimRight(cursor);
+                                captureToEOS();
+                                return lastNode = new ReturnNode(expr, st, cursor - st, fields, pCtx);
+
+                            case IF:
+                                return captureCodeBlock(ASTNode.BLOCK_IF);
+
+                            case ELSE:
+                                throw new CompileException("else without if", expr, st);
+
+                            case FOREACH:
+                                return captureCodeBlock(ASTNode.BLOCK_FOREACH);
+
+                            case WHILE:
+                                return captureCodeBlock(ASTNode.BLOCK_WHILE);
+
+                            case UNTIL:
+                                return captureCodeBlock(ASTNode.BLOCK_UNTIL);
+
+                            case FOR:
+                                return captureCodeBlock(ASTNode.BLOCK_FOR);
+
+                            case WITH:
+                                return captureCodeBlock(ASTNode.BLOCK_WITH);
+
+                            case DO:
+                                return captureCodeBlock(ASTNode.BLOCK_DO);
+
+                            case STACKLANG:
+                                return captureCodeBlock(STACKLANG);
+
+                            case PROTO:
+                                return captureCodeBlock(PROTO);
+
+                            case ISDEF:
+                                st = cursor = trimRight(cursor);
+                                captureToNextTokenJunction();
+                                return lastNode = new IsDef(expr, st, cursor - st, pCtx);
+
+                            case IMPORT:
+                                st = cursor = trimRight(cursor);
+                                captureToEOS();
+                                ImportNode importNode = new ImportNode(expr, st, cursor - st, pCtx);
+
+                                if (importNode.isPackageImport()) {
+                                    pCtx.addPackageImport(importNode.getPackageImport());
+                                } else {
+                                    pCtx.addImport(importNode.getImportClass().getSimpleName(), importNode.getImportClass());
+                                }
+                                return lastNode = importNode;
+
+                            case IMPORT_STATIC:
+                                st = cursor = trimRight(cursor);
+                                captureToEOS();
+                                StaticImportNode staticImportNode = new StaticImportNode(expr, st, trimLeft(cursor) - st, pCtx);
+                                pCtx.addImport(staticImportNode.getMethod().getName(), staticImportNode.getMethod());
+                                return lastNode = staticImportNode;
+
+                            case FUNCTION:
+                                lastNode = captureCodeBlock(FUNCTION);
+                                st = cursor + 1;
+                                return lastNode;
+
+                            case UNTYPED_VAR:
+                                int end;
+                                st = cursor + 1;
+
+                                while (true) {
+                                    captureToEOT();
+                                    end = cursor;
+                                    skipWhitespace();
+
+                                    if (cursor != end && expr[cursor] == '=') {
+                                        if (end == (cursor = st)) throw new CompileException("illegal use of reserved word: var", expr, st);
+
+                                        continue Mainloop;
+                                    } else {
+                                        name = new String(expr, st, end - st);
+                                        if (pCtx != null && (idx = pCtx.variableIndexOf(name)) != -1) {
+                                            splitAccumulator
+                                                    .add(lastNode = new IndexedDeclTypedVarNode(idx, st, end - st, Object.class, pCtx));
+                                        } else {
+                                            splitAccumulator.add(
+                                                    lastNode = new DeclTypedVarNode(name, expr, st, end - st, Object.class, fields, pCtx));
+                                        }
+                                    }
+
+                                    if (cursor == this.end || expr[cursor] != ',') break;
+                                    else {
+                                        cursor++;
+                                        skipWhitespace();
+                                        st = cursor;
+                                    }
+                                }
+
+                                return (ASTNode) splitAccumulator.pop();
+
+                            case CONTAINS:
+                                lastWasIdentifier = false;
+                                return lastNode = new OperatorNode(Operator.CONTAINS, expr, st, pCtx);
+
+                        }
+                    }
+
+                    skipWhitespace();
+
+                    /**
+                     * If we *were* capturing a token, and we just hit a non-identifier
+                     * character, we stop and figure out what to do.
+                     */
+                    if (cursor != end && expr[cursor] == '(') {
+                        cursor = balancedCaptureWithLineAccounting(expr, cursor, end, '(', pCtx) + 1;
+                    }
+
+                    /**
+                     * If we encounter any of the following cases, we are still dealing with
+                     * a contiguous token.
+                     */
+                    CaptureLoop: while (cursor != end) {
+                        switch (expr[cursor]) {
+                            case '.':
+                                union = true;
+                                cursor++;
+                                skipWhitespace();
+
+                                continue;
+
+                            case '?':
+                                if (lookToLast() == '.' || cursor == start) {
+                                    union = true;
+                                    cursor++;
+                                    continue;
+                                } else {
+                                    break CaptureLoop;
+                                }
+
+                            case '+':
+                                switch (lookAhead()) {
+                                    case '+':
+                                        name = new String(subArray(st, trimLeft(cursor)));
+                                        if (pCtx != null && (idx = pCtx.variableIndexOf(name)) != -1) {
+                                            lastNode = new IndexedPostFixIncNode(idx, pCtx);
+                                        } else {
+                                            lastNode = new PostFixIncNode(name, pCtx);
+                                        }
+
+                                        cursor += 2;
+
+                                        expectEOS();
+
+                                        return lastNode;
+
+                                    case '=':
+                                        name = createStringTrimmed(expr, st, cursor - st);
+                                        st = cursor += 2;
+
+                                        captureToEOS();
+
+                                        if (union) {
+                                            return lastNode = new DeepAssignmentNode(expr, st = trimRight(st), trimLeft(cursor) - st,
+                                                    fields, ADD, name, pCtx);
+                                        } else if (pCtx != null && (idx = pCtx.variableIndexOf(name)) != -1) {
+                                            return lastNode = new IndexedAssignmentNode(expr, st, cursor - st, fields, ADD, name, idx,
+                                                    pCtx);
+                                        } else {
+                                            return lastNode = new OperativeAssign(name, expr, st = trimRight(st), trimLeft(cursor) - st,
+                                                    ADD, fields, pCtx);
+                                        }
+                                }
+
+                                if (isDigit(lookAhead()) && cursor > 1 && (expr[cursor - 1] == 'E' || expr[cursor - 1] == 'e')
+                                        && isDigit(expr[cursor - 2])) {
+                                    cursor++;
+                                    //     capture = true;
+                                    continue Mainloop;
+                                }
+                                break CaptureLoop;
+
+                            case '-':
+                                switch (lookAhead()) {
+                                    case '-':
+                                        name = new String(subArray(st, trimLeft(cursor)));
+                                        if (pCtx != null && (idx = pCtx.variableIndexOf(name)) != -1) {
+                                            lastNode = new IndexedPostFixDecNode(idx, pCtx);
+                                        } else {
+                                            lastNode = new PostFixDecNode(name, pCtx);
+                                        }
+                                        cursor += 2;
+
+                                        expectEOS();
+
+                                        return lastNode;
+
+                                    case '=':
+                                        name = new String(expr, st, trimLeft(cursor) - st);
+                                        st = cursor += 2;
+
+                                        captureToEOS();
+
+                                        if (union) {
+                                            return lastNode = new DeepAssignmentNode(expr, st, cursor - st, fields, SUB, t, pCtx);
+                                        } else if (pCtx != null && (idx = pCtx.variableIndexOf(name)) != -1) {
+                                            return lastNode = new IndexedOperativeAssign(expr, st, cursor - st, SUB, idx, fields, pCtx);
+                                        } else {
+                                            return lastNode = new OperativeAssign(name, expr, st, cursor - st, SUB, fields, pCtx);
+                                        }
+                                }
+
+                                if (isDigit(lookAhead()) && cursor > 1 && (expr[cursor - 1] == 'E' || expr[cursor - 1] == 'e')
+                                        && isDigit(expr[cursor - 2])) {
+                                    cursor++;
+                                    capture = true;
+                                    continue Mainloop;
+                                }
+                                break CaptureLoop;
+
+                            /**
+                             * Exit immediately for any of these cases.
+                             */
+                            case '!':
+                            case ',':
+                            case '"':
+                            case '\'':
+                            case ';':
+                            case ':':
+                                break CaptureLoop;
+
+                            case '\u00AB': // special compact code for recursive parses
+                            case '\u00BB':
+                            case '\u00AC':
+                            case '&':
+                            case '^':
+                            case '|':
+                            case '*':
+                            case '/':
+                            case '%':
+                                char op = expr[cursor];
+                                if (lookAhead() == '=') {
+                                    name = new String(expr, st, trimLeft(cursor) - st);
+
+                                    st = cursor += 2;
+                                    captureToEOS();
+
+                                    if (union) {
+                                        return lastNode = new DeepAssignmentNode(expr, st, cursor - st, fields, opLookup(op), t, pCtx);
+                                    } else if (pCtx != null && (idx = pCtx.variableIndexOf(name)) != -1) {
+                                        return lastNode = new IndexedOperativeAssign(expr, st, cursor - st, opLookup(op), idx, fields,
+                                                pCtx);
+                                    } else {
+                                        return lastNode = new OperativeAssign(name, expr, st, cursor - st, opLookup(op), fields, pCtx);
+                                    }
+                                }
+                                break CaptureLoop;
+
+                            case '<':
+                                if ((lookAhead() == '<' && lookAhead(2) == '=')) {
+                                    name = new String(expr, st, trimLeft(cursor) - st);
+
+                                    st = cursor += 3;
+                                    captureToEOS();
+
+                                    if (union) {
+                                        return lastNode = new DeepAssignmentNode(expr, st, cursor - st, fields, BW_SHIFT_LEFT, t, pCtx);
+                                    } else if (pCtx != null && (idx = pCtx.variableIndexOf(name)) != -1) {
+                                        return lastNode = new IndexedOperativeAssign(expr, st, cursor - st, BW_SHIFT_LEFT, idx, fields,
+                                                pCtx);
+                                    } else {
+                                        return lastNode = new OperativeAssign(name, expr, st, cursor - st, BW_SHIFT_LEFT, fields, pCtx);
+                                    }
+                                }
+                                break CaptureLoop;
+
+                            case '>':
+                                if (lookAhead() == '>') {
+                                    if (lookAhead(2) == '=') {
+                                        name = new String(expr, st, trimLeft(cursor) - st);
+
+                                        st = cursor += 3;
+                                        captureToEOS();
+
+                                        if (union) {
+                                            return lastNode = new DeepAssignmentNode(expr, st, cursor - st, fields, BW_SHIFT_RIGHT, t,
+                                                    pCtx);
+                                        } else if (pCtx != null && (idx = pCtx.variableIndexOf(name)) != -1) {
+                                            return lastNode = new IndexedOperativeAssign(expr, st, cursor - st, BW_SHIFT_RIGHT, idx, fields,
+                                                    pCtx);
+                                        } else {
+                                            return lastNode = new OperativeAssign(name, expr, st, cursor - st, BW_SHIFT_RIGHT, fields,
+                                                    pCtx);
+                                        }
+                                    } else if ((lookAhead(2) == '>' && lookAhead(3) == '=')) {
+                                        name = new String(expr, st, trimLeft(cursor) - st);
+
+                                        st = cursor += 4;
+                                        captureToEOS();
+
+                                        if (union) {
+                                            return lastNode = new DeepAssignmentNode(expr, st, cursor - st, fields, BW_USHIFT_RIGHT, t,
+                                                    pCtx);
+                                        } else if (pCtx != null && (idx = pCtx.variableIndexOf(name)) != -1) {
+                                            return lastNode = new IndexedOperativeAssign(expr, st, cursor - st, BW_USHIFT_RIGHT, idx,
+                                                    fields, pCtx);
+                                        } else {
+                                            return lastNode = new OperativeAssign(name, expr, st, cursor - st, BW_USHIFT_RIGHT, fields,
+                                                    pCtx);
+                                        }
+                                    }
+                                }
+                                break CaptureLoop;
+
+                            case '(':
+                                cursor = balancedCaptureWithLineAccounting(expr, cursor, end, '(', pCtx) + 1;
+                                continue;
+
+                            case '[':
+                                cursor = balancedCaptureWithLineAccounting(expr, cursor, end, '[', pCtx) + 1;
+                                continue;
+
+                            case '{':
+                                if (!union) break CaptureLoop;
+                                cursor = balancedCaptureWithLineAccounting(expr, cursor, end, '{', pCtx) + 1;
+                                continue;
+
+                            case '~':
+                                if (lookAhead() == '=') {
+                                    // tmp = subArray(start, trimLeft(cursor));
+                                    tmpStart = st;
+                                    int tmpOffset = cursor - st;
+                                    st = cursor += 2;
+
+                                    captureToEOT();
+
+                                    return lastNode = new RegExMatch(expr, tmpStart, tmpOffset, fields, st, cursor - st, pCtx);
+                                }
+                                break CaptureLoop;
+
+                            case '=':
+                                if (lookAhead() == '+') {
+                                    name = new String(expr, st, trimLeft(cursor) - st);
+
+                                    st = cursor += 2;
+
+                                    if (!isNextIdentifierOrLiteral()) {
+                                        throw new CompileException("unexpected symbol '" + expr[cursor] + "'", expr, st);
+                                    }
+
+                                    captureToEOS();
+
+                                    if (pCtx != null && (idx = pCtx.variableIndexOf(name)) != -1) {
+                                        return lastNode = new IndexedOperativeAssign(expr, st, cursor - st, ADD, idx, fields, pCtx);
+                                    } else {
+                                        return lastNode = new OperativeAssign(name, expr, st, cursor - st, ADD, fields, pCtx);
+                                    }
+                                } else if (lookAhead() == '-') {
+                                    name = new String(expr, st, trimLeft(cursor) - st);
+
+                                    st = cursor += 2;
+
+                                    if (!isNextIdentifierOrLiteral()) {
+                                        throw new CompileException("unexpected symbol '" + expr[cursor] + "'", expr, st);
+                                    }
+
+                                    captureToEOS();
+
+                                    if (pCtx != null && (idx = pCtx.variableIndexOf(name)) != -1) {
+                                        return lastNode = new IndexedOperativeAssign(expr, st, cursor - st, SUB, idx, fields, pCtx);
+                                    } else {
+                                        return lastNode = new OperativeAssign(name, expr, st, cursor - st, SUB, fields, pCtx);
+                                    }
+                                }
+                                if (greedy && lookAhead() != '=') {
+                                    cursor++;
+
+                                    if (union) {
+                                        captureToEOS();
+
+                                        return lastNode = new DeepAssignmentNode(expr, st, cursor - st, fields | ASTNode.ASSIGN, pCtx);
+                                    } else if (lastWasIdentifier) {
+                                        return procTypedNode(false);
+                                    } else if (pCtx != null && ((idx = pCtx.variableIndexOf(t)) != -1 && (pCtx.isIndexAllocation()))) {
+                                        captureToEOS();
+
+                                        IndexedAssignmentNode ian = new IndexedAssignmentNode(expr, st = trimRight(st),
+                                                trimLeft(cursor) - st, ASTNode.ASSIGN, idx, pCtx);
+
+                                        if (idx == -1) {
+                                            pCtx.addIndexedInput(t = ian.getVarName());
+                                            ian.setRegister(pCtx.variableIndexOf(t));
+                                        }
+                                        return lastNode = ian;
+                                    } else {
+                                        captureToEOS();
+
+                                        return lastNode = new AssignmentNode(expr, st, cursor - st, fields | ASTNode.ASSIGN, pCtx);
+                                    }
+                                }
+                                break CaptureLoop;
+
+                            default:
+                                if (cursor != end) {
+                                    if (isIdentifierPart(expr[cursor])) {
+                                        if (!union) {
+                                            break CaptureLoop;
+                                        }
+                                        cursor++;
+                                        while (cursor != end && isIdentifierPart(expr[cursor]))
+                                            cursor++;
+                                    } else if ((cursor + 1) != end && isIdentifierPart(expr[cursor + 1])) {
+                                        break CaptureLoop;
+                                    } else {
+                                        cursor++;
+                                    }
+                                } else {
+                                    break CaptureLoop;
+                                }
+                        }
+                    }
+
+                    /**
+                     * Produce the token.
+                     */
+                    trimWhitespace();
+
+                    return createPropertyToken(st, cursor);
+                } else {
+                    switch (expr[cursor]) {
+                        case '.': {
+                            cursor++;
+                            if (isDigit(expr[cursor])) {
+                                capture = true;
+                                continue;
+                            }
+                            expectNextChar_IW('{');
+
+                            return lastNode = new ThisWithNode(expr, st, cursor - st - 1, cursor + 1,
+                                    (cursor = balancedCaptureWithLineAccounting(expr, cursor, end, '{', pCtx) + 1) - 3, fields, pCtx);
+                        }
+
+                        case '@': {
+                            st++;
+                            captureToEOT();
+
+                            if (pCtx == null || (pCtx.getInterceptors() == null
+                                    || !pCtx.getInterceptors().containsKey(name = new String(expr, st, cursor - st)))) {
+                                throw new CompileException("reference to undefined interceptor: " + new String(expr, st, cursor - st), expr,
+                                        st);
+                            }
+
+                            return lastNode = new InterceptorWrapper(pCtx.getInterceptors().get(name), nextToken(), pCtx);
+                        }
+
+                        case '=':
+                            return createOperator(expr, st, (cursor += 2));
+
+                        case '-':
+                            if (lookAhead() == '-') {
+                                cursor += 2;
+                                skipWhitespace();
+                                st = cursor;
+                                captureIdentifier();
+
+                                name = new String(subArray(st, cursor));
+                                if (pCtx != null && (idx = pCtx.variableIndexOf(name)) != -1) {
+                                    return lastNode = new IndexedPreFixDecNode(idx, pCtx);
+                                } else {
+                                    return lastNode = new PreFixDecNode(name, pCtx);
+                                }
+                            } else if ((cursor == start || (lastNode != null && (lastNode instanceof BooleanNode || lastNode.isOperator())))
+                                    && !isDigit(lookAhead())) {
+
+                                cursor += 1;
+                                captureToEOT();
+                                return new Sign(expr, st, cursor - st, fields, pCtx);
+                            } else if ((cursor != start
+                                    && (lastNode != null && !(lastNode instanceof BooleanNode || lastNode.isOperator())))
+                                    || !isDigit(lookAhead())) {
+
+                                return createOperator(expr, st, cursor++ + 1);
+                            } else if ((cursor - 1) != start || (!isDigit(expr[cursor - 1])) && isDigit(lookAhead())) {
+                                cursor++;
+                                break;
+                            } else {
+                                throw new CompileException("not a statement", expr, st);
+                            }
+
+                        case '+':
+                            if (lookAhead() == '+') {
+                                cursor += 2;
+                                skipWhitespace();
+                                st = cursor;
+                                captureIdentifier();
+
+                                name = new String(subArray(st, cursor));
+                                if (pCtx != null && (idx = pCtx.variableIndexOf(name)) != -1) {
+                                    return lastNode = new IndexedPreFixIncNode(idx, pCtx);
+                                } else {
+                                    return lastNode = new PreFixIncNode(name, pCtx);
+                                }
+                            }
+                            return createOperator(expr, st, cursor++ + 1);
+
+                        case '*':
+                            if (lookAhead() == '*') {
+                                cursor++;
+                            }
+                            return createOperator(expr, st, cursor++ + 1);
+
+                        case ';':
+                            cursor++;
+                            lastWasIdentifier = false;
+                            return lastNode = new EndOfStatement(pCtx);
+
+                        case '?':
+                            if (cursor == start) {
+                                cursor++;
+                                continue;
+                            }
+
+                        case '#':
+                        case '/':
+                        case ':':
+                        case '^':
+                        case '%': {
+                            return createOperator(expr, st, cursor++ + 1);
+                        }
+
+                        case '(': {
+                            cursor++;
+
+                            boolean singleToken = true;
+
+                            skipWhitespace();
+                            for (brace = 1; cursor != end && brace != 0; cursor++) {
+                                switch (expr[cursor]) {
+                                    case '(':
+                                        brace++;
+                                        break;
+                                    case ')':
+                                        brace--;
+                                        break;
+                                    case '\'':
+                                        cursor = captureStringLiteral('\'', expr, cursor, end);
+                                        break;
+                                    case '"':
+                                        cursor = captureStringLiteral('"', expr, cursor, end);
+                                        break;
+                                    case 'i':
+                                        if (brace == 1 && isWhitespace(lookBehind()) && lookAhead() == 'n' && isWhitespace(lookAhead(2))) {
+
+                                            for (int level = brace; cursor != end; cursor++) {
+                                                switch (expr[cursor]) {
+                                                    case '(':
+                                                        brace++;
+                                                        break;
+                                                    case ')':
+                                                        if (--brace < level) {
+                                                            cursor++;
+                                                            if (tokenContinues()) {
+                                                                lastNode = new Fold(expr, trimRight(st + 1), cursor - st - 2, fields, pCtx);
+                                                                if (expr[st = cursor] == '.') st++;
+                                                                captureToEOT();
+                                                                return lastNode = new Union(expr, st = trimRight(st), cursor - st, fields,
+                                                                        lastNode, pCtx);
+                                                            } else {
+                                                                return lastNode = new Fold(expr, trimRight(st + 1), cursor - st - 2, fields,
+                                                                        pCtx);
+                                                            }
+                                                        }
+                                                        break;
+                                                    case '\'':
+                                                        cursor = captureStringLiteral('\'', expr, cursor, end);
+                                                        break;
+                                                    case '"':
+                                                        cursor = captureStringLiteral('\"', expr, cursor, end);
+                                                        break;
+                                                }
+                                            }
+
+                                            throw new CompileException("unterminated projection; closing parathesis required", expr, st);
+                                        }
+                                        break;
+
+                                    default:
+                                        /**
+                                         * Check to see if we should disqualify this current token as a potential
+                                         * type-cast candidate.
+                                         */
+
+                                        if (expr[cursor] != '.') {
+                                            switch (expr[cursor]) {
+                                                case '[':
+                                                case ']':
+                                                    break;
+
+                                                default:
+                                                    if (!(isIdentifierPart(expr[cursor]) || expr[cursor] == '.')) {
+                                                        singleToken = false;
+                                                    }
+                                            }
+                                        }
+                                }
+                            }
+
+                            if (brace != 0) {
+                                throw new CompileException("unbalanced braces in expression: (" + brace + "):", expr, st);
+                            }
+
+                            tmpStart = -1;
+                            if (singleToken) {
+                                int _st;
+                                TypeDescriptor tDescr = new TypeDescriptor(expr, _st = trimRight(st + 1), trimLeft(cursor - 1) - _st,
+                                        fields);
+
+                                Class cls;
+                                try {
+                                    if (tDescr.isClass() && (cls = getClassReference(pCtx, tDescr)) != null) {
+
+                                        // lookahead to check if it could be a real cast
+                                        boolean isCast = false;
+                                        for (int i = cursor; i < expr.length; i++) {
+                                            if (expr[i] == ' ' || expr[i] == '\t') continue;
+                                            isCast = isIdentifierPart(expr[i]) || expr[i] == '\'' || expr[i] == '"' || expr[i] == '(';
+                                            break;
+                                        }
+
+                                        if (isCast) {
+                                            st = cursor;
+
+                                            captureToEOT();
+                                            //   captureToEOS();
+
+                                            return lastNode = new TypeCast(expr, st, cursor - st, cls, fields, pCtx);
+                                        }
+                                    }
+                                } catch (ClassNotFoundException e) {
+                                    // fallthrough
+                                }
+
+                            }
+
+                            if (tmpStart != -1) {
+                                return handleUnion(handleSubstatement(new Substatement(expr, tmpStart, cursor - tmpStart, fields, pCtx)));
+                            } else {
+                                return handleUnion(handleSubstatement(
+                                        new Substatement(expr, st = trimRight(st + 1), trimLeft(cursor - 1) - st, fields, pCtx)));
+                            }
+                        }
+
+                        case '}':
+                        case ']':
+                        case ')': {
+                            throw new CompileException("unbalanced braces", expr, st);
+                        }
+
+                        case '>': {
+                            switch (expr[cursor + 1]) {
+                                case '>':
+                                    if (expr[cursor += 2] == '>') cursor++;
+                                    return createOperator(expr, st, cursor);
+                                case '=':
+                                    return createOperator(expr, st, cursor += 2);
+                                default:
+                                    return createOperator(expr, st, ++cursor);
+                            }
+                        }
+
+                        case '<': {
+                            if (expr[++cursor] == '<') {
+                                if (expr[++cursor] == '<') cursor++;
+                                return createOperator(expr, st, cursor);
+                            } else if (expr[cursor] == '=') {
+                                return createOperator(expr, st, ++cursor);
+                            } else {
+                                return createOperator(expr, st, cursor);
+                            }
+                        }
+
+                        case '\'':
+                        case '"':
+                            lastNode = new LiteralNode(
+                                    handleStringEscapes(subset(expr, st + 1,
+                                            (cursor = captureStringLiteral(expr[cursor], expr, cursor, end)) - st - 1)),
+                                    String.class, pCtx);
+
+                            cursor++;
+
+                            if (tokenContinues()) {
+                                return lastNode = handleUnion(lastNode);
+                            }
+
+                            return lastNode;
+
+                        case '&': {
+                            if (expr[cursor++ + 1] == '&') {
+                                return createOperator(expr, st, ++cursor);
+                            } else {
+                                return createOperator(expr, st, cursor);
+                            }
+                        }
+
+                        case '|': {
+                            if (expr[cursor++ + 1] == '|') {
+                                return createOperator(expr, st, ++cursor);
+                            } else {
+                                return createOperator(expr, st, cursor);
+                            }
+                        }
+
+                        case '~':
+                            if ((cursor++ - 1 != 0 || !isIdentifierPart(lookBehind())) && isDigit(expr[cursor])) {
+                                st = cursor;
+                                captureToEOT();
+                                return lastNode = new Invert(expr, st, cursor - st, fields, pCtx);
+                            } else if (expr[cursor] == '(') {
+                                st = cursor--;
+                                captureToEOT();
+                                return lastNode = new Invert(expr, st, cursor - st, fields, pCtx);
+                            } else {
+                                if (expr[cursor] == '=') cursor++;
+                                return createOperator(expr, st, cursor);
+                            }
+
+                        case '!': {
+                            ++cursor;
+                            if (isNextIdentifier()) {
+                                if (lastNode != null && !lastNode.isOperator()) {
+                                    throw new CompileException("unexpected operator '!'", expr, st);
+                                }
+
+                                st = cursor;
+                                captureToEOT();
+                                if ("new".equals(name = new String(expr, st, cursor - st)) || "isdef".equals(name)) {
+                                    captureToEOT();
+                                    return lastNode = new Negation(expr, st, cursor - st, fields, pCtx);
+                                } else {
+                                    return lastNode = new Negation(expr, st, cursor - st, fields, pCtx);
+                                }
+                            } else if (expr[cursor] == '(') {
+                                st = cursor--;
+                                captureToEOT();
+                                return lastNode = new Negation(expr, st, cursor - st, fields, pCtx);
+                            } else if (expr[cursor] == '!') {
+                                // just ignore a double negation
+                                ++cursor;
+                                return nextToken();
+                            } else if (expr[cursor] != '=') throw new CompileException("unexpected operator '!'", expr, st, null);
+                            else {
+                                return createOperator(expr, st, ++cursor);
+                            }
+                        }
+
+                        case '[':
+                        case '{':
+                            cursor = balancedCaptureWithLineAccounting(expr, cursor, end, expr[cursor], pCtx) + 1;
+                            if (tokenContinues()) {
+                                lastNode = new InlineCollectionNode(expr, st, cursor - st, fields, pCtx);
+                                st = cursor;
+                                captureToEOT();
+                                if (expr[st] == '.') st++;
+
+                                return lastNode = new Union(expr, st, cursor - st, fields, lastNode, pCtx);
+                            } else {
+                                return lastNode = new InlineCollectionNode(expr, st, cursor - st, fields, pCtx);
+                            }
+
+                        default:
+                            cursor++;
+                    }
+                }
+            }
+
+            if (st == cursor) return null;
+            else return createPropertyToken(st, cursor);
+        } catch (RedundantCodeException e) {
+            return nextToken();
+        } catch (NumberFormatException e) {
+            throw new CompileException("badly formatted number: " + e.getMessage(), expr, st, e);
+        } catch (StringIndexOutOfBoundsException e) {
+            throw new CompileException("unexpected end of statement", expr, cursor, e);
+        } catch (ArrayIndexOutOfBoundsException e) {
+            throw new CompileException("unexpected end of statement", expr, cursor, e);
+        } catch (CompileException e) {
+            throw ErrorUtil.rewriteIfNeeded(e, expr, cursor);
+        }
+    }
+
+    public ASTNode handleSubstatement(Substatement stmt) {
+        if (stmt.getStatement() != null && stmt.getStatement().isLiteralOnly()) {
+            return new LiteralNode(stmt.getStatement().getValue(null, null, null), pCtx);
+        } else {
+            return stmt;
+        }
+    }
+
+    /**
+     * Handle a union between a closed statement and a residual property chain.
+     *
+     * @param node an ast node
+     * @return ASTNode
+     */
+    protected ASTNode handleUnion(ASTNode node) {
+        if (cursor != end) {
+            skipWhitespace();
+            int union = -1;
+            if (cursor < end) {
+                switch (expr[cursor]) {
+                    case '.':
+                        union = cursor + 1;
+                        break;
+                    case '[':
+                        union = cursor;
+                }
+            }
+
+            if (union != -1) {
+                captureToEOT();
+                return lastNode = new Union(expr, union, cursor - union, fields, node, pCtx);
+            }
+
+        }
+        return lastNode = node;
+    }
+
+    /**
+     * Create an operator node.
+     *
+     * @param expr  an char[] containing the expression
+     * @param start the start offet for the token
+     * @param end   the end offset for the token
+     * @return ASTNode
+     */
+    private ASTNode createOperator(final char[] expr, final int start, final int end) {
+        lastWasIdentifier = false;
+        return lastNode = new OperatorNode(OPERATORS.get(new String(expr, start, end - start)), expr, start, pCtx);
+    }
+
+    /**
+     * Create a copy of an array based on a sub-range.  Works faster than System.arrayCopy() for arrays shorter than
+     * 1000 elements in most cases, so the parser uses this internally.
+     *
+     * @param start the start offset
+     * @param end   the end offset
+     * @return an array
+     */
+    private char[] subArray(final int start, final int end) {
+        if (start >= end) return new char[0];
+
+        char[] newA = new char[end - start];
+        for (int i = 0; i != newA.length; i++) {
+            newA[i] = expr[i + start];
+        }
+
+        return newA;
+    }
+
+    /**
+     * Generate a property token
+     *
+     * @param st  the start offset
+     * @param end the end offset
+     * @return an ast node
+     */
+    private ASTNode createPropertyToken(int st, int end) {
+        String tmp;
+
+        if (isPropertyOnly(expr, st, end)) {
+            if (pCtx != null && pCtx.hasImports()) {
+                int find;
+
+                if ((find = findFirst('.', st, end - st, expr)) != -1) {
+                    String iStr = new String(expr, st, find - st);
+                    if (pCtx.hasImport(iStr)) {
+                        lastWasIdentifier = true;
+                        return lastNode = new LiteralDeepPropertyNode(expr, find + 1, end - find - 1, fields, pCtx.getImport(iStr), pCtx);
+                    }
+                } else {
+                    if (pCtx.hasImport(tmp = new String(expr, st, cursor - st))) {
+                        lastWasIdentifier = true;
+                        return lastNode = new LiteralNode(pCtx.getStaticOrClassImport(tmp), pCtx);
+                    }
+                }
+            }
+
+            if (LITERALS.containsKey(tmp = new String(expr, st, end - st))) {
+                lastWasIdentifier = true;
+                return lastNode = new LiteralNode(LITERALS.get(tmp), pCtx);
+            } else if (OPERATORS.containsKey(tmp)) {
+                lastWasIdentifier = false;
+                return lastNode = new OperatorNode(OPERATORS.get(tmp), expr, st, pCtx);
+            } else if (lastWasIdentifier) {
+                return procTypedNode(true);
+            }
+        }
+
+        if (pCtx != null && isArrayType(expr, st, end)) {
+            if (pCtx.hasImport(new String(expr, st, cursor - st - 2))) {
+                lastWasIdentifier = true;
+                TypeDescriptor typeDescriptor = new TypeDescriptor(expr, st, cursor - st, fields);
+
+                try {
+                    return lastNode = new LiteralNode(typeDescriptor.getClassReference(pCtx), pCtx);
+                } catch (ClassNotFoundException e) {
+                    throw new CompileException("could not resolve class: " + typeDescriptor.getClassName(), expr, st);
+                }
+            }
+        }
+
+        lastWasIdentifier = true;
+
+        return lastNode = new ASTNode(expr, trimRight(st), trimLeft(end) - st, fields, pCtx);
+    }
+
+    /**
+     * Process the current typed node
+     *
+     * @param decl node is a declaration or not
+     * @return and ast node
+     */
+    private ASTNode procTypedNode(boolean decl) {
+        while (true) {
+            if (lastNode.getLiteralValue() instanceof String) {
+                char[] tmp = ((String) lastNode.getLiteralValue()).toCharArray();
+                TypeDescriptor tDescr = new TypeDescriptor(tmp, 0, tmp.length, 0);
+
+                try {
+                    lastNode.setLiteralValue(getClassReference(pCtx, tDescr));
+                    lastNode.discard();
+                } catch (Exception e) {
+                    // fall through;
+                }
+            }
+
+            if (lastNode.isLiteral() && lastNode.getLiteralValue() instanceof Class) {
+                lastNode.discard();
+
+                captureToEOS();
+
+                if (decl) {
+                    splitAccumulator.add(new DeclTypedVarNode(new String(expr, st, cursor - st), expr, st, cursor - st,
+                            (Class) lastNode.getLiteralValue(), fields | ASTNode.ASSIGN, pCtx));
+                } else {
+                    captureToEOS();
+                    splitAccumulator.add(
+                            new TypedVarNode(expr, st, cursor - st - 1, fields | ASTNode.ASSIGN, (Class) lastNode.getLiteralValue(), pCtx));
+                }
+            } else if (lastNode instanceof Proto) {
+                captureToEOS();
+                if (decl) {
+                    splitAccumulator
+                            .add(new DeclProtoVarNode(new String(expr, st, cursor - st), (Proto) lastNode, fields | ASTNode.ASSIGN, pCtx));
+                } else {
+                    splitAccumulator.add(new ProtoVarNode(expr, st, cursor - st, fields | ASTNode.ASSIGN, (Proto) lastNode, pCtx));
+                }
+            }
+
+            // this redundant looking code is needed to work with the interpreter and MVELSH properly.
+            else if ((fields & ASTNode.COMPILE_IMMEDIATE) == 0) {
+                if (stk.peek() instanceof Class) {
+                    captureToEOS();
+                    if (decl) {
+                        splitAccumulator.add(new DeclTypedVarNode(new String(expr, st, cursor - st), expr, st, cursor - st,
+                                (Class) stk.pop(), fields | ASTNode.ASSIGN, pCtx));
+                    } else {
+                        splitAccumulator.add(new TypedVarNode(expr, st, cursor - st, fields | ASTNode.ASSIGN, (Class) stk.pop(), pCtx));
+                    }
+                } else if (stk.peek() instanceof Proto) {
+                    captureToEOS();
+                    if (decl) {
+                        splitAccumulator.add(
+                                new DeclProtoVarNode(new String(expr, st, cursor - st), (Proto) stk.pop(), fields | ASTNode.ASSIGN, pCtx));
+                    } else {
+                        splitAccumulator.add(new ProtoVarNode(expr, st, cursor - st, fields | ASTNode.ASSIGN, (Proto) stk.pop(), pCtx));
+                    }
+                } else {
+                    throw new CompileException("unknown class or illegal statement: " + lastNode.getLiteralValue(), expr, cursor);
+                }
+            } else {
+                throw new CompileException("unknown class or illegal statement: " + lastNode.getLiteralValue(), expr, cursor);
+            }
+
+            skipWhitespace();
+            if (cursor < end && expr[cursor] == ',') {
+                st = ++cursor;
+                splitAccumulator.add(new EndOfStatement(pCtx));
+            } else {
+                return (ASTNode) splitAccumulator.pop();
+            }
+        }
+    }
+
+    /**
+     * Generate a code block token.
+     *
+     * @param condStart  the start offset for the condition
+     * @param condEnd    the end offset for the condition
+     * @param blockStart the start offset for the block
+     * @param blockEnd   the end offset for the block
+     * @param type       the type of block
+     * @return and ast node
+     */
+    private ASTNode createBlockToken(final int condStart, final int condEnd, final int blockStart, final int blockEnd, int type) {
+        lastWasIdentifier = false;
+        cursor++;
+
+        if (isStatementNotManuallyTerminated()) {
+            splitAccumulator.add(new EndOfStatement(pCtx));
+        }
+
+        int condOffset = condEnd - condStart;
+        int blockOffset = blockEnd - blockStart;
+
+        if (blockOffset < 0) blockOffset = 0;
+
+        switch (type) {
+            case ASTNode.BLOCK_IF:
+                return new IfNode(expr, condStart, condOffset, blockStart, blockOffset, fields, pCtx);
+            case ASTNode.BLOCK_FOR:
+                for (int i = condStart; i < condEnd; i++) {
+                    if (expr[i] == ';') return new ForNode(expr, condStart, condOffset, blockStart, blockOffset, fields, pCtx);
+                    else if (expr[i] == ':') break;
+                }
+            case ASTNode.BLOCK_FOREACH:
+                return new ForEachNode(expr, condStart, condOffset, blockStart, blockOffset, fields, pCtx);
+            case ASTNode.BLOCK_WHILE:
+                return new WhileNode(expr, condStart, condOffset, blockStart, blockOffset, fields, pCtx);
+            case ASTNode.BLOCK_UNTIL:
+                return new UntilNode(expr, condStart, condOffset, blockStart, blockOffset, fields, pCtx);
+            case ASTNode.BLOCK_DO:
+                return new DoNode(expr, condStart, condOffset, blockStart, blockOffset, fields, pCtx);
+            case ASTNode.BLOCK_DO_UNTIL:
+                return new DoUntilNode(expr, condStart, condOffset, blockStart, blockOffset, pCtx);
+            default:
+                return new WithNode(expr, condStart, condOffset, blockStart, blockOffset, fields, pCtx);
+        }
+    }
+
+    /**
+     * Capture a code block by type.
+     *
+     * @param type the block type
+     * @return an ast node
+     */
+    private ASTNode captureCodeBlock(int type) {
+        boolean cond = true;
+
+        ASTNode first = null;
+        ASTNode tk = null;
+
+        switch (type) {
+            case ASTNode.BLOCK_IF: {
+                do {
+                    if (tk != null) {
+                        captureToNextTokenJunction();
+                        skipWhitespace();
+                        cond = expr[cursor] != '{' && expr[cursor] == 'i' && expr[++cursor] == 'f'
+                                && expr[cursor = incNextNonBlank()] == '(';
+                    }
+
+                    if (((IfNode) (tk = _captureBlock(tk, expr, cond, type))).getElseBlock() != null) {
+                        cursor++;
+                        return first;
+                    }
+
+                    if (first == null) first = tk;
+
+                    if (cursor != end && expr[cursor] != ';') {
+                        cursor++;
+                    }
+                } while (ifThenElseBlockContinues());
+
+                return first;
+            }
+
+            case ASTNode.BLOCK_DO:
+                skipWhitespace();
+                return _captureBlock(null, expr, false, type);
+
+            default: // either BLOCK_WITH or BLOCK_FOREACH
+                captureToNextTokenJunction();
+                skipWhitespace();
+                return _captureBlock(null, expr, true, type);
+        }
+    }
+
+    private ASTNode _captureBlock(ASTNode node, final char[] expr, boolean cond, int type) {
+        skipWhitespace();
+        int startCond = 0;
+        int endCond = 0;
+
+        int blockStart;
+        int blockEnd;
+
+        String name;
+
+        /**
+         * Functions are a special case we handle differently from the rest of block parsing
+         */
+        switch (type) {
+            case FUNCTION: {
+                int st = cursor;
+
+                captureToNextTokenJunction();
+
+                if (cursor == end) {
+                    throw new CompileException("unexpected end of statement", expr, st);
+                }
+
+                /**
+                 * Check to see if the name is legal.
+                 */
+                if (isReservedWord(name = createStringTrimmed(expr, st, cursor - st)) || isNotValidNameorLabel(name))
+                    throw new CompileException("illegal function name or use of reserved word", expr, cursor);
+
+                FunctionParser parser = new FunctionParser(name, cursor, end - cursor, expr, fields, pCtx, splitAccumulator);
+                Function function = parser.parse();
+                cursor = parser.getCursor();
+
+                return lastNode = function;
+            }
+            case PROTO: {
+                if (ProtoParser.isUnresolvedWaiting()) {
+                    ProtoParser.checkForPossibleUnresolvedViolations(expr, cursor, pCtx);
+                }
+
+                int st = cursor;
+                captureToNextTokenJunction();
+
+                if (isReservedWord(name = createStringTrimmed(expr, st, cursor - st)) || isNotValidNameorLabel(name))
+                    throw new CompileException("illegal prototype name or use of reserved word", expr, cursor);
+
+                if (expr[cursor = nextNonBlank()] != '{') {
+                    throw new CompileException("expected '{' but found: " + expr[cursor], expr, cursor);
+                }
+
+                cursor = balancedCaptureWithLineAccounting(expr, st = cursor + 1, end, '{', pCtx);
+
+                ProtoParser parser = new ProtoParser(expr, st, cursor, name, pCtx, fields, splitAccumulator);
+                Proto proto = parser.parse();
+
+                pCtx.addImport(proto);
+
+                proto.setCursorPosition(st, cursor);
+                cursor = parser.getCursor();
+
+                ProtoParser.notifyForLateResolution(proto);
+
+                return lastNode = proto;
+            }
+            case STACKLANG: {
+                if (expr[cursor = nextNonBlank()] != '{') {
+                    throw new CompileException("expected '{' but found: " + expr[cursor], expr, cursor);
+                }
+                int st;
+                cursor = balancedCaptureWithLineAccounting(expr, st = cursor + 1, end, '{', pCtx);
+
+                Stacklang stacklang = new Stacklang(expr, st, cursor - st, fields, pCtx);
+                cursor++;
+
+                return lastNode = stacklang;
+
+            }
+            default:
+                if (cond) {
+                    if (expr[cursor] != '(') {
+                        throw new CompileException("expected '(' but encountered: " + expr[cursor], expr, cursor);
+                    }
+
+                    /**
+                     * This block is an: IF, FOREACH or WHILE node.
+                     */
+
+                    endCond = cursor = balancedCaptureWithLineAccounting(expr, startCond = cursor, end, '(', pCtx);
+
+                    startCond++;
+                    cursor++;
+                }
+        }
+
+        skipWhitespace();
+
+        if (cursor >= end) {
+            throw new CompileException("unexpected end of statement", expr, end);
+        } else if (expr[cursor] == '{') {
+            blockEnd = cursor = balancedCaptureWithLineAccounting(expr, blockStart = cursor, end, '{', pCtx);
+        } else {
+            blockStart = cursor - 1;
+            captureToEOSorEOL();
+            blockEnd = cursor + 1;
+        }
+
+        if (type == ASTNode.BLOCK_IF) {
+            IfNode ifNode = (IfNode) node;
+
+            if (node != null) {
+                if (!cond) {
+                    return ifNode.setElseBlock(expr, st = trimRight(blockStart + 1), trimLeft(blockEnd) - st, pCtx);
+                } else {
+                    return ifNode
+                            .setElseIf((IfNode) createBlockToken(startCond, endCond, trimRight(blockStart + 1), trimLeft(blockEnd), type));
+                }
+            } else {
+                return createBlockToken(startCond, endCond, blockStart + 1, blockEnd, type);
+            }
+        } else if (type == ASTNode.BLOCK_DO) {
+            cursor++;
+            skipWhitespace();
+            st = cursor;
+            captureToNextTokenJunction();
+
+            if ("while".equals(name = new String(expr, st, cursor - st))) {
+                skipWhitespace();
+                startCond = cursor + 1;
+                endCond = cursor = balancedCaptureWithLineAccounting(expr, cursor, end, '(', pCtx);
+                return createBlockToken(startCond, endCond, trimRight(blockStart + 1), trimLeft(blockEnd), type);
+            } else if ("until".equals(name)) {
+                skipWhitespace();
+                startCond = cursor + 1;
+                endCond = cursor = balancedCaptureWithLineAccounting(expr, cursor, end, '(', pCtx);
+                return createBlockToken(startCond, endCond, trimRight(blockStart + 1), trimLeft(blockEnd), ASTNode.BLOCK_DO_UNTIL);
+            } else {
+                throw new CompileException("expected 'while' or 'until' but encountered: " + name, expr, cursor);
+            }
+        }
+        // DON"T REMOVE THIS COMMENT!
+        // else if (isFlag(ASTNode.BLOCK_FOREACH) || isFlag(ASTNode.BLOCK_WITH)) {
+        else {
+            return createBlockToken(startCond, endCond, trimRight(blockStart + 1), trimLeft(blockEnd), type);
+        }
+    }
+
+    /**
+     * Checking from the current cursor position, check to see if the if-then-else block continues.
+     *
+     * @return boolean value
+     */
+    protected boolean ifThenElseBlockContinues() {
+        if ((cursor + 4) < end) {
+            if (expr[cursor] != ';') cursor--;
+            skipWhitespace();
+
+            return expr[cursor] == 'e' && expr[cursor + 1] == 'l' && expr[cursor + 2] == 's' && expr[cursor + 3] == 'e'
+                    && (isWhitespace(expr[cursor + 4]) || expr[cursor + 4] == '{');
+        }
+        return false;
+    }
+
+    /**
+     * Checking from the current cursor position, check to see if we're inside a contiguous identifier.
+     *
+     * @return -
+     */
+    protected boolean tokenContinues() {
+        if (cursor == end) return false;
+        else if (expr[cursor] == '.' || expr[cursor] == '[') return true;
+        else if (isWhitespace(expr[cursor])) {
+            int markCurrent = cursor;
+            skipWhitespace();
+            if (cursor != end && (expr[cursor] == '.' || expr[cursor] == '[')) return true;
+            cursor = markCurrent;
+        }
+        return false;
+    }
+
+    /**
+     * The parser should find a statement ending condition when this is called, otherwise everything should blow up.
+     */
+    protected void expectEOS() {
+        skipWhitespace();
+        if (cursor != end && expr[cursor] != ';') {
+            switch (expr[cursor]) {
+                case '&':
+                    if (lookAhead() == '&') return;
+                    else break;
+                case '|':
+                    if (lookAhead() == '|') return;
+                    else break;
+                case '!':
+                    if (lookAhead() == '=') return;
+                    else break;
+
+                case '<':
+                case '>':
+                    return;
+
+                case '=': {
+                    switch (lookAhead()) {
+                        case '=':
+                        case '+':
+                        case '-':
+                        case '*':
+                            return;
+                    }
+                    break;
+                }
+
+                case '+':
+                case '-':
+                case '/':
+                case '*':
+                    if (lookAhead() == '=') return;
+                    else break;
+            }
+
+            throw new CompileException("expected end of statement but encountered: " + (cursor == end ? "<end of stream>" : expr[cursor]),
+                    expr, cursor);
+        }
+    }
+
+    /**
+     * Checks to see if the next part of the statement is an identifier part.
+     *
+     * @return boolean true if next part is identifier part.
+     */
+    protected boolean isNextIdentifier() {
+        while (cursor != end && isWhitespace(expr[cursor]))
+            cursor++;
+        return cursor != end && isIdentifierPart(expr[cursor]);
+    }
+
+    /**
+     * Capture from the current cursor position, to the end of the statement.
+     */
+    protected void captureToEOS() {
+        while (cursor != end) {
+            switch (expr[cursor]) {
+                case '(':
+                case '[':
+                case '{':
+                    if ((cursor = balancedCaptureWithLineAccounting(expr, cursor, end, expr[cursor], pCtx)) >= end) return;
+                    break;
+
+                case '"':
+                case '\'':
+                    cursor = captureStringLiteral(expr[cursor], expr, cursor, end);
+                    break;
+
+                case ',':
+                case ';':
+                case '}':
+                    return;
+            }
+            cursor++;
+        }
+    }
+
+    /**
+     * From the current cursor position, capture to the end of statement, or the end of line, whichever comes first.
+     */
+    protected void captureToEOSorEOL() {
+        while (cursor != end && (expr[cursor] != '\n' && expr[cursor] != '\r' && expr[cursor] != ';')) {
+            cursor++;
+        }
+    }
+
+    /**
+     * Capture to the end of the current identifier under the cursor.
+     */
+    protected void captureIdentifier() {
+        boolean captured = false;
+        if (cursor == end) throw new CompileException("unexpected end of statement: EOF", expr, cursor);
+        while (cursor != end) {
+            switch (expr[cursor]) {
+                case ';':
+                    return;
+
+                default: {
+                    if (!isIdentifierPart(expr[cursor])) {
+                        if (captured) return;
+                        throw new CompileException("unexpected symbol (was expecting an identifier): " + expr[cursor], expr, cursor);
+                    } else {
+                        captured = true;
+                    }
+                }
+            }
+            cursor++;
+        }
+    }
+
+    /**
+     * From the current cursor position, capture to the end of the current token.
+     */
+    protected void captureToEOT() {
+        skipWhitespace();
+        do {
+            switch (expr[cursor]) {
+                case '(':
+                case '[':
+                case '{':
+                    if ((cursor = balancedCaptureWithLineAccounting(expr, cursor, end, expr[cursor], pCtx)) == -1) {
+                        throw new CompileException("unbalanced braces", expr, cursor);
+                    }
+                    break;
+
+                case '*':
+                case '/':
+                case '+':
+                case '%':
+                case ',':
+                case '=':
+                case '&':
+                case '|':
+                case ';':
+                    return;
+
+                case '.':
+                    skipWhitespace();
+                    break;
+
+                case '\'':
+                    cursor = captureStringLiteral('\'', expr, cursor, end);
+                    break;
+                case '"':
+                    cursor = captureStringLiteral('"', expr, cursor, end);
+                    break;
+
+                default:
+                    if (isWhitespace(expr[cursor])) {
+                        skipWhitespace();
+
+                        if (cursor < end && expr[cursor] == '.') {
+                            if (cursor != end) cursor++;
+                            skipWhitespace();
+                            break;
+                        } else {
+                            trimWhitespace();
+                            return;
+                        }
+                    }
+            }
+        } while (++cursor < end);
+    }
+
+    protected boolean lastNonWhite(char c) {
+        int i = cursor - 1;
+        while (isWhitespace(expr[i]))
+            i--;
+        return c == expr[i];
+    }
+
+    /**
+     * From the specified cursor position, trim out any whitespace between the current position and the end of the
+     * last non-whitespace character.
+     *
+     * @param pos - current position
+     * @return new position.
+     */
+    protected int trimLeft(int pos) {
+        if (pos > end) pos = end;
+        while (pos > 0 && pos >= st && (isWhitespace(expr[pos - 1]) || expr[pos - 1] == ';'))
+            pos--;
+        return pos;
+    }
+
+    /**
+     * From the specified cursor position, trim out any whitespace between the current position and beginning of the
+     * first non-whitespace character.
+     *
+     * @param pos -
+     * @return -
+     */
+    protected int trimRight(int pos) {
+        while (pos != end && isWhitespace(expr[pos]))
+            pos++;
+        return pos;
+    }
+
+    /**
+     * If the cursor is currently pointing to whitespace, move the cursor forward to the first non-whitespace
+     * character, but account for carriage returns in the script (updates parser field: line).
+     */
+    protected void skipWhitespace() {
+        Skip: while (cursor != end) {
+            switch (expr[cursor]) {
+                case '\n':
+                    line++;
+                    lastLineStart = cursor;
+                case '\r':
+                    cursor++;
+                    continue;
+                case '/':
+                    if (cursor + 1 != end) {
+                        switch (expr[cursor + 1]) {
+                            case '/':
+
+                                expr[cursor++] = ' ';
+                                while (cursor != end && expr[cursor] != '\n') {
+                                    expr[cursor++] = ' ';
+                                }
+                                if (cursor != end) {
+                                    cursor++;
+                                }
+
+                                line++;
+                                lastLineStart = cursor;
+
+                                continue;
+
+                            case '*':
+                                int len = end - 1;
+                                int st = cursor;
+                                cursor++;
+
+                                while (cursor != len && !(expr[cursor] == '*' && expr[cursor + 1] == '/')) {
+                                    cursor++;
+                                }
+                                if (cursor != len) {
+                                    cursor += 2;
+                                }
+
+                                for (int i = st; i < cursor; i++) {
+                                    expr[i] = ' ';
+                                }
+
+                                continue;
+
+                            default:
+                                break Skip;
+
+                        }
+                    }
+                default:
+                    if (!isWhitespace(expr[cursor])) break Skip;
+
+            }
+            cursor++;
+        }
+    }
+
+    /**
+     * From the current cursor position, capture to the end of the next token junction.
+     */
+    protected void captureToNextTokenJunction() {
+        while (cursor != end) {
+            switch (expr[cursor]) {
+                case '{':
+                case '(':
+                    return;
+                case '/':
+                    if (expr[cursor + 1] == '*') return;
+                case '[':
+                    cursor = balancedCaptureWithLineAccounting(expr, cursor, end, '[', pCtx) + 1;
+                    continue;
+                default:
+                    if (isWhitespace(expr[cursor])) {
+                        return;
+                    }
+                    cursor++;
+            }
+        }
+    }
+
+    /**
+     * From the current cursor position, trim backward over any whitespace to the first non-whitespace character.
+     */
+    protected void trimWhitespace() {
+        while (cursor != 0 && isWhitespace(expr[cursor - 1]))
+            cursor--;
+    }
+
+    /**
+     * Set and finesse the expression, trimming an leading or proceeding whitespace.
+     *
+     * @param expression the expression
+     */
+    protected void setExpression(String expression) {
+        if (expression != null && expression.length() != 0) {
+            synchronized (EX_PRECACHE) {
+                if ((this.expr = EX_PRECACHE.get(expression)) == null) {
+                    end = length = (this.expr = expression.toCharArray()).length;
+
+                    // trim any whitespace.
+                    while (start < length && isWhitespace(expr[start]))
+                        start++;
+
+                    while (length != 0 && isWhitespace(this.expr[length - 1]))
+                        length--;
+
+                    char[] e = new char[length];
+
+                    for (int i = 0; i != e.length; i++)
+                        e[i] = expr[i];
+
+                    EX_PRECACHE.put(expression, e);
+                } else {
+                    end = length = this.expr.length;
+                }
+            }
+        }
+    }
+
+    /**
+     * Return the previous non-whitespace character.
+     *
+     * @return -
+     */
+    protected char lookToLast() {
+        if (cursor == start) return 0;
+        int temp = cursor;
+        for (;;) {
+            if (temp == start || !isWhitespace(expr[--temp])) break;
+        }
+        return expr[temp];
+    }
+
+    /**
+     * Return the last character (delta -1 of cursor position).
+     *
+     * @return -
+     */
+    protected char lookBehind() {
+        if (cursor == start) return 0;
+        else return expr[cursor - 1];
+    }
+
+    /**
+     * Return the next character (delta 1 of cursor position).
+     *
+     * @return -
+     */
+    protected char lookAhead() {
+        if (cursor + 1 != end) {
+            return expr[cursor + 1];
+        } else {
+            return 0;
+        }
+    }
+
+    /**
+     * Return the character, forward of the currrent cursor position based on the specified range delta.
+     *
+     * @param range -
+     * @return -
+     */
+    protected char lookAhead(int range) {
+        if ((cursor + range) >= end) return 0;
+        else {
+            return expr[cursor + range];
+        }
+    }
+
+    /**
+     * Returns true if the next is an identifier or literal.
+     *
+     * @return true of false
+     */
+    protected boolean isNextIdentifierOrLiteral() {
+        int tmp = cursor;
+        if (tmp == end) return false;
+        else {
+            while (tmp != end && isWhitespace(expr[tmp]))
+                tmp++;
+            if (tmp == end) return false;
+            char n = expr[tmp];
+            return isIdentifierPart(n) || isDigit(n) || n == '\'' || n == '"';
+        }
+    }
+
+    /**
+     * Increment one cursor position, and move cursor to next non-blank part.
+     *
+     * @return cursor position
+     */
+    public int incNextNonBlank() {
+        cursor++;
+        return nextNonBlank();
+    }
+
+    /**
+     * Move to next cursor position from current cursor position.
+     *
+     * @return cursor position
+     */
+    public int nextNonBlank() {
+        if ((cursor + 1) >= end) {
+            throw new CompileException("unexpected end of statement", expr, st);
+        }
+        int i = cursor;
+        while (i != end && isWhitespace(expr[i]))
+            i++;
+        return i;
+    }
+
+    /**
+     * Expect the next specified character or fail
+     *
+     * @param c character
+     */
+    public void expectNextChar_IW(char c) {
+        nextNonBlank();
+        if (cursor == end) throw new CompileException("unexpected end of statement", expr, st);
+        if (expr[cursor] != c) throw new CompileException("unexpected character ('" + expr[cursor] + "'); was expecting: " + c, expr, st);
+    }
+
+    /**
+     * NOTE: This method assumes that the current position of the cursor is at the end of a logical statement, to
+     * begin with.
+     * <p/>
+     * Determines whether or not the logical statement is manually terminated with a statement separator (';').
+     *
+     * @return -
+     */
+    protected boolean isStatementNotManuallyTerminated() {
+        if (cursor >= end) return false;
+        int c = cursor;
+        while (c != end && isWhitespace(expr[c]))
+            c++;
+        return !(c != end && expr[c] == ';');
+    }
+
+    protected void addFatalError(String message) {
+        pCtx.addError(new ErrorDetail(expr, st, true, message));
+    }
+
+    protected void addFatalError(String message, int start) {
+        pCtx.addError(new ErrorDetail(expr, start, true, message));
+    }
+
+    /**
+     * Reduce the current operations on the stack.
+     *
+     * @param operator the operator
+     * @return a stack control code
+     */
+    protected int arithmeticFunctionReduction(int operator) {
+        ASTNode tk;
+        int operator2;
+
+        /**
+         * If the next token is an operator, we check to see if it has a higher
+         * precdence.
+         */
+        if ((tk = nextToken()) != null) {
+            if (isArithmeticOperator(operator2 = tk.getOperator()) && PTABLE[operator2] > PTABLE[operator]) {
+                stk.xswap();
+                /**
+                 * The current arith. operator is of higher precedence the last.
+                 */
+
+                tk = nextToken();
+
+                /**
+                 * Check to see if we're compiling or executing interpretively.  If we're compiling, we really
+                 * need to stop if this is not a literal.
+                 */
+                if (compileMode && !tk.isLiteral()) {
+                    splitAccumulator.push(tk, new OperatorNode(operator2, expr, st, pCtx));
+                    return OP_OVERFLOW;
+                }
+
+                dStack.push(operator = operator2, tk.getReducedValue(ctx, ctx, variableFactory));
+
+                while (true) {
+                    ASTNode previousToken = tk;
+                    // look ahead again
+                    if ((tk = nextToken()) != null && (operator2 = tk.getOperator()) != -1 && operator2 != END_OF_STMT
+                            && PTABLE[operator2] > PTABLE[operator]) {
+                        // if we have back to back operations on the stack, we don't xswap
+
+                        if (dStack.isReduceable()) {
+                            stk.copyx2(dStack);
+                        }
+
+                        /**
+                         * This operator is of higher precedence, or the same level precedence.  push to the RHS.
+                         */
+                        ASTNode nextToken = nextToken();
+                        if (compileMode && !nextToken.isLiteral()) {
+                            splitAccumulator.push(nextToken, new OperatorNode(operator2, expr, st, pCtx));
+                            return OP_OVERFLOW;
+                        }
+                        dStack.push(operator = operator2, nextToken.getReducedValue(ctx, ctx, variableFactory));
+
+                        continue;
+                    } else if (tk != null && operator2 != -1 && operator2 != END_OF_STMT) {
+                        if (PTABLE[operator2] == PTABLE[operator]) {
+                            if (!dStack.isEmpty()) dreduce();
+                            else {
+                                while (stk.isReduceable()) {
+                                    stk.xswap_op();
+                                }
+                            }
+
+                            /**
+                             * This operator is of the same level precedence.  push to the RHS.
+                             */
+
+                            dStack.push(operator = operator2, nextToken().getReducedValue(ctx, ctx, variableFactory));
+
+                            continue;
+                        } else {
+                            /**
+                             * The operator doesn't have higher precedence. Therfore reduce the LHS.
+                             */
+                            while (dStack.size() > 1) {
+                                dreduce();
+                            }
+
+                            operator = tk.getOperator();
+                            // Reduce the lesser or equal precedence operations.
+                            while (stk.size() != 1 && stk.peek2() instanceof Integer
+                                    && ((operator2 = (Integer) stk.peek2()) < PTABLE.length) && PTABLE[operator2] >= PTABLE[operator]) {
+                                stk.xswap_op();
+                            }
+                        }
+                    } else {
+                        /**
+                         * There are no more tokens.
+                         */
+
+                        if (dStack.size() > 1) {
+                            dreduce();
+                        }
+
+                        if (stk.isReduceable()) stk.xswap();
+
+                        break;
+                    }
+
+                    if ((tk = nextToken()) != null) {
+                        switch (operator) {
+                            case AND: {
+                                if (!(stk.peekBoolean())) return OP_TERMINATE;
+                                else {
+                                    splitAccumulator.add(tk);
+                                    return AND;
+                                }
+                            }
+                            case OR: {
+                                if ((stk.peekBoolean())) return OP_TERMINATE;
+                                else {
+                                    splitAccumulator.add(tk);
+                                    return OR;
+                                }
+                            }
+
+                            default:
+                                if (compileMode && !tk.isLiteral()) {
+                                    stk.push(operator, tk);
+                                    return OP_NOT_LITERAL;
+                                }
+                                stk.push(operator, tk.getReducedValue(ctx, ctx, variableFactory));
+                        }
+                    }
+                }
+            } else if (!tk.isOperator()) {
+                throw new CompileException("unexpected token: " + tk.getName(), expr, st);
+            } else {
+                reduce();
+                splitAccumulator.push(tk);
+            }
+        }
+
+        // while any values remain on the stack
+        // keep XSWAPing and reducing, until there is nothing left.
+        if (stk.isReduceable()) {
+            while (true) {
+                reduce();
+                if (stk.isReduceable()) {
+                    stk.xswap();
+                } else {
+                    break;
+                }
+            }
+        }
+
+        return OP_RESET_FRAME;
+    }
+
+    private void dreduce() {
+        stk.copy2(dStack);
+        stk.op();
+    }
+
+    /**
+     * This method is called when we reach the point where we must subEval a trinary operation in the expression.
+     * (ie. val1 op val2).  This is not the same as a binary operation, although binary operations would appear
+     * to have 3 structures as well.  A binary structure (or also a junction in the expression) compares the
+     * current state against 2 downrange structures (usually an op and a val).
+     */
+    protected void reduce() {
+        Object v1, v2;
+        int operator;
+        try {
+            switch (operator = (Integer) stk.pop()) {
+                case ADD:
+                case SUB:
+                case DIV:
+                case MULT:
+                case MOD:
+                case EQUAL:
+                case NEQUAL:
+                case GTHAN:
+                case LTHAN:
+                case GETHAN:
+                case LETHAN:
+                case POWER:
+                    stk.op(operator);
+                    break;
+
+                case AND:
+                    v1 = stk.pop();
+                    stk.push(((Boolean) stk.pop()) && ((Boolean) v1));
+                    break;
+
+                case OR:
+                    v1 = stk.pop();
+                    stk.push(((Boolean) stk.pop()) || ((Boolean) v1));
+                    break;
+
+                case CHOR:
+                    v1 = stk.pop();
+                    if (!isEmpty(v2 = stk.pop()) || !isEmpty(v1)) {
+                        stk.clear();
+                        stk.push(!isEmpty(v2) ? v2 : v1);
+                        return;
+                    } else stk.push(null);
+                    break;
+
+                case REGEX:
+                    stk.push(java.util.regex.Pattern.compile(String.valueOf(stk.pop()))
+                            .matcher(String.valueOf(stk.pop())).matches());
+                    break;
+
+                case INSTANCEOF:
+                    stk.push(((Class) stk.pop()).isInstance(stk.pop()));
+                    break;
+
+                case CONVERTABLE_TO:
+                    stk.push(org.mvel2.DataConversion.canConvert(stk.peek2().getClass(), (Class) stk.pop2()));
+                    break;
+
+                case CONTAINS:
+                    stk.push(containsCheck(stk.peek2(), stk.pop2()));
+                    break;
+
+                case SOUNDEX:
+                    stk.push(soundex(String.valueOf(stk.pop())).equals(soundex(String.valueOf(stk.pop()))));
+                    break;
+
+                case SIMILARITY:
+                    stk.push(similarity(String.valueOf(stk.pop()), String.valueOf(stk.pop())));
+                    break;
+
+                default:
+                    reduceNumeric(operator);
+            }
+        } catch (ClassCastException e) {
+            throw new CompileException("syntax error or incompatable types", expr, st, e);
+        } catch (ArithmeticException e) {
+            throw new CompileException("arithmetic error: " + e.getMessage(), expr, st, e);
+        } catch (Exception e) {
+            throw new CompileException("failed to subEval expression", expr, st, e);
+        }
+    }
+
+    private void reduceNumeric(int operator) {
+        Object op1 = stk.peek2();
+        Object op2 = stk.pop2();
+        if (op1 instanceof Integer) {
+            if (op2 instanceof Integer) {
+                reduce((Integer) op1, operator, (Integer) op2);
+            } else {
+                reduce((Integer) op1, operator, (Long) op2);
+            }
+        } else {
+            if (op2 instanceof Integer) {
+                reduce((Long) op1, operator, (Integer) op2);
+            } else {
+                reduce((Long) op1, operator, (Long) op2);
+            }
+        }
+    }
+
+    private void reduce(int op1, int operator, int op2) {
+        switch (operator) {
+            case BW_AND:
+                stk.push(op1 & op2);
+                break;
+
+            case BW_OR:
+                stk.push(op1 | op2);
+                break;
+
+            case BW_XOR:
+                stk.push(op1 ^ op2);
+                break;
+
+            case BW_SHIFT_LEFT:
+                stk.push(op1 << op2);
+                break;
+
+            case BW_USHIFT_LEFT:
+                int iv2 = op1;
+                if (iv2 < 0) iv2 *= -1;
+                stk.push(iv2 << op2);
+                break;
+
+            case BW_SHIFT_RIGHT:
+                stk.push(op1 >> op2);
+                break;
+
+            case BW_USHIFT_RIGHT:
+                stk.push(op1 >>> op2);
+                break;
+        }
+    }
+
+    private void reduce(int op1, int operator, long op2) {
+        switch (operator) {
+            case BW_AND:
+                stk.push(op1 & op2);
+                break;
+
+            case BW_OR:
+                stk.push(op1 | op2);
+                break;
+
+            case BW_XOR:
+                stk.push(op1 ^ op2);
+                break;
+
+            case BW_SHIFT_LEFT:
+                stk.push(op1 << op2);
+                break;
+
+            case BW_USHIFT_LEFT:
+                int iv2 = op1;
+                if (iv2 < 0) iv2 *= -1;
+                stk.push(iv2 << op2);
+                break;
+
+            case BW_SHIFT_RIGHT:
+                stk.push(op1 >> op2);
+                break;
+
+            case BW_USHIFT_RIGHT:
+                stk.push(op1 >>> op2);
+                break;
+        }
+    }
+
+    private void reduce(long op1, int operator, int op2) {
+        switch (operator) {
+            case BW_AND:
+                stk.push(op1 & op2);
+                break;
+
+            case BW_OR:
+                stk.push(op1 | op2);
+                break;
+
+            case BW_XOR:
+                stk.push(op1 ^ op2);
+                break;
+
+            case BW_SHIFT_LEFT:
+                stk.push(op1 << op2);
+                break;
+
+            case BW_USHIFT_LEFT:
+                long iv2 = op1;
+                if (iv2 < 0) iv2 *= -1;
+                stk.push(iv2 << op2);
+                break;
+
+            case BW_SHIFT_RIGHT:
+                stk.push(op1 >> op2);
+                break;
+
+            case BW_USHIFT_RIGHT:
+                stk.push(op1 >>> op2);
+                break;
+        }
+    }
+
+    private void reduce(long op1, int operator, long op2) {
+        switch (operator) {
+            case BW_AND:
+                stk.push(op1 & op2);
+                break;
+
+            case BW_OR:
+                stk.push(op1 | op2);
+                break;
+
+            case BW_XOR:
+                stk.push(op1 ^ op2);
+                break;
+
+            case BW_SHIFT_LEFT:
+                stk.push(op1 << op2);
+                break;
+
+            case BW_USHIFT_LEFT:
+                long iv2 = op1;
+                if (iv2 < 0) iv2 *= -1;
+                stk.push(iv2 << op2);
+                break;
+
+            case BW_SHIFT_RIGHT:
+                stk.push(op1 >> op2);
+                break;
+
+            case BW_USHIFT_RIGHT:
+                stk.push(op1 >>> op2);
+                break;
+        }
+    }
+
+    public int getCursor() {
+        return cursor;
+    }
+
+    public char[] getExpression() {
+        return expr;
+    }
+
+    /**
+     * Set and finesse the expression, trimming an leading or proceeding whitespace.
+     *
+     * @param expression the expression
+     */
+    protected void setExpression(char[] expression) {
+        end = length = (this.expr = expression).length;
+        while (start < length && isWhitespace(expr[start]))
+            start++;
+        while (length != 0 && isWhitespace(this.expr[length - 1]))
+            length--;
+    }
+}

--- a/core/src/main/java/org/mvel2/compiler/Accessor.java
+++ b/core/src/main/java/org/mvel2/compiler/Accessor.java
@@ -1,0 +1,30 @@
+/**
+ * MVEL 2.0
+ * Copyright (C) 2007 The Codehaus
+ * Mike Brock, Dhanji Prasanna, John Graham, Mark Proctor
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mvel2.compiler;
+
+import org.mvel2.integration.VariableResolverFactory;
+
+public interface Accessor {
+
+    public Object getValue(Object ctx, Object elCtx, VariableResolverFactory variableFactory);
+
+    public Object setValue(Object ctx, Object elCtx, VariableResolverFactory variableFactory, Object value);
+
+    public Class getKnownEgressType();
+}

--- a/core/src/main/java/org/mvel2/compiler/AccessorNode.java
+++ b/core/src/main/java/org/mvel2/compiler/AccessorNode.java
@@ -1,0 +1,28 @@
+/**
+ * MVEL 2.0
+ * Copyright (C) 2007 The Codehaus
+ * Mike Brock, Dhanji Prasanna, John Graham, Mark Proctor
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mvel2.compiler;
+
+import java.io.Serializable;
+
+public interface AccessorNode extends Accessor, Serializable {
+
+    public AccessorNode getNextNode();
+
+    public AccessorNode setNextNode(AccessorNode accessorNode);
+}

--- a/core/src/main/java/org/mvel2/compiler/BlankLiteral.java
+++ b/core/src/main/java/org/mvel2/compiler/BlankLiteral.java
@@ -1,0 +1,57 @@
+/**
+ * MVEL 2.0
+ * Copyright (C) 2007 The Codehaus
+ * Mike Brock, Dhanji Prasanna, John Graham, Mark Proctor
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mvel2.compiler;
+
+import static java.lang.String.valueOf;
+import static java.lang.reflect.Array.getLength;
+import static org.mvel2.util.ParseTools.isNumeric;
+
+import java.io.Serializable;
+import java.util.Collection;
+
+public class BlankLiteral implements Serializable {
+
+    public static final BlankLiteral INSTANCE = new BlankLiteral();
+
+    public BlankLiteral() {
+    }
+
+    public boolean equals(Object obj) {
+        if (obj == null || valueOf(obj).trim().length() == 0) {
+            return true;
+        }
+        if (isNumeric(obj)) {
+            return "0".equals(valueOf(obj));
+        }
+        if (obj instanceof Collection) {
+            return ((Collection) obj).size() == 0;
+        }
+        if (obj.getClass().isArray()) {
+            return getLength(obj) == 0;
+        }
+        if (obj instanceof Boolean) {
+            return !(Boolean) obj;
+        }
+        return false;
+    }
+
+    public String toString() {
+        return "";
+    }
+}

--- a/core/src/main/java/org/mvel2/compiler/CompiledAccExpression.java
+++ b/core/src/main/java/org/mvel2/compiler/CompiledAccExpression.java
@@ -1,0 +1,132 @@
+/**
+ * MVEL 2.0
+ * Copyright (C) 2007 The Codehaus
+ * Mike Brock, Dhanji Prasanna, John Graham, Mark Proctor
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mvel2.compiler;
+
+import static org.mvel2.optimizers.OptimizerFactory.getThreadAccessorOptimizer;
+
+import java.io.Serializable;
+
+import org.mvel2.ParserContext;
+import org.mvel2.integration.VariableResolverFactory;
+import org.mvel2.optimizers.OptimizerFactory;
+
+public class CompiledAccExpression implements ExecutableStatement, Serializable {
+
+    private char[] expression;
+    private int start;
+    private int offset;
+
+    private transient Accessor accessor;
+    private ParserContext context;
+    private Class ingressType;
+
+    public CompiledAccExpression(char[] expression, Class ingressType, ParserContext context) {
+        this(expression, 0, expression.length, ingressType, context);
+    }
+
+    public CompiledAccExpression(char[] expression, int start, int offset, Class ingressType, ParserContext context) {
+        this.expression = expression;
+        this.start = start;
+        this.offset = offset;
+
+        this.context = context;
+        this.ingressType = ingressType != null ? ingressType : Object.class;
+    }
+
+    public Object setValue(Object ctx, Object elCtx, VariableResolverFactory vrf, Object value) {
+        if (accessor == null) {
+            if (ingressType == Object.class && value != null) ingressType = value.getClass();
+            accessor = getThreadAccessorOptimizer().optimizeSetAccessor(context, expression, 0, expression.length, ctx, ctx, vrf, false,
+                    value, ingressType);
+
+        } else {
+            accessor.setValue(ctx, elCtx, vrf, value);
+        }
+        return value;
+    }
+
+    public Object getValue(Object staticContext, VariableResolverFactory factory) {
+        if (accessor == null) {
+            try {
+                accessor = getThreadAccessorOptimizer().optimizeAccessor(context, expression, 0, expression.length, staticContext,
+                        staticContext, factory, false, ingressType);
+                return getValue(staticContext, factory);
+            } finally {
+                OptimizerFactory.clearThreadAccessorOptimizer();
+            }
+        }
+        return accessor.getValue(staticContext, staticContext, factory);
+    }
+
+    public Class getKnownIngressType() {
+        return ingressType;
+    }
+
+    public void setKnownIngressType(Class type) {
+        this.ingressType = type;
+    }
+
+    public Class getKnownEgressType() {
+        return null;
+    }
+
+    public void setKnownEgressType(Class type) {
+
+    }
+
+    public boolean isConvertableIngressEgress() {
+        return false;
+    }
+
+    public void computeTypeConversionRule() {
+    }
+
+    public boolean intOptimized() {
+        return false;
+    }
+
+    public boolean isLiteralOnly() {
+        return false;
+    }
+
+    public Object getValue(Object ctx, Object elCtx, VariableResolverFactory variableFactory) {
+        if (accessor == null) {
+            try {
+                accessor = getThreadAccessorOptimizer().optimizeAccessor(context, expression, start, offset, ctx, elCtx, variableFactory,
+                        false, ingressType);
+                return getValue(ctx, elCtx, variableFactory);
+            } finally {
+                OptimizerFactory.clearThreadAccessorOptimizer();
+            }
+        }
+        return accessor.getValue(ctx, elCtx, variableFactory);
+    }
+
+    public Accessor getAccessor() {
+        return accessor;
+    }
+
+    public boolean isEmptyStatement() {
+        return accessor == null;
+    }
+
+    public boolean isExplicitCast() {
+        return false;
+    }
+}

--- a/core/src/main/java/org/mvel2/compiler/CompiledExpression.java
+++ b/core/src/main/java/org/mvel2/compiler/CompiledExpression.java
@@ -1,0 +1,181 @@
+/**
+ * MVEL 2.0
+ * Copyright (C) 2007 The Codehaus
+ * Mike Brock, Dhanji Prasanna, John Graham, Mark Proctor
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mvel2.compiler;
+
+import static org.mvel2.MVELRuntime.execute;
+import static org.mvel2.optimizers.OptimizerFactory.setThreadAccessorOptimizer;
+
+import java.io.Serializable;
+
+import org.mvel2.ParserConfiguration;
+import org.mvel2.ast.ASTNode;
+import org.mvel2.ast.TypeCast;
+import org.mvel2.integration.VariableResolverFactory;
+import org.mvel2.integration.impl.ClassImportResolverFactory;
+import org.mvel2.integration.impl.StackResetResolverFactory;
+import org.mvel2.optimizers.AccessorOptimizer;
+import org.mvel2.optimizers.OptimizerFactory;
+import org.mvel2.util.ASTLinkedList;
+
+public class CompiledExpression implements Serializable, ExecutableStatement {
+
+    private ASTNode firstNode;
+
+    private Class knownEgressType;
+    private Class knownIngressType;
+
+    private boolean convertableIngressEgress;
+    private boolean optimized = false;
+    private boolean importInjectionRequired = false;
+    private boolean literalOnly;
+
+    private Class<? extends AccessorOptimizer> accessorOptimizer;
+
+    private String sourceName;
+
+    private ParserConfiguration parserConfiguration;
+
+    public CompiledExpression(ASTLinkedList astMap, String sourceName, Class egressType, ParserConfiguration parserConfiguration,
+            boolean literalOnly) {
+        this.firstNode = astMap.firstNode();
+        this.sourceName = sourceName;
+        this.knownEgressType = astMap.isSingleNode() ? astMap.firstNonSymbol().getEgressType() : egressType;
+        this.literalOnly = literalOnly;
+        this.parserConfiguration = parserConfiguration;
+        this.importInjectionRequired = !parserConfiguration.getImports().isEmpty();
+    }
+
+    public ASTNode getFirstNode() {
+        return firstNode;
+    }
+
+    public boolean isSingleNode() {
+        return firstNode != null && firstNode.nextASTNode == null;
+    }
+
+    public Class getKnownEgressType() {
+        return knownEgressType;
+    }
+
+    public void setKnownEgressType(Class knownEgressType) {
+        this.knownEgressType = knownEgressType;
+    }
+
+    public Class getKnownIngressType() {
+        return knownIngressType;
+    }
+
+    public void setKnownIngressType(Class knownIngressType) {
+        this.knownIngressType = knownIngressType;
+    }
+
+    public boolean isConvertableIngressEgress() {
+        return convertableIngressEgress;
+    }
+
+    public void computeTypeConversionRule() {
+        if (knownIngressType != null && knownEgressType != null) {
+            convertableIngressEgress = knownIngressType.isAssignableFrom(knownEgressType);
+        }
+    }
+
+    public Object getValue(Object ctx, Object elCtx, VariableResolverFactory variableFactory) {
+        if (!optimized) {
+            setupOptimizers();
+            try {
+                return getValue(ctx, variableFactory);
+            } finally {
+                OptimizerFactory.clearThreadAccessorOptimizer();
+            }
+        }
+        return getValue(ctx, variableFactory);
+    }
+
+    public Object getValue(Object staticContext, VariableResolverFactory factory) {
+        if (!optimized) {
+            setupOptimizers();
+            try {
+                return getValue(staticContext, factory);
+            } finally {
+                OptimizerFactory.clearThreadAccessorOptimizer();
+            }
+        }
+        return getDirectValue(staticContext, factory);
+    }
+
+    public Object getDirectValue(Object staticContext, VariableResolverFactory factory) {
+        return execute(false, this, staticContext, importInjectionRequired ? new ClassImportResolverFactory(parserConfiguration, factory,
+                true) : new StackResetResolverFactory(factory));
+    }
+
+    private void setupOptimizers() {
+        if (accessorOptimizer != null) setThreadAccessorOptimizer(accessorOptimizer);
+        optimized = true;
+    }
+
+    public boolean isOptimized() {
+        return optimized;
+    }
+
+    public Class<? extends AccessorOptimizer> getAccessorOptimizer() {
+        return accessorOptimizer;
+    }
+
+    public String getSourceName() {
+        return sourceName;
+    }
+
+    public boolean intOptimized() {
+        return false;
+    }
+
+    public ParserConfiguration getParserConfiguration() {
+        return parserConfiguration;
+    }
+
+    public boolean isImportInjectionRequired() {
+        return importInjectionRequired;
+    }
+
+    public Object setValue(Object ctx, Object elCtx, VariableResolverFactory variableFactory, Object value) {
+        return null;
+    }
+
+    public boolean isLiteralOnly() {
+        return literalOnly;
+    }
+
+    public boolean isEmptyStatement() {
+        return firstNode == null;
+    }
+
+    public boolean isExplicitCast() {
+        return firstNode != null && firstNode instanceof TypeCast;
+    }
+
+    public String toString() {
+        StringBuilder appender = new StringBuilder();
+        ASTNode node = firstNode;
+        while (node != null) {
+            appender.append(node.toString()).append(";\n");
+            node = node.nextASTNode;
+        }
+        return appender.toString();
+    }
+}

--- a/core/src/main/java/org/mvel2/compiler/EndWithValue.java
+++ b/core/src/main/java/org/mvel2/compiler/EndWithValue.java
@@ -1,0 +1,35 @@
+/**
+ * MVEL 2.0
+ * Copyright (C) 2007 The Codehaus
+ * Mike Brock, Dhanji Prasanna, John Graham, Mark Proctor
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mvel2.compiler;
+
+/**
+ * @author Christopher Brock
+ */
+public class EndWithValue extends RuntimeException {
+
+    private Object value;
+
+    public EndWithValue(Object value) {
+        this.value = value;
+    }
+
+    public Object getValue() {
+        return value;
+    }
+}

--- a/core/src/main/java/org/mvel2/compiler/ExecutableAccessor.java
+++ b/core/src/main/java/org/mvel2/compiler/ExecutableAccessor.java
@@ -1,0 +1,100 @@
+/**
+ * MVEL 2.0
+ * Copyright (C) 2007 The Codehaus
+ * Mike Brock, Dhanji Prasanna, John Graham, Mark Proctor
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mvel2.compiler;
+
+import org.mvel2.ast.ASTNode;
+import org.mvel2.ast.TypeCast;
+import org.mvel2.integration.VariableResolverFactory;
+
+public class ExecutableAccessor implements ExecutableStatement {
+
+    private ASTNode node;
+
+    private Class ingress;
+    private Class egress;
+    private boolean convertable;
+
+    public ExecutableAccessor(ASTNode node, Class egress) {
+        this.node = node;
+        this.egress = egress;
+    }
+
+    public Object getValue(Object ctx, Object elCtx, VariableResolverFactory variableFactory) {
+        return node.getReducedValueAccelerated(ctx, elCtx, variableFactory);
+    }
+
+    public Object getValue(Object staticContext, VariableResolverFactory factory) {
+        return node.getReducedValueAccelerated(staticContext, staticContext, factory);
+    }
+
+    public Class getKnownIngressType() {
+        return ingress;
+    }
+
+    public void setKnownIngressType(Class type) {
+        this.ingress = type;
+    }
+
+    public Class getKnownEgressType() {
+        return egress;
+    }
+
+    public void setKnownEgressType(Class type) {
+        this.egress = type;
+    }
+
+    public boolean isConvertableIngressEgress() {
+        return convertable;
+    }
+
+    public void computeTypeConversionRule() {
+        if (ingress != null && egress != null) {
+            convertable = ingress.isAssignableFrom(egress);
+        }
+    }
+
+    public boolean intOptimized() {
+        return false;
+    }
+
+    public ASTNode getNode() {
+        return node;
+    }
+
+    public Object setValue(Object ctx, Object elCtx, VariableResolverFactory variableFactory, Object value) {
+        return null;
+    }
+
+    public boolean isLiteralOnly() {
+        return false;
+    }
+
+    public boolean isExplicitCast() {
+        return node instanceof TypeCast;
+    }
+
+    public boolean isEmptyStatement() {
+        return node == null;
+    }
+
+    @Override
+    public String toString() {
+        return node.toString();
+    }
+}

--- a/core/src/main/java/org/mvel2/compiler/ExecutableAccessorSafe.java
+++ b/core/src/main/java/org/mvel2/compiler/ExecutableAccessorSafe.java
@@ -1,0 +1,100 @@
+/**
+ * MVEL 2.0
+ * Copyright (C) 2007 The Codehaus
+ * Mike Brock, Dhanji Prasanna, John Graham, Mark Proctor
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mvel2.compiler;
+
+import org.mvel2.ast.ASTNode;
+import org.mvel2.ast.Safe;
+import org.mvel2.ast.TypeCast;
+import org.mvel2.integration.VariableResolverFactory;
+
+public class ExecutableAccessorSafe implements ExecutableStatement, Safe {
+
+    private ASTNode node;
+
+    private Class ingress;
+    private Class egress;
+    private boolean convertable;
+
+    public ExecutableAccessorSafe(ASTNode node) {
+        this.node = node;
+    }
+
+    public ExecutableAccessorSafe(ASTNode node, Class returnType) {
+        this.node = node;
+        this.egress = returnType;
+    }
+
+    public Object getValue(Object ctx, Object elCtx, VariableResolverFactory variableFactory) {
+        return node.getReducedValueAccelerated(ctx, elCtx, variableFactory);
+    }
+
+    public Object getValue(Object staticContext, VariableResolverFactory factory) {
+        return node.getReducedValueAccelerated(staticContext, staticContext, factory);
+    }
+
+    public Class getKnownIngressType() {
+        return ingress;
+    }
+
+    public void setKnownIngressType(Class type) {
+        this.ingress = type;
+    }
+
+    public Class getKnownEgressType() {
+        return egress;
+    }
+
+    public void setKnownEgressType(Class type) {
+        this.egress = type;
+    }
+
+    public boolean isConvertableIngressEgress() {
+        return convertable;
+    }
+
+    public void computeTypeConversionRule() {
+        if (ingress != null && egress != null) {
+            convertable = ingress.isAssignableFrom(egress);
+        }
+    }
+
+    public boolean intOptimized() {
+        return false;
+    }
+
+    public ASTNode getNode() {
+        return node;
+    }
+
+    public Object setValue(Object ctx, Object elCtx, VariableResolverFactory variableFactory, Object value) {
+        return null;
+    }
+
+    public boolean isLiteralOnly() {
+        return false;
+    }
+
+    public boolean isEmptyStatement() {
+        return node == null;
+    }
+
+    public boolean isExplicitCast() {
+        return node != null && node instanceof TypeCast;
+    }
+}

--- a/core/src/main/java/org/mvel2/compiler/ExecutableLiteral.java
+++ b/core/src/main/java/org/mvel2/compiler/ExecutableLiteral.java
@@ -1,0 +1,106 @@
+/**
+ * MVEL 2.0
+ * Copyright (C) 2007 The Codehaus
+ * Mike Brock, Dhanji Prasanna, John Graham, Mark Proctor
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mvel2.compiler;
+
+import org.mvel2.ast.Safe;
+import org.mvel2.integration.VariableResolverFactory;
+
+/**
+ * @author Christopher Brock
+ */
+public class ExecutableLiteral implements ExecutableStatement, Safe {
+
+    private Object literal;
+    private int integer32;
+    private boolean intOptimized;
+
+    public ExecutableLiteral(Object literal) {
+        if ((this.literal = literal) instanceof Integer) this.integer32 = (Integer) literal;
+    }
+
+    public ExecutableLiteral(int literal) {
+        this.literal = this.integer32 = literal;
+        this.intOptimized = true;
+    }
+
+    public int getInteger32() {
+        return integer32;
+    }
+
+    public void setInteger32(int integer32) {
+        this.integer32 = integer32;
+    }
+
+    public Object getValue(Object staticContext, VariableResolverFactory factory) {
+        return literal;
+    }
+
+    public Class getKnownIngressType() {
+        return null;
+    }
+
+    public void setKnownIngressType(Class type) {
+
+    }
+
+    public Class getKnownEgressType() {
+        return this.literal == null ? Object.class : this.literal.getClass();
+    }
+
+    public void setKnownEgressType(Class type) {
+
+    }
+
+    public boolean isConvertableIngressEgress() {
+        return false;
+    }
+
+    public void computeTypeConversionRule() {
+
+    }
+
+    public Object getValue(Object ctx, Object elCtx, VariableResolverFactory variableFactory) {
+        return literal;
+    }
+
+    public Object getLiteral() {
+        return literal;
+    }
+
+    public boolean intOptimized() {
+        return intOptimized;
+    }
+
+    public Object setValue(Object ctx, Object elCtx, VariableResolverFactory variableFactory, Object value) {
+        // not implemented
+        return null;
+    }
+
+    public boolean isLiteralOnly() {
+        return true;
+    }
+
+    public boolean isEmptyStatement() {
+        return false;
+    }
+
+    public boolean isExplicitCast() {
+        return false;
+    }
+}

--- a/core/src/main/java/org/mvel2/compiler/ExecutableStatement.java
+++ b/core/src/main/java/org/mvel2/compiler/ExecutableStatement.java
@@ -1,0 +1,48 @@
+/**
+ * MVEL 2.0
+ * Copyright (C) 2007 The Codehaus
+ * Mike Brock, Dhanji Prasanna, John Graham, Mark Proctor
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mvel2.compiler;
+
+import java.io.Serializable;
+
+import org.mvel2.integration.VariableResolverFactory;
+
+public interface ExecutableStatement extends Accessor, Serializable, Cloneable {
+
+    public Object getValue(Object staticContext, VariableResolverFactory factory);
+
+    public Class getKnownIngressType();
+
+    public void setKnownIngressType(Class type);
+
+    public Class getKnownEgressType();
+
+    public void setKnownEgressType(Class type);
+
+    public boolean isExplicitCast();
+
+    public boolean isConvertableIngressEgress();
+
+    public void computeTypeConversionRule();
+
+    public boolean intOptimized();
+
+    public boolean isLiteralOnly();
+
+    public boolean isEmptyStatement();
+}

--- a/core/src/main/java/org/mvel2/compiler/ExpressionCompiler.java
+++ b/core/src/main/java/org/mvel2/compiler/ExpressionCompiler.java
@@ -1,0 +1,540 @@
+/**
+ * MVEL 2.0
+ * Copyright (C) 2007 The Codehaus
+ * Mike Brock, Dhanji Prasanna, John Graham, Mark Proctor
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mvel2.compiler;
+
+import static org.mvel2.DataConversion.canConvert;
+import static org.mvel2.DataConversion.convert;
+import static org.mvel2.Operator.PTABLE;
+import static org.mvel2.ast.ASTNode.COMPILE_IMMEDIATE;
+import static org.mvel2.ast.ASTNode.OPT_SUBTR;
+import static org.mvel2.util.CompilerTools.finalizePayload;
+import static org.mvel2.util.CompilerTools.signNumber;
+import static org.mvel2.util.ParseTools.subCompileExpression;
+import static org.mvel2.util.ParseTools.unboxPrimitive;
+
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+
+import org.mvel2.CompileException;
+import org.mvel2.ErrorDetail;
+import org.mvel2.MVEL;
+import org.mvel2.Operator;
+import org.mvel2.ParserContext;
+import org.mvel2.ast.ASTNode;
+import org.mvel2.ast.Assignment;
+import org.mvel2.ast.LiteralNode;
+import org.mvel2.ast.NewObjectNode;
+import org.mvel2.ast.OperatorNode;
+import org.mvel2.ast.Substatement;
+import org.mvel2.ast.Union;
+import org.mvel2.util.ASTLinkedList;
+import org.mvel2.util.CompilerTools;
+import org.mvel2.util.ErrorUtil;
+import org.mvel2.util.ExecutionStack;
+import org.mvel2.util.ParseTools;
+import org.mvel2.util.StringAppender;
+
+/**
+ * This is the main MVEL compiler.
+ */
+public class ExpressionCompiler extends AbstractParser {
+
+    private Class returnType;
+
+    private boolean verifyOnly = false;
+    private boolean verifying = true;
+    private boolean secondPassOptimization = false;
+
+    public ExpressionCompiler(String expression) {
+        setExpression(expression);
+    }
+
+    public ExpressionCompiler(String expression, boolean verifying) {
+        setExpression(expression);
+        this.verifying = verifying;
+    }
+
+    public ExpressionCompiler(char[] expression) {
+        setExpression(expression);
+    }
+
+    public ExpressionCompiler(String expression, ParserContext ctx) {
+        setExpression(expression);
+        this.pCtx = ctx;
+    }
+
+    public ExpressionCompiler(char[] expression, int start, int offset) {
+        this.expr = expression;
+        this.start = start;
+        this.end = start + offset;
+        this.end = trimLeft(this.end);
+        this.length = this.end - start;
+    }
+
+    public ExpressionCompiler(String expression, int start, int offset, ParserContext ctx) {
+        this.expr = expression.toCharArray();
+        this.start = start;
+        this.end = start + offset;
+        this.end = trimLeft(this.end);
+        this.length = this.end - start;
+        this.pCtx = ctx;
+    }
+
+    public ExpressionCompiler(char[] expression, int start, int offset, ParserContext ctx) {
+        this.expr = expression;
+        this.start = start;
+        this.end = start + offset;
+        this.end = trimLeft(this.end);
+        this.length = this.end - start;
+        this.pCtx = ctx;
+    }
+
+    public ExpressionCompiler(char[] expression, ParserContext ctx) {
+        setExpression(expression);
+        this.pCtx = ctx;
+    }
+
+    private static boolean isBooleanOperator(int operator) {
+        return operator == Operator.AND || operator == Operator.OR || operator == Operator.TERNARY || operator == Operator.TERNARY_ELSE;
+    }
+
+    public CompiledExpression compile() {
+        try {
+            this.debugSymbols = pCtx.isDebugSymbols();
+            return _compile();
+        } finally {
+            if (pCtx.isFatalError()) {
+                StringAppender err = new StringAppender();
+
+                Iterator<ErrorDetail> iter = pCtx.getErrorList().iterator();
+                ErrorDetail e;
+                while (iter.hasNext()) {
+                    e = iter.next();
+
+                    e = ErrorUtil.rewriteIfNeeded(e, expr, cursor);
+
+                    if (e.getExpr() != expr) {
+                        iter.remove();
+                    } else {
+                        err.append("\n - ").append("(").append(e.getLineNumber()).append(",").append(e.getColumn()).append(")").append(" ")
+                                .append(e.getMessage());
+                    }
+                }
+
+                //noinspection ThrowFromFinallyBlock
+                throw new CompileException(
+                        "Failed to compileShared: " + pCtx.getErrorList().size() + " compilation error(s): " + err.toString(),
+                        pCtx.getErrorList(), expr, cursor, pCtx);
+            }
+        }
+
+    }
+
+    /**
+     * Initiate an in-context compileShared.  This method should really only be called by the internal API.
+     *
+     * @return compiled expression object
+     */
+    public CompiledExpression _compile() {
+        ASTNode tk;
+        ASTNode tkOp;
+        ASTNode tkOp2;
+        ASTNode tkLA;
+        ASTNode tkLA2;
+
+        int op, lastOp = -1;
+        cursor = start;
+
+        ASTLinkedList astBuild = new ASTLinkedList();
+        stk = new ExecutionStack();
+        dStack = new ExecutionStack();
+        compileMode = true;
+
+        boolean firstLA;
+
+        try {
+            if (verifying) {
+                pCtx.initializeTables();
+            }
+
+            fields |= COMPILE_IMMEDIATE;
+
+            main_loop: while ((tk = nextToken()) != null) {
+                /**
+                 * If this is a debug symbol, just add it and continue.
+                 */
+                if (tk.fields == -1) {
+                    astBuild.addTokenNode(tk);
+                    continue;
+                }
+
+                /**
+                 * Record the type of the current node..
+                 */
+                returnType = tk.getEgressType();
+
+                if (tk instanceof Substatement) {
+                    String key = new String(expr, tk.getStart(), tk.getOffset());
+                    Map<String, CompiledExpression> cec = pCtx.getCompiledExpressionCache();
+                    Map<String, Class> rtc = pCtx.getReturnTypeCache();
+                    CompiledExpression compiled = cec.get(key);
+                    Class rt = rtc.get(key);
+                    if (compiled == null) {
+                        ExpressionCompiler subCompiler = new ExpressionCompiler(expr, tk.getStart(), tk.getOffset(), pCtx);
+                        compiled = subCompiler._compile();
+                        rt = subCompiler.getReturnType();
+                        cec.put(key, compiled);
+                        rtc.put(key, rt);
+                    }
+                    tk.setAccessor(compiled);
+                    returnType = rt;
+                }
+
+                /**
+                 * This kludge of code is to handle compileShared-time literal reduction.  We need to avoid
+                 * reducing for certain literals like, 'this', ternary and ternary else.
+                 */
+                if (!verifyOnly && tk.isLiteral()) {
+                    if (literalOnly == -1) literalOnly = 1;
+
+                    if ((tkOp = nextTokenSkipSymbols()) != null && tkOp.isOperator() && !tkOp.isOperator(Operator.TERNARY)
+                            && !tkOp.isOperator(Operator.TERNARY_ELSE)) {
+
+                        /**
+                         * If the next token is ALSO a literal, then we have a candidate for a compileShared-time literal
+                         * reduction.
+                         */
+                        if ((tkLA = nextTokenSkipSymbols()) != null && tkLA.isLiteral() && tkOp.getOperator() < 34
+                                && ((lastOp == -1 || (lastOp < PTABLE.length && PTABLE[lastOp] < PTABLE[tkOp.getOperator()])))) {
+                            stk.push(tk.getLiteralValue(), tkLA.getLiteralValue(), op = tkOp.getOperator());
+
+                            /**
+                             * Reduce the token now.
+                             */
+                            if (isArithmeticOperator(op)) {
+                                if (!compileReduce(op, astBuild)) continue;
+                            } else {
+                                reduce();
+                            }
+
+                            firstLA = true;
+
+                            /**
+                             * Now we need to check to see if this is a continuing reduction.
+                             */
+                            while ((tkOp2 = nextTokenSkipSymbols()) != null) {
+                                if (isBooleanOperator(tkOp2.getOperator())) {
+                                    astBuild.addTokenNode(new LiteralNode(stk.pop(), pCtx), verify(pCtx, tkOp2));
+                                    break;
+                                } else if ((tkLA2 = nextTokenSkipSymbols()) != null) {
+
+                                    if (tkLA2.isLiteral()) {
+                                        stk.push(tkLA2.getLiteralValue(), op = tkOp2.getOperator());
+
+                                        if (isArithmeticOperator(op)) {
+                                            if (!compileReduce(op, astBuild)) continue main_loop;
+                                        } else {
+                                            reduce();
+                                        }
+                                    } else {
+                                        /**
+                                         * A reducable line of literals has ended.  We must now terminate here and
+                                         * leave the rest to be determined at runtime.
+                                         */
+                                        if (!stk.isEmpty()) {
+                                            astBuild.addTokenNode(new LiteralNode(getStackValueResult(), pCtx));
+                                        }
+
+                                        astBuild.addTokenNode(new OperatorNode(tkOp2.getOperator(), expr, st, pCtx), verify(pCtx, tkLA2));
+                                        break;
+                                    }
+
+                                    firstLA = false;
+                                    literalOnly = 0;
+                                } else {
+                                    if (firstLA) {
+                                        /**
+                                         * There are more tokens, but we can't reduce anymore.  So
+                                         * we create a reduced token for what we've got.
+                                         */
+                                        astBuild.addTokenNode(new LiteralNode(getStackValueResult(), pCtx));
+                                    } else {
+                                        /**
+                                         * We have reduced additional tokens, but we can't reduce
+                                         * anymore.
+                                         */
+                                        astBuild.addTokenNode(new LiteralNode(getStackValueResult(), pCtx), tkOp2);
+
+                                        if (tkLA2 != null) astBuild.addTokenNode(verify(pCtx, tkLA2));
+                                    }
+
+                                    break;
+                                }
+                            }
+
+                            /**
+                             * If there are no more tokens left to parse, we check to see if
+                             * we've been doing any reducing, and if so we create the token
+                             * now.
+                             */
+                            if (!stk.isEmpty()) astBuild.addTokenNode(new LiteralNode(getStackValueResult(), pCtx));
+
+                            continue;
+                        } else {
+                            astBuild.addTokenNode(verify(pCtx, tk), verify(pCtx, tkOp));
+                            if (tkLA != null) astBuild.addTokenNode(verify(pCtx, tkLA));
+                            continue;
+                        }
+                    } else if (tkOp != null && !tkOp.isOperator() && !(tk.getLiteralValue() instanceof Class)) {
+                        throw new CompileException("unexpected token: " + tkOp.getName(), expr, tkOp.getStart());
+                    } else {
+                        literalOnly = 0;
+                        astBuild.addTokenNode(verify(pCtx, tk));
+                        if (tkOp != null) astBuild.addTokenNode(verify(pCtx, tkOp));
+                        continue;
+                    }
+                } else {
+                    if (tk.isOperator()) {
+                        lastOp = tk.getOperator();
+                    } else {
+                        literalOnly = 0;
+                    }
+                }
+
+                astBuild.addTokenNode(verify(pCtx, tk));
+            }
+
+            astBuild.finish();
+
+            if (verifying && !verifyOnly) {
+                pCtx.processTables();
+            }
+
+            if (!stk.isEmpty()) {
+                throw new CompileException("COMPILE ERROR: non-empty stack after compileShared.", expr, cursor);
+            }
+
+            if (!verifyOnly) {
+                try {
+                    return new CompiledExpression(finalizePayload(astBuild, secondPassOptimization, pCtx), pCtx.getSourceFile(), returnType,
+                            pCtx.getParserConfiguration(), literalOnly == 1);
+                } catch (RuntimeException e) {
+                    throw new CompileException(e.getMessage(), expr, st, e);
+                }
+            } else {
+                try {
+                    returnType = CompilerTools.getReturnType(astBuild, pCtx.isStrongTyping());
+                } catch (RuntimeException e) {
+                    throw new CompileException(e.getMessage(), expr, st, e);
+                }
+                return null;
+            }
+        } catch (NullPointerException e) {
+            throw new CompileException("not a statement, or badly formed structure", expr, st, e);
+        } catch (CompileException e) {
+            throw ErrorUtil.rewriteIfNeeded(e, expr, st);
+        } catch (Throwable e) {
+            if (e instanceof RuntimeException) throw (RuntimeException) e;
+            else {
+                throw new CompileException(e.getMessage(), expr, st, e);
+            }
+        }
+    }
+
+    private Object getStackValueResult() {
+        return (fields & OPT_SUBTR) == 0 ? stk.pop() : signNumber(stk.pop());
+    }
+
+    private boolean compileReduce(int opCode, ASTLinkedList astBuild) {
+        switch (arithmeticFunctionReduction(opCode)) {
+            case OP_TERMINATE:
+                /**
+                 * The reduction failed because we encountered a non-literal,
+                 * so we must now back out and cleanup.
+                 */
+
+                stk.xswap_op();
+
+                astBuild.addTokenNode(new LiteralNode(stk.pop(), pCtx));
+                astBuild.addTokenNode((OperatorNode) splitAccumulator.pop(), verify(pCtx, (ASTNode) splitAccumulator.pop()));
+                return false;
+            case OP_OVERFLOW:
+                /**
+                 * Back out completely, pull everything back off the stack and add the instructions
+                 * to the output payload as they are.
+                 */
+
+                LiteralNode rightValue = new LiteralNode(stk.pop(), pCtx);
+                OperatorNode operator = new OperatorNode((Integer) stk.pop(), expr, st, pCtx);
+
+                astBuild.addTokenNode(new LiteralNode(stk.pop(), pCtx), operator);
+                astBuild.addTokenNode(rightValue, (OperatorNode) splitAccumulator.pop());
+                astBuild.addTokenNode(verify(pCtx, (ASTNode) splitAccumulator.pop()));
+                return false;
+            case OP_NOT_LITERAL:
+                ASTNode tkLA2 = (ASTNode) stk.pop();
+                Integer tkOp2 = (Integer) stk.pop();
+                astBuild.addTokenNode(new LiteralNode(getStackValueResult(), pCtx));
+                astBuild.addTokenNode(new OperatorNode(tkOp2, expr, st, pCtx), verify(pCtx, tkLA2));
+                return false;
+        }
+        return true;
+    }
+
+    protected ASTNode verify(ParserContext pCtx, ASTNode tk) {
+        if (tk.isOperator() && (tk.getOperator().equals(Operator.AND) || tk.getOperator().equals(Operator.OR))) {
+            secondPassOptimization = true;
+        }
+        if (tk.isDiscard() || tk.isOperator()) {
+            return tk;
+        } else if (tk.isLiteral()) {
+            /**
+             * Convert literal values from the default ASTNode to the more-efficient LiteralNode.
+             */
+            if ((fields & COMPILE_IMMEDIATE) != 0 && tk.getClass() == ASTNode.class) {
+                return new LiteralNode(tk.getLiteralValue(), pCtx);
+            } else {
+                return tk;
+            }
+        }
+
+        if (verifying) {
+            if (tk.isIdentifier()) {
+                PropertyVerifier propVerifier = new PropertyVerifier(expr, tk.getStart(), tk.getOffset(), pCtx);
+
+                if (tk instanceof Union) {
+                    propVerifier.setCtx(((Union) tk).getLeftEgressType());
+                    tk.setEgressType(returnType = propVerifier.analyze());
+                } else {
+                    tk.setEgressType(returnType = propVerifier.analyze());
+
+                    if (propVerifier.isFqcn()) {
+                        tk.setAsFQCNReference();
+                    }
+
+                    if (propVerifier.isClassLiteral()) {
+                        return new LiteralNode(returnType, pCtx);
+                    }
+                    if (propVerifier.isInput()) {
+                        pCtx.addInput(tk.getAbsoluteName(), propVerifier.isDeepProperty() ? Object.class : returnType);
+                    }
+
+                    if (!propVerifier.isMethodCall() && !returnType.isEnum() && !pCtx.isOptimizerNotified() && pCtx.isStrongTyping()
+                            && !pCtx.isVariableVisible(tk.getAbsoluteName()) && !tk.isFQCN()) {
+                        throw new CompileException("no such identifier: " + tk.getAbsoluteName(), expr, tk.getStart());
+                    }
+                }
+            } else if (tk.isAssignment()) {
+                Assignment a = (Assignment) tk;
+
+                if (a.getAssignmentVar() != null) {
+                    //    pCtx.makeVisible(a.getAssignmentVar());
+
+                    PropertyVerifier propVerifier = new PropertyVerifier(a.getAssignmentVar(), pCtx);
+                    tk.setEgressType(returnType = propVerifier.analyze());
+
+                    if (!a.isNewDeclaration() && propVerifier.isResolvedExternally()) {
+                        pCtx.addInput(tk.getAbsoluteName(), returnType);
+                    }
+
+                    ExecutableStatement c = (ExecutableStatement) subCompileExpression(expr, tk.getStart(), tk.getOffset(), pCtx);
+
+                    if (pCtx.isStrictTypeEnforcement()) {
+                        /**
+                         * If we're using strict type enforcement, we need to see if this coercion can be done now,
+                         * or fail epicly.
+                         */
+                        if (!returnType.isAssignableFrom(c.getKnownEgressType()) && c.isLiteralOnly()) {
+                            if (canConvert(c.getKnownEgressType(), returnType)) {
+                                /**
+                                 * We convert the literal to the proper type.
+                                 */
+                                try {
+                                    a.setValueStatement(new ExecutableLiteral(convert(c.getValue(null, null), returnType)));
+                                    return tk;
+                                } catch (Exception e) {
+                                    // fall through.
+                                }
+                            } else if (returnType.isPrimitive() && unboxPrimitive(c.getKnownEgressType()).equals(returnType)) {
+                                /**
+                                 * We ignore boxed primitive cases, since MVEL does not recognize primitives.
+                                 */
+                                return tk;
+                            }
+
+                            throw new CompileException(
+                                    "cannot assign type " + c.getKnownEgressType().getName() + " to " + returnType.getName(), expr, st);
+                        }
+                    }
+                }
+            } else if (tk instanceof NewObjectNode) {
+                // this is a bit of a hack for now.
+                NewObjectNode n = (NewObjectNode) tk;
+                List<char[]> parms = ParseTools.parseMethodOrConstructor(tk.getNameAsArray());
+                if (parms != null) {
+                    for (char[] p : parms) {
+                        MVEL.analyze(p, pCtx);
+                    }
+                }
+            }
+            returnType = tk.getEgressType();
+        }
+
+        if (!tk.isLiteral() && tk.getClass() == ASTNode.class && (tk.getFields() & ASTNode.ARRAY_TYPE_LITERAL) == 0) {
+            if (pCtx.isStrongTyping()) tk.strongTyping();
+            tk.storePctx();
+            tk.storeInLiteralRegister(pCtx);
+        }
+
+        return tk;
+    }
+
+    public boolean isVerifying() {
+        return verifying;
+    }
+
+    public void setVerifying(boolean verifying) {
+        this.verifying = verifying;
+    }
+
+    public boolean isVerifyOnly() {
+        return verifyOnly;
+    }
+
+    public void setVerifyOnly(boolean verifyOnly) {
+        this.verifyOnly = verifyOnly;
+    }
+
+    public Class getReturnType() {
+        return returnType;
+    }
+
+    public void setReturnType(Class returnType) {
+        this.returnType = returnType;
+    }
+
+    public ParserContext getParserContextState() {
+        return pCtx;
+    }
+
+    public boolean isLiteralOnly() {
+        return literalOnly == 1;
+    }
+}

--- a/core/src/main/java/org/mvel2/compiler/Parser.java
+++ b/core/src/main/java/org/mvel2/compiler/Parser.java
@@ -1,0 +1,11 @@
+package org.mvel2.compiler;
+
+/**
+ * @author Mike Brock .
+ */
+public interface Parser {
+
+    public int getCursor();
+
+    public char[] getExpression();
+}

--- a/core/src/main/java/org/mvel2/compiler/PropertyVerifier.java
+++ b/core/src/main/java/org/mvel2/compiler/PropertyVerifier.java
@@ -1,0 +1,701 @@
+/**
+ * MVEL 2.0
+ * Copyright (C) 2007 The Codehaus
+ * Mike Brock, Dhanji Prasanna, John Graham, Mark Proctor
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mvel2.compiler;
+
+import static org.mvel2.util.ParseTools.balancedCapture;
+import static org.mvel2.util.ParseTools.balancedCaptureWithLineAccounting;
+import static org.mvel2.util.ParseTools.findClass;
+import static org.mvel2.util.ParseTools.getBestCandidate;
+import static org.mvel2.util.ParseTools.getSubComponentType;
+import static org.mvel2.util.ParseTools.parseParameterList;
+import static org.mvel2.util.PropertyTools.getFieldOrAccessor;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Member;
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.lang.reflect.TypeVariable;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+
+import org.mvel2.CompileException;
+import org.mvel2.ErrorDetail;
+import org.mvel2.MVEL;
+import org.mvel2.ParserContext;
+import org.mvel2.ast.Function;
+import org.mvel2.optimizers.AbstractOptimizer;
+import org.mvel2.optimizers.impl.refl.nodes.WithAccessor;
+import org.mvel2.util.ErrorUtil;
+import org.mvel2.util.NullType;
+import org.mvel2.util.ParseTools;
+import org.mvel2.util.StringAppender;
+
+/**
+ * This verifier is used by the compiler to enforce rules such as type strictness.  It is, as side-effect, also
+ * responsible for extracting type information.
+ *
+ * @author Mike Brock
+ * @author Dhanji Prasanna
+ */
+public class PropertyVerifier extends AbstractOptimizer {
+
+    private static final int DONE = -1;
+    private static final int NORM = 0;
+    private static final int METH = 1;
+    private static final int COL = 2;
+    private static final int WITH = 3;
+
+    private List<String> inputs = new LinkedList<String>();
+    private boolean first = false;
+    private boolean classLiteral = false;
+    private boolean resolvedExternally;
+    private boolean methodCall = false;
+    private boolean deepProperty = false;
+    private boolean fqcn = false;
+
+    private Map<String, Type> paramTypes;
+
+    private Class ctx = null;
+
+    public PropertyVerifier(char[] property, ParserContext parserContext) {
+        this.length = end = (this.expr = property).length;
+        this.pCtx = parserContext;
+    }
+
+    public PropertyVerifier(char[] property, int start, int offset, ParserContext parserContext) {
+        this.expr = property;
+        this.start = start;
+        this.length = offset;
+        this.end = start + offset;
+
+        this.pCtx = parserContext;
+    }
+
+    public PropertyVerifier(String property, ParserContext parserContext) {
+        this.length = end = (this.expr = property.toCharArray()).length;
+        this.pCtx = parserContext;
+    }
+
+    public PropertyVerifier(String property, ParserContext parserContext, Class root) {
+        this.end = this.length = (this.expr = property.toCharArray()).length;
+
+        if (property.length() > 0 && property.charAt(0) == '.') {
+            this.cursor = this.st = this.start = 1;
+        }
+
+        this.pCtx = parserContext;
+        this.ctx = root;
+    }
+
+    private static Class type2Class(Type type) {
+        return type instanceof Class ? (Class) type : (Class) ((ParameterizedType) type).getRawType();
+    }
+
+    public List<String> getInputs() {
+        return inputs;
+    }
+
+    public void setInputs(List<String> inputs) {
+        this.inputs = inputs;
+    }
+
+    /**
+     * Analyze the statement and return the known egress type.
+     *
+     * @return known engress type
+     */
+    public Class analyze() {
+        cursor = start;
+        resolvedExternally = true;
+        if (ctx == null) {
+            ctx = Object.class;
+            first = true;
+        }
+
+        while (cursor < end) {
+            classLiteral = false;
+            switch (nextSubToken()) {
+                case NORM:
+                    ctx = getBeanProperty(ctx, capture());
+                    break;
+                case METH:
+                    ctx = getMethod(ctx, capture());
+                    break;
+                case COL:
+                    ctx = getCollectionProperty(ctx, capture());
+                    break;
+                case WITH:
+                    ctx = getWithProperty(ctx);
+                    break;
+
+                case DONE:
+                    break;
+            }
+            if (cursor < length && !first) deepProperty = true;
+
+            first = false;
+        }
+        return ctx;
+    }
+
+    private void recordTypeParmsForProperty(String property) {
+        if (pCtx.isStrictTypeEnforcement()) {
+            pCtx.setLastTypeParameters(pCtx.getTypeParametersAsArray(property));
+        }
+    }
+
+    /**
+     * Process bean property
+     *
+     * @param ctx      - the ingress type
+     * @param property - the property component
+     * @return known egress type.
+     */
+    private Class getBeanProperty(Class ctx, String property) {
+        if (first) {
+            if (pCtx.hasVarOrInput(property)) {
+                if (pCtx.isStrictTypeEnforcement()) {
+                    recordTypeParmsForProperty(property);
+                }
+                return pCtx.getVarOrInputType(property);
+            } else if (pCtx.hasImport(property)) {
+                resolvedExternally = false;
+                return pCtx.getImport(property);
+            } else if (!pCtx.isStrongTyping()) {
+                return Object.class;
+
+            } else if (pCtx.hasVarOrInput("this")) {
+                if (pCtx.isStrictTypeEnforcement()) {
+                    recordTypeParmsForProperty("this");
+                }
+                ctx = pCtx.getVarOrInputType("this");
+                resolvedExternally = false;
+            }
+        }
+
+        st = cursor;
+        boolean switchStateReg;
+
+        Member member = ctx != null ? getFieldOrAccessor(ctx, property) : null;
+
+        if (MVEL.COMPILER_OPT_SUPPORT_JAVA_STYLE_CLASS_LITERALS) {
+            if ("class".equals(property)) {
+                return Class.class;
+            }
+        }
+
+        if (member instanceof Field) {
+            if (pCtx.isStrictTypeEnforcement()) {
+                Field f = ((Field) member);
+
+                if (f.getGenericType() != null) {
+                    if (f.getGenericType() instanceof ParameterizedType) {
+                        ParameterizedType pt = (ParameterizedType) f.getGenericType();
+                        pCtx.setLastTypeParameters(pt.getActualTypeArguments());
+
+                        Type[] gpt = pt.getActualTypeArguments();
+                        Type[] classArgs = type2Class(pt.getRawType()).getTypeParameters();
+
+                        if (gpt.length > 0 && paramTypes == null) paramTypes = new HashMap<String, Type>();
+                        for (int i = 0; i < gpt.length; i++) {
+                            paramTypes.put(classArgs[i].toString(), gpt[i]);
+                        }
+                    } else if (f.getGenericType() instanceof TypeVariable) {
+                        TypeVariable tv = (TypeVariable) f.getGenericType();
+                        Type paramType = paramTypes.remove(tv.getName());
+                        if (paramType != null && paramType instanceof Class) {
+                            return (Class) paramType;
+                        }
+                    }
+                }
+
+                return f.getType();
+            } else {
+                return ((Field) member).getType();
+            }
+        }
+
+        if (member != null) {
+            return getReturnType(ctx, (Method) member);
+        }
+
+        if (pCtx != null && first && pCtx.hasImport(property)) {
+            Class<?> importedClass = pCtx.getImport(property);
+            if (importedClass != null) return pCtx.getImport(property);
+        }
+
+        if (pCtx != null && pCtx.getLastTypeParameters() != null && pCtx.getLastTypeParameters().length != 0
+                && ((Collection.class.isAssignableFrom(ctx) && !(switchStateReg = false))
+                        || (Map.class.isAssignableFrom(ctx) && (switchStateReg = true)))) {
+            Type parm = pCtx.getLastTypeParameters()[switchStateReg ? 1 : 0];
+            pCtx.setLastTypeParameters(null);
+            return parm instanceof ParameterizedType ? Object.class : (Class) parm;
+        }
+
+        if (pCtx != null && "length".equals(property) && ctx.isArray()) {
+            return Integer.class;
+        }
+
+        Object tryStaticMethodRef = tryStaticAccess();
+
+        if (tryStaticMethodRef != null) {
+            fqcn = true;
+            resolvedExternally = false;
+            if (tryStaticMethodRef instanceof Class) {
+                classLiteral = !(MVEL.COMPILER_OPT_SUPPORT_JAVA_STYLE_CLASS_LITERALS && new String(expr, end - 6, 6).equals(".class"));
+                return classLiteral ? (Class) tryStaticMethodRef : Class.class;
+            } else if (tryStaticMethodRef instanceof Field) {
+                try {
+                    return ((Field) tryStaticMethodRef).get(null).getClass();
+                } catch (Exception e) {
+                    throw new CompileException("in verifier: ", expr, start, e);
+                }
+            } else {
+                try {
+                    return ((Method) tryStaticMethodRef).getReturnType();
+                } catch (Exception e) {
+                    throw new CompileException("in verifier: ", expr, start, e);
+                }
+            }
+        }
+
+        if (ctx != null) {
+            try {
+                return findClass(variableFactory, ctx.getName() + "$" + property, pCtx);
+            } catch (ClassNotFoundException cnfe) {
+                // fall through.
+            }
+        }
+
+        if (pCtx != null && pCtx.getParserConfiguration() != null ? pCtx.getParserConfiguration()
+                .isAllowNakedMethCall() : MVEL.COMPILER_OPT_ALLOW_NAKED_METH_CALL) {
+            Class cls = getMethod(ctx, property);
+            if (cls != Object.class) {
+                return cls;
+            }
+        }
+
+        if (pCtx.isStrictTypeEnforcement()) {
+            throw new CompileException("unqualified type in strict mode for: " + property, expr, tkStart);
+        }
+
+        return Object.class;
+    }
+
+    private Class getReturnType(Class context, Method m) {
+        Class declaringClass = m.getDeclaringClass();
+        if (context == declaringClass) {
+            return returnGenericType(m);
+        }
+        Type returnType = m.getGenericReturnType();
+        if (returnType instanceof TypeVariable) {
+            String typeName = ((TypeVariable) returnType).getName();
+            Type superType = context.getGenericSuperclass();
+            Class superClass = context.getSuperclass();
+            while (superClass != null && superClass != declaringClass) {
+                superType = superClass.getGenericSuperclass();
+                superClass = superClass.getSuperclass();
+            }
+            if (superClass == null) {
+                return returnGenericType(m);
+            }
+            if (superType instanceof ParameterizedType) {
+                TypeVariable[] typeParams = superClass.getTypeParameters();
+                int typePos = -1;
+                for (int i = 0; i < typeParams.length; i++) {
+                    if (typeParams[i].getName().equals(typeName)) {
+                        typePos = i;
+                        break;
+                    }
+                }
+                if (typePos < 0) {
+                    return returnGenericType(m);
+                }
+                Type actualType = ((ParameterizedType) superType).getActualTypeArguments()[typePos];
+                return actualType instanceof Class ? (Class) actualType : returnGenericType(m);
+            }
+        }
+        return returnGenericType(m);
+    }
+
+    private void recordParametricReturnedType(Type parametricReturnType) {
+        //push return type parameters onto parser context, only if this is a parametric type
+        if (parametricReturnType instanceof ParameterizedType) {
+            pCtx.setLastTypeParameters(((ParameterizedType) parametricReturnType).getActualTypeArguments());
+            ParameterizedType pt = (ParameterizedType) parametricReturnType;
+
+            Type[] gpt = pt.getActualTypeArguments();
+            Type[] classArgs = type2Class(pt.getRawType()).getTypeParameters();
+
+            if (gpt.length > 0 && paramTypes == null) paramTypes = new HashMap<String, Type>();
+            for (int i = 0; i < gpt.length; i++) {
+                paramTypes.put(classArgs[i].toString(), gpt[i]);
+            }
+        }
+    }
+
+    private Class<?> returnGenericType(Method m) {
+        Type parametricReturnType = m.getGenericReturnType();
+        recordParametricReturnedType(parametricReturnType);
+        String returnTypeArg = parametricReturnType.toString();
+
+        //push return type parameters onto parser context, only if this is a parametric type
+        if (parametricReturnType instanceof ParameterizedType) {
+            pCtx.setLastTypeParameters(((ParameterizedType) parametricReturnType).getActualTypeArguments());
+        }
+
+        if (paramTypes != null && paramTypes.containsKey(returnTypeArg)) {
+            /**
+             * If the paramTypes Map contains the known type, return that type.
+             */
+            return type2Class(paramTypes.get(returnTypeArg));
+        }
+
+        return m.getReturnType();
+    }
+
+    /**
+     * Process collection property
+     *
+     * @param ctx      - the ingress type
+     * @param property - the property component
+     * @return known egress type
+     */
+    private Class getCollectionProperty(Class ctx, String property) {
+        if (first) {
+            if (pCtx.hasVarOrInput(property)) {
+                ctx = getSubComponentType(pCtx.getVarOrInputType(property));
+            } else if (pCtx.hasImport(property)) {
+                resolvedExternally = false;
+                ctx = getSubComponentType(pCtx.getImport(property));
+            } else {
+                ctx = Object.class;
+            }
+        }
+
+        if (pCtx.isStrictTypeEnforcement()) {
+            if (Map.class.isAssignableFrom(property.length() != 0 ? ctx = getBeanProperty(ctx, property) : ctx)) {
+                ctx = type2Class(pCtx.getLastTypeParameters() != null
+                        && pCtx.getLastTypeParameters().length != 0 ? pCtx.getLastTypeParameters()[1] : Object.class);
+            } else if (Collection.class.isAssignableFrom(ctx)) {
+                ctx = pCtx.getLastTypeParameters() == null
+                        || pCtx.getLastTypeParameters().length == 0 ? Object.class : type2Class(pCtx.getLastTypeParameters()[0]);
+            } else if (ctx.isArray()) {
+                ctx = ctx.getComponentType();
+            } else if (pCtx.isStrongTyping()) {
+                throw new CompileException("unknown collection type: " + ctx + "; property=" + property, expr, start);
+            }
+        } else {
+            ctx = Object.class;
+        }
+
+        ++cursor;
+
+        skipWhitespace();
+
+        int start = cursor;
+
+        if (scanTo(']')) {
+            addFatalError("unterminated [ in token");
+        }
+
+        MVEL.analysisCompile(new String(expr, start, cursor - start), pCtx);
+
+        ++cursor;
+
+        return ctx;
+    }
+
+    /**
+     * Process method
+     *
+     * @param ctx  - the ingress type
+     * @param name - the property component
+     * @return known egress type.
+     */
+    private Class getMethod(Class ctx, String name) {
+        int st = cursor;
+
+        /**
+         * Check to see if this is the first element in the statement.
+         */
+        if (first) {
+            first = false;
+            methodCall = true;
+
+            /**
+             * It's the first element in the statement, therefore we check to see if there is a static import of a
+             * native Java method or an MVEL function.
+             */
+            if (pCtx.hasImport(name)) {
+                Method m = pCtx.getStaticImport(name).getMethod();
+
+                /**
+                 * Replace the method parameters.
+                 */
+                ctx = m.getDeclaringClass();
+                name = m.getName();
+            } else {
+                Function f = pCtx.getFunction(name);
+                if (f != null && f.getEgressType() != null) {
+                    resolvedExternally = false;
+                    f.checkArgumentCount(parseParameterList((((cursor = balancedCapture(expr, cursor, end, '(')) - st) > 1 ? ParseTools
+                            .subset(expr, st + 1, cursor - st - 1) : new char[0]), 0, -1).size());
+
+                    return f.getEgressType();
+                } else if (pCtx.hasVarOrInput("this")) {
+                    if (pCtx.isStrictTypeEnforcement()) {
+                        recordTypeParmsForProperty("this");
+                    }
+                    ctx = pCtx.getVarOrInputType("this");
+                    resolvedExternally = false;
+                }
+            }
+        }
+
+        /**
+         * Get the arguments for the method.
+         */
+        String tk;
+
+        if (cursor < end && expr[cursor] == '(' && ((cursor = balancedCapture(expr, cursor, end, '(')) - st) > 1) {
+            tk = new String(expr, st + 1, cursor - st - 1);
+        } else {
+            tk = "";
+        }
+
+        cursor++;
+
+        /**
+         * Parse out the arguments list.
+         */
+        Class[] args;
+        List<char[]> subtokens = parseParameterList(tk.toCharArray(), 0, -1);
+
+        if (subtokens.size() == 0) {
+            args = new Class[0];
+            subtokens = Collections.emptyList();
+        } else {
+            //   ParserContext subCtx = pCtx.createSubcontext();
+            args = new Class[subtokens.size()];
+
+            /**
+             *  Subcompile all the arguments to determine their known types.
+             */
+            //  ExpressionCompiler compiler;
+
+            List<ErrorDetail> errors = pCtx.getErrorList().isEmpty() ? pCtx
+                    .getErrorList() : new ArrayList<ErrorDetail>(pCtx.getErrorList());
+
+            CompileException rethrow = null;
+            for (int i = 0; i < subtokens.size(); i++) {
+                try {
+                    args[i] = MVEL.analyze(subtokens.get(i), pCtx);
+
+                    if ("null".equals(String.valueOf(subtokens.get(i)))) {
+                        args[i] = NullType.class;
+                    }
+
+                } catch (CompileException e) {
+                    rethrow = ErrorUtil.rewriteIfNeeded(e, expr, this.st);
+                }
+
+                if (errors.size() < pCtx.getErrorList().size()) {
+                    for (ErrorDetail detail : pCtx.getErrorList()) {
+                        if (!errors.contains(detail)) {
+                            detail.setExpr(expr);
+                            detail.setCursor(new String(expr).substring(this.st).indexOf(new String(subtokens.get(i))) + this.st);
+                            detail.setColumn(0);
+                            detail.setLineNumber(0);
+                            detail.calcRowAndColumn();
+                        }
+                    }
+                }
+
+                if (rethrow != null) {
+                    throw rethrow;
+                }
+            }
+        }
+
+        /**
+         * If the target object is an instance of java.lang.Class itself then do not
+         * adjust the Class scope target.
+         */
+
+        Method m;
+
+        /**
+         * If we have not cached the method then we need to go ahead and try to resolve it.
+         */
+
+        if ((m = getBestCandidate(args, name, ctx, ctx.getMethods(), pCtx.isStrongTyping())) == null) {
+            if ((m = getBestCandidate(args, name, ctx, ctx.getDeclaredMethods(), pCtx.isStrongTyping())) == null) {
+                StringAppender errorBuild = new StringAppender();
+                for (int i = 0; i < args.length; i++) {
+                    errorBuild.append(args[i] != null ? args[i].getName() : null);
+                    if (i < args.length - 1) errorBuild.append(", ");
+                }
+
+                if (("size".equals(name) || "length".equals(name)) && args.length == 0 && ctx.isArray()) {
+                    return Integer.class;
+                }
+
+                if (pCtx.isStrictTypeEnforcement()) {
+                    throw new CompileException(
+                            "unable to resolve method using strict-mode: " + ctx.getName() + "." + name + "(" + errorBuild.toString() + ")",
+                            expr, tkStart);
+                }
+
+                return Object.class;
+            }
+        }
+
+        /**
+         * If we're in strict mode, we look for generic type information.
+         */
+        if (pCtx.isStrictTypeEnforcement() && m.getGenericReturnType() != null) {
+            Map<String, Class> typeArgs = new HashMap<String, Class>();
+
+            Type[] gpt = m.getGenericParameterTypes();
+            Class z;
+            ParameterizedType pt;
+
+            for (int i = 0; i < gpt.length; i++) {
+                if (gpt[i] instanceof ParameterizedType) {
+                    pt = (ParameterizedType) gpt[i];
+                    if ((z = pCtx.getImport(new String(subtokens.get(i)))) != null) {
+                        /**
+                         * We record the value of the type parameter to our typeArgs Map.
+                         */
+                        if (pt.getRawType().equals(Class.class)) {
+                            /**
+                             * If this is an instance of Class, we deal with the special parameterization case.
+                             */
+                            typeArgs.put(pt.getActualTypeArguments()[0].toString(), z);
+                        } else {
+                            typeArgs.put(gpt[i].toString(), z);
+                        }
+                    }
+                }
+            }
+
+            if (pCtx.isStrictTypeEnforcement() && ctx.getTypeParameters().length != 0 && pCtx.getLastTypeParameters() != null
+                    && pCtx.getLastTypeParameters().length == ctx.getTypeParameters().length) {
+
+                TypeVariable[] typeVariables = ctx.getTypeParameters();
+                for (int i = 0; i < typeVariables.length; i++) {
+                    Type typeArg = pCtx.getLastTypeParameters()[i];
+                    typeArgs.put(typeVariables[i].getName(),
+                            typeArg instanceof Class ? type2Class(pCtx.getLastTypeParameters()[i]) : Object.class);
+                }
+            }
+
+            /**
+             * Get the return type argument
+             */
+            Type parametricReturnType = m.getGenericReturnType();
+            String returnTypeArg = parametricReturnType.toString();
+
+            //push return type parameters onto parser context, only if this is a parametric type
+            if (parametricReturnType instanceof ParameterizedType) {
+                pCtx.setLastTypeParameters(((ParameterizedType) parametricReturnType).getActualTypeArguments());
+            }
+
+            if (paramTypes != null && paramTypes.containsKey(returnTypeArg)) {
+                /**
+                 * If the paramTypes Map contains the known type, return that type.
+                 */
+                return type2Class(paramTypes.get(returnTypeArg));
+            } else if (typeArgs.containsKey(returnTypeArg)) {
+                /**
+                 * If the generic type was declared as part of the method, it will be in this
+                 * Map.
+                 */
+                return typeArgs.get(returnTypeArg);
+            }
+        }
+
+        if (!Modifier.isPublic(m.getModifiers()) && pCtx.isStrictTypeEnforcement()) {
+            StringAppender errorBuild = new StringAppender();
+            for (int i = 0; i < args.length; i++) {
+                errorBuild.append(args[i] != null ? args[i].getName() : null);
+                if (i < args.length - 1) errorBuild.append(", ");
+            }
+
+            String scope = Modifier.toString(m.getModifiers());
+            if (scope.trim().equals("")) scope = "<package local>";
+
+            addFatalError("the referenced method is not accessible: " + ctx.getName() + "." + name + "(" + errorBuild.toString() + ")"
+                    + " (scope: " + scope + "; required: public", this.tkStart);
+        }
+
+        return getReturnType(ctx, m);
+    }
+
+    private Class getWithProperty(Class ctx) {
+        String root = new String(expr, 0, cursor - 1).trim();
+
+        int start = cursor + 1;
+        cursor = balancedCaptureWithLineAccounting(expr, cursor, end, '{', pCtx);
+
+        new WithAccessor(pCtx, root, expr, start, cursor++ - start, ctx);
+
+        return ctx;
+    }
+
+    public boolean isResolvedExternally() {
+        return resolvedExternally;
+    }
+
+    public boolean isClassLiteral() {
+        return classLiteral;
+    }
+
+    public boolean isDeepProperty() {
+        return deepProperty;
+    }
+
+    public boolean isInput() {
+        return resolvedExternally && !methodCall;
+    }
+
+    public boolean isMethodCall() {
+        return methodCall;
+    }
+
+    public boolean isFqcn() {
+        return fqcn;
+    }
+
+    public Class getCtx() {
+        return ctx;
+    }
+
+    public void setCtx(Class ctx) {
+        this.ctx = ctx;
+    }
+}

--- a/core/src/main/java/org/mvel2/conversion/ArrayCH.java
+++ b/core/src/main/java/org/mvel2/conversion/ArrayCH.java
@@ -1,0 +1,87 @@
+/**
+ * MVEL 2.0
+ * Copyright (C) 2007 The Codehaus
+ * Mike Brock, Dhanji Prasanna, John Graham, Mark Proctor
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mvel2.conversion;
+
+import static java.lang.Integer.parseInt;
+import static java.lang.String.valueOf;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.mvel2.ConversionException;
+import org.mvel2.ConversionHandler;
+
+public class ArrayCH implements ConversionHandler {
+
+    private static final Map<Class, Converter> CNV = new HashMap<Class, Converter>();
+
+    static {
+        CNV.put(String[].class, new Converter() {
+
+            public Object convert(Object o) {
+                Object[] old = (Object[]) o;
+                String[] n = new String[old.length];
+                for (int i = 0; i < old.length; i++) {
+                    n[i] = valueOf(old[i]);
+                }
+
+                return n;
+            }
+        });
+
+        CNV.put(Integer[].class, new Converter() {
+
+            public Object convert(Object o) {
+                Object[] old = (Object[]) o;
+                Integer[] n = new Integer[old.length];
+                for (int i = 0; i < old.length; i++) {
+                    n[i] = parseInt(valueOf(old[i]));
+                }
+
+                return n;
+            }
+
+        });
+
+        CNV.put(int[].class, new Converter() {
+
+            public Object convert(Object o) {
+                Object[] old = (Object[]) o;
+                int[] n = new int[old.length];
+                for (int i = 0; i < old.length; i++) {
+                    n[i] = parseInt(valueOf(old[i]));
+                }
+
+                return n;
+            }
+
+        });
+
+    }
+
+    public Object convertFrom(Object in) {
+        if (!CNV.containsKey(in.getClass()))
+            throw new ConversionException("cannot convert type: " + in.getClass().getName() + " to: " + Boolean.class.getName());
+        return CNV.get(in.getClass()).convert(in);
+    }
+
+    public boolean canConvertFrom(Class cls) {
+        return CNV.containsKey(cls);
+    }
+}

--- a/core/src/main/java/org/mvel2/conversion/ArrayHandler.java
+++ b/core/src/main/java/org/mvel2/conversion/ArrayHandler.java
@@ -1,0 +1,86 @@
+/**
+ * MVEL 2.0
+ * Copyright (C) 2007 The Codehaus
+ * Mike Brock, Dhanji Prasanna, John Graham, Mark Proctor
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mvel2.conversion;
+
+import static java.lang.reflect.Array.get;
+import static java.lang.reflect.Array.getLength;
+import static java.lang.reflect.Array.newInstance;
+import static java.lang.reflect.Array.set;
+import static org.mvel2.DataConversion.convert;
+
+import java.lang.reflect.Array;
+import java.util.Collection;
+
+import org.mvel2.ConversionHandler;
+
+public class ArrayHandler implements ConversionHandler {
+
+    private final Class type;
+
+    public ArrayHandler(Class type) {
+        this.type = type;
+    }
+
+    /**
+     * Messy method to handle primitive boxing for conversion. If someone can re-write this more
+     * elegantly, be my guest.
+     *
+     * @param sourceType
+     * @param input
+     * @param targetType
+     * @return
+     */
+    private static Object handleLooseTypeConversion(Class sourceType, Object input, Class targetType) {
+        Class targType = targetType.getComponentType();
+        if (Collection.class.isAssignableFrom(sourceType)) {
+            Object newArray = newInstance(targType, ((Collection) input).size());
+
+            int i = 0;
+            for (Object o : ((Collection) input)) {
+                Array.set(newArray, i++, convert(o, targType));
+            }
+
+            return newArray;
+        }
+
+        if (!input.getClass().isArray()) {
+            // if the input isn't an array converts it in an array with lenght = 1 having has its single item the input itself
+            Object target = newInstance(targType, 1);
+            set(target, 0, input);
+            return target;
+        }
+
+        int len = getLength(input);
+        Object target = newInstance(targType, len);
+
+        for (int i = 0; i < len; i++) {
+            set(target, i, convert(get(input, i), targType));
+        }
+
+        return target;
+    }
+
+    public Object convertFrom(Object in) {
+        return handleLooseTypeConversion(in.getClass(), in, type);
+    }
+
+    public boolean canConvertFrom(Class cls) {
+        return cls.isArray() || Collection.class.isAssignableFrom(cls);
+    }
+}

--- a/core/src/main/java/org/mvel2/conversion/BigDecimalCH.java
+++ b/core/src/main/java/org/mvel2/conversion/BigDecimalCH.java
@@ -1,0 +1,124 @@
+/**
+ * MVEL 2.0
+ * Copyright (C) 2007 The Codehaus
+ * Mike Brock, Dhanji Prasanna, John Graham, Mark Proctor
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mvel2.conversion;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.math.MathContext;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.mvel2.ConversionException;
+import org.mvel2.ConversionHandler;
+
+public class BigDecimalCH implements ConversionHandler {
+
+    private static final Map<Class, Converter> CNV = new HashMap<Class, Converter>();
+
+    static {
+        CNV.put(Object.class, new Converter() {
+
+            public BigDecimal convert(Object o) {
+                return new BigDecimal(String.valueOf(o), MathContext.DECIMAL128);
+            }
+        });
+
+        CNV.put(BigDecimal.class, new Converter() {
+
+            public BigDecimal convert(Object o) {
+                return (BigDecimal) o;
+            }
+        });
+
+        CNV.put(BigInteger.class, new Converter() {
+
+            public BigDecimal convert(Object o) {
+                return new BigDecimal(((BigInteger) o).doubleValue(), MathContext.DECIMAL128);
+            }
+        });
+
+        CNV.put(String.class, new Converter() {
+
+            public BigDecimal convert(Object o) {
+                return new BigDecimal((String) o, MathContext.DECIMAL128);
+            }
+        });
+
+        CNV.put(Double.class, new Converter() {
+
+            public BigDecimal convert(Object o) {
+                return new BigDecimal(((Double) o).doubleValue(), MathContext.DECIMAL128);
+            }
+        });
+
+        CNV.put(Float.class, new Converter() {
+
+            public BigDecimal convert(Object o) {
+                return new BigDecimal(((Float) o).doubleValue(), MathContext.DECIMAL128);
+            }
+        });
+
+        CNV.put(Short.class, new Converter() {
+
+            public BigDecimal convert(Object o) {
+                return new BigDecimal(((Short) o).doubleValue(), MathContext.DECIMAL128);
+            }
+        });
+
+        CNV.put(Long.class, new Converter() {
+
+            public BigDecimal convert(Object o) {
+                return new BigDecimal(((Long) o).doubleValue(), MathContext.DECIMAL128);
+            }
+        });
+
+        CNV.put(Integer.class, new Converter() {
+
+            public BigDecimal convert(Object o) {
+                return new BigDecimal(((Integer) o).doubleValue(), MathContext.DECIMAL128);
+            }
+        });
+
+        CNV.put(String.class, new Converter() {
+
+            public BigDecimal convert(Object o) {
+                return new BigDecimal((String) o, MathContext.DECIMAL128);
+            }
+        });
+
+        CNV.put(char[].class, new Converter() {
+
+            public BigDecimal convert(Object o) {
+                return new BigDecimal((char[]) o, MathContext.DECIMAL128);
+            }
+        }
+
+        );
+    }
+
+    public Object convertFrom(Object in) {
+        if (!CNV.containsKey(in.getClass()))
+            throw new ConversionException("cannot convert type: " + in.getClass().getName() + " to: " + Integer.class.getName());
+        return CNV.get(in.getClass()).convert(in);
+    }
+
+    public boolean canConvertFrom(Class cls) {
+        return CNV.containsKey(cls);
+    }
+}

--- a/core/src/main/java/org/mvel2/conversion/BigIntegerCH.java
+++ b/core/src/main/java/org/mvel2/conversion/BigIntegerCH.java
@@ -1,0 +1,109 @@
+/**
+ * MVEL 2.0
+ * Copyright (C) 2007 The Codehaus
+ * Mike Brock, Dhanji Prasanna, John Graham, Mark Proctor
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mvel2.conversion;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.mvel2.ConversionException;
+import org.mvel2.ConversionHandler;
+
+public class BigIntegerCH implements ConversionHandler {
+
+    private static final Map<Class, Converter> CNV = new HashMap<Class, Converter>();
+
+    static {
+        CNV.put(Object.class, new Converter() {
+
+            public BigInteger convert(Object o) {
+                return new BigInteger(String.valueOf(o));
+            }
+        });
+
+        CNV.put(BigInteger.class, new Converter() {
+
+            public BigInteger convert(Object o) {
+                return (BigInteger) o;
+            }
+        });
+
+        CNV.put(BigDecimal.class, new Converter() {
+
+            public BigInteger convert(Object o) {
+                return ((BigDecimal) o).toBigInteger();
+            }
+        });
+
+        CNV.put(String.class, new Converter() {
+
+            public BigInteger convert(Object o) {
+                return new BigInteger((String) o);
+            }
+        });
+
+        CNV.put(Short.class, new Converter() {
+
+            public BigInteger convert(Object o) {
+                return new BigInteger(String.valueOf(o));
+            }
+        });
+
+        CNV.put(Long.class, new Converter() {
+
+            public BigInteger convert(Object o) {
+                return new BigInteger(String.valueOf(o));
+            }
+        });
+
+        CNV.put(Integer.class, new Converter() {
+
+            public BigInteger convert(Object o) {
+                return new BigInteger(String.valueOf(o));
+            }
+        });
+
+        CNV.put(String.class, new Converter() {
+
+            public BigInteger convert(Object o) {
+                return new BigInteger((String) o);
+            }
+        });
+
+        CNV.put(char[].class, new Converter() {
+
+            public BigInteger convert(Object o) {
+                return new BigInteger(new String((char[]) o));
+            }
+        }
+
+        );
+    }
+
+    public Object convertFrom(Object in) {
+        if (!CNV.containsKey(in.getClass()))
+            throw new ConversionException("cannot convert type: " + in.getClass().getName() + " to: " + Integer.class.getName());
+        return CNV.get(in.getClass()).convert(in);
+    }
+
+    public boolean canConvertFrom(Class cls) {
+        return CNV.containsKey(cls);
+    }
+}

--- a/core/src/main/java/org/mvel2/conversion/BooleanCH.java
+++ b/core/src/main/java/org/mvel2/conversion/BooleanCH.java
@@ -1,0 +1,119 @@
+/**
+ * MVEL 2.0
+ * Copyright (C) 2007 The Codehaus
+ * Mike Brock, Dhanji Prasanna, John Graham, Mark Proctor
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mvel2.conversion;
+
+import static java.lang.String.valueOf;
+
+import java.math.BigDecimal;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.mvel2.ConversionException;
+import org.mvel2.ConversionHandler;
+
+public class BooleanCH implements ConversionHandler {
+
+    private static final Map<Class, Converter> CNV = new HashMap<Class, Converter>();
+
+    private static Converter stringConverter = new Converter() {
+
+        public Object convert(Object o) {
+            return !(((String) o).equalsIgnoreCase("false") || (((String) o).equalsIgnoreCase("no"))
+                    || (((String) o).equalsIgnoreCase("off")) || ("0".equals(o)) || ("".equals(o)));
+        }
+    };
+
+    static {
+        CNV.put(String.class, stringConverter);
+
+        CNV.put(Object.class, new Converter() {
+
+            public Object convert(Object o) {
+                return stringConverter.convert(valueOf(o));
+            }
+        });
+
+        CNV.put(Boolean.class, new Converter() {
+
+            public Object convert(Object o) {
+                return o;
+            }
+        });
+
+        CNV.put(Integer.class, new Converter() {
+
+            public Boolean convert(Object o) {
+                return (((Integer) o) > 0);
+            }
+        });
+
+        CNV.put(Float.class, new Converter() {
+
+            public Boolean convert(Object o) {
+                return (((Float) o) > 0);
+            }
+        });
+
+        CNV.put(Double.class, new Converter() {
+
+            public Boolean convert(Object o) {
+                return (((Double) o) > 0);
+            }
+        });
+
+        CNV.put(Short.class, new Converter() {
+
+            public Boolean convert(Object o) {
+                return (((Short) o) > 0);
+            }
+        });
+
+        CNV.put(Long.class, new Converter() {
+
+            public Boolean convert(Object o) {
+                return (((Long) o) > 0);
+            }
+        });
+
+        CNV.put(boolean.class, new Converter() {
+
+            public Boolean convert(Object o) {
+                return Boolean.valueOf((Boolean) o);
+            }
+        });
+
+        CNV.put(BigDecimal.class, new Converter() {
+
+            public Boolean convert(Object o) {
+                return Boolean.valueOf(((BigDecimal) o).doubleValue() > 0);
+            }
+        });
+
+    }
+
+    public Object convertFrom(Object in) {
+        if (!CNV.containsKey(in.getClass()))
+            throw new ConversionException("cannot convert type: " + in.getClass().getName() + " to: " + Boolean.class.getName());
+        return CNV.get(in.getClass()).convert(in);
+    }
+
+    public boolean canConvertFrom(Class cls) {
+        return CNV.containsKey(cls);
+    }
+}

--- a/core/src/main/java/org/mvel2/conversion/ByteCH.java
+++ b/core/src/main/java/org/mvel2/conversion/ByteCH.java
@@ -1,0 +1,103 @@
+/**
+ * MVEL 2.0
+ * Copyright (C) 2007 The Codehaus
+ * Mike Brock, Dhanji Prasanna, John Graham, Mark Proctor
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mvel2.conversion;
+
+import static java.lang.String.valueOf;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.mvel2.ConversionException;
+import org.mvel2.ConversionHandler;
+
+public class ByteCH implements ConversionHandler {
+
+    private static final Map<Class, Converter> CNV = new HashMap<Class, Converter>();
+
+    private static Converter stringConverter = new Converter() {
+
+        public Object convert(Object o) {
+            return Byte.parseByte(((String) o));
+        }
+    };
+
+    static {
+        CNV.put(String.class, stringConverter);
+
+        CNV.put(Object.class, new Converter() {
+
+            public Object convert(Object o) {
+                return stringConverter.convert(valueOf(o));
+            }
+        });
+
+        CNV.put(Byte.class, new Converter() {
+
+            public Object convert(Object o) {
+                //noinspection UnnecessaryBoxing
+                return new Byte(((Byte) o));
+            }
+        });
+
+        CNV.put(Integer.class, new Converter() {
+
+            public Object convert(Object o) {
+                return ((Integer) o).byteValue();
+            }
+        });
+
+        CNV.put(Long.class, new Converter() {
+
+            public Object convert(Object o) {
+                return ((Long) o).byteValue();
+            }
+        });
+
+        CNV.put(Double.class, new Converter() {
+
+            public Object convert(Object o) {
+                return ((Double) o).byteValue();
+            }
+        });
+
+        CNV.put(Float.class, new Converter() {
+
+            public Object convert(Object o) {
+                return ((Float) o).byteValue();
+            }
+        });
+
+        CNV.put(Short.class, new Converter() {
+
+            public Object convert(Object o) {
+                return ((Short) o).byteValue();
+            }
+        });
+    }
+
+    public Object convertFrom(Object in) {
+        if (!CNV.containsKey(in.getClass()))
+            throw new ConversionException("cannot convert type: " + in.getClass().getName() + " to: " + Integer.class.getName());
+        return CNV.get(in.getClass()).convert(in);
+    }
+
+    public boolean canConvertFrom(Class cls) {
+        return CNV.containsKey(cls);
+    }
+}

--- a/core/src/main/java/org/mvel2/conversion/CharArrayCH.java
+++ b/core/src/main/java/org/mvel2/conversion/CharArrayCH.java
@@ -1,0 +1,50 @@
+/**
+ * MVEL 2.0
+ * Copyright (C) 2007 The Codehaus
+ * Mike Brock, Dhanji Prasanna, John Graham, Mark Proctor
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mvel2.conversion;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.mvel2.ConversionException;
+import org.mvel2.ConversionHandler;
+
+public class CharArrayCH implements ConversionHandler {
+
+    private static final Map<Class, Converter> CNV = new HashMap<Class, Converter>();
+
+    static {
+        CNV.put(String.class, new Converter() {
+
+            public Object convert(Object o) {
+                return ((String) o).toCharArray();
+            }
+        });
+
+    }
+
+    public Object convertFrom(Object in) {
+        if (!CNV.containsKey(in.getClass()))
+            throw new ConversionException("cannot convert type: " + in.getClass().getName() + " to: " + Boolean.class.getName());
+        return CNV.get(in.getClass()).convert(in);
+    }
+
+    public boolean canConvertFrom(Class cls) {
+        return CNV.containsKey(cls);
+    }
+}

--- a/core/src/main/java/org/mvel2/conversion/CharCH.java
+++ b/core/src/main/java/org/mvel2/conversion/CharCH.java
@@ -1,0 +1,86 @@
+/**
+ * MVEL 2.0
+ * Copyright (C) 2007 The Codehaus
+ * Mike Brock, Dhanji Prasanna, John Graham, Mark Proctor
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mvel2.conversion;
+
+import static java.lang.String.valueOf;
+
+import java.math.BigDecimal;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.mvel2.ConversionException;
+import org.mvel2.ConversionHandler;
+
+public class CharCH implements ConversionHandler {
+
+    private static final Map<Class, Converter> CNV = new HashMap<Class, Converter>();
+
+    private static final Converter stringConverter = new Converter() {
+
+        public Object convert(Object o) {
+            if ((((String) o).length()) > 1)
+                throw new ConversionException("cannot convert a string with a length greater than 1 to java.lang.Character");
+
+            return (((String) o)).charAt(0);
+        }
+    };
+
+    static {
+        CNV.put(String.class, stringConverter);
+
+        CNV.put(Object.class, new Converter() {
+
+            public Object convert(Object o) {
+                return stringConverter.convert(valueOf(o));
+            }
+        });
+
+        CNV.put(Character.class, new Converter() {
+
+            public Object convert(Object o) {
+                //noinspection UnnecessaryBoxing
+                return new Character(((Character) o));
+            }
+        });
+
+        CNV.put(BigDecimal.class, new Converter() {
+
+            public Object convert(Object o) {
+                return (char) ((BigDecimal) o).intValue();
+            }
+        });
+
+        CNV.put(Integer.class, new Converter() {
+
+            public Object convert(Object o) {
+                return (char) ((Integer) o).intValue();
+            }
+        });
+    }
+
+    public Object convertFrom(Object in) {
+        if (!CNV.containsKey(in.getClass()))
+            throw new ConversionException("cannot convert type: " + in.getClass().getName() + " to: " + Integer.class.getName());
+        return CNV.get(in.getClass()).convert(in);
+    }
+
+    public boolean canConvertFrom(Class cls) {
+        return CNV.containsKey(cls);
+    }
+}

--- a/core/src/main/java/org/mvel2/conversion/CompositeCH.java
+++ b/core/src/main/java/org/mvel2/conversion/CompositeCH.java
@@ -1,0 +1,26 @@
+package org.mvel2.conversion;
+
+import org.mvel2.ConversionHandler;
+
+public class CompositeCH implements ConversionHandler {
+
+    private final ConversionHandler[] converters;
+
+    public CompositeCH(ConversionHandler... converters) {
+        this.converters = converters;
+    }
+
+    public Object convertFrom(Object in) {
+        for (ConversionHandler converter : converters) {
+            if (converter.canConvertFrom(in.getClass())) return converter.convertFrom(in);
+        }
+        return null;
+    }
+
+    public boolean canConvertFrom(Class cls) {
+        for (ConversionHandler converter : converters) {
+            if (converter.canConvertFrom(cls)) return true;
+        }
+        return false;
+    }
+}

--- a/core/src/main/java/org/mvel2/conversion/Converter.java
+++ b/core/src/main/java/org/mvel2/conversion/Converter.java
@@ -1,0 +1,24 @@
+/**
+ * MVEL 2.0
+ * Copyright (C) 2007 The Codehaus
+ * Mike Brock, Dhanji Prasanna, John Graham, Mark Proctor
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mvel2.conversion;
+
+public interface Converter {
+
+    public Object convert(Object o);
+}

--- a/core/src/main/java/org/mvel2/conversion/DoubleCH.java
+++ b/core/src/main/java/org/mvel2/conversion/DoubleCH.java
@@ -1,0 +1,131 @@
+/**
+ * MVEL 2.0
+ * Copyright (C) 2007 The Codehaus
+ * Mike Brock, Dhanji Prasanna, John Graham, Mark Proctor
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mvel2.conversion;
+
+import static java.lang.String.valueOf;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.mvel2.ConversionException;
+import org.mvel2.ConversionHandler;
+
+public class DoubleCH implements ConversionHandler {
+
+    private static final Map<Class, Converter> CNV = new HashMap<Class, Converter>();
+
+    private static Converter stringConverter = new Converter() {
+
+        public Object convert(Object o) {
+            if (((String) o).length() == 0) return (double) 0;
+
+            return Double.parseDouble(((String) o));
+        }
+    };
+
+    static {
+        CNV.put(String.class, stringConverter);
+
+        CNV.put(Object.class, new Converter() {
+
+            public Object convert(Object o) {
+                return stringConverter.convert(valueOf(o));
+            }
+        });
+
+        CNV.put(BigDecimal.class, new Converter() {
+
+            public Double convert(Object o) {
+                return ((BigDecimal) o).doubleValue();
+            }
+        });
+
+        CNV.put(BigInteger.class, new Converter() {
+
+            public Double convert(Object o) {
+                return ((BigInteger) o).doubleValue();
+            }
+        });
+
+        CNV.put(Double.class, new Converter() {
+
+            public Object convert(Object o) {
+                return o;
+            }
+        });
+
+        CNV.put(Float.class, new Converter() {
+
+            public Double convert(Object o) {
+                if (((Float) o) > Double.MAX_VALUE) {
+                    throw new ConversionException(
+                            "cannot coerce Float to Double since the value (" + valueOf(o) + ") exceeds that maximum precision of Double.");
+
+                }
+
+                return ((Float) o).doubleValue();
+            }
+        });
+
+        CNV.put(Integer.class, new Converter() {
+
+            public Double convert(Object o) {
+                //noinspection UnnecessaryBoxing
+                return ((Integer) o).doubleValue();
+            }
+        });
+
+        CNV.put(Short.class, new Converter() {
+
+            public Double convert(Object o) {
+                //noinspection UnnecessaryBoxing
+                return ((Short) o).doubleValue();
+            }
+        });
+
+        CNV.put(Long.class, new Converter() {
+
+            public Double convert(Object o) {
+                //noinspection UnnecessaryBoxing
+                return ((Long) o).doubleValue();
+            }
+        });
+
+        CNV.put(Boolean.class, new Converter() {
+
+            public Double convert(Object o) {
+                if ((Boolean) o) return 1d;
+                else return 0d;
+            }
+        });
+
+    }
+
+    public Object convertFrom(Object in) {
+        if (!CNV.containsKey(in.getClass()))
+            throw new ConversionException("cannot convert type: " + in.getClass().getName() + " to: " + Integer.class.getName());
+        return CNV.get(in.getClass()).convert(in);
+    }
+
+    public boolean canConvertFrom(Class cls) {
+        return CNV.containsKey(cls);
+    }
+}

--- a/core/src/main/java/org/mvel2/conversion/FloatCH.java
+++ b/core/src/main/java/org/mvel2/conversion/FloatCH.java
@@ -1,0 +1,123 @@
+/**
+ * MVEL 2.0
+ * Copyright (C) 2007 The Codehaus
+ * Mike Brock, Dhanji Prasanna, John Graham, Mark Proctor
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mvel2.conversion;
+
+import static java.lang.String.valueOf;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.mvel2.ConversionException;
+import org.mvel2.ConversionHandler;
+
+public class FloatCH implements ConversionHandler {
+
+    private static final Map<Class, Converter> CNV = new HashMap<Class, Converter>();
+
+    private static Converter stringConverter = new Converter() {
+
+        public Object convert(Object o) {
+            if (((String) o).length() == 0) return (float) 0;
+
+            return Float.parseFloat(((String) o));
+        }
+    };
+
+    static {
+        CNV.put(String.class, stringConverter);
+
+        CNV.put(Object.class, new Converter() {
+
+            public Object convert(Object o) {
+                return stringConverter.convert(valueOf(o));
+            }
+        });
+
+        CNV.put(BigDecimal.class, new Converter() {
+
+            public Float convert(Object o) {
+                return ((BigDecimal) o).floatValue();
+            }
+        });
+
+        CNV.put(BigInteger.class, new Converter() {
+
+            public Float convert(Object o) {
+                return ((BigInteger) o).floatValue();
+            }
+        });
+
+        CNV.put(Float.class, new Converter() {
+
+            public Object convert(Object o) {
+                return o;
+            }
+        });
+
+        CNV.put(Integer.class, new Converter() {
+
+            public Float convert(Object o) {
+                //noinspection UnnecessaryBoxing
+                return ((Integer) o).floatValue();
+            }
+        });
+
+        CNV.put(Double.class, new Converter() {
+
+            public Float convert(Object o) {
+                return ((Double) o).floatValue();
+            }
+        });
+
+        CNV.put(Long.class, new Converter() {
+
+            public Float convert(Object o) {
+                return ((Long) o).floatValue();
+            }
+        });
+
+        CNV.put(Short.class, new Converter() {
+
+            public Float convert(Object o) {
+                return ((Short) o).floatValue();
+            }
+        });
+
+        CNV.put(Boolean.class, new Converter() {
+
+            public Float convert(Object o) {
+                if ((Boolean) o) return 1f;
+                else return 0f;
+            }
+        });
+
+    }
+
+    public Object convertFrom(Object in) {
+        if (!CNV.containsKey(in.getClass()))
+            throw new ConversionException("cannot convert type: " + in.getClass().getName() + " to: " + Integer.class.getName());
+        return CNV.get(in.getClass()).convert(in);
+    }
+
+    public boolean canConvertFrom(Class cls) {
+        return CNV.containsKey(cls);
+    }
+}

--- a/core/src/main/java/org/mvel2/conversion/IntArrayCH.java
+++ b/core/src/main/java/org/mvel2/conversion/IntArrayCH.java
@@ -1,0 +1,70 @@
+/**
+ * MVEL 2.0
+ * Copyright (C) 2007 The Codehaus
+ * Mike Brock, Dhanji Prasanna, John Graham, Mark Proctor
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mvel2.conversion;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.mvel2.ConversionException;
+import org.mvel2.ConversionHandler;
+
+public class IntArrayCH implements ConversionHandler {
+
+    private static final Map<Class, Converter> CNV = new HashMap<Class, Converter>();
+
+    static {
+        CNV.put(String[].class, new Converter() {
+
+            public Object convert(Object o) {
+                String[] old = (String[]) o;
+                Integer[] n = new Integer[old.length];
+                for (int i = 0; i < old.length; i++) {
+                    n[i] = Integer.parseInt(old[i]);
+                }
+
+                return n;
+            }
+        });
+
+        CNV.put(Object[].class, new Converter() {
+
+            public Object convert(Object o) {
+                Object[] old = (Object[]) o;
+                Integer[] n = new Integer[old.length];
+                for (int i = 0; i < old.length; i++) {
+                    n[i] = Integer.parseInt(String.valueOf(old[i]));
+                }
+
+                return n;
+            }
+        });
+
+    }
+
+    public Object convertFrom(Object in) {
+
+        if (!CNV.containsKey(in.getClass()))
+            throw new ConversionException("cannot convert type: " + in.getClass().getName() + " to: " + Boolean.class.getName());
+        return CNV.get(in.getClass()).convert(in);
+    }
+
+    public boolean canConvertFrom(Class cls) {
+        return CNV.containsKey(cls);
+    }
+}

--- a/core/src/main/java/org/mvel2/conversion/IntegerCH.java
+++ b/core/src/main/java/org/mvel2/conversion/IntegerCH.java
@@ -1,0 +1,146 @@
+/**
+ * MVEL 2.0
+ * Copyright (C) 2007 The Codehaus
+ * Mike Brock, Dhanji Prasanna, John Graham, Mark Proctor
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mvel2.conversion;
+
+import static java.lang.Integer.parseInt;
+import static java.lang.String.valueOf;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.mvel2.ConversionException;
+import org.mvel2.ConversionHandler;
+
+public class IntegerCH implements ConversionHandler {
+
+    private static final Map<Class, Converter> CNV = new HashMap<Class, Converter>(10);
+
+    static {
+        CNV.put(Object.class, new Converter() {
+
+            public Object convert(Object o) {
+                if (((String) o).length() == 0) return 0;
+
+                return parseInt(valueOf(o));
+            }
+        });
+
+        CNV.put(BigDecimal.class, new Converter() {
+
+            public Integer convert(Object o) {
+                return ((BigDecimal) o).intValue();
+            }
+        });
+
+        CNV.put(BigInteger.class, new Converter() {
+
+            public Integer convert(Object o) {
+                return ((BigInteger) o).intValue();
+            }
+        });
+
+        CNV.put(String.class, new Converter() {
+
+            public Object convert(Object o) {
+                return parseInt(((String) o));
+            }
+        });
+
+        CNV.put(Short.class, new Converter() {
+
+            public Object convert(Object o) {
+                return ((Short) o).intValue();
+            }
+        });
+
+        CNV.put(Long.class, new Converter() {
+
+            public Object convert(Object o) {
+                //noinspection UnnecessaryBoxing
+                if (((Long) o) > Integer.MAX_VALUE) {
+                    throw new ConversionException("cannot coerce Long to Integer since the value (" + valueOf(o)
+                            + ") exceeds that maximum precision of Integer.");
+                } else {
+                    return ((Long) o).intValue();
+                }
+            }
+        });
+
+        CNV.put(Float.class, new Converter() {
+
+            public Object convert(Object o) {
+                //noinspection UnnecessaryBoxing
+                if (((Float) o) > Integer.MAX_VALUE) {
+                    throw new ConversionException("cannot coerce Float to Integer since the value (" + valueOf(o)
+                            + ") exceeds that maximum precision of Integer.");
+                } else {
+                    return ((Float) o).intValue();
+                }
+            }
+        });
+
+        CNV.put(Double.class, new Converter() {
+
+            public Object convert(Object o) {
+                //noinspection UnnecessaryBoxing
+                if (((Double) o) > Integer.MAX_VALUE) {
+                    throw new ConversionException("cannot coerce Long to Integer since the value (" + valueOf(o)
+                            + ") exceeds that maximum precision of Integer.");
+                } else {
+                    return ((Double) o).intValue();
+                }
+            }
+        });
+
+        CNV.put(Integer.class, new Converter() {
+
+            public Object convert(Object o) {
+                return o;
+            }
+        });
+
+        CNV.put(Boolean.class, new Converter() {
+
+            public Integer convert(Object o) {
+                if ((Boolean) o) return 1;
+                else return 0;
+            }
+        });
+
+        CNV.put(Character.class, new Converter() {
+
+            public Integer convert(Object o) {
+                return (int) ((Character) o).charValue();
+            }
+        });
+    }
+
+    public Object convertFrom(Object in) {
+        if (!CNV.containsKey(in.getClass()))
+            throw new ConversionException("cannot convert type: " + in.getClass().getName() + " to: " + Integer.class.getName());
+
+        return CNV.get(in.getClass()).convert(in);
+    }
+
+    public boolean canConvertFrom(Class cls) {
+        return CNV.containsKey(cls);
+    }
+}

--- a/core/src/main/java/org/mvel2/conversion/ListCH.java
+++ b/core/src/main/java/org/mvel2/conversion/ListCH.java
@@ -1,0 +1,49 @@
+/**
+ * MVEL 2.0
+ * Copyright (C) 2007 The Codehaus
+ * Mike Brock, Dhanji Prasanna, John Graham, Mark Proctor
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mvel2.conversion;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+
+import org.mvel2.ConversionHandler;
+
+public class ListCH implements ConversionHandler {
+
+    public Object convertFrom(Object in) {
+        Class type = in.getClass();
+        List newList = new ArrayList();
+        if (type.isArray()) {
+            newList.addAll(Arrays.asList(((Object[]) in)));
+        } else if (Collection.class.isAssignableFrom(type)) {
+            newList.addAll((Collection) in);
+        } else if (Iterable.class.isAssignableFrom(type)) {
+            for (Object o : (Iterable) in) {
+                newList.add(o);
+            }
+        }
+
+        return newList;
+    }
+
+    public boolean canConvertFrom(Class cls) {
+        return cls.isArray() || Collection.class.isAssignableFrom(cls) || Iterable.class.isAssignableFrom(cls);
+    }
+}

--- a/core/src/main/java/org/mvel2/conversion/LongCH.java
+++ b/core/src/main/java/org/mvel2/conversion/LongCH.java
@@ -1,0 +1,124 @@
+/**
+ * MVEL 2.0
+ * Copyright (C) 2007 The Codehaus
+ * Mike Brock, Dhanji Prasanna, John Graham, Mark Proctor
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mvel2.conversion;
+
+import static java.lang.String.valueOf;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.mvel2.ConversionException;
+import org.mvel2.ConversionHandler;
+
+public class LongCH implements ConversionHandler {
+
+    private static final Map<Class, Converter> CNV = new HashMap<Class, Converter>();
+
+    private static Converter stringConverter = new Converter() {
+
+        public Object convert(Object o) {
+            if (((String) o).length() == 0) return (long) 0;
+
+            return Long.parseLong(((String) o));
+        }
+    };
+
+    static {
+        CNV.put(String.class, stringConverter);
+
+        CNV.put(Object.class, new Converter() {
+
+            public Object convert(Object o) {
+                return stringConverter.convert(valueOf(o));
+            }
+        });
+
+        CNV.put(BigDecimal.class, new Converter() {
+
+            public Long convert(Object o) {
+                return ((BigDecimal) o).longValue();
+            }
+        });
+
+        CNV.put(BigInteger.class, new Converter() {
+
+            public Long convert(Object o) {
+                return ((BigInteger) o).longValue();
+            }
+        });
+
+        CNV.put(Short.class, new Converter() {
+
+            public Object convert(Object o) {
+                //noinspection UnnecessaryBoxing
+                return ((Short) o).longValue();
+            }
+        });
+
+        CNV.put(Long.class, new Converter() {
+
+            public Object convert(Object o) {
+                //noinspection UnnecessaryBoxing
+                return new Long(((Long) o));
+            }
+        });
+
+        CNV.put(Integer.class, new Converter() {
+
+            public Object convert(Object o) {
+                //noinspection UnnecessaryBoxing
+                return ((Integer) o).longValue();
+            }
+        });
+
+        CNV.put(Double.class, new Converter() {
+
+            public Object convert(Object o) {
+                return ((Double) o).longValue();
+            }
+        });
+
+        CNV.put(Float.class, new Converter() {
+
+            public Object convert(Object o) {
+                return ((Float) o).longValue();
+            }
+        });
+
+        CNV.put(Boolean.class, new Converter() {
+
+            public Long convert(Object o) {
+                if ((Boolean) o) return 1l;
+                else return 0l;
+            }
+        });
+    }
+
+    public Object convertFrom(Object in) {
+        if (!CNV.containsKey(in.getClass()))
+            throw new ConversionException("cannot convert type: " + in.getClass().getName() + " to: " + Long.class.getName());
+        return CNV.get(in.getClass()).convert(in);
+    }
+
+    public boolean canConvertFrom(Class cls) {
+        return CNV.containsKey(cls);
+    }
+}

--- a/core/src/main/java/org/mvel2/conversion/ObjectCH.java
+++ b/core/src/main/java/org/mvel2/conversion/ObjectCH.java
@@ -1,0 +1,32 @@
+/**
+ * MVEL 2.0
+ * Copyright (C) 2007 The Codehaus
+ * Mike Brock, Dhanji Prasanna, John Graham, Mark Proctor
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mvel2.conversion;
+
+import org.mvel2.ConversionHandler;
+
+public class ObjectCH implements ConversionHandler {
+
+    public Object convertFrom(Object in) {
+        return in;
+    }
+
+    public boolean canConvertFrom(Class cls) {
+        return true;
+    }
+}

--- a/core/src/main/java/org/mvel2/conversion/PrimIntArrayCH.java
+++ b/core/src/main/java/org/mvel2/conversion/PrimIntArrayCH.java
@@ -1,0 +1,82 @@
+/**
+ * MVEL 2.0
+ * Copyright (C) 2007 The Codehaus
+ * Mike Brock, Dhanji Prasanna, John Graham, Mark Proctor
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mvel2.conversion;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.mvel2.ConversionException;
+import org.mvel2.ConversionHandler;
+
+public class PrimIntArrayCH implements ConversionHandler {
+
+    private static final Map<Class, Converter> CNV = new HashMap<Class, Converter>();
+
+    static {
+        CNV.put(String[].class, new Converter() {
+
+            public Object convert(Object o) {
+                String[] old = (String[]) o;
+                int[] n = new int[old.length];
+                for (int i = 0; i < old.length; i++) {
+                    n[i] = Integer.parseInt(old[i]);
+                }
+
+                return n;
+            }
+        });
+
+        CNV.put(Object[].class, new Converter() {
+
+            public Object convert(Object o) {
+                Object[] old = (Object[]) o;
+                int[] n = new int[old.length];
+                for (int i = 0; i < old.length; i++) {
+                    n[i] = Integer.parseInt(String.valueOf(old[i]));
+                }
+
+                return n;
+            }
+        });
+
+        CNV.put(Integer[].class, new Converter() {
+
+            public Object convert(Object o) {
+                Integer[] old = (Integer[]) o;
+                int[] n = new int[old.length];
+                for (int i = 0; i < old.length; i++) {
+                    n[i] = old[i];
+                }
+
+                return n;
+            }
+        });
+
+    }
+
+    public Object convertFrom(Object in) {
+        if (!CNV.containsKey(in.getClass()))
+            throw new ConversionException("cannot convert type: " + in.getClass().getName() + " to: " + Boolean.class.getName());
+        return CNV.get(in.getClass()).convert(in);
+    }
+
+    public boolean canConvertFrom(Class cls) {
+        return CNV.containsKey(cls);
+    }
+}

--- a/core/src/main/java/org/mvel2/conversion/SetCH.java
+++ b/core/src/main/java/org/mvel2/conversion/SetCH.java
@@ -1,0 +1,49 @@
+/**
+ * MVEL 2.0
+ * Copyright (C) 2007 The Codehaus
+ * Mike Brock, Dhanji Prasanna, John Graham, Mark Proctor
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mvel2.conversion;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.LinkedHashSet;
+import java.util.Set;
+
+import org.mvel2.ConversionHandler;
+
+public class SetCH implements ConversionHandler {
+
+    public Object convertFrom(Object in) {
+        Class type = in.getClass();
+        Set newSet = new LinkedHashSet();
+        if (type.isArray()) {
+            newSet.addAll(Arrays.asList(((Object[]) in)));
+        } else if (Collection.class.isAssignableFrom(type)) {
+            newSet.addAll((Collection) in);
+        } else if (Iterable.class.isAssignableFrom(type)) {
+            for (Object o : (Iterable) in) {
+                newSet.add(o);
+            }
+        }
+
+        return newSet;
+    }
+
+    public boolean canConvertFrom(Class cls) {
+        return cls.isArray() || Collection.class.isAssignableFrom(cls) || Iterable.class.isAssignableFrom(cls);
+    }
+}

--- a/core/src/main/java/org/mvel2/conversion/ShortCH.java
+++ b/core/src/main/java/org/mvel2/conversion/ShortCH.java
@@ -1,0 +1,150 @@
+/**
+ * MVEL 2.0
+ * Copyright (C) 2007 The Codehaus
+ * Mike Brock, Dhanji Prasanna, John Graham, Mark Proctor
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mvel2.conversion;
+
+import static java.lang.Short.parseShort;
+import static java.lang.String.valueOf;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.mvel2.ConversionException;
+import org.mvel2.ConversionHandler;
+
+public class ShortCH implements ConversionHandler {
+
+    /**
+     * This is purely because Eclipse sucks, and has a serious bug with
+     * it's java parser.
+     */
+    private static final Short TRUE = (short) 1;
+    private static final Short FALSE = (short) 0;
+    private static final Map<Class, Converter> CNV = new HashMap<Class, Converter>();
+    private static Converter stringConverter = new Converter() {
+
+        public Short convert(Object o) {
+            return parseShort(((String) o));
+        }
+    };
+
+    static {
+        CNV.put(String.class, stringConverter);
+
+        CNV.put(Object.class, new Converter() {
+
+            public Object convert(Object o) {
+                return stringConverter.convert(valueOf(o));
+            }
+        });
+
+        CNV.put(BigDecimal.class, new Converter() {
+
+            public Short convert(Object o) {
+                return ((BigDecimal) o).shortValue();
+            }
+        });
+
+        CNV.put(BigInteger.class, new Converter() {
+
+            public Short convert(Object o) {
+                return ((BigInteger) o).shortValue();
+            }
+        });
+
+        CNV.put(Short.class, new Converter() {
+
+            public Object convert(Object o) {
+                return o;
+            }
+        });
+
+        CNV.put(Integer.class, new Converter() {
+
+            public Short convert(Object o) {
+                if (((Integer) o) > Short.MAX_VALUE) {
+                    throw new ConversionException("cannot coerce Integer to Short since the value (" + valueOf(o)
+                            + ") exceeds that maximum precision of Integer.");
+                } else {
+                    return ((Integer) o).shortValue();
+                }
+            }
+        });
+
+        CNV.put(Float.class, new Converter() {
+
+            public Short convert(Object o) {
+                if (((Float) o) > Short.MAX_VALUE) {
+                    throw new ConversionException(
+                            "cannot coerce Float to Short since the value (" + valueOf(o) + ") exceeds that maximum precision of Integer.");
+                } else {
+                    return ((Float) o).shortValue();
+                }
+            }
+        });
+
+        CNV.put(Double.class, new Converter() {
+
+            public Short convert(Object o) {
+                if (((Double) o) > Short.MAX_VALUE) {
+                    throw new ConversionException("cannot coerce Double to Short since the value (" + valueOf(o)
+                            + ") exceeds that maximum precision of Integer.");
+                } else {
+                    return ((Double) o).shortValue();
+                }
+            }
+        });
+
+        CNV.put(Long.class, new Converter() {
+
+            public Short convert(Object o) {
+                if (((Long) o) > Short.MAX_VALUE) {
+                    throw new ConversionException("cannot coerce Integer to Short since the value (" + valueOf(o)
+                            + ") exceeds that maximum precision of Integer.");
+                } else {
+                    return ((Long) o).shortValue();
+                }
+            }
+        });
+
+        CNV.put(Boolean.class, new Converter() {
+
+            public Short convert(Object o) {
+
+                if ((Boolean) o) return TRUE;
+                else {
+                    return FALSE;
+                }
+
+            }
+        });
+
+    }
+
+    public Object convertFrom(Object in) {
+        if (!CNV.containsKey(in.getClass()))
+            throw new ConversionException("cannot convert type: " + in.getClass().getName() + " to: " + Short.class.getName());
+        return CNV.get(in.getClass()).convert(in);
+    }
+
+    public boolean canConvertFrom(Class cls) {
+        return CNV.containsKey(cls);
+    }
+}

--- a/core/src/main/java/org/mvel2/conversion/StringArrayCH.java
+++ b/core/src/main/java/org/mvel2/conversion/StringArrayCH.java
@@ -1,0 +1,67 @@
+/**
+ * MVEL 2.0
+ * Copyright (C) 2007 The Codehaus
+ * Mike Brock, Dhanji Prasanna, John Graham, Mark Proctor
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mvel2.conversion;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.mvel2.ConversionHandler;
+
+public class StringArrayCH implements ConversionHandler {
+
+    private static final Map<Class, Converter> CNV = new HashMap<Class, Converter>();
+
+    static {
+        CNV.put(Object[].class, new Converter() {
+
+            public Object convert(Object o) {
+                Object[] old = (Object[]) o;
+                String[] n = new String[old.length];
+                for (int i = 0; i < old.length; i++) {
+                    n[i] = String.valueOf(old[i]);
+                }
+
+                return n;
+            }
+        });
+
+    }
+
+    public Object convertFrom(Object in) {
+
+        if (in.getClass().isArray()) {
+
+            Object[] old = (Object[]) in;
+            String[] n = new String[old.length];
+            for (int i = 0; i < old.length; i++) {
+                n[i] = String.valueOf(old[i]);
+            }
+
+            return n;
+        } else {
+            return new String[] { String.valueOf(in) };
+        }
+
+        //    return CNV.get(in.getClass()).convert(in);
+    }
+
+    public boolean canConvertFrom(Class cls) {
+        return CNV.containsKey(cls);
+    }
+}

--- a/core/src/main/java/org/mvel2/conversion/StringCH.java
+++ b/core/src/main/java/org/mvel2/conversion/StringCH.java
@@ -1,0 +1,35 @@
+/**
+ * MVEL 2.0
+ * Copyright (C) 2007 The Codehaus
+ * Mike Brock, Dhanji Prasanna, John Graham, Mark Proctor
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mvel2.conversion;
+
+import static java.lang.String.valueOf;
+
+import org.mvel2.ConversionHandler;
+import org.mvel2.compiler.BlankLiteral;
+
+public class StringCH implements ConversionHandler {
+
+    public Object convertFrom(Object in) {
+        return valueOf(in);
+    }
+
+    public boolean canConvertFrom(Class cls) {
+        return cls != BlankLiteral.class;
+    }
+}

--- a/core/src/main/java/org/mvel2/conversion/UnitConversion.java
+++ b/core/src/main/java/org/mvel2/conversion/UnitConversion.java
@@ -1,0 +1,49 @@
+/**
+ * MVEL 2.0
+ * Copyright (C) 2007 The Codehaus
+ * Mike Brock, Dhanji Prasanna, John Graham, Mark Proctor
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mvel2.conversion;
+
+import org.mvel2.ConversionHandler;
+import org.mvel2.Unit;
+
+public class UnitConversion implements ConversionHandler {
+
+    public Object convertFrom(Object in) {
+        try {
+            return Unit.class.newInstance().convertFrom(in);
+        } catch (InstantiationException e) {
+            e.printStackTrace();
+        } catch (IllegalAccessException e) {
+            e.printStackTrace();
+        }
+        return null;
+    }
+
+    public boolean canConvertFrom(Class cls) {
+        if (Unit.class.isAssignableFrom(cls) || Number.class.isAssignableFrom(cls)) {
+            try {
+                return Unit.class.newInstance().canConvertFrom(cls);
+            } catch (InstantiationException e) {
+                e.printStackTrace();
+            } catch (IllegalAccessException e) {
+                e.printStackTrace();
+            }
+        }
+        return false;
+    }
+}

--- a/core/src/main/java/org/mvel2/debug/DebugTools.java
+++ b/core/src/main/java/org/mvel2/debug/DebugTools.java
@@ -1,0 +1,375 @@
+/**
+ * MVEL 2.0
+ * Copyright (C) 2007 The Codehaus
+ * Mike Brock, Dhanji Prasanna, John Graham, Mark Proctor
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mvel2.debug;
+
+import static org.mvel2.Operator.ADD;
+import static org.mvel2.Operator.SUB;
+
+import java.io.Serializable;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.mvel2.Operator;
+import org.mvel2.ast.ASTNode;
+import org.mvel2.ast.BinaryOperation;
+import org.mvel2.ast.NestedStatement;
+import org.mvel2.ast.Substatement;
+import org.mvel2.compiler.CompiledExpression;
+import org.mvel2.compiler.ExecutableAccessor;
+import org.mvel2.compiler.ExecutableLiteral;
+import org.mvel2.integration.VariableResolver;
+import org.mvel2.integration.VariableResolverFactory;
+import org.mvel2.util.ASTIterator;
+import org.mvel2.util.ASTLinkedList;
+
+/**
+ * @author Christopher Brock
+ */
+public class DebugTools {
+
+    public static String decompile(Serializable expr) {
+        if (expr instanceof CompiledExpression) return decompile((CompiledExpression) expr);
+        else if (expr instanceof ExecutableAccessor) return "CANNOT DECOMPILE OPTIMIZED STATEMENT (Run with -Dmvel.optimizer=false)";
+        else if (expr instanceof ExecutableLiteral) {
+            return "LITERAL: " + ((ExecutableLiteral) expr).getValue(null, null);
+        } else return "NOT A KNOWN PAYLOAD: " + expr.getClass().getName();
+    }
+
+    public static String decompile(CompiledExpression cExp) {
+        return decompile(cExp, false, new DecompileContext());
+    }
+
+    private static String decompile(CompiledExpression cExp, boolean nest, DecompileContext context) {
+        ASTIterator iter = new ASTLinkedList(cExp.getFirstNode());
+        ASTNode tk;
+
+        StringBuffer sbuf = new StringBuffer();
+
+        if (!nest) {
+            sbuf.append("Expression Decompile\n-------------\n");
+        }
+
+        while (iter.hasMoreNodes()) {
+            sbuf.append("(").append(context.node++).append(") ");
+
+            if ((tk = iter.nextNode()) instanceof NestedStatement
+                    && ((NestedStatement) tk).getNestedStatement() instanceof CompiledExpression) {
+                //noinspection StringConcatenationInsideStringBufferAppend
+                sbuf.append("NEST [" + tk.getClass().getSimpleName() + "]: { " + tk.getName() + " }\n");
+                sbuf.append(decompile((CompiledExpression) ((NestedStatement) tk).getNestedStatement(), true, context));
+            }
+            if (tk instanceof Substatement && ((Substatement) tk).getStatement() instanceof CompiledExpression) {
+                //noinspection StringConcatenationInsideStringBufferAppend
+                sbuf.append("NEST [" + tk.getClass().getSimpleName() + "]: { " + tk.getName() + " }\n");
+                sbuf.append(decompile((CompiledExpression) ((Substatement) tk).getStatement(), true, context));
+            }
+            //            else if (tk instanceof Function) {
+            //                sbuf.append("FUNCTION [" + tk.getName() + "]: ")
+            //                        .append(decompile((CompiledExpression) ((Function)tk).getCompiledBlock(), true, context));
+            //            }
+            else if (tk.isDebuggingSymbol()) {
+                //noinspection StringConcatenationInsideStringBufferAppend
+                sbuf.append("DEBUG_SYMBOL :: " + tk.toString());
+            } else if (tk.isLiteral()) {
+                sbuf.append("LITERAL :: ").append(tk.getLiteralValue()).append("'");
+            } else if (tk.isOperator()) {
+                sbuf.append("OPERATOR [").append(getOperatorName(tk.getOperator())).append("]: ").append(tk.getName());
+
+                if (tk.isOperator(Operator.END_OF_STMT)) sbuf.append("\n");
+            } else if (tk.isIdentifier()) {
+                sbuf.append("REFERENCE :: ").append(tk.getClass().getSimpleName()).append(":").append(tk.getName());
+            } else if (tk instanceof BinaryOperation) {
+                BinaryOperation bo = (BinaryOperation) tk;
+                sbuf.append("OPERATION [" + getOperatorName(bo.getOperation()) + "] {").append(bo.getLeft().getName()).append("} {")
+                        .append(bo.getRight().getName()).append("}");
+            } else {
+                //noinspection StringConcatenationInsideStringBufferAppend
+                sbuf.append("NODE [" + tk.getClass().getSimpleName() + "] :: " + tk.getName());
+            }
+
+            sbuf.append("\n");
+
+        }
+
+        sbuf.append("==END==");
+
+        return sbuf.toString();
+    }
+
+    public static String getOperatorSymbol(int operator) {
+        switch (operator) {
+            case ADD:
+                return "+";
+            case SUB:
+                return "-";
+            case Operator.ASSIGN:
+                return "=";
+            case Operator.ASSIGN_ADD:
+                return "=+";
+            case Operator.ASSIGN_STR_APPEND:
+                return "=+";
+            case Operator.ASSIGN_SUB:
+                return "=";
+            case Operator.BW_AND:
+                return "&";
+            case Operator.BW_OR:
+                return "|";
+            case Operator.BW_SHIFT_LEFT:
+                return "<<";
+            case Operator.BW_SHIFT_RIGHT:
+                return ">>";
+            case Operator.BW_USHIFT_LEFT:
+                return "<<<";
+            case Operator.BW_USHIFT_RIGHT:
+                return ">>>";
+            case Operator.BW_XOR:
+                return "^";
+            case Operator.CONTAINS:
+                return "contains";
+            case Operator.CONVERTABLE_TO:
+                return "convertable_to";
+            case Operator.DEC:
+                return "--";
+            case Operator.DEC_ASSIGN:
+                return "++";
+            case Operator.DIV:
+                return "/";
+            case Operator.DO:
+                return "do";
+            case Operator.ELSE:
+                return "else";
+            case Operator.END_OF_STMT:
+                return ";";
+            case Operator.EQUAL:
+                return "==";
+            case Operator.FOR:
+                return "for";
+            case Operator.FOREACH:
+                return "foreach";
+            case Operator.FUNCTION:
+                return "function";
+            case Operator.GETHAN:
+                return ">=";
+            case Operator.GTHAN:
+                return ">";
+            case Operator.IF:
+                return "if";
+            case Operator.INC:
+                return "++";
+            case Operator.INC_ASSIGN:
+                return "++";
+            case Operator.INSTANCEOF:
+                return "instanceof";
+            case Operator.LETHAN:
+                return "<=";
+            case Operator.LTHAN:
+                return "<";
+            case Operator.MOD:
+                return "%";
+            case Operator.MULT:
+                return "*";
+            case Operator.NEQUAL:
+                return "!=";
+            case Operator.NEW:
+                return "new";
+
+            case Operator.AND:
+                return "&&";
+
+            case Operator.OR:
+                return "||";
+            case Operator.POWER:
+                return "**";
+            case Operator.PROJECTION:
+                return "PROJECT";
+            case Operator.REGEX:
+                return "REGEX";
+            case Operator.RETURN:
+                return "RETURN";
+            case Operator.SIMILARITY:
+                return "SIMILARITY";
+            case Operator.SOUNDEX:
+                return "SOUNDEX";
+            case Operator.STR_APPEND:
+                return "+";
+            case Operator.SWITCH:
+                return "SWITCH";
+            case Operator.TERNARY:
+                return "TERNARY_IF";
+            case Operator.TERNARY_ELSE:
+                return "TERNARY_ELSE";
+            case Operator.WHILE:
+                return "while";
+            case Operator.CHOR:
+                return "or";
+
+            case Operator.STACKLANG:
+                return "stacklang";
+
+        }
+
+        return "UNKNOWN_OPERATOR";
+    }
+
+    public static String getOperatorName(int operator) {
+        switch (operator) {
+            case ADD:
+                return "ADD";
+            case SUB:
+                return "SUBTRACT";
+            case Operator.ASSIGN:
+                return "ASSIGN";
+            case Operator.ASSIGN_ADD:
+                return "ASSIGN_ADD";
+            case Operator.ASSIGN_STR_APPEND:
+                return "ASSIGN_STR_APPEND";
+            case Operator.ASSIGN_SUB:
+                return "ASSIGN_SUB";
+            case Operator.BW_AND:
+                return "BIT_AND";
+            case Operator.BW_OR:
+                return "BIT_OR";
+            case Operator.BW_SHIFT_LEFT:
+                return "BIT_SHIFT_LEFT";
+            case Operator.BW_SHIFT_RIGHT:
+                return "BIT_SHIFT_RIGHT";
+            case Operator.BW_USHIFT_LEFT:
+                return "BIT_UNSIGNED_SHIFT_LEFT";
+            case Operator.BW_USHIFT_RIGHT:
+                return "BIT_UNSIGNED_SHIFT_RIGHT";
+            case Operator.BW_XOR:
+                return "BIT_XOR";
+            case Operator.CONTAINS:
+                return "CONTAINS";
+            case Operator.CONVERTABLE_TO:
+                return "CONVERTABLE_TO";
+            case Operator.DEC:
+                return "DECREMENT";
+            case Operator.DEC_ASSIGN:
+                return "DECREMENT_ASSIGN";
+            case Operator.DIV:
+                return "DIVIDE";
+            case Operator.DO:
+                return "DO";
+            case Operator.ELSE:
+                return "ELSE";
+            case Operator.END_OF_STMT:
+                return "END_OF_STATEMENT";
+            case Operator.EQUAL:
+                return "EQUAL";
+            case Operator.FOR:
+                return "FOR";
+            case Operator.FOREACH:
+                return "FOREACH";
+            case Operator.FUNCTION:
+                return "FUNCTION";
+            case Operator.GETHAN:
+                return "GREATER_THAN_OR_EQUAL";
+            case Operator.GTHAN:
+                return "GREATHER_THAN";
+            case Operator.IF:
+                return "IF";
+            case Operator.INC:
+                return "INCREMENT";
+            case Operator.INC_ASSIGN:
+                return "INCREMENT_ASSIGN";
+            case Operator.INSTANCEOF:
+                return "INSTANCEOF";
+            case Operator.LETHAN:
+                return "LESS_THAN_OR_EQUAL";
+            case Operator.LTHAN:
+                return "LESS_THAN";
+            case Operator.MOD:
+                return "MODULUS";
+            case Operator.MULT:
+                return "MULTIPLY";
+            case Operator.NEQUAL:
+                return "NOT_EQUAL";
+            case Operator.NEW:
+                return "NEW_OBJECT";
+
+            case Operator.AND:
+                return "AND";
+
+            case Operator.OR:
+                return "OR";
+            case Operator.POWER:
+                return "POWER_OF";
+            case Operator.PROJECTION:
+                return "PROJECT";
+            case Operator.REGEX:
+                return "REGEX";
+            case Operator.RETURN:
+                return "RETURN";
+            case Operator.SIMILARITY:
+                return "SIMILARITY";
+            case Operator.SOUNDEX:
+                return "SOUNDEX";
+            case Operator.STR_APPEND:
+                return "STR_APPEND";
+            case Operator.SWITCH:
+                return "SWITCH";
+            case Operator.TERNARY:
+                return "TERNARY_IF";
+            case Operator.TERNARY_ELSE:
+                return "TERNARY_ELSE";
+            case Operator.WHILE:
+                return "WHILE";
+            case Operator.CHOR:
+                return "CHAINED_OR";
+            case Operator.STACKLANG:
+                return "STACKLANG";
+
+        }
+
+        return "UNKNOWN_OPERATOR";
+    }
+
+    public static Class determineType(String name, CompiledExpression compiledExpression) {
+        ASTIterator iter = new ASTLinkedList(compiledExpression.getFirstNode());
+        ASTNode node;
+        while (iter.hasMoreNodes()) {
+            if (name.equals((node = iter.nextNode()).getName()) && node.isAssignment()) {
+                return node.getEgressType();
+            }
+        }
+
+        return null;
+    }
+
+    public static Map<String, VariableResolver> getAllVariableResolvers(VariableResolverFactory rootFactory) {
+
+        Map<String, VariableResolver> allVariableResolvers = new HashMap<String, VariableResolver>();
+
+        VariableResolverFactory vrf = rootFactory;
+        do {
+            for (String var : vrf.getKnownVariables()) {
+                allVariableResolvers.put(var, vrf.getVariableResolver(var));
+            }
+        } while ((vrf = vrf.getNextFactory()) != null);
+
+        return allVariableResolvers;
+    }
+
+    private static final class DecompileContext {
+
+        public int node = 0;
+    }
+
+}

--- a/core/src/main/java/org/mvel2/debug/Debugger.java
+++ b/core/src/main/java/org/mvel2/debug/Debugger.java
@@ -1,0 +1,34 @@
+/**
+ * MVEL 2.0
+ * Copyright (C) 2007 The Codehaus
+ * Mike Brock, Dhanji Prasanna, John Graham, Mark Proctor
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mvel2.debug;
+
+public interface Debugger {
+
+    public static int CONTINUE = 0;
+    public static int STEP = 1;
+    public static int STEP_OVER = STEP;
+
+    /**
+     * When a breakpoint is recached,
+     *
+     * @param frame
+     * @return continuation command
+     */
+    public int onBreak(Frame frame);
+}

--- a/core/src/main/java/org/mvel2/debug/DebuggerContext.java
+++ b/core/src/main/java/org/mvel2/debug/DebuggerContext.java
@@ -1,0 +1,105 @@
+/**
+ * MVEL 2.0
+ * Copyright (C) 2007 The Codehaus
+ * Mike Brock, Dhanji Prasanna, John Graham, Mark Proctor
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mvel2.debug;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+import org.mvel2.ast.LineLabel;
+import org.mvel2.compiler.CompiledExpression;
+import org.mvel2.integration.VariableResolverFactory;
+
+public class DebuggerContext {
+
+    private Map<String, Set<Integer>> breakpoints;
+    private Debugger debugger;
+    private int debuggerState = 0;
+
+    public DebuggerContext() {
+        breakpoints = new HashMap<String, Set<Integer>>();
+    }
+
+    public Map<String, Set<Integer>> getBreakpoints() {
+        return breakpoints;
+    }
+
+    public void setBreakpoints(Map<String, Set<Integer>> breakpoints) {
+        this.breakpoints = breakpoints;
+    }
+
+    public Debugger getDebugger() {
+        return debugger;
+    }
+
+    public void setDebugger(Debugger debugger) {
+        this.debugger = debugger;
+    }
+
+    public int getDebuggerState() {
+        return debuggerState;
+    }
+
+    public void setDebuggerState(int debuggerState) {
+        this.debuggerState = debuggerState;
+    }
+
+    // utility methods
+
+    public void registerBreakpoint(String sourceFile, int lineNumber) {
+        if (!breakpoints.containsKey(sourceFile)) breakpoints.put(sourceFile, new HashSet<Integer>());
+        breakpoints.get(sourceFile).add(lineNumber);
+    }
+
+    public void removeBreakpoint(String sourceFile, int lineNumber) {
+        if (!breakpoints.containsKey(sourceFile)) return;
+        breakpoints.get(sourceFile).remove(lineNumber);
+    }
+
+    public void clearAllBreakpoints() {
+        breakpoints.clear();
+    }
+
+    public boolean hasBreakpoints() {
+        return breakpoints.size() != 0;
+    }
+
+    public boolean hasBreakpoint(LineLabel label) {
+        return breakpoints.containsKey(label.getSourceFile()) && breakpoints.get(label.getSourceFile()).contains(label.getLineNumber());
+    }
+
+    public boolean hasBreakpoint(String sourceFile, int lineNumber) {
+        return breakpoints.containsKey(sourceFile) && breakpoints.get(sourceFile).contains(lineNumber);
+    }
+
+    public boolean hasDebugger() {
+        return debugger != null;
+    }
+
+    public int checkBreak(LineLabel label, VariableResolverFactory factory, CompiledExpression expression) {
+        if (debuggerState == Debugger.STEP || hasBreakpoint(label)) {
+            if (debugger == null) throw new RuntimeException("no debugger registered to handle breakpoint");
+            return debuggerState = debugger.onBreak(new Frame(label, factory));
+
+        }
+        return 0;
+    }
+
+}

--- a/core/src/main/java/org/mvel2/debug/Frame.java
+++ b/core/src/main/java/org/mvel2/debug/Frame.java
@@ -1,0 +1,49 @@
+/**
+ * MVEL 2.0
+ * Copyright (C) 2007 The Codehaus
+ * Mike Brock, Dhanji Prasanna, John Graham, Mark Proctor
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mvel2.debug;
+
+import org.mvel2.ast.LineLabel;
+import org.mvel2.integration.VariableResolverFactory;
+
+public class Frame {
+
+    private LineLabel label;
+    private VariableResolverFactory factory;
+
+    public Frame(LineLabel label, VariableResolverFactory factory) {
+        this.label = label;
+        this.factory = factory;
+    }
+
+    public String getSourceName() {
+        return label.getSourceFile();
+    }
+
+    public int getLineNumber() {
+        return label.getLineNumber();
+    }
+
+    public VariableResolverFactory getFactory() {
+        return factory;
+    }
+
+    public void setFactory(VariableResolverFactory factory) {
+        this.factory = factory;
+    }
+}

--- a/core/src/main/java/org/mvel2/integration/GlobalListenerFactory.java
+++ b/core/src/main/java/org/mvel2/integration/GlobalListenerFactory.java
@@ -1,0 +1,49 @@
+package org.mvel2.integration;
+
+import java.util.LinkedList;
+import java.util.List;
+
+public class GlobalListenerFactory {
+
+    private static List<Listener> propertyGetListeners;
+    private static List<Listener> propertySetListeners;
+
+    public static boolean hasGetListeners() {
+        return propertyGetListeners != null && !propertyGetListeners.isEmpty();
+    }
+
+    public static boolean hasSetListeners() {
+        return propertySetListeners != null && !propertySetListeners.isEmpty();
+    }
+
+    public static boolean registerGetListener(Listener getListener) {
+        if (propertyGetListeners == null) propertyGetListeners = new LinkedList<Listener>();
+        return propertyGetListeners.add(getListener);
+    }
+
+    public static boolean registerSetListener(Listener getListener) {
+        if (propertySetListeners == null) propertySetListeners = new LinkedList<Listener>();
+        return propertySetListeners.add(getListener);
+    }
+
+    public static void notifyGetListeners(Object target, String name, VariableResolverFactory variableFactory) {
+        if (propertyGetListeners != null) {
+            for (Listener l : propertyGetListeners) {
+                l.onEvent(target, name, variableFactory, null);
+            }
+        }
+    }
+
+    public static void notifySetListeners(Object target, String name, VariableResolverFactory variableFactory, Object value) {
+        if (propertySetListeners != null) {
+            for (Listener l : propertySetListeners) {
+                l.onEvent(target, name, variableFactory, value);
+            }
+        }
+    }
+
+    public static void disposeAll() {
+        propertyGetListeners = null;
+        propertySetListeners = null;
+    }
+}

--- a/core/src/main/java/org/mvel2/integration/Interceptor.java
+++ b/core/src/main/java/org/mvel2/integration/Interceptor.java
@@ -1,0 +1,53 @@
+/**
+ * MVEL 2.0
+ * Copyright (C) 2007 The Codehaus
+ * Mike Brock, Dhanji Prasanna, John Graham, Mark Proctor
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.mvel2.integration;
+
+import org.mvel2.ast.ASTNode;
+
+/**
+ * An interceptor can be used to decorate functionality into an expression or to hook into external functionality, such
+ * as to log an event or fire some other event.
+ *
+ * @author Christopher Brock
+ */
+public interface Interceptor {
+
+    public static final int NORMAL_FLOW = 0;
+    public static final int SKIP = 1;
+    public static final int END = 2;
+
+    /**
+     * This method is executed before the wrapped statement.
+     *
+     * @param node    The ASTNode wrapped by the interceptor
+     * @param factory The variable factory
+     * @return The response code.  Should return 0.
+     */
+    public int doBefore(ASTNode node, VariableResolverFactory factory);
+
+    /**
+     * This method is called after the wrapped statement has completed.  A copy of the top-value of the execution
+     * stack is also availablehere.
+     *
+     * @param exitStackValue The value on the top of the stack after executing the statement.
+     * @param node           The ASTNode wrapped by the interceptor
+     * @param factory        The variable factory
+     * @return The response code.  Should return 0.
+     */
+    public int doAfter(Object exitStackValue, ASTNode node, VariableResolverFactory factory);
+}

--- a/core/src/main/java/org/mvel2/integration/Listener.java
+++ b/core/src/main/java/org/mvel2/integration/Listener.java
@@ -1,0 +1,6 @@
+package org.mvel2.integration;
+
+public interface Listener {
+
+    public void onEvent(Object context, String contextName, VariableResolverFactory variableFactory, Object value);
+}

--- a/core/src/main/java/org/mvel2/integration/PropertyHandler.java
+++ b/core/src/main/java/org/mvel2/integration/PropertyHandler.java
@@ -1,0 +1,48 @@
+/**
+ * MVEL 2.0
+ * Copyright (C) 2007 The Codehaus
+ * Mike Brock, Dhanji Prasanna, John Graham, Mark Proctor
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mvel2.integration;
+
+/**
+ * This interface allows an external property handler to resolve a property against the provided context.
+ *
+ * @see org.mvel2.optimizers.impl.asm.ProducesBytecode
+ */
+public interface PropertyHandler {
+
+    /**
+     * Retrieves the value of the property.
+     *
+     * @param name            - the name of the property to be resolved.
+     * @param contextObj      - the current context object.
+     * @param variableFactory - the root variable factory provided by the runtime.
+     * @return - the value of the property.
+     */
+    public Object getProperty(String name, Object contextObj, VariableResolverFactory variableFactory);
+
+    /**
+     * Sets the value of the property.
+     *
+     * @param name            - the name of the property to be resolved.
+     * @param contextObj      - the current context object.
+     * @param variableFactory - the root variable factory provided by the runtime.
+     * @param value           - the value to be set to the resolved property
+     * @return - the resultant value of the property (should normally be the same as the value passed)
+     */
+    public Object setProperty(String name, Object contextObj, VariableResolverFactory variableFactory, Object value);
+}

--- a/core/src/main/java/org/mvel2/integration/PropertyHandlerFactory.java
+++ b/core/src/main/java/org/mvel2/integration/PropertyHandlerFactory.java
@@ -1,0 +1,94 @@
+/**
+ * MVEL 2.0
+ * Copyright (C) 2007 The Codehaus
+ * Mike Brock, Dhanji Prasanna, John Graham, Mark Proctor
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mvel2.integration;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class PropertyHandlerFactory {
+
+    protected static Map<Class, PropertyHandler> propertyHandlerClass = new HashMap<Class, PropertyHandler>();
+
+    protected static PropertyHandler nullPropertyHandler;
+    protected static PropertyHandler nullMethodHandler;
+
+    public static PropertyHandler getPropertyHandler(Class clazz) {
+        return propertyHandlerClass.get(clazz);
+    }
+
+    public static boolean hasPropertyHandler(Class clazz) {
+        if (clazz == null) return false;
+        if (!propertyHandlerClass.containsKey(clazz)) {
+            Class clazzWalk = clazz;
+            do {
+                if (clazz != clazzWalk && propertyHandlerClass.containsKey(clazzWalk)) {
+                    propertyHandlerClass.put(clazz, propertyHandlerClass.get(clazzWalk));
+                    return true;
+                }
+                for (Class c : clazzWalk.getInterfaces()) {
+                    if (propertyHandlerClass.containsKey(c)) {
+                        propertyHandlerClass.put(clazz, propertyHandlerClass.get(c));
+                        return true;
+                    }
+                }
+            } while ((clazzWalk = clazzWalk.getSuperclass()) != null && clazzWalk != Object.class);
+            return false;
+        } else {
+            return true;
+        }
+    }
+
+    public static void registerPropertyHandler(Class clazz, PropertyHandler propertyHandler) {
+        propertyHandlerClass.put(clazz, propertyHandler);
+    }
+
+    public static boolean hasNullPropertyHandler() {
+        return nullPropertyHandler != null;
+    }
+
+    public static PropertyHandler getNullPropertyHandler() {
+        return nullPropertyHandler;
+    }
+
+    public static void setNullPropertyHandler(PropertyHandler handler) {
+        nullPropertyHandler = handler;
+    }
+
+    public static boolean hasNullMethodHandler() {
+        return nullMethodHandler != null;
+    }
+
+    public static PropertyHandler getNullMethodHandler() {
+        return nullMethodHandler;
+    }
+
+    public static void setNullMethodHandler(PropertyHandler handler) {
+        nullMethodHandler = handler;
+    }
+
+    public static void unregisterPropertyHandler(Class clazz) {
+        propertyHandlerClass.remove(clazz);
+    }
+
+    public static void disposeAll() {
+        nullMethodHandler = null;
+        nullPropertyHandler = null;
+        propertyHandlerClass.clear();
+    }
+}

--- a/core/src/main/java/org/mvel2/integration/ResolverTools.java
+++ b/core/src/main/java/org/mvel2/integration/ResolverTools.java
@@ -1,0 +1,66 @@
+/**
+ * MVEL 2.0
+ * Copyright (C) 2007 The Codehaus
+ * Mike Brock, Dhanji Prasanna, John Graham, Mark Proctor
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.mvel2.integration;
+
+/**
+ * A set of tools for dealing with factorys, specifically to make chaining issues easy to deal with.
+ *
+ * @author Christopher Brock
+ */
+public class ResolverTools {
+
+    /**
+     * Based on a root factory, append the new factory to the end of the chain.
+     *
+     * @param root       The root factory
+     * @param newFactory The new factory
+     * @return An instance of the new factory
+     */
+    public static <T extends VariableResolverFactory> T appendFactory(VariableResolverFactory root, T newFactory) {
+        if (root.getNextFactory() == null) {
+            root.setNextFactory(newFactory);
+        } else {
+            VariableResolverFactory vrf = root;
+
+            while (vrf.getNextFactory() != null) {
+                vrf = vrf.getNextFactory();
+            }
+            vrf.setNextFactory(newFactory);
+        }
+
+        return newFactory;
+    }
+
+    /**
+     * Based on the root factory, insert the new factory right after the root, and before any other in the chain.
+     *
+     * @param root       The root factory
+     * @param newFactory The new factory
+     * @return An instance of the new factory.
+     */
+    public static <T extends VariableResolverFactory> T insertFactory(VariableResolverFactory root, T newFactory) {
+        if (root.getNextFactory() == null) {
+            root.setNextFactory(newFactory);
+        } else {
+            newFactory.setNextFactory(root.getNextFactory());
+            root.setNextFactory(newFactory);
+        }
+
+        return newFactory;
+    }
+}

--- a/core/src/main/java/org/mvel2/integration/VariableResolver.java
+++ b/core/src/main/java/org/mvel2/integration/VariableResolver.java
@@ -1,0 +1,72 @@
+/**
+ * MVEL 2.0
+ * Copyright (C) 2007 The Codehaus
+ * Mike Brock, Dhanji Prasanna, John Graham, Mark Proctor
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mvel2.integration;
+
+import java.io.Serializable;
+
+/**
+ * A variable resolver is responsible for physically accessing a variable, for either read or write.  VariableResolver's
+ * are obtained via a {@link VariableResolverFactory}.
+ */
+public interface VariableResolver extends Serializable {
+
+    /**
+     * Returns the name of external variable.
+     *
+     * @return A string representing the variable name.
+     */
+    public String getName();
+
+    /**
+     * This should return the type of the variable.  However, this is not completely necessary, and is particularily
+     * only of benefit to systems that require use of MVEL's strict typing facilities.  In most cases, this implementation
+     * can simply return: Object.class
+     *
+     * @return A Class instance representing the type of the target variable.
+     */
+    public Class getType();
+
+    /*
+    * If this is a declared variable of a static type, MVEL will make it known by passing the type here.
+    */
+    public void setStaticType(Class type);
+
+    /**
+     * Returns the bitset of special variable flags.  Internal use only.  This should just return 0 in custom
+     * implentations.
+     *
+     * @return Bitset of special flags.
+     */
+    public int getFlags();
+
+    /**
+     * Returns the physical target value of the variable.
+     *
+     * @return The actual variable value.
+     */
+    public Object getValue();
+
+    /**
+     * Sets the value of the physical target value.
+     *
+     * @param value The new value.
+     * @return value after any conversion
+     */
+    public void setValue(Object value);
+}

--- a/core/src/main/java/org/mvel2/integration/VariableResolverFactory.java
+++ b/core/src/main/java/org/mvel2/integration/VariableResolverFactory.java
@@ -1,0 +1,122 @@
+/**
+ * MVEL 2.0
+ * Copyright (C) 2007 The Codehaus
+ * Mike Brock, Dhanji Prasanna, John Graham, Mark Proctor
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mvel2.integration;
+
+import java.io.Serializable;
+import java.util.Set;
+
+/**
+ * A VariableResolverFactory is the primary integration point for tying in external variables.  The factory is
+ * responsible for returing {@link org.mvel2.integration.VariableResolver}'s to the MVEL runtime.  Factories are
+ * also structured in a chain to maintain locality-of-reference.
+ */
+public interface VariableResolverFactory extends Serializable {
+
+    /**
+     * Creates a new variable.  This probably doesn't need to be implemented in most scenarios.  This is
+     * used for variable assignment.
+     *
+     * @param name  - name of the variable being created
+     * @param value - value of the variable
+     * @return instance of the variable resolver associated with the variable
+     */
+    public VariableResolver createVariable(String name, Object value);
+
+    public VariableResolver createIndexedVariable(int index, String name, Object value);
+
+    /**
+     * Creates a new variable, and assigns a static type. It is expected the underlying factory and resolver
+     * will enforce this.
+     *
+     * @param name  - name of the variable being created
+     * @param value - value of the variable
+     * @param type  - the static type
+     * @return instance of the variable resolver associated with the variable
+     */
+    public VariableResolver createVariable(String name, Object value, Class<?> type);
+
+    public VariableResolver createIndexedVariable(int index, String name, Object value, Class<?> typee);
+
+    public VariableResolver setIndexedVariableResolver(int index, VariableResolver variableResolver);
+
+    /**
+     * Returns the next factory in the factory chain.  MVEL uses a hierarchical variable resolution strategy,
+     * much in the same way as Classloaders in Java.   For performance reasons, it is the responsibility of
+     * the individual VariableResolverFactory to pass off to the next one.
+     *
+     * @return instance of the next factory - null if none.
+     */
+    public VariableResolverFactory getNextFactory();
+
+    /**
+     * Sets the next factory in the chain. Proper implementation:
+     * <code>
+     * <p/>
+     * return this.nextFactory = resolverFactory;
+     * </code>
+     *
+     * @param resolverFactory - instance of next resolver factory
+     * @return - instance of next resolver factory
+     */
+    public VariableResolverFactory setNextFactory(VariableResolverFactory resolverFactory);
+
+    /**
+     * Return a variable resolver for the specified variable name.  This method is expected to traverse the
+     * heirarchy of ResolverFactories.
+     *
+     * @param name - variable name
+     * @return - instance of the VariableResolver for the specified variable
+     */
+    public VariableResolver getVariableResolver(String name);
+
+    public VariableResolver getIndexedVariableResolver(int index);
+
+    /**
+     * Deterimines whether or not the current VariableResolverFactory is the physical target for the actual
+     * variable.
+     *
+     * @param name - variable name
+     * @return - boolean indicating whether or not factory is the physical target
+     */
+    public boolean isTarget(String name);
+
+    /**
+     * Determines whether or not the variable is resolver in the chain of factories.
+     *
+     * @param name - variable name
+     * @return - boolean
+     */
+    public boolean isResolveable(String name);
+
+    /**
+     * Return a list of known variables inside the factory.  This method should not recurse into other factories.
+     * But rather return only the variables living inside this factory.
+     *
+     * @return
+     */
+    public Set<String> getKnownVariables();
+
+    public int variableIndexOf(String name);
+
+    public boolean isIndexedFactory();
+
+    public boolean tiltFlag();
+
+    public void setTiltFlag(boolean tilt);
+}

--- a/core/src/main/java/org/mvel2/integration/impl/BaseVariableResolverFactory.java
+++ b/core/src/main/java/org/mvel2/integration/impl/BaseVariableResolverFactory.java
@@ -1,0 +1,172 @@
+/**
+ * MVEL 2.0
+ * Copyright (C) 2007 The Codehaus
+ * Mike Brock, Dhanji Prasanna, John Graham, Mark Proctor
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mvel2.integration.impl;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+import org.mvel2.UnresolveablePropertyException;
+import org.mvel2.integration.VariableResolver;
+import org.mvel2.integration.VariableResolverFactory;
+
+/**
+ * Use this class to extend you own VariableResolverFactories. It contains most of the baseline implementation needed
+ * for the vast majority of integration needs.
+ */
+public abstract class BaseVariableResolverFactory implements VariableResolverFactory {
+
+    protected Map<String, VariableResolver> variableResolvers = new HashMap<String, VariableResolver>();
+    protected VariableResolverFactory nextFactory;
+
+    protected int indexOffset = 0;
+    protected String[] indexedVariableNames;
+    protected VariableResolver[] indexedVariableResolvers;
+
+    private boolean tiltFlag;
+
+    public VariableResolverFactory getNextFactory() {
+        return nextFactory;
+    }
+
+    public VariableResolverFactory setNextFactory(VariableResolverFactory resolverFactory) {
+        return nextFactory = resolverFactory;
+    }
+
+    public VariableResolver getVariableResolver(String name) {
+        if (isResolveable(name)) {
+            if (variableResolvers.containsKey(name)) {
+                return variableResolvers.get(name);
+            } else if (nextFactory != null) {
+                return nextFactory.getVariableResolver(name);
+            }
+        }
+
+        throw new UnresolveablePropertyException("unable to resolve variable '" + name + "'");
+    }
+
+    public boolean isNextResolveable(String name) {
+        return nextFactory != null && nextFactory.isResolveable(name);
+    }
+
+    public void appendFactory(VariableResolverFactory resolverFactory) {
+        if (nextFactory == null) {
+            nextFactory = resolverFactory;
+        } else {
+            VariableResolverFactory vrf = nextFactory;
+            while (vrf.getNextFactory() != null) {
+                vrf = vrf.getNextFactory();
+            }
+            vrf.setNextFactory(nextFactory);
+        }
+    }
+
+    public void insertFactory(VariableResolverFactory resolverFactory) {
+        if (nextFactory == null) {
+            nextFactory = resolverFactory;
+        } else {
+            resolverFactory.setNextFactory(nextFactory = resolverFactory);
+        }
+    }
+
+    public Set<String> getKnownVariables() {
+        if (nextFactory == null) {
+            return new HashSet<String>(variableResolvers.keySet());
+            //   return new HashSet<String>(0);
+        } else {
+            HashSet<String> vars = new HashSet<String>(variableResolvers.keySet());
+            vars.addAll(nextFactory.getKnownVariables());
+            return vars;
+        }
+    }
+
+    public VariableResolver createIndexedVariable(int index, String name, Object value) {
+        if (nextFactory != null) {
+            return nextFactory.createIndexedVariable(index - indexOffset, name, value);
+        } else {
+            throw new RuntimeException("cannot create indexed variable: " + name + "(" + index + "). operation not supported by resolver: "
+                    + this.getClass().getName());
+        }
+    }
+
+    public VariableResolver getIndexedVariableResolver(int index) {
+        if (nextFactory != null) {
+            return nextFactory.getIndexedVariableResolver(index - indexOffset);
+        } else {
+            throw new RuntimeException(
+                    "cannot access indexed variable: " + index + ".  operation not supported by resolver: " + this.getClass().getName());
+        }
+    }
+
+    public VariableResolver createIndexedVariable(int index, String name, Object value, Class<?> type) {
+        if (nextFactory != null) {
+            return nextFactory.createIndexedVariable(index - indexOffset, name, value, type);
+        } else {
+            throw new RuntimeException("cannot access indexed variable: " + name + "(" + index
+                    + ").  operation not supported by resolver.: " + this.getClass().getName());
+        }
+    }
+
+    public Map<String, VariableResolver> getVariableResolvers() {
+        return variableResolvers;
+    }
+
+    public void setVariableResolvers(Map<String, VariableResolver> variableResolvers) {
+        this.variableResolvers = variableResolvers;
+    }
+
+    public String[] getIndexedVariableNames() {
+        return indexedVariableNames;
+    }
+
+    public void setIndexedVariableNames(String[] indexedVariableNames) {
+        this.indexedVariableNames = indexedVariableNames;
+    }
+
+    public int variableIndexOf(String name) {
+        if (indexedVariableNames != null) for (int i = 0; i < indexedVariableNames.length; i++) {
+            if (name.equals(indexedVariableNames[i])) {
+                return i;
+            }
+        }
+        return -1;
+    }
+
+    public VariableResolver setIndexedVariableResolver(int index, VariableResolver resolver) {
+        if (indexedVariableResolvers == null) {
+            return (indexedVariableResolvers = new VariableResolver[indexedVariableNames.length])[index - indexOffset] = resolver;
+        } else {
+            return indexedVariableResolvers[index - indexOffset] = resolver;
+        }
+    }
+
+    public boolean isIndexedFactory() {
+        return false;
+    }
+
+    public boolean tiltFlag() {
+        return tiltFlag;
+    }
+
+    public void setTiltFlag(boolean tiltFlag) {
+        this.tiltFlag = tiltFlag;
+        if (nextFactory != null) nextFactory.setTiltFlag(tiltFlag);
+    }
+}

--- a/core/src/main/java/org/mvel2/integration/impl/CachedMapVariableResolverFactory.java
+++ b/core/src/main/java/org/mvel2/integration/impl/CachedMapVariableResolverFactory.java
@@ -1,0 +1,110 @@
+package org.mvel2.integration.impl;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+import org.mvel2.UnresolveablePropertyException;
+import org.mvel2.integration.VariableResolver;
+import org.mvel2.integration.VariableResolverFactory;
+
+public class CachedMapVariableResolverFactory extends BaseVariableResolverFactory {
+
+    /**
+     * Holds the instance of the variables.
+     */
+    protected Map<String, Object> variables;
+
+    public CachedMapVariableResolverFactory() {
+    }
+
+    public CachedMapVariableResolverFactory(Map<String, Object> variables) {
+        this.variables = variables;
+        variableResolvers = new HashMap<String, VariableResolver>(variables.size() * 2);
+
+        for (Map.Entry<String, Object> entry : variables.entrySet()) {
+            variableResolvers.put(entry.getKey(), new PrecachedMapVariableResolver(entry, entry.getKey()));
+        }
+
+    }
+
+    public CachedMapVariableResolverFactory(Map<String, Object> variables, VariableResolverFactory nextFactory) {
+        this.variables = variables;
+        variableResolvers = new HashMap<String, VariableResolver>(variables.size() * 2);
+
+        for (Map.Entry<String, Object> entry : variables.entrySet()) {
+            variableResolvers.put(entry.getKey(), new PrecachedMapVariableResolver(entry, entry.getKey()));
+        }
+
+        this.nextFactory = nextFactory;
+    }
+
+    public VariableResolver createVariable(String name, Object value) {
+        VariableResolver vr;
+
+        try {
+            (vr = getVariableResolver(name)).setValue(value);
+            return vr;
+        } catch (UnresolveablePropertyException e) {
+            addResolver(name, vr = new MapVariableResolver(variables, name)).setValue(value);
+            return vr;
+        }
+    }
+
+    public VariableResolver createVariable(String name, Object value, Class<?> type) {
+        VariableResolver vr;
+        try {
+            vr = getVariableResolver(name);
+        } catch (UnresolveablePropertyException e) {
+            vr = null;
+        }
+
+        if (vr != null && vr.getType() != null) {
+            throw new RuntimeException("variable already defined within scope: " + vr.getType() + " " + name);
+        } else {
+            addResolver(name, vr = new MapVariableResolver(variables, name, type)).setValue(value);
+            return vr;
+        }
+    }
+
+    public VariableResolver getVariableResolver(String name) {
+
+        VariableResolver vr = variableResolvers.get(name);
+        if (vr != null) {
+            return vr;
+        } else if (variables.containsKey(name)) {
+            variableResolvers.put(name, vr = new MapVariableResolver(variables, name));
+            return vr;
+        } else if (nextFactory != null) {
+            return nextFactory.getVariableResolver(name);
+        }
+
+        throw new UnresolveablePropertyException("unable to resolve variable '" + name + "'");
+    }
+
+    public boolean isResolveable(String name) {
+        return (variableResolvers != null && variableResolvers.containsKey(name)) || (variables != null && variables.containsKey(name))
+                || (nextFactory != null && nextFactory.isResolveable(name));
+    }
+
+    protected VariableResolver addResolver(String name, VariableResolver vr) {
+        if (variableResolvers == null) variableResolvers = new HashMap<String, VariableResolver>();
+        variableResolvers.put(name, vr);
+        return vr;
+    }
+
+    public boolean isTarget(String name) {
+        return variableResolvers != null && variableResolvers.containsKey(name);
+    }
+
+    public Set<String> getKnownVariables() {
+        if (nextFactory == null) {
+            if (variables != null) return new HashSet<String>(variables.keySet());
+            return new HashSet<String>(0);
+        } else {
+            if (variables != null) return new HashSet<String>(variables.keySet());
+            return new HashSet<String>(0);
+        }
+    }
+}

--- a/core/src/main/java/org/mvel2/integration/impl/CachingMapVariableResolverFactory.java
+++ b/core/src/main/java/org/mvel2/integration/impl/CachingMapVariableResolverFactory.java
@@ -1,0 +1,116 @@
+/**
+ * MVEL 2.0
+ * Copyright (C) 2007 The Codehaus
+ * Mike Brock, Dhanji Prasanna, John Graham, Mark Proctor
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mvel2.integration.impl;
+
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+import org.mvel2.UnresolveablePropertyException;
+import org.mvel2.integration.VariableResolver;
+
+@SuppressWarnings({ "unchecked" })
+public class CachingMapVariableResolverFactory extends BaseVariableResolverFactory {
+
+    /**
+     * Holds the instance of the variables.
+     */
+    protected Map<String, Object> variables;
+
+    public CachingMapVariableResolverFactory(Map variables) {
+        this.variables = variables;
+    }
+
+    public VariableResolver createVariable(String name, Object value) {
+        VariableResolver vr;
+
+        try {
+            (vr = getVariableResolver(name)).setValue(value);
+            return vr;
+        } catch (UnresolveablePropertyException e) {
+            addResolver(name, vr = new SimpleSTValueResolver(value, null, true));
+            return vr;
+        }
+    }
+
+    public VariableResolver createVariable(String name, Object value, Class<?> type) {
+        VariableResolver vr;
+        try {
+            vr = getVariableResolver(name);
+        } catch (UnresolveablePropertyException e) {
+            vr = null;
+        }
+
+        if (vr != null && vr.getType() != null) {
+            throw new RuntimeException("variable already defined within scope: " + vr.getType() + " " + name);
+        } else {
+            addResolver(name, vr = new SimpleSTValueResolver(value, type, true));
+            return vr;
+        }
+    }
+
+    public VariableResolver getVariableResolver(String name) {
+        VariableResolver vr = variableResolvers.get(name);
+        if (vr != null) {
+            return vr;
+        } else if (variables.containsKey(name)) {
+            variableResolvers.put(name, vr = new SimpleSTValueResolver(variables.get(name), null));
+            return vr;
+        } else if (nextFactory != null) {
+            return nextFactory.getVariableResolver(name);
+        }
+
+        throw new UnresolveablePropertyException("unable to resolve variable '" + name + "'");
+    }
+
+    public boolean isResolveable(String name) {
+        return (variableResolvers.containsKey(name)) || (variables != null && variables.containsKey(name))
+                || (nextFactory != null && nextFactory.isResolveable(name));
+    }
+
+    protected VariableResolver addResolver(String name, VariableResolver vr) {
+        variableResolvers.put(name, vr);
+        return vr;
+    }
+
+    public void externalize() {
+        for (Map.Entry<String, VariableResolver> entry : variableResolvers.entrySet()) {
+            if (entry.getValue().getFlags() == -1) variables.put(entry.getKey(), entry.getValue().getValue());
+        }
+    }
+
+    public boolean isTarget(String name) {
+        return variableResolvers.containsKey(name);
+    }
+
+    public Set<String> getKnownVariables() {
+        if (nextFactory == null) {
+            if (variables != null) return new HashSet<String>(variables.keySet());
+            return new HashSet<String>(0);
+        } else {
+            if (variables != null) return new HashSet<String>(variables.keySet());
+            return new HashSet<String>(0);
+        }
+    }
+
+    public void clear() {
+        variableResolvers.clear();
+        variables.clear();
+    }
+}

--- a/core/src/main/java/org/mvel2/integration/impl/ClassImportResolverFactory.java
+++ b/core/src/main/java/org/mvel2/integration/impl/ClassImportResolverFactory.java
@@ -1,0 +1,132 @@
+/**
+ * MVEL 2.0
+ * Copyright (C) 2007 The Codehaus
+ * Mike Brock, Dhanji Prasanna, John Graham, Mark Proctor
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mvel2.integration.impl;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+import org.mvel2.ParserConfiguration;
+import org.mvel2.UnresolveablePropertyException;
+import org.mvel2.integration.VariableResolver;
+import org.mvel2.integration.VariableResolverFactory;
+
+public class ClassImportResolverFactory extends BaseVariableResolverFactory {
+
+    private Set<String> packageImports;
+    private ClassLoader classLoader;
+    private Map<String, Object> imports;
+    private Map<String, Object> dynImports;
+
+    public ClassImportResolverFactory(ParserConfiguration pCfg, VariableResolverFactory nextFactory, boolean compiled) {
+        if (pCfg != null) {
+            if (!compiled) {
+                packageImports = pCfg.getPackageImports();
+            }
+            classLoader = pCfg.getClassLoader();
+            imports = Collections.unmodifiableMap(pCfg.getImports());
+        } else {
+            classLoader = Thread.currentThread().getContextClassLoader();
+        }
+
+        this.nextFactory = nextFactory;
+    }
+
+    public VariableResolver createVariable(String name, Object value) {
+        if (nextFactory == null) {
+            nextFactory = new MapVariableResolverFactory(new HashMap());
+        }
+
+        return nextFactory.createVariable(name, value);
+    }
+
+    public VariableResolver createVariable(String name, Object value, Class type) {
+        if (nextFactory == null) {
+            nextFactory = new MapVariableResolverFactory(new HashMap());
+        }
+
+        return nextFactory.createVariable(name, value);
+    }
+
+    public Class addClass(Class clazz) {
+        if (dynImports == null) dynImports = new HashMap<String, Object>();
+        dynImports.put(clazz.getSimpleName(), clazz);
+        return clazz;
+    }
+
+    public boolean isTarget(String name) {
+        if (name == null) return false;
+        return (imports != null && imports.containsKey(name)) || (dynImports != null && dynImports.containsKey(name));
+    }
+
+    public boolean isResolveable(String name) {
+        if (name == null) return false;
+        if ((imports != null && imports.containsKey(name)) || (dynImports != null && dynImports.containsKey(name))
+                || isNextResolveable(name)) {
+            return true;
+        } else if (packageImports != null) {
+            for (String s : packageImports) {
+                try {
+                    addClass(classLoader.loadClass(s + "." + name));
+                    return true;
+                } catch (ClassNotFoundException e) {
+                    // do nothing;
+                } catch (NoClassDefFoundError e) {
+                    // do nothing;
+                }
+            }
+        }
+        return false;
+    }
+
+    @Override
+    public VariableResolver getVariableResolver(String name) {
+        if (isResolveable(name)) {
+            if (imports != null && imports.containsKey(name)) {
+                return new SimpleValueResolver(imports.get(name));
+            } else if (dynImports != null && dynImports.containsKey(name)) {
+                return new SimpleValueResolver(dynImports.get(name));
+            } else if (nextFactory != null) {
+                return nextFactory.getVariableResolver(name);
+            }
+        }
+
+        throw new UnresolveablePropertyException("unable to resolve variable '" + name + "'");
+    }
+
+    public void clear() {
+        //   variableResolvers.clear();
+    }
+
+    public Map<String, Object> getImportedClasses() {
+        return imports;
+    }
+
+    public void addPackageImport(String packageName) {
+        if (packageImports == null) packageImports = new HashSet<String>();
+        packageImports.add(packageName);
+    }
+
+    @Override
+    public Set<String> getKnownVariables() {
+        return nextFactory == null ? new HashSet(0) : nextFactory.getKnownVariables();
+    }
+}

--- a/core/src/main/java/org/mvel2/integration/impl/DefaultLocalVariableResolverFactory.java
+++ b/core/src/main/java/org/mvel2/integration/impl/DefaultLocalVariableResolverFactory.java
@@ -1,0 +1,129 @@
+/**
+ * MVEL 2.0
+ * Copyright (C) 2007 The Codehaus
+ * Mike Brock, Dhanji Prasanna, John Graham, Mark Proctor
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mvel2.integration.impl;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.mvel2.UnresolveablePropertyException;
+import org.mvel2.integration.VariableResolver;
+import org.mvel2.integration.VariableResolverFactory;
+
+public class DefaultLocalVariableResolverFactory extends MapVariableResolverFactory implements LocalVariableResolverFactory {
+
+    private boolean noTilt = false;
+
+    public DefaultLocalVariableResolverFactory() {
+        super(new HashMap<String, Object>());
+    }
+
+    public DefaultLocalVariableResolverFactory(Map<String, Object> variables) {
+        super(variables);
+    }
+
+    public DefaultLocalVariableResolverFactory(Map<String, Object> variables, VariableResolverFactory nextFactory) {
+        super(variables, nextFactory);
+    }
+
+    public DefaultLocalVariableResolverFactory(Map<String, Object> variables, boolean cachingSafe) {
+        super(variables);
+    }
+
+    public DefaultLocalVariableResolverFactory(VariableResolverFactory nextFactory) {
+        super(new HashMap<String, Object>(), nextFactory);
+    }
+
+    public DefaultLocalVariableResolverFactory(VariableResolverFactory nextFactory, String[] indexedVariables) {
+        super(new HashMap<String, Object>(), nextFactory);
+        this.indexedVariableNames = indexedVariables;
+        this.indexedVariableResolvers = new VariableResolver[indexedVariables.length];
+    }
+
+    public VariableResolver getIndexedVariableResolver(int index) {
+        if (indexedVariableNames == null) return null;
+
+        if (indexedVariableResolvers[index] == null) {
+            /**
+             * If the register is null, this means we need to forward-allocate the variable onto the
+             * register table.
+             */
+            return indexedVariableResolvers[index] = super.getVariableResolver(indexedVariableNames[index]);
+        }
+        return indexedVariableResolvers[index];
+    }
+
+    public VariableResolver getVariableResolver(String name) {
+        if (indexedVariableNames == null) return super.getVariableResolver(name);
+
+        int idx;
+        //   if (variableResolvers.containsKey(name)) return variableResolvers.get(name);
+        if ((idx = variableIndexOf(name)) != -1) {
+            if (indexedVariableResolvers[idx] == null) {
+                indexedVariableResolvers[idx] = new SimpleValueResolver(null);
+            }
+            variableResolvers.put(indexedVariableNames[idx], null);
+            return indexedVariableResolvers[idx];
+        }
+
+        return super.getVariableResolver(name);
+    }
+
+    public VariableResolver createVariable(String name, Object value, Class<?> type) {
+        if (indexedVariableNames == null) return super.createVariable(name, value, type);
+
+        VariableResolver vr;
+        boolean newVar = false;
+
+        try {
+            int idx;
+            if ((idx = variableIndexOf(name)) != -1) {
+                vr = new SimpleValueResolver(value);
+                if (indexedVariableResolvers[idx] == null) {
+                    indexedVariableResolvers[idx] = vr;
+                }
+                variableResolvers.put(indexedVariableNames[idx], vr);
+                vr = indexedVariableResolvers[idx];
+
+                newVar = true;
+            } else {
+                return super.createVariable(name, value, type);
+            }
+
+        } catch (UnresolveablePropertyException e) {
+            vr = null;
+        }
+
+        if (!newVar && vr != null && vr.getType() != null) {
+            throw new RuntimeException("variable already defined within scope: " + vr.getType() + " " + name);
+        } else {
+            addResolver(name, vr = new MapVariableResolver(variables, name, type)).setValue(value);
+            return vr;
+        }
+    }
+
+    public VariableResolverFactory setNoTilt(boolean noTilt) {
+        this.noTilt = noTilt;
+        return this;
+    }
+
+    @Override
+    public void setTiltFlag(boolean tiltFlag) {
+        if (!noTilt) super.setTiltFlag(tiltFlag);
+    }
+}

--- a/core/src/main/java/org/mvel2/integration/impl/FunctionVariableResolverFactory.java
+++ b/core/src/main/java/org/mvel2/integration/impl/FunctionVariableResolverFactory.java
@@ -1,0 +1,182 @@
+/**
+ * MVEL 2.0
+ * Copyright (C) 2007 The Codehaus
+ * Mike Brock, Dhanji Prasanna, John Graham, Mark Proctor
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mvel2.integration.impl;
+
+import java.util.HashMap;
+
+import org.mvel2.ast.Function;
+import org.mvel2.integration.VariableResolver;
+import org.mvel2.integration.VariableResolverFactory;
+
+public class FunctionVariableResolverFactory extends BaseVariableResolverFactory implements LocalVariableResolverFactory {
+
+    private Function function;
+    private boolean noTilt = false;
+
+    public FunctionVariableResolverFactory(Function function, VariableResolverFactory nextFactory, String[] indexedVariables,
+            Object[] parameters) {
+        this.function = function;
+
+        this.variableResolvers = new HashMap<String, VariableResolver>();
+        this.nextFactory = nextFactory;
+        this.indexedVariableResolvers = new VariableResolver[(this.indexedVariableNames = indexedVariables).length];
+        for (int i = 0; i < parameters.length; i++) {
+            variableResolvers.put(indexedVariableNames[i], null);
+            this.indexedVariableResolvers[i] = new SimpleValueResolver(parameters[i]);
+            //     variableResolvers.put(indexedVariableNames[i], this.indexedVariableResolvers[i] = new SimpleValueResolver(parameters[i]));
+        }
+    }
+
+    public boolean isResolveable(String name) {
+        return variableResolvers.containsKey(name) || (nextFactory != null && nextFactory.isResolveable(name));
+    }
+
+    public VariableResolver createVariable(String name, Object value) {
+        VariableResolver resolver = getVariableResolver(name);
+        if (resolver == null) {
+            int idx = increaseRegisterTableSize();
+            this.indexedVariableNames[idx] = name;
+            this.indexedVariableResolvers[idx] = new SimpleValueResolver(value);
+            variableResolvers.put(name, null);
+
+            //     variableResolvers.put(name, this.indexedVariableResolvers[idx] = new SimpleValueResolver(value));
+            return this.indexedVariableResolvers[idx];
+        } else {
+            resolver.setValue(value);
+            return resolver;
+        }
+    }
+
+    public VariableResolver createVariable(String name, Object value, Class<?> type) {
+        VariableResolver vr = this.variableResolvers != null ? this.variableResolvers.get(name) : null;
+        if (vr != null && vr.getType() != null) {
+            throw new RuntimeException("variable already defined within scope: " + vr.getType() + " " + name);
+        } else {
+            return createIndexedVariable(variableIndexOf(name), name, value);
+        }
+    }
+
+    public VariableResolver createIndexedVariable(int index, String name, Object value) {
+        index = index - indexOffset;
+        if (indexedVariableResolvers[index] != null) {
+            indexedVariableResolvers[index].setValue(value);
+        } else {
+            indexedVariableResolvers[index] = new SimpleValueResolver(value);
+        }
+
+        variableResolvers.put(name, null);
+
+        return indexedVariableResolvers[index];
+    }
+
+    public VariableResolver createIndexedVariable(int index, String name, Object value, Class<?> type) {
+        index = index - indexOffset;
+        if (indexedVariableResolvers[index] != null) {
+            indexedVariableResolvers[index].setValue(value);
+        } else {
+            indexedVariableResolvers[index] = new SimpleValueResolver(value);
+        }
+        return indexedVariableResolvers[index];
+    }
+
+    public VariableResolver getIndexedVariableResolver(int index) {
+        if (indexedVariableResolvers[index] == null) {
+            /**
+             * If the register is null, this means we need to forward-allocate the variable onto the
+             * register table.
+             */
+            return indexedVariableResolvers[index] = super.getVariableResolver(indexedVariableNames[index]);
+        }
+        return indexedVariableResolvers[index];
+    }
+
+    public VariableResolver getVariableResolver(String name) {
+        int idx;
+        //   if (variableResolvers.containsKey(name)) return variableResolvers.get(name);
+        if ((idx = variableIndexOf(name)) != -1) {
+            if (indexedVariableResolvers[idx] == null) {
+                indexedVariableResolvers[idx] = new SimpleValueResolver(null);
+            }
+            variableResolvers.put(indexedVariableNames[idx], null);
+            return indexedVariableResolvers[idx];
+        }
+
+        return super.getVariableResolver(name);
+    }
+
+    public boolean isIndexedFactory() {
+        return true;
+    }
+
+    public boolean isTarget(String name) {
+        return variableResolvers.containsKey(name) || variableIndexOf(name) != -1;
+    }
+
+    private int increaseRegisterTableSize() {
+        String[] oldNames = indexedVariableNames;
+        VariableResolver[] oldResolvers = indexedVariableResolvers;
+
+        int newLength = oldNames.length + 1;
+        indexedVariableNames = new String[newLength];
+        indexedVariableResolvers = new VariableResolver[newLength];
+
+        for (int i = 0; i < oldNames.length; i++) {
+            indexedVariableNames[i] = oldNames[i];
+            indexedVariableResolvers[i] = oldResolvers[i];
+        }
+
+        return newLength - 1;
+    }
+
+    public void updateParameters(Object[] parameters) {
+        //    this.indexedVariableResolvers = new VariableResolver[parameters.length];
+        for (int i = 0; i < parameters.length; i++) {
+            this.indexedVariableResolvers[i] = new SimpleValueResolver(parameters[i]);
+        }
+        //        for (int i = parameters.length; i < indexedVariableResolvers.length; i++) {
+        //            this.indexedVariableResolvers[i] = null;
+        //        }
+    }
+
+    public VariableResolver[] getIndexedVariableResolvers() {
+        return this.indexedVariableResolvers;
+    }
+
+    public void setIndexedVariableResolvers(VariableResolver[] vr) {
+        this.indexedVariableResolvers = vr;
+    }
+
+    public Function getFunction() {
+        return function;
+    }
+
+    public void setIndexOffset(int offset) {
+        this.indexOffset = offset;
+    }
+
+    public VariableResolverFactory setNoTilt(boolean noTilt) {
+        this.noTilt = noTilt;
+        return this;
+    }
+
+    @Override
+    public void setTiltFlag(boolean tiltFlag) {
+        if (!noTilt) super.setTiltFlag(tiltFlag);
+    }
+}

--- a/core/src/main/java/org/mvel2/integration/impl/ImmutableDefaultFactory.java
+++ b/core/src/main/java/org/mvel2/integration/impl/ImmutableDefaultFactory.java
@@ -1,0 +1,105 @@
+/**
+ * MVEL 2.0
+ * Copyright (C) 2007 The Codehaus
+ * Mike Brock, Dhanji Prasanna, John Graham, Mark Proctor
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mvel2.integration.impl;
+
+import java.util.Set;
+
+import org.mvel2.ScriptRuntimeException;
+import org.mvel2.UnresolveablePropertyException;
+import org.mvel2.integration.VariableResolver;
+import org.mvel2.integration.VariableResolverFactory;
+
+public class ImmutableDefaultFactory implements VariableResolverFactory {
+
+    private boolean tiltFlag;
+
+    private void throwError() {
+        throw new ScriptRuntimeException("cannot assign variables; no variable resolver factory available.");
+    }
+
+    public VariableResolver createVariable(String name, Object value) {
+        throwError();
+        return null;
+    }
+
+    public VariableResolver createIndexedVariable(int index, String name, Object value) {
+        throwError();
+        return null;
+    }
+
+    public VariableResolver createVariable(String name, Object value, Class<?> type) {
+        throwError();
+        return null;
+    }
+
+    public VariableResolver createIndexedVariable(int index, String name, Object value, Class<?> typee) {
+        throwError();
+        return null;
+    }
+
+    public VariableResolver setIndexedVariableResolver(int index, VariableResolver variableResolver) {
+        throwError();
+        return null;
+    }
+
+    public VariableResolverFactory getNextFactory() {
+        return null;
+    }
+
+    public VariableResolverFactory setNextFactory(VariableResolverFactory resolverFactory) {
+        throw new RuntimeException("cannot chain to this factory");
+    }
+
+    public VariableResolver getVariableResolver(String name) {
+        throw new UnresolveablePropertyException(name);
+    }
+
+    public VariableResolver getIndexedVariableResolver(int index) {
+        throwError();
+        return null;
+    }
+
+    public boolean isTarget(String name) {
+        return false;
+    }
+
+    public boolean isResolveable(String name) {
+        return false;
+    }
+
+    public Set<String> getKnownVariables() {
+        return null;
+    }
+
+    public int variableIndexOf(String name) {
+        return -1;
+    }
+
+    public boolean isIndexedFactory() {
+        return false;
+    }
+
+    public boolean tiltFlag() {
+        return tiltFlag;
+    }
+
+    public void setTiltFlag(boolean tilt) {
+        this.tiltFlag = tilt;
+    }
+}

--- a/core/src/main/java/org/mvel2/integration/impl/IndexVariableResolver.java
+++ b/core/src/main/java/org/mvel2/integration/impl/IndexVariableResolver.java
@@ -1,0 +1,37 @@
+package org.mvel2.integration.impl;
+
+import org.mvel2.integration.VariableResolver;
+
+public class IndexVariableResolver implements VariableResolver {
+
+    private int indexPos;
+    private Object[] vars;
+
+    public IndexVariableResolver(int indexPos, Object[] vars) {
+        this.indexPos = indexPos;
+        this.vars = vars;
+    }
+
+    public String getName() {
+        return null;
+    }
+
+    public Class getType() {
+        return null;
+    }
+
+    public void setStaticType(Class type) {
+    }
+
+    public int getFlags() {
+        return 0;
+    }
+
+    public Object getValue() {
+        return vars[indexPos];
+    }
+
+    public void setValue(Object value) {
+        vars[indexPos] = value;
+    }
+}

--- a/core/src/main/java/org/mvel2/integration/impl/IndexedVariableResolverFactory.java
+++ b/core/src/main/java/org/mvel2/integration/impl/IndexedVariableResolverFactory.java
@@ -1,0 +1,136 @@
+/**
+ * MVEL 2.0
+ * Copyright (C) 2007 The Codehaus
+ * Mike Brock, Dhanji Prasanna, John Graham, Mark Proctor
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mvel2.integration.impl;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+
+import org.mvel2.UnresolveablePropertyException;
+import org.mvel2.integration.VariableResolver;
+import org.mvel2.integration.VariableResolverFactory;
+
+public class IndexedVariableResolverFactory extends BaseVariableResolverFactory {
+
+    public IndexedVariableResolverFactory(String[] varNames, VariableResolver[] resolvers) {
+        this.indexedVariableNames = varNames;
+        this.indexedVariableResolvers = resolvers;
+    }
+
+    public IndexedVariableResolverFactory(String[] varNames, Object[] values) {
+        this.indexedVariableNames = varNames;
+        this.indexedVariableResolvers = createResolvers(values, varNames.length);
+    }
+
+    public IndexedVariableResolverFactory(String[] varNames, Object[] values, VariableResolverFactory nextFactory) {
+        this.indexedVariableNames = varNames;
+        this.nextFactory = new MapVariableResolverFactory();
+        this.nextFactory.setNextFactory(nextFactory);
+        this.indexedVariableResolvers = createResolvers(values, varNames.length);
+
+    }
+
+    private static VariableResolver[] createResolvers(Object[] values, int size) {
+        VariableResolver[] vr = new VariableResolver[size];
+        for (int i = 0; i < size; i++) {
+            vr[i] = i >= values.length ? new SimpleValueResolver(null) : new IndexVariableResolver(i, values);
+        }
+        return vr;
+    }
+
+    public VariableResolver createIndexedVariable(int index, String name, Object value) {
+        VariableResolver r = indexedVariableResolvers[index];
+        r.setValue(value);
+        return r;
+    }
+
+    public VariableResolver getIndexedVariableResolver(int index) {
+        return indexedVariableResolvers[index];
+    }
+
+    public VariableResolver createVariable(String name, Object value) {
+        VariableResolver vr = getResolver(name);
+        if (vr != null) {
+            vr.setValue(value);
+        }
+        return vr;
+    }
+
+    public VariableResolver createVariable(String name, Object value, Class<?> type) {
+        VariableResolver vr = getResolver(name);
+        if (vr != null) {
+            vr.setValue(value);
+        }
+        return vr;
+
+        //        if (nextFactory == null) nextFactory = new MapVariableResolverFactory(new HashMap());
+        //        return nextFactory.createVariable(name, value, type);
+    }
+
+    public VariableResolver getVariableResolver(String name) {
+        VariableResolver vr = getResolver(name);
+        if (vr != null) return vr;
+        else if (nextFactory != null) {
+            return nextFactory.getVariableResolver(name);
+        }
+
+        throw new UnresolveablePropertyException("unable to resolve variable '" + name + "'");
+    }
+
+    public boolean isResolveable(String name) {
+        return isTarget(name) || (nextFactory != null && nextFactory.isResolveable(name));
+    }
+
+    protected VariableResolver addResolver(String name, VariableResolver vr) {
+        variableResolvers.put(name, vr);
+        return vr;
+    }
+
+    private VariableResolver getResolver(String name) {
+        for (int i = 0; i < indexedVariableNames.length; i++) {
+            if (indexedVariableNames[i].equals(name)) {
+                return indexedVariableResolvers[i];
+            }
+        }
+        return null;
+    }
+
+    public boolean isTarget(String name) {
+        for (String indexedVariableName : indexedVariableNames) {
+            if (indexedVariableName.equals(name)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    public Set<String> getKnownVariables() {
+        return new HashSet<String>(Arrays.asList(indexedVariableNames));
+    }
+
+    public void clear() {
+        // variableResolvers.clear();
+
+    }
+
+    @Override
+    public boolean isIndexedFactory() {
+        return true;
+    }
+}

--- a/core/src/main/java/org/mvel2/integration/impl/ItemResolverFactory.java
+++ b/core/src/main/java/org/mvel2/integration/impl/ItemResolverFactory.java
@@ -1,0 +1,101 @@
+/**
+ * MVEL 2.0
+ * Copyright (C) 2007 The Codehaus
+ * Mike Brock, Dhanji Prasanna, John Graham, Mark Proctor
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mvel2.integration.impl;
+
+import org.mvel2.integration.VariableResolver;
+import org.mvel2.integration.VariableResolverFactory;
+
+public class ItemResolverFactory extends BaseVariableResolverFactory {
+
+    private final ItemResolver resolver;
+
+    public ItemResolverFactory(ItemResolver resolver, VariableResolverFactory nextFactory) {
+        this.resolver = resolver;
+        this.nextFactory = nextFactory;
+    }
+
+    public VariableResolver createVariable(String name, Object value) {
+        if (isTarget(name)) {
+            resolver.setValue(value);
+            return resolver;
+        } else {
+            return nextFactory.createVariable(name, value);
+        }
+    }
+
+    public VariableResolver createVariable(String name, Object value, Class<?> type) {
+        if (isTarget(name)) {
+            throw new RuntimeException("variable already defined in scope: " + name);
+        } else {
+            return nextFactory.createVariable(name, value);
+        }
+    }
+
+    public VariableResolver getVariableResolver(String name) {
+        return isTarget(name) ? resolver : nextFactory.getVariableResolver(name);
+    }
+
+    public boolean isTarget(String name) {
+        return resolver.getName().equals(name);
+    }
+
+    public boolean isResolveable(String name) {
+        return resolver.getName().equals(name) || (nextFactory != null && nextFactory.isResolveable(name));
+    }
+
+    public static class ItemResolver implements VariableResolver {
+
+        private final String name;
+        public Object value;
+        private Class type = Object.class;
+
+        public ItemResolver(String name, Class type) {
+            this.name = name;
+            this.type = type;
+        }
+
+        public ItemResolver(String name) {
+            this.name = name;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public Class getType() {
+            return type;
+        }
+
+        public void setStaticType(Class type) {
+            this.type = type;
+        }
+
+        public int getFlags() {
+            return 0;
+        }
+
+        public Object getValue() {
+            return value;
+        }
+
+        public void setValue(Object value) {
+            this.value = value;
+        }
+    }
+}

--- a/core/src/main/java/org/mvel2/integration/impl/LocalVariableResolverFactory.java
+++ b/core/src/main/java/org/mvel2/integration/impl/LocalVariableResolverFactory.java
@@ -1,0 +1,22 @@
+/**
+ * MVEL 2.0
+ * Copyright (C) 2007 The Codehaus
+ * Mike Brock, Dhanji Prasanna, John Graham, Mark Proctor
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mvel2.integration.impl;
+
+public interface LocalVariableResolverFactory {
+}

--- a/core/src/main/java/org/mvel2/integration/impl/MapVariableResolver.java
+++ b/core/src/main/java/org/mvel2/integration/impl/MapVariableResolver.java
@@ -1,0 +1,88 @@
+/**
+ * MVEL 2.0
+ * Copyright (C) 2007 The Codehaus
+ * Mike Brock, Dhanji Prasanna, John Graham, Mark Proctor
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mvel2.integration.impl;
+
+import static org.mvel2.DataConversion.canConvert;
+import static org.mvel2.DataConversion.convert;
+
+import java.util.Map;
+
+import org.mvel2.integration.VariableResolver;
+
+public class MapVariableResolver implements VariableResolver {
+
+    private String name;
+    private Class<?> knownType;
+    private Map<String, Object> variableMap;
+
+    public MapVariableResolver(Map<String, Object> variableMap, String name) {
+        this.variableMap = variableMap;
+        this.name = name;
+    }
+
+    public MapVariableResolver(Map<String, Object> variableMap, String name, Class knownType) {
+        this.name = name;
+        this.knownType = knownType;
+        this.variableMap = variableMap;
+    }
+
+    public void setStaticType(Class knownType) {
+        this.knownType = knownType;
+    }
+
+    public void setVariableMap(Map<String, Object> variableMap) {
+        this.variableMap = variableMap;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public Class getType() {
+        return knownType;
+    }
+
+    public Object getValue() {
+        return variableMap.get(name);
+    }
+
+    public void setValue(Object value) {
+        if (knownType != null && value != null && value.getClass() != knownType) {
+            if (!canConvert(knownType, value.getClass())) {
+                throw new RuntimeException("cannot assign " + value.getClass().getName() + " to type: " + knownType.getName());
+            }
+            try {
+                value = convert(value, knownType);
+            } catch (Exception e) {
+                throw new RuntimeException("cannot convert value of " + value.getClass().getName() + " to: " + knownType.getName());
+            }
+        }
+
+        //noinspection unchecked
+        variableMap.put(name, value);
+    }
+
+    public int getFlags() {
+        return 0;
+    }
+}

--- a/core/src/main/java/org/mvel2/integration/impl/MapVariableResolverFactory.java
+++ b/core/src/main/java/org/mvel2/integration/impl/MapVariableResolverFactory.java
@@ -1,0 +1,125 @@
+/**
+ * MVEL 2.0
+ * Copyright (C) 2007 The Codehaus
+ * Mike Brock, Dhanji Prasanna, John Graham, Mark Proctor
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mvel2.integration.impl;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+import org.mvel2.UnresolveablePropertyException;
+import org.mvel2.integration.VariableResolver;
+import org.mvel2.integration.VariableResolverFactory;
+
+@SuppressWarnings({ "unchecked" })
+public class MapVariableResolverFactory extends BaseVariableResolverFactory {
+
+    /**
+     * Holds the instance of the variables.
+     */
+    protected Map<String, Object> variables;
+
+    public MapVariableResolverFactory() {
+        this.variables = new HashMap();
+    }
+
+    public MapVariableResolverFactory(Map variables) {
+        this.variables = variables;
+    }
+
+    public MapVariableResolverFactory(Map<String, Object> variables, VariableResolverFactory nextFactory) {
+        this.variables = variables;
+        this.nextFactory = nextFactory;
+    }
+
+    public MapVariableResolverFactory(Map<String, Object> variables, boolean cachingSafe) {
+        this.variables = variables;
+    }
+
+    public VariableResolver createVariable(String name, Object value) {
+        VariableResolver vr;
+
+        try {
+            (vr = getVariableResolver(name)).setValue(value);
+            return vr;
+        } catch (UnresolveablePropertyException e) {
+            addResolver(name, vr = new MapVariableResolver(variables, name)).setValue(value);
+            return vr;
+        }
+    }
+
+    public VariableResolver createVariable(String name, Object value, Class<?> type) {
+        VariableResolver vr;
+        try {
+            vr = getVariableResolver(name);
+        } catch (UnresolveablePropertyException e) {
+            vr = null;
+        }
+
+        if (vr != null && vr.getType() != null) {
+            throw new RuntimeException("variable already defined within scope: " + vr.getType() + " " + name);
+        } else {
+            addResolver(name, vr = new MapVariableResolver(variables, name, type)).setValue(value);
+            return vr;
+        }
+    }
+
+    public VariableResolver getVariableResolver(String name) {
+        VariableResolver vr = variableResolvers.get(name);
+        if (vr != null) {
+            return vr;
+        } else if (variables.containsKey(name)) {
+            variableResolvers.put(name, vr = new MapVariableResolver(variables, name));
+            return vr;
+        } else if (nextFactory != null) {
+            return nextFactory.getVariableResolver(name);
+        }
+
+        throw new UnresolveablePropertyException("unable to resolve variable '" + name + "'");
+    }
+
+    public boolean isResolveable(String name) {
+        return (variableResolvers.containsKey(name)) || (variables != null && variables.containsKey(name))
+                || (nextFactory != null && nextFactory.isResolveable(name));
+    }
+
+    protected VariableResolver addResolver(String name, VariableResolver vr) {
+        variableResolvers.put(name, vr);
+        return vr;
+    }
+
+    public boolean isTarget(String name) {
+        return variableResolvers.containsKey(name);
+    }
+
+    public Set<String> getKnownVariables() {
+        if (nextFactory == null) {
+            if (variables != null) return new HashSet<String>(variables.keySet());
+            return new HashSet<String>(0);
+        } else {
+            if (variables != null) return new HashSet<String>(variables.keySet());
+            return new HashSet<String>(0);
+        }
+    }
+
+    public void clear() {
+        variableResolvers.clear();
+        variables.clear();
+    }
+}

--- a/core/src/main/java/org/mvel2/integration/impl/PrecachedMapVariableResolver.java
+++ b/core/src/main/java/org/mvel2/integration/impl/PrecachedMapVariableResolver.java
@@ -1,0 +1,67 @@
+package org.mvel2.integration.impl;
+
+import static org.mvel2.DataConversion.canConvert;
+import static org.mvel2.DataConversion.convert;
+
+import java.util.Map;
+
+import org.mvel2.integration.VariableResolver;
+
+public class PrecachedMapVariableResolver implements VariableResolver {
+
+    private String name;
+    private Class<?> knownType;
+    private Map.Entry entry;
+
+    public PrecachedMapVariableResolver(Map.Entry entry, String name) {
+        this.entry = entry;
+        this.name = name;
+    }
+
+    public PrecachedMapVariableResolver(Map.Entry entry, String name, Class knownType) {
+        this.name = name;
+        this.knownType = knownType;
+        this.entry = entry;
+    }
+
+    public void setStaticType(Class knownType) {
+        this.knownType = knownType;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public Class getType() {
+        return knownType;
+    }
+
+    public Object getValue() {
+        return entry.getValue();
+    }
+
+    public void setValue(Object value) {
+        if (knownType != null && value != null && value.getClass() != knownType) {
+            Class t = value.getClass();
+            if (!canConvert(knownType, t)) {
+                throw new RuntimeException("cannot assign " + value.getClass().getName() + " to type: " + knownType.getName());
+            }
+            try {
+                value = convert(value, knownType);
+            } catch (Exception e) {
+                throw new RuntimeException("cannot convert value of " + value.getClass().getName() + " to: " + knownType.getName());
+            }
+        }
+
+        //noinspection unchecked
+        entry.setValue(value);
+    }
+
+    public int getFlags() {
+        return 0;
+    }
+}

--- a/core/src/main/java/org/mvel2/integration/impl/SimpleSTValueResolver.java
+++ b/core/src/main/java/org/mvel2/integration/impl/SimpleSTValueResolver.java
@@ -1,0 +1,82 @@
+/**
+ * MVEL 2.0
+ * Copyright (C) 2007 The Codehaus
+ * Mike Brock, Dhanji Prasanna, John Graham, Mark Proctor
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mvel2.integration.impl;
+
+import static org.mvel2.DataConversion.canConvert;
+import static org.mvel2.DataConversion.convert;
+
+import org.mvel2.integration.VariableResolver;
+
+public class SimpleSTValueResolver implements VariableResolver {
+
+    private Object value;
+    private Class type;
+    private boolean updated = false;
+
+    public SimpleSTValueResolver(Object value, Class type) {
+        this.value = handleTypeCoercion(type, value);
+        this.type = type;
+    }
+
+    public SimpleSTValueResolver(Object value, Class type, boolean updated) {
+        this.value = handleTypeCoercion(type, value);
+        this.type = type;
+        this.updated = updated;
+    }
+
+    private static Object handleTypeCoercion(Class type, Object value) {
+        if (type != null && value != null && value.getClass() != type) {
+            if (!canConvert(type, value.getClass())) {
+                throw new RuntimeException("cannot assign " + value.getClass().getName() + " to type: " + type.getName());
+            }
+            try {
+                return convert(value, type);
+            } catch (Exception e) {
+                throw new RuntimeException("cannot convert value of " + value.getClass().getName() + " to: " + type.getName());
+            }
+        }
+        return value;
+    }
+
+    public String getName() {
+        return null;
+    }
+
+    public Class getType() {
+        return type;
+    }
+
+    public void setStaticType(Class type) {
+        this.type = type;
+    }
+
+    public int getFlags() {
+        return updated ? -1 : 0;
+    }
+
+    public Object getValue() {
+        return value;
+    }
+
+    public void setValue(Object value) {
+        updated = true;
+        this.value = handleTypeCoercion(type, value);
+    }
+
+}

--- a/core/src/main/java/org/mvel2/integration/impl/SimpleValueResolver.java
+++ b/core/src/main/java/org/mvel2/integration/impl/SimpleValueResolver.java
@@ -1,0 +1,53 @@
+/**
+ * MVEL 2.0
+ * Copyright (C) 2007 The Codehaus
+ * Mike Brock, Dhanji Prasanna, John Graham, Mark Proctor
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mvel2.integration.impl;
+
+import org.mvel2.integration.VariableResolver;
+
+public class SimpleValueResolver implements VariableResolver {
+
+    private Object value;
+
+    public SimpleValueResolver(Object value) {
+        this.value = value;
+    }
+
+    public String getName() {
+        return null;
+    }
+
+    public Class getType() {
+        return Object.class;
+    }
+
+    public void setStaticType(Class type) {
+    }
+
+    public int getFlags() {
+        return 0;
+    }
+
+    public Object getValue() {
+        return value;
+    }
+
+    public void setValue(Object value) {
+        this.value = value;
+    }
+}

--- a/core/src/main/java/org/mvel2/integration/impl/SimpleVariableResolverFactory.java
+++ b/core/src/main/java/org/mvel2/integration/impl/SimpleVariableResolverFactory.java
@@ -1,0 +1,68 @@
+package org.mvel2.integration.impl;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+import org.mvel2.integration.VariableResolver;
+
+public class SimpleVariableResolverFactory extends BaseVariableResolverFactory {
+
+    public SimpleVariableResolverFactory(Map<String, Object> variables) {
+        for (Map.Entry<String, Object> entry : variables.entrySet()) {
+            createVariable(entry.getKey(), entry.getValue());
+        }
+    }
+
+    public VariableResolver createVariable(String name, Object value) {
+        if (variableResolvers == null) variableResolvers = new HashMap<String, VariableResolver>(5, 0.6f);
+        SimpleValueResolver svr = new SimpleValueResolver(value);
+        variableResolvers.put(name, svr);
+        return svr;
+    }
+
+    public VariableResolver createIndexedVariable(int index, String name, Object value) {
+        return null;
+    }
+
+    public VariableResolver createVariable(String name, Object value, Class<?> type) {
+        if (variableResolvers == null) variableResolvers = new HashMap<String, VariableResolver>(5, 0.6f);
+        SimpleSTValueResolver svr = new SimpleSTValueResolver(value, type);
+        variableResolvers.put(name, svr);
+        return svr;
+    }
+
+    public VariableResolver createIndexedVariable(int index, String name, Object value, Class<?> typee) {
+        return null;
+    }
+
+    public VariableResolver setIndexedVariableResolver(int index, VariableResolver variableResolver) {
+        return null;
+    }
+
+    public boolean isTarget(String name) {
+        return variableResolvers.containsKey(name);
+    }
+
+    public boolean isResolveable(String name) {
+        return variableResolvers.containsKey(name) || (nextFactory != null && nextFactory.isResolveable(name));
+    }
+
+    @Override
+    public VariableResolver getVariableResolver(String name) {
+        VariableResolver vr = variableResolvers.get(name);
+        return vr != null ? vr : (nextFactory == null ? null : nextFactory.getVariableResolver(name));
+    }
+
+    public Set<String> getKnownVariables() {
+        return variableResolvers.keySet();
+    }
+
+    public int variableIndexOf(String name) {
+        return 0; //To change body of implemented methods use File | Settings | File Templates.
+    }
+
+    public boolean isIndexedFactory() {
+        return false; //To change body of implemented methods use File | Settings | File Templates.
+    }
+}

--- a/core/src/main/java/org/mvel2/integration/impl/StackDelimiterResolverFactory.java
+++ b/core/src/main/java/org/mvel2/integration/impl/StackDelimiterResolverFactory.java
@@ -1,0 +1,23 @@
+package org.mvel2.integration.impl;
+
+import org.mvel2.integration.VariableResolver;
+import org.mvel2.integration.VariableResolverFactory;
+
+/**
+ * @author Mike Brock
+ */
+public class StackDelimiterResolverFactory extends StackDemarcResolverFactory {
+
+    public StackDelimiterResolverFactory(VariableResolverFactory delegate) {
+        super(delegate);
+    }
+
+    public VariableResolver createVariable(String name, Object value) {
+        VariableResolverFactory delegate = getDelegate();
+        VariableResolverFactory nextFactory = delegate.getNextFactory();
+        delegate.setNextFactory(null);
+        VariableResolver resolver = delegate.createVariable(name, value);
+        delegate.setNextFactory(nextFactory);
+        return resolver;
+    }
+}

--- a/core/src/main/java/org/mvel2/integration/impl/StackDemarcResolverFactory.java
+++ b/core/src/main/java/org/mvel2/integration/impl/StackDemarcResolverFactory.java
@@ -1,0 +1,87 @@
+package org.mvel2.integration.impl;
+
+import java.util.Set;
+
+import org.mvel2.integration.VariableResolver;
+import org.mvel2.integration.VariableResolverFactory;
+
+/**
+ * @author Mike Brock
+ */
+public class StackDemarcResolverFactory implements VariableResolverFactory {
+
+    private VariableResolverFactory delegate;
+    private boolean tilt = false;
+
+    public StackDemarcResolverFactory(VariableResolverFactory delegate) {
+        this.delegate = delegate;
+    }
+
+    public VariableResolver createVariable(String name, Object value) {
+        return delegate.createVariable(name, value);
+    }
+
+    public VariableResolver createIndexedVariable(int index, String name, Object value) {
+        return delegate.createIndexedVariable(index, name, value);
+    }
+
+    public VariableResolver createVariable(String name, Object value, Class<?> type) {
+        return delegate.createVariable(name, value, type);
+    }
+
+    public VariableResolver createIndexedVariable(int index, String name, Object value, Class<?> typee) {
+        return delegate.createIndexedVariable(index, name, value, typee);
+    }
+
+    public VariableResolver setIndexedVariableResolver(int index, VariableResolver variableResolver) {
+        return delegate.setIndexedVariableResolver(index, variableResolver);
+    }
+
+    public VariableResolverFactory getNextFactory() {
+        return delegate.getNextFactory();
+    }
+
+    public VariableResolverFactory setNextFactory(VariableResolverFactory resolverFactory) {
+        return delegate.setNextFactory(resolverFactory);
+    }
+
+    public VariableResolver getVariableResolver(String name) {
+        return delegate.getVariableResolver(name);
+    }
+
+    public VariableResolver getIndexedVariableResolver(int index) {
+        return delegate.getIndexedVariableResolver(index);
+    }
+
+    public boolean isTarget(String name) {
+        return delegate.isTarget(name);
+    }
+
+    public boolean isResolveable(String name) {
+        return delegate.isResolveable(name);
+    }
+
+    public Set<String> getKnownVariables() {
+        return delegate.getKnownVariables();
+    }
+
+    public int variableIndexOf(String name) {
+        return delegate.variableIndexOf(name);
+    }
+
+    public boolean isIndexedFactory() {
+        return delegate.isIndexedFactory();
+    }
+
+    public boolean tiltFlag() {
+        return tilt;
+    }
+
+    public void setTiltFlag(boolean tilt) {
+        this.tilt = tilt;
+    }
+
+    public VariableResolverFactory getDelegate() {
+        return delegate;
+    }
+}

--- a/core/src/main/java/org/mvel2/integration/impl/StackResetResolverFactory.java
+++ b/core/src/main/java/org/mvel2/integration/impl/StackResetResolverFactory.java
@@ -1,0 +1,89 @@
+package org.mvel2.integration.impl;
+
+import java.util.Set;
+
+import org.mvel2.integration.VariableResolver;
+import org.mvel2.integration.VariableResolverFactory;
+
+/**
+ * @author Mike Brock
+ */
+public class StackResetResolverFactory implements VariableResolverFactory {
+
+    private VariableResolverFactory delegate;
+
+    public StackResetResolverFactory(VariableResolverFactory delegate) {
+        delegate.setTiltFlag(false);
+        this.delegate = delegate;
+    }
+
+    public VariableResolver createVariable(String name, Object value) {
+        return delegate.createVariable(name, value);
+    }
+
+    public VariableResolver createIndexedVariable(int index, String name, Object value) {
+        return delegate.createIndexedVariable(index, name, value);
+    }
+
+    public VariableResolver createVariable(String name, Object value, Class<?> type) {
+        return delegate.createVariable(name, value, type);
+    }
+
+    public VariableResolver createIndexedVariable(int index, String name, Object value, Class<?> typee) {
+        return delegate.createIndexedVariable(index, name, value, typee);
+    }
+
+    public VariableResolver setIndexedVariableResolver(int index, VariableResolver variableResolver) {
+        return delegate.setIndexedVariableResolver(index, variableResolver);
+    }
+
+    public VariableResolverFactory getNextFactory() {
+        return delegate.getNextFactory();
+    }
+
+    public VariableResolverFactory setNextFactory(VariableResolverFactory resolverFactory) {
+        return delegate.setNextFactory(resolverFactory);
+    }
+
+    public VariableResolver getVariableResolver(String name) {
+        return delegate.getVariableResolver(name);
+    }
+
+    public VariableResolver getIndexedVariableResolver(int index) {
+        return delegate.getIndexedVariableResolver(index);
+    }
+
+    public boolean isTarget(String name) {
+        return delegate.isTarget(name);
+    }
+
+    public boolean isResolveable(String name) {
+        return delegate.isResolveable(name);
+    }
+
+    public Set<String> getKnownVariables() {
+        return delegate.getKnownVariables();
+    }
+
+    public int variableIndexOf(String name) {
+        return delegate.variableIndexOf(name);
+    }
+
+    public boolean isIndexedFactory() {
+        return delegate.isIndexedFactory();
+    }
+
+    public boolean tiltFlag() {
+        return delegate.tiltFlag();
+    }
+
+    public void setTiltFlag(boolean tilt) {
+        if (!delegate.tiltFlag()) {
+            delegate.setTiltFlag(tilt);
+        }
+    }
+
+    public VariableResolverFactory getDelegate() {
+        return delegate;
+    }
+}

--- a/core/src/main/java/org/mvel2/integration/impl/StaticMethodImportResolver.java
+++ b/core/src/main/java/org/mvel2/integration/impl/StaticMethodImportResolver.java
@@ -1,0 +1,59 @@
+/**
+ * MVEL 2.0
+ * Copyright (C) 2007 The Codehaus
+ * Mike Brock, Dhanji Prasanna, John Graham, Mark Proctor
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mvel2.integration.impl;
+
+import org.mvel2.integration.VariableResolver;
+import org.mvel2.util.MethodStub;
+
+/**
+ * @author Christopher Brock
+ */
+public class StaticMethodImportResolver implements VariableResolver {
+
+    private String name;
+    private MethodStub method;
+
+    public StaticMethodImportResolver(String name, MethodStub method) {
+        this.name = name;
+        this.method = method;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public Class getType() {
+        return null;
+    }
+
+    public void setStaticType(Class type) {
+    }
+
+    public int getFlags() {
+        return 0;
+    }
+
+    public MethodStub getValue() {
+        return method;
+    }
+
+    public void setValue(Object value) {
+        this.method = (MethodStub) value;
+    }
+}

--- a/core/src/main/java/org/mvel2/integration/impl/StaticMethodImportResolverFactory.java
+++ b/core/src/main/java/org/mvel2/integration/impl/StaticMethodImportResolverFactory.java
@@ -1,0 +1,75 @@
+/**
+ * MVEL 2.0
+ * Copyright (C) 2007 The Codehaus
+ * Mike Brock, Dhanji Prasanna, John Graham, Mark Proctor
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mvel2.integration.impl;
+
+import java.lang.reflect.Method;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.mvel2.ParserContext;
+import org.mvel2.integration.VariableResolver;
+import org.mvel2.util.MethodStub;
+
+/**
+ * @author Christopher Brock
+ */
+public class StaticMethodImportResolverFactory extends BaseVariableResolverFactory {
+
+    public StaticMethodImportResolverFactory(ParserContext ctx) {
+        this.variableResolvers = new HashMap<String, VariableResolver>();
+        for (Map.Entry<String, Object> entry : ctx.getImports().entrySet()) {
+            if (entry.getValue() instanceof Method) {
+                createVariable(entry.getKey(), entry.getValue());
+            }
+        }
+    }
+
+    public StaticMethodImportResolverFactory() {
+        this.variableResolvers = new HashMap<String, VariableResolver>();
+    }
+
+    public VariableResolver createVariable(String name, Object value) {
+        if (value instanceof Method) value = new MethodStub((Method) value);
+
+        StaticMethodImportResolver methodResolver = new StaticMethodImportResolver(name, (MethodStub) value);
+        this.variableResolvers.put(name, methodResolver);
+        return methodResolver;
+    }
+
+    public VariableResolver createVariable(String name, Object value, Class<?> type) {
+        return null;
+    }
+
+    public boolean isTarget(String name) {
+        return this.variableResolvers.containsKey(name);
+    }
+
+    public boolean isResolveable(String name) {
+        return isTarget(name) || isNextResolveable(name);
+    }
+
+    public Map<String, Method> getImportedMethods() {
+        Map<String, Method> im = new HashMap<String, Method>();
+        for (Map.Entry<String, VariableResolver> e : this.variableResolvers.entrySet()) {
+            im.put(e.getKey(), (Method) e.getValue().getValue());
+        }
+        return im;
+    }
+
+}

--- a/core/src/main/java/org/mvel2/integration/impl/TypeInjectionResolverFactory.java
+++ b/core/src/main/java/org/mvel2/integration/impl/TypeInjectionResolverFactory.java
@@ -1,0 +1,25 @@
+/**
+ * MVEL 2.0
+ * Copyright (C) 2007 The Codehaus
+ * Mike Brock, Dhanji Prasanna, John Graham, Mark Proctor
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mvel2.integration.impl;
+
+/**
+ * This is a marker interface
+ */
+public interface TypeInjectionResolverFactory {
+}

--- a/core/src/main/java/org/mvel2/integration/impl/TypeInjectionResolverFactoryImpl.java
+++ b/core/src/main/java/org/mvel2/integration/impl/TypeInjectionResolverFactoryImpl.java
@@ -1,0 +1,80 @@
+/**
+ * MVEL 2.0
+ * Copyright (C) 2007 The Codehaus
+ * Mike Brock, Dhanji Prasanna, John Graham, Mark Proctor
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mvel2.integration.impl;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+import org.mvel2.ParserContext;
+import org.mvel2.integration.VariableResolver;
+import org.mvel2.integration.VariableResolverFactory;
+
+public class TypeInjectionResolverFactoryImpl extends MapVariableResolverFactory implements TypeInjectionResolverFactory {
+
+    public TypeInjectionResolverFactoryImpl() {
+        this.variables = new HashMap();
+    }
+
+    public TypeInjectionResolverFactoryImpl(Map<String, Object> variables) {
+        this.variables = variables;
+    }
+
+    public TypeInjectionResolverFactoryImpl(ParserContext ctx, VariableResolverFactory nextVariableResolverFactory) {
+        super(ctx.getImports(), ctx.hasFunction() ? new TypeInjectionResolverFactoryImpl(ctx.getFunctions(),
+                nextVariableResolverFactory) : nextVariableResolverFactory);
+    }
+
+    public TypeInjectionResolverFactoryImpl(Map<String, Object> variables, VariableResolverFactory nextFactory) {
+        super(variables, nextFactory);
+    }
+
+    public TypeInjectionResolverFactoryImpl(Map<String, Object> variables, boolean cachingSafe) {
+        super(variables);
+    }
+
+    public VariableResolver createVariable(String name, Object value) {
+        if (nextFactory == null) {
+            nextFactory = new MapVariableResolverFactory(new HashMap());
+        }
+        /**
+         * Delegate to the next factory.
+         */
+        return nextFactory.createVariable(name, value);
+    }
+
+    public VariableResolver createVariable(String name, Object value, Class<?> type) {
+        if (nextFactory == null) {
+            nextFactory = new MapVariableResolverFactory(new HashMap());
+        }
+        /**
+         * Delegate to the next factory.
+         */
+        return nextFactory.createVariable(name, value, type);
+    }
+
+    public Set<String> getKnownVariables() {
+        if (nextFactory == null) {
+            return new HashSet<String>(0);
+        } else {
+            return nextFactory.getKnownVariables();
+        }
+    }
+}

--- a/core/src/main/java/org/mvel2/jsr223/MvelBindings.java
+++ b/core/src/main/java/org/mvel2/jsr223/MvelBindings.java
@@ -1,0 +1,171 @@
+package org.mvel2.jsr223;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+import javax.script.Bindings;
+
+public class MvelBindings implements Bindings {
+
+    /**
+     * The <code>Map</code> field stores the attributes.
+     */
+    private Map<String, Object> map;
+
+    /**
+     * Constructor uses an existing <code>Map</code> to store the values.
+     *
+     * @param m The <code>Map</code> backing this <code>SimpleBindings</code>.
+     * @throws NullPointerException if m is null
+     */
+    public MvelBindings(Map<String, Object> m) {
+        if (m == null) {
+            throw new NullPointerException();
+        }
+        this.map = m;
+    }
+
+    /**
+     * Default constructor uses a <code>HashMap</code>.
+     */
+    public MvelBindings() {
+        this(new HashMap<String, Object>());
+    }
+
+    /**
+     * Sets the specified key/value in the underlying <code>map</code> field.
+     *
+     * @param name Name of value
+     * @param value Value to set.
+     *
+     * @return Previous value for the specified key. Returns null if key was previously unset.
+     *
+     * @throws NullPointerException if the name is null.
+     * @throws IllegalArgumentException if the name is empty.
+     */
+    public Object put(String name, Object value) {
+        return map.put(name, value);
+    }
+
+    /**
+     * <code>putAll</code> is implemented using <code>Map.putAll</code>.
+     *
+     * @param toMerge The <code>Map</code> of values to add.
+     *
+     * @throws NullPointerException if toMerge map is null or if some key in the map is null.
+     * @throws IllegalArgumentException if some key in the map is an empty String.
+     */
+    public void putAll(Map<? extends String, ? extends Object> toMerge) {
+        if (toMerge == null) {
+            throw new NullPointerException("toMerge map is null");
+        }
+        for (Entry<? extends String, ? extends Object> entry : toMerge.entrySet()) {
+            String key = entry.getKey();
+            put(key, entry.getValue());
+        }
+    }
+
+    /** {@inheritDoc} */
+    public void clear() {
+        map.clear();
+    }
+
+    /**
+     * Returns <tt>true</tt> if this map contains a mapping for the specified key. More formally,
+     * returns <tt>true</tt> if and only if this map contains a mapping for a key <tt>k</tt> such
+     * that <tt>(key==null ? k==null : key.equals(k))</tt>. (There can be at most one such mapping.)
+     *
+     * @param key key whose presence in this map is to be tested.
+     * @return <tt>true</tt> if this map contains a mapping for the specified key.
+     *
+     * @throws NullPointerException if key is null
+     * @throws ClassCastException if key is not String
+     * @throws IllegalArgumentException if key is empty String
+     */
+    public boolean containsKey(Object key) {
+        return map.containsKey(key);
+    }
+
+    /** {@inheritDoc} */
+    public boolean containsValue(Object value) {
+        return map.containsValue(value);
+    }
+
+    /** {@inheritDoc} */
+    public Set<Entry<String, Object>> entrySet() {
+        return map.entrySet();
+    }
+
+    /**
+     * Returns the value to which this map maps the specified key. Returns <tt>null</tt> if the map
+     * contains no mapping for this key. A return value of <tt>null</tt> does not <i>necessarily</i>
+     * indicate that the map contains no mapping for the key; it's also possible that the map
+     * explicitly maps the key to <tt>null</tt>. The <tt>containsKey</tt> operation may be used to
+     * distinguish these two cases.
+     *
+     * <p>
+     * More formally, if this map contains a mapping from a key <tt>k</tt> to a value <tt>v</tt>
+     * such that <tt>(key==null ? k==null :
+     * key.equals(k))</tt>, then this method returns <tt>v</tt>; otherwise it returns <tt>null</tt>.
+     * (There can be at most one such mapping.)
+     *
+     * @param key key whose associated value is to be returned.
+     * @return the value to which this map maps the specified key, or <tt>null</tt> if the map
+     *         contains no mapping for this key.
+     *
+     * @throws NullPointerException if key is null
+     * @throws ClassCastException if key is not String
+     * @throws IllegalArgumentException if key is empty String
+     */
+    public Object get(Object key) {
+        return map.get(key);
+    }
+
+    /** {@inheritDoc} */
+    public boolean isEmpty() {
+        return map.isEmpty();
+    }
+
+    /** {@inheritDoc} */
+    public Set<String> keySet() {
+        return map.keySet();
+    }
+
+    /**
+     * Removes the mapping for this key from this map if it is present (optional operation). More
+     * formally, if this map contains a mapping from key <tt>k</tt> to value <tt>v</tt> such that
+     * <code>(key==null ?  k==null : key.equals(k))</code>, that mapping is removed. (The map can
+     * contain at most one such mapping.)
+     *
+     * <p>
+     * Returns the value to which the map previously associated the key, or <tt>null</tt> if the map
+     * contained no mapping for this key. (A <tt>null</tt> return can also indicate that the map
+     * previously associated <tt>null</tt> with the specified key if the implementation supports
+     * <tt>null</tt> values.) The map will not contain a mapping for the specified key once the call
+     * returns.
+     *
+     * @param key key whose mapping is to be removed from the map.
+     * @return previous value associated with specified key, or <tt>null</tt> if there was no
+     *         mapping for key.
+     *
+     * @throws NullPointerException if key is null
+     * @throws ClassCastException if key is not String
+     * @throws IllegalArgumentException if key is empty String
+     */
+    public Object remove(Object key) {
+        return map.remove(key);
+    }
+
+    /** {@inheritDoc} */
+    public int size() {
+        return map.size();
+    }
+
+    /** {@inheritDoc} */
+    public Collection<Object> values() {
+        return map.values();
+    }
+
+}

--- a/core/src/main/java/org/mvel2/jsr223/MvelCompiledScript.java
+++ b/core/src/main/java/org/mvel2/jsr223/MvelCompiledScript.java
@@ -1,0 +1,29 @@
+package org.mvel2.jsr223;
+
+import java.io.Serializable;
+
+import javax.script.CompiledScript;
+import javax.script.ScriptContext;
+import javax.script.ScriptEngine;
+import javax.script.ScriptException;
+
+public class MvelCompiledScript extends CompiledScript {
+
+    private final MvelScriptEngine scriptEngine;
+    private final Serializable compiledScript;
+
+    public MvelCompiledScript(MvelScriptEngine engine, Serializable compiledScript) {
+        this.scriptEngine = engine;
+        this.compiledScript = compiledScript;
+    }
+
+    @Override
+    public Object eval(ScriptContext context) throws ScriptException {
+        return scriptEngine.evaluate(compiledScript, context);
+    }
+
+    @Override
+    public ScriptEngine getEngine() {
+        return scriptEngine;
+    }
+}

--- a/core/src/main/java/org/mvel2/jsr223/MvelScriptEngine.java
+++ b/core/src/main/java/org/mvel2/jsr223/MvelScriptEngine.java
@@ -1,0 +1,93 @@
+package org.mvel2.jsr223;
+
+import java.io.IOException;
+import java.io.Reader;
+import java.io.Serializable;
+
+import javax.script.AbstractScriptEngine;
+import javax.script.Bindings;
+import javax.script.Compilable;
+import javax.script.CompiledScript;
+import javax.script.ScriptContext;
+import javax.script.ScriptEngine;
+import javax.script.ScriptEngineFactory;
+import javax.script.ScriptException;
+
+import org.mvel2.MVEL;
+
+public class MvelScriptEngine extends AbstractScriptEngine implements ScriptEngine, Compilable {
+
+    private volatile MvelScriptEngineFactory factory;
+
+    private static String readFully(Reader reader) throws ScriptException {
+        char[] arr = new char[8192];
+        StringBuilder buf = new StringBuilder();
+
+        int numChars;
+        try {
+            while ((numChars = reader.read(arr, 0, arr.length)) > 0) {
+                buf.append(arr, 0, numChars);
+            }
+        } catch (IOException var5) {
+            throw new ScriptException(var5);
+        }
+
+        return buf.toString();
+    }
+
+    @Override
+    public Object eval(String script, ScriptContext context) throws ScriptException {
+        Serializable expression = compiledScript(script);
+        return evaluate(expression, context);
+    }
+
+    @Override
+    public Object eval(Reader reader, ScriptContext context) throws ScriptException {
+        return this.eval(readFully(reader), context);
+    }
+
+    @Override
+    public Bindings createBindings() {
+        return new MvelBindings();
+    }
+
+    @Override
+    public ScriptEngineFactory getFactory() {
+        if (this.factory == null) {
+            synchronized (this) {
+                if (this.factory == null) {
+                    this.factory = new MvelScriptEngineFactory();
+                }
+            }
+        }
+
+        return this.factory;
+    }
+
+    @Override
+    public CompiledScript compile(String script) throws ScriptException {
+        return new MvelCompiledScript(this, compiledScript(script));
+    }
+
+    @Override
+    public CompiledScript compile(Reader reader) throws ScriptException {
+        return this.compile(readFully(reader));
+    }
+
+    public Serializable compiledScript(String script) throws ScriptException {
+        try {
+            Serializable expression = MVEL.compileExpression(script);
+            return expression;
+        } catch (Exception e) {
+            throw new ScriptException(e);
+        }
+    }
+
+    public Object evaluate(Serializable expression, ScriptContext context) throws ScriptException {
+        try {
+            return MVEL.executeExpression(expression, context.getBindings(ScriptContext.ENGINE_SCOPE));
+        } catch (Exception e) {
+            throw new ScriptException(e);
+        }
+    }
+}

--- a/core/src/main/java/org/mvel2/jsr223/MvelScriptEngineFactory.java
+++ b/core/src/main/java/org/mvel2/jsr223/MvelScriptEngineFactory.java
@@ -1,0 +1,112 @@
+package org.mvel2.jsr223;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import javax.script.ScriptEngine;
+import javax.script.ScriptEngineFactory;
+
+import org.mvel2.MVEL;
+
+public class MvelScriptEngineFactory implements ScriptEngineFactory {
+
+    private static final String ENGINE_NAME = MVEL.NAME;
+    private static final String ENGINE_VERSION = MVEL.VERSION;
+    private static final String LANGUAGE_NAME = "mvel";
+    private static final String LANGUAGE_VERSION = MVEL.VERSION;
+
+    private static final List<String> NAMES;
+    private static final List<String> EXTENSIONS;
+    private static final List<String> MIME_TYPES;
+    private static final MvelScriptEngine MVEL_SCRIPT_ENGINE = new MvelScriptEngine();
+
+    static {
+        List<String> n = new ArrayList<String>(1);
+        n.add(LANGUAGE_NAME);
+        NAMES = Collections.unmodifiableList(n);
+
+        EXTENSIONS = NAMES;
+
+        n = new ArrayList<String>(1);
+        n.add("application/x-" + LANGUAGE_NAME);
+        MIME_TYPES = Collections.unmodifiableList(n);
+    }
+
+    public MvelScriptEngineFactory() {
+    }
+
+    @Override
+    public String getEngineName() {
+        return ENGINE_NAME;
+    }
+
+    @Override
+    public String getEngineVersion() {
+        return ENGINE_VERSION;
+    }
+
+    @Override
+    public List<String> getExtensions() {
+        return EXTENSIONS;
+    }
+
+    @Override
+    public List<String> getMimeTypes() {
+        return MIME_TYPES;
+    }
+
+    @Override
+    public List<String> getNames() {
+        return NAMES;
+    }
+
+    @Override
+    public String getLanguageName() {
+        return LANGUAGE_NAME;
+    }
+
+    @Override
+    public String getLanguageVersion() {
+        return LANGUAGE_VERSION;
+    }
+
+    @Override
+    public Object getParameter(String key) {
+        if (key.equals(ScriptEngine.NAME)) {
+            return getLanguageName();
+        } else if (key.equals(ScriptEngine.ENGINE)) {
+            return getEngineName();
+        } else if (key.equals(ScriptEngine.ENGINE_VERSION)) {
+            return getEngineVersion();
+        } else if (key.equals(ScriptEngine.LANGUAGE)) {
+            return getLanguageName();
+        } else if (key.equals(ScriptEngine.LANGUAGE_VERSION)) {
+            return getLanguageVersion();
+        } else if (key.equals("THREADING")) {
+            return "THREAD-ISOLATED";
+        } else {
+            return null;
+        }
+    }
+
+    @Override
+    public String getMethodCallSyntax(String obj, String m, String... args) {
+        return null;
+    }
+
+    @Override
+    public String getOutputStatement(String toDisplay) {
+        return null;
+    }
+
+    @Override
+    public String getProgram(String... statements) {
+        return null;
+    }
+
+    @Override
+    public ScriptEngine getScriptEngine() {
+        return MVEL_SCRIPT_ENGINE;
+    }
+}

--- a/core/src/main/java/org/mvel2/math/MathProcessor.java
+++ b/core/src/main/java/org/mvel2/math/MathProcessor.java
@@ -1,0 +1,742 @@
+/**
+ * MVEL 2.0
+ * Copyright (C) 2007 The Codehaus
+ * Mike Brock, Dhanji Prasanna, John Graham, Mark Proctor
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.mvel2.math;
+
+import static java.lang.String.valueOf;
+import static org.mvel2.DataConversion.convert;
+import static org.mvel2.DataTypes.BIG_DECIMAL;
+import static org.mvel2.DataTypes.EMPTY;
+import static org.mvel2.Operator.ADD;
+import static org.mvel2.Operator.BW_AND;
+import static org.mvel2.Operator.BW_NOT;
+import static org.mvel2.Operator.BW_OR;
+import static org.mvel2.Operator.BW_SHIFT_LEFT;
+import static org.mvel2.Operator.BW_SHIFT_RIGHT;
+import static org.mvel2.Operator.BW_USHIFT_LEFT;
+import static org.mvel2.Operator.BW_USHIFT_RIGHT;
+import static org.mvel2.Operator.BW_XOR;
+import static org.mvel2.Operator.DIV;
+import static org.mvel2.Operator.EQUAL;
+import static org.mvel2.Operator.GETHAN;
+import static org.mvel2.Operator.GTHAN;
+import static org.mvel2.Operator.LETHAN;
+import static org.mvel2.Operator.LTHAN;
+import static org.mvel2.Operator.MOD;
+import static org.mvel2.Operator.MULT;
+import static org.mvel2.Operator.NEQUAL;
+import static org.mvel2.Operator.POWER;
+import static org.mvel2.Operator.SOUNDEX;
+import static org.mvel2.Operator.STR_APPEND;
+import static org.mvel2.Operator.SUB;
+import static org.mvel2.util.ParseTools.__resolveType;
+import static org.mvel2.util.ParseTools.isNumber;
+import static org.mvel2.util.ParseTools.narrowType;
+import static org.mvel2.util.Soundex.soundex;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.math.MathContext;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+import org.mvel2.DataTypes;
+import org.mvel2.Unit;
+import org.mvel2.compiler.BlankLiteral;
+import org.mvel2.debug.DebugTools;
+import org.mvel2.util.InternalNumber;
+
+/**
+ * @author Christopher Brock
+ */
+public strictfp class MathProcessor {
+
+    private static final MathContext MATH_CONTEXT = MathContext.DECIMAL128;
+
+    public static Object doOperations(Object val1, int operation, Object val2) {
+        return doOperations(val1 == null ? DataTypes.OBJECT : __resolveType(val1.getClass()), val1, operation,
+                val2 == null ? DataTypes.NULL : __resolveType(val2.getClass()), val2);
+    }
+
+    public static Object doOperations(Object val1, int operation, int type2, Object val2) {
+        return doOperations(val1 == null ? DataTypes.OBJECT : __resolveType(val1.getClass()), val1, operation, type2, val2);
+    }
+
+    public static Object doOperations(int type1, Object val1, int operation, int type2, Object val2) {
+        if (type1 == -1) type1 = val1 == null ? DataTypes.OBJECT : __resolveType(val1.getClass());
+
+        if (type2 == -1) type2 = val2 == null ? DataTypes.OBJECT : __resolveType(val2.getClass());
+
+        switch (type1) {
+            case BIG_DECIMAL:
+
+                switch (type2) {
+                    case BIG_DECIMAL:
+                        return doBigDecimalArithmetic((BigDecimal) val1, operation, (BigDecimal) val2, false, -1);
+                    default:
+                        if (type2 > 99) {
+                            return doBigDecimalArithmetic((BigDecimal) val1, operation, getInternalNumberFromType(val2, type2), false, -1);
+                        } else {
+                            return _doOperations(type1, val1, operation, type2, val2);
+                        }
+                }
+            default:
+                return _doOperations(type1, val1, operation, type2, val2);
+
+        }
+    }
+
+    private static Object doPrimWrapperArithmetic(final Number val1, final int operation, final Number val2, boolean iNumber,
+            int returnTarget) {
+        switch (operation) {
+            case ADD:
+                return toType(val1.doubleValue() + val2.doubleValue(), returnTarget);
+            case DIV:
+                return toType(val1.doubleValue() / val2.doubleValue(), returnTarget);
+            case SUB:
+                return toType(val1.doubleValue() - val2.doubleValue(), returnTarget);
+            case MULT:
+                return toType(val1.doubleValue() * val2.doubleValue(), returnTarget);
+            case POWER:
+                return toType(Math.pow(val1.doubleValue(), val2.doubleValue()), returnTarget);
+            case MOD:
+                return toType(val1.doubleValue() % val2.doubleValue(), returnTarget);
+            case GTHAN:
+                return val1.doubleValue() > val2.doubleValue() ? Boolean.TRUE : Boolean.FALSE;
+            case GETHAN:
+                return val1.doubleValue() >= val2.doubleValue() ? Boolean.TRUE : Boolean.FALSE;
+            case LTHAN:
+                return val1.doubleValue() < val2.doubleValue() ? Boolean.TRUE : Boolean.FALSE;
+            case LETHAN:
+                return val1.doubleValue() <= val2.doubleValue() ? Boolean.TRUE : Boolean.FALSE;
+            case EQUAL:
+                return val1.doubleValue() == val2.doubleValue() ? Boolean.TRUE : Boolean.FALSE;
+            case NEQUAL:
+                return val1.doubleValue() != val2.doubleValue() ? Boolean.TRUE : Boolean.FALSE;
+        }
+        return null;
+
+    }
+
+    private static Object toType(Number val, int returnType) {
+        switch (returnType) {
+            case DataTypes.W_DOUBLE:
+            case DataTypes.DOUBLE:
+                return val.doubleValue();
+            case DataTypes.W_FLOAT:
+            case DataTypes.FLOAT:
+                return val.floatValue();
+            case DataTypes.INTEGER:
+            case DataTypes.W_INTEGER:
+                return val.intValue();
+            case DataTypes.W_LONG:
+            case DataTypes.LONG:
+                return val.longValue();
+            case DataTypes.W_SHORT:
+            case DataTypes.SHORT:
+                return val.shortValue();
+            case DataTypes.BIG_DECIMAL:
+                return new BigDecimal(val.doubleValue());
+            case DataTypes.BIG_INTEGER:
+                return BigInteger.valueOf(val.longValue());
+
+            case DataTypes.STRING:
+                return val.doubleValue();
+        }
+        throw new RuntimeException("internal error: " + returnType);
+    }
+
+    private static Object doBigDecimalArithmetic(final BigDecimal val1, final int operation, final BigDecimal val2, boolean iNumber,
+            int returnTarget) {
+        switch (operation) {
+            case ADD:
+                if (iNumber) {
+                    return narrowType(val1.add(val2, MATH_CONTEXT), returnTarget);
+                } else {
+                    return val1.add(val2, MATH_CONTEXT);
+                }
+            case DIV:
+                if (iNumber) {
+                    return narrowType(val1.divide(val2, MATH_CONTEXT), returnTarget);
+                } else {
+                    return val1.divide(val2, MATH_CONTEXT);
+                }
+
+            case SUB:
+                if (iNumber) {
+                    return narrowType(val1.subtract(val2, MATH_CONTEXT), returnTarget);
+                } else {
+                    return val1.subtract(val2, MATH_CONTEXT);
+                }
+            case MULT:
+                if (iNumber) {
+                    return narrowType(val1.multiply(val2, MATH_CONTEXT), returnTarget);
+                } else {
+                    return val1.multiply(val2, MATH_CONTEXT);
+                }
+
+            case POWER:
+                if (iNumber) {
+                    return narrowType(val1.pow(val2.intValue(), MATH_CONTEXT), returnTarget);
+                } else {
+                    return val1.pow(val2.intValue(), MATH_CONTEXT);
+                }
+
+            case MOD:
+                if (iNumber) {
+                    return narrowType(val1.remainder(val2), returnTarget);
+                } else {
+                    return val1.remainder(val2);
+                }
+
+            case GTHAN:
+                return val1.compareTo(val2) == 1 ? Boolean.TRUE : Boolean.FALSE;
+            case GETHAN:
+                return val1.compareTo(val2) >= 0 ? Boolean.TRUE : Boolean.FALSE;
+            case LTHAN:
+                return val1.compareTo(val2) == -1 ? Boolean.TRUE : Boolean.FALSE;
+            case LETHAN:
+                return val1.compareTo(val2) <= 0 ? Boolean.TRUE : Boolean.FALSE;
+            case EQUAL:
+                return val1.compareTo(val2) == 0 ? Boolean.TRUE : Boolean.FALSE;
+            case NEQUAL:
+                return val1.compareTo(val2) != 0 ? Boolean.TRUE : Boolean.FALSE;
+        }
+        return null;
+    }
+
+    private static Object _doOperations(int type1, Object val1, int operation, int type2, Object val2) {
+        if (operation < 20) {
+            if (((type1 > 49 || operation == EQUAL || operation == NEQUAL) && type1 == type2)
+                    || (isIntegerType(type1) && isIntegerType(type2) && operation >= BW_AND && operation <= BW_NOT)) {
+                return doOperationsSameType(type1, val1, operation, val2);
+            } else if (isNumericOperation(type1, val1, operation, type2, val2)) {
+                return doPrimWrapperArithmetic(getNumber(val1, type1), operation, getNumber(val2, type2), true,
+                        box(type2) > box(type1) ? box(type2) : box(type1));
+            } else if (operation != ADD && (type1 == DataTypes.W_BOOLEAN || type2 == DataTypes.W_BOOLEAN) && type1 != type2
+                    && type1 != EMPTY && type2 != EMPTY) {
+
+                return doOperationNonNumeric(type1, convert(val1, Boolean.class), operation, convert(val2, Boolean.class));
+            }
+            // Fix for: MVEL-56
+            else if ((type1 == 1 || type2 == 1) && (type1 == 8 || type1 == 112 || type2 == 8 || type2 == 112)) {
+                if (type1 == 1) {
+                    return doOperationNonNumeric(type1, val1, operation, valueOf(val2));
+                } else {
+                    return doOperationNonNumeric(type1, valueOf(val1), operation, val2);
+                }
+            }
+        }
+        return doOperationNonNumeric(type1, val1, operation, val2);
+    }
+
+    private static boolean isNumericOperation(int type1, Object val1, int operation, int type2, Object val2) {
+        return (type1 > 99 && type2 > 99) || (operation != ADD && (type1 > 99 || type2 > 99 || operation < LTHAN || operation > GETHAN)
+                && isNumber(val1) && isNumber(val2));
+    }
+
+    private static boolean isIntegerType(int type) {
+        return type == DataTypes.INTEGER || type == DataTypes.W_INTEGER || type == DataTypes.LONG || type == DataTypes.W_LONG;
+    }
+
+    private static Object doOperationNonNumeric(int type1, final Object val1, final int operation, final Object val2) {
+        switch (operation) {
+            case ADD:
+                if (type1 == DataTypes.COLLECTION) {
+                    List list = new ArrayList((Collection) val1);
+                    list.add(val2);
+                    return list;
+                } else {
+                    return valueOf(val1) + valueOf(val2);
+                }
+
+            case EQUAL:
+                return safeEquals(val2, val1) ? Boolean.TRUE : Boolean.FALSE;
+
+            case NEQUAL:
+                return safeNotEquals(val2, val1) ? Boolean.TRUE : Boolean.FALSE;
+
+            case SUB:
+            case DIV:
+            case MULT:
+            case MOD:
+            case GTHAN:
+                if (val1 instanceof Comparable) {
+                    try {
+                        return val2 != null && (((Comparable) val1).compareTo(val2) >= 1 ? Boolean.TRUE : Boolean.FALSE);
+                    } catch (ClassCastException e) {
+                        throw new RuntimeException("uncomparable values <<" + val1 + ">> and <<" + val2 + ">>", e);
+                    }
+                } else {
+                    return Boolean.FALSE;
+                }
+                //     break;
+
+            case GETHAN:
+                if (val1 instanceof Comparable) {
+                    //noinspection unchecked
+                    try {
+                        return val2 != null && ((Comparable) val1).compareTo(val2) >= 0 ? Boolean.TRUE : Boolean.FALSE;
+                    } catch (ClassCastException e) {
+                        throw new RuntimeException("uncomparable values <<" + val1 + ">> and <<" + val2 + ">>", e);
+                    }
+
+                } else {
+                    return Boolean.FALSE;
+                }
+
+            case LTHAN:
+                if (val1 instanceof Comparable) {
+                    //noinspection unchecked
+                    try {
+                        return val2 != null && ((Comparable) val1).compareTo(val2) <= -1 ? Boolean.TRUE : Boolean.FALSE;
+                    } catch (ClassCastException e) {
+                        throw new RuntimeException("uncomparable values <<" + val1 + ">> and <<" + val2 + ">>", e);
+                    }
+
+                } else {
+                    return Boolean.FALSE;
+                }
+
+            case LETHAN:
+                if (val1 instanceof Comparable) {
+                    //noinspection unchecked
+                    try {
+                        return val2 != null && ((Comparable) val1).compareTo(val2) <= 0 ? Boolean.TRUE : Boolean.FALSE;
+                    } catch (ClassCastException e) {
+                        throw new RuntimeException("uncomparable values <<" + val1 + ">> and <<" + val2 + ">>", e);
+                    }
+
+                } else {
+                    return Boolean.FALSE;
+                }
+
+            case SOUNDEX:
+                return soundex(String.valueOf(val1)).equals(soundex(String.valueOf(val2)));
+
+            case STR_APPEND:
+                return valueOf(val1) + valueOf(val2);
+        }
+
+        throw new RuntimeException(
+                "could not perform numeric operation on non-numeric types: left-type=" + (val1 != null ? val1.getClass().getName() : "null")
+                        + "; right-type=" + (val2 != null ? val2.getClass().getName() : "null") + " [vals (" + valueOf(val1) + ", "
+                        + valueOf(val2) + ") operation=" + DebugTools.getOperatorName(operation) + " (opcode:" + operation + ") ]");
+    }
+
+    private static Boolean safeEquals(final Object val1, final Object val2) {
+        if (val1 != null) {
+            return val1.equals(val2) ? Boolean.TRUE : Boolean.FALSE;
+        } else return val2 == null || (val2.equals(val1) ? Boolean.TRUE : Boolean.FALSE);
+    }
+
+    private static Boolean safeNotEquals(final Object val1, final Object val2) {
+        if (val1 != null) {
+            return !val1.equals(val2) ? Boolean.TRUE : Boolean.FALSE;
+        } else return (val2 != null && !val2.equals(val1)) ? Boolean.TRUE : Boolean.FALSE;
+    }
+
+    private static Object doOperationsSameType(int type1, Object val1, int operation, Object val2) {
+        switch (type1) {
+            case DataTypes.COLLECTION:
+                switch (operation) {
+                    case ADD:
+                        List list = new ArrayList((Collection) val1);
+                        list.addAll((Collection) val2);
+                        return list;
+
+                    case EQUAL:
+                        return val1.equals(val2);
+
+                    case NEQUAL:
+                        return !val1.equals(val2);
+
+                    default:
+                        throw new UnsupportedOperationException("illegal operation on Collection type");
+                }
+
+            case DataTypes.INTEGER:
+            case DataTypes.W_INTEGER:
+                switch (operation) {
+                    case ADD:
+                        return ((Integer) val1) + ((Integer) val2);
+                    case SUB:
+                        return ((Integer) val1) - ((Integer) val2);
+                    case DIV:
+                        return ((Integer) val1).doubleValue() / ((Integer) val2).doubleValue();
+                    case MULT:
+                        return ((Integer) val1) * ((Integer) val2);
+                    case POWER:
+                        double d = Math.pow((Integer) val1, (Integer) val2);
+                        if (d > Integer.MAX_VALUE) return d;
+                        else return (int) d;
+                    case MOD:
+                        return ((Integer) val1) % ((Integer) val2);
+                    case GTHAN:
+                        return ((Integer) val1) > ((Integer) val2) ? Boolean.TRUE : Boolean.FALSE;
+                    case GETHAN:
+                        return ((Integer) val1) >= ((Integer) val2) ? Boolean.TRUE : Boolean.FALSE;
+                    case LTHAN:
+                        return ((Integer) val1) < ((Integer) val2) ? Boolean.TRUE : Boolean.FALSE;
+                    case LETHAN:
+                        return ((Integer) val1) <= ((Integer) val2) ? Boolean.TRUE : Boolean.FALSE;
+                    case EQUAL:
+                        return ((Integer) val1).intValue() == ((Integer) val2).intValue() ? Boolean.TRUE : Boolean.FALSE;
+                    case NEQUAL:
+                        return ((Integer) val1).intValue() != ((Integer) val2).intValue() ? Boolean.TRUE : Boolean.FALSE;
+                    case BW_AND:
+                        if (val2 instanceof Long) return (Integer) val1 & (Long) val2;
+                        return (Integer) val1 & (Integer) val2;
+                    case BW_OR:
+                        if (val2 instanceof Long) return (Integer) val1 | (Long) val2;
+                        return (Integer) val1 | (Integer) val2;
+                    case BW_SHIFT_LEFT:
+                        if (val2 instanceof Long) return (Integer) val1 << (Long) val2;
+                        return (Integer) val1 << (Integer) val2;
+                    case BW_SHIFT_RIGHT:
+                        if (val2 instanceof Long) return (Integer) val1 >> (Long) val2;
+                        return (Integer) val1 >> (Integer) val2;
+                    case BW_USHIFT_RIGHT:
+                        if (val2 instanceof Long) return (Integer) val1 >>> (Long) val2;
+                        return (Integer) val1 >>> (Integer) val2;
+                    case BW_XOR:
+                        if (val2 instanceof Long) return (Integer) val1 ^ (Long) val2;
+                        return (Integer) val1 ^ (Integer) val2;
+                }
+
+            case DataTypes.SHORT:
+            case DataTypes.W_SHORT:
+                switch (operation) {
+                    case ADD:
+                        return ((Short) val1) + ((Short) val2);
+                    case SUB:
+                        return ((Short) val1) - ((Short) val2);
+                    case DIV:
+                        return ((Short) val1).doubleValue() / ((Short) val2).doubleValue();
+                    case MULT:
+                        return ((Short) val1) * ((Short) val2);
+                    case POWER:
+                        double d = Math.pow((Short) val1, (Short) val2);
+                        if (d > Short.MAX_VALUE) return d;
+                        else return (short) d;
+                    case MOD:
+                        return ((Short) val1) % ((Short) val2);
+                    case GTHAN:
+                        return ((Short) val1) > ((Short) val2) ? Boolean.TRUE : Boolean.FALSE;
+                    case GETHAN:
+                        return ((Short) val1) >= ((Short) val2) ? Boolean.TRUE : Boolean.FALSE;
+                    case LTHAN:
+                        return ((Short) val1) < ((Short) val2) ? Boolean.TRUE : Boolean.FALSE;
+                    case LETHAN:
+                        return ((Short) val1) <= ((Short) val2) ? Boolean.TRUE : Boolean.FALSE;
+                    case EQUAL:
+                        return ((Short) val1).shortValue() == ((Short) val2).shortValue() ? Boolean.TRUE : Boolean.FALSE;
+                    case NEQUAL:
+                        return ((Short) val1).shortValue() != ((Short) val2).shortValue() ? Boolean.TRUE : Boolean.FALSE;
+                    case BW_AND:
+                        return (Short) val1 & (Short) val2;
+                    case BW_OR:
+                        return (Short) val1 | (Short) val2;
+                    case BW_SHIFT_LEFT:
+                        return (Short) val1 << (Short) val2;
+                    case BW_SHIFT_RIGHT:
+                        return (Short) val1 >> (Short) val2;
+                    case BW_USHIFT_RIGHT:
+                        return (Short) val1 >>> (Short) val2;
+                    case BW_XOR:
+                        return (Short) val1 ^ (Short) val2;
+                }
+
+            case DataTypes.LONG:
+            case DataTypes.W_LONG:
+                switch (operation) {
+                    case ADD:
+                        return ((Long) val1) + ((Long) val2);
+                    case SUB:
+                        return ((Long) val1) - ((Long) val2);
+                    case DIV:
+                        return ((Long) val1).doubleValue() / ((Long) val2).doubleValue();
+                    case MULT:
+                        return ((Long) val1) * ((Long) val2);
+                    case POWER:
+                        double d = Math.pow((Long) val1, (Long) val2);
+                        if (d > Long.MAX_VALUE) return d;
+                        else return (long) d;
+                    case MOD:
+                        return ((Long) val1) % ((Long) val2);
+                    case GTHAN:
+                        return ((Long) val1) > ((Long) val2) ? Boolean.TRUE : Boolean.FALSE;
+                    case GETHAN:
+                        return ((Long) val1) >= ((Long) val2) ? Boolean.TRUE : Boolean.FALSE;
+                    case LTHAN:
+                        return ((Long) val1) < ((Long) val2) ? Boolean.TRUE : Boolean.FALSE;
+                    case LETHAN:
+                        return ((Long) val1) <= ((Long) val2) ? Boolean.TRUE : Boolean.FALSE;
+                    case EQUAL:
+                        return ((Long) val1).longValue() == ((Long) val2).longValue() ? Boolean.TRUE : Boolean.FALSE;
+                    case NEQUAL:
+                        return ((Long) val1).longValue() != ((Long) val2).longValue() ? Boolean.TRUE : Boolean.FALSE;
+                    case BW_AND:
+                        if (val2 instanceof Integer) return (Long) val1 & (Integer) val2;
+                        return (Long) val1 & (Long) val2;
+                    case BW_OR:
+                        if (val2 instanceof Integer) return (Long) val1 | (Integer) val2;
+                        return (Long) val1 | (Long) val2;
+                    case BW_SHIFT_LEFT:
+                        if (val2 instanceof Integer) return (Long) val1 << (Integer) val2;
+                        return (Long) val1 << (Long) val2;
+                    case BW_USHIFT_LEFT:
+                        throw new UnsupportedOperationException("unsigned left-shift not supported");
+                    case BW_SHIFT_RIGHT:
+                        if (val2 instanceof Integer) return (Long) val1 >> (Integer) val2;
+                        return (Long) val1 >> (Long) val2;
+                    case BW_USHIFT_RIGHT:
+                        if (val2 instanceof Integer) return (Long) val1 >>> (Integer) val2;
+                        return (Long) val1 >>> (Long) val2;
+                    case BW_XOR:
+                        if (val2 instanceof Integer) return (Long) val1 ^ (Integer) val2;
+                        return (Long) val1 ^ (Long) val2;
+                }
+
+            case DataTypes.UNIT:
+                val2 = ((Unit) val1).convertFrom(val2);
+                val1 = ((Unit) val1).getValue();
+
+            case DataTypes.DOUBLE:
+            case DataTypes.W_DOUBLE:
+                switch (operation) {
+                    case ADD:
+                        return ((Double) val1) + ((Double) val2);
+                    case SUB:
+                        return ((Double) val1) - ((Double) val2);
+                    case DIV:
+                        return ((Double) val1) / ((Double) val2);
+                    case MULT:
+                        return ((Double) val1) * ((Double) val2);
+                    case POWER:
+                        return Math.pow((Double) val1, (Double) val2);
+                    case MOD:
+                        return ((Double) val1) % ((Double) val2);
+                    case GTHAN:
+                        return ((Double) val1) > ((Double) val2) ? Boolean.TRUE : Boolean.FALSE;
+                    case GETHAN:
+                        return ((Double) val1) >= ((Double) val2) ? Boolean.TRUE : Boolean.FALSE;
+                    case LTHAN:
+                        return ((Double) val1) < ((Double) val2) ? Boolean.TRUE : Boolean.FALSE;
+                    case LETHAN:
+                        return ((Double) val1) <= ((Double) val2) ? Boolean.TRUE : Boolean.FALSE;
+                    case EQUAL:
+                        return ((Double) val1).doubleValue() == ((Double) val2).doubleValue() ? Boolean.TRUE : Boolean.FALSE;
+                    case NEQUAL:
+                        return ((Double) val1).doubleValue() != ((Double) val2).doubleValue() ? Boolean.TRUE : Boolean.FALSE;
+                    case BW_AND:
+                    case BW_OR:
+                    case BW_SHIFT_LEFT:
+                    case BW_SHIFT_RIGHT:
+                    case BW_USHIFT_RIGHT:
+                    case BW_XOR:
+                        throw new RuntimeException("bitwise operation on a non-fixed-point number.");
+                }
+
+            case DataTypes.FLOAT:
+            case DataTypes.W_FLOAT:
+                switch (operation) {
+                    case ADD:
+                        return ((Float) val1) + ((Float) val2);
+                    case SUB:
+                        return ((Float) val1) - ((Float) val2);
+                    case DIV:
+                        return ((Float) val1).doubleValue() / ((Float) val2).doubleValue();
+                    case MULT:
+                        return ((Float) val1) * ((Float) val2);
+                    case POWER:
+                        return narrowType(new InternalNumber((Float) val1, MATH_CONTEXT).pow(new InternalNumber((Float) val2).intValue(),
+                                MATH_CONTEXT), -1);
+                    case MOD:
+                        return ((Float) val1) % ((Float) val2);
+                    case GTHAN:
+                        return ((Float) val1) > ((Float) val2) ? Boolean.TRUE : Boolean.FALSE;
+                    case GETHAN:
+                        return ((Float) val1) >= ((Float) val2) ? Boolean.TRUE : Boolean.FALSE;
+                    case LTHAN:
+                        return ((Float) val1) < ((Float) val2) ? Boolean.TRUE : Boolean.FALSE;
+                    case LETHAN:
+                        return ((Float) val1) <= ((Float) val2) ? Boolean.TRUE : Boolean.FALSE;
+                    case EQUAL:
+                        return ((Float) val1).floatValue() == ((Float) val2).floatValue() ? Boolean.TRUE : Boolean.FALSE;
+                    case NEQUAL:
+                        return ((Float) val1).floatValue() != ((Float) val2).floatValue() ? Boolean.TRUE : Boolean.FALSE;
+                    case BW_AND:
+                    case BW_OR:
+                    case BW_SHIFT_LEFT:
+                    case BW_SHIFT_RIGHT:
+                    case BW_USHIFT_RIGHT:
+                    case BW_XOR:
+                        throw new RuntimeException("bitwise operation on a non-fixed-point number.");
+                }
+
+            case DataTypes.BIG_INTEGER:
+                switch (operation) {
+                    case ADD:
+                        return ((BigInteger) val1).add(((BigInteger) val2));
+                    case SUB:
+                        return ((BigInteger) val1).subtract(((BigInteger) val2));
+                    case DIV:
+                        return ((BigInteger) val1).divide(((BigInteger) val2));
+                    case MULT:
+                        return ((BigInteger) val1).multiply(((BigInteger) val2));
+                    case POWER:
+                        return ((BigInteger) val1).pow(((BigInteger) val2).intValue());
+                    case MOD:
+                        return ((BigInteger) val1).remainder(((BigInteger) val2));
+                    case GTHAN:
+                        return ((BigInteger) val1).compareTo(((BigInteger) val2)) == 1 ? Boolean.TRUE : Boolean.FALSE;
+                    case GETHAN:
+                        return ((BigInteger) val1).compareTo(((BigInteger) val2)) >= 0 ? Boolean.TRUE : Boolean.FALSE;
+                    case LTHAN:
+                        return ((BigInteger) val1).compareTo(((BigInteger) val2)) == -1 ? Boolean.TRUE : Boolean.FALSE;
+                    case LETHAN:
+                        return ((BigInteger) val1).compareTo(((BigInteger) val2)) <= 0 ? Boolean.TRUE : Boolean.FALSE;
+                    case EQUAL:
+                        return ((BigInteger) val1).compareTo(((BigInteger) val2)) == 0 ? Boolean.TRUE : Boolean.FALSE;
+                    case NEQUAL:
+                        return ((BigInteger) val1).compareTo(((BigInteger) val2)) != 0 ? Boolean.TRUE : Boolean.FALSE;
+                    case BW_AND:
+                    case BW_OR:
+                    case BW_SHIFT_LEFT:
+                    case BW_SHIFT_RIGHT:
+                    case BW_USHIFT_RIGHT:
+                    case BW_XOR:
+                        throw new RuntimeException("bitwise operation on a number greater than 32-bits not possible");
+                }
+
+            default:
+                switch (operation) {
+                    case EQUAL:
+                        return safeEquals(val2, val1);
+                    case NEQUAL:
+                        return safeNotEquals(val2, val1);
+                    case ADD:
+                        return valueOf(val1) + valueOf(val2);
+                }
+        }
+        return null;
+    }
+
+    private static int box(int type) {
+        switch (type) {
+            case DataTypes.INTEGER:
+                return DataTypes.W_INTEGER;
+            case DataTypes.DOUBLE:
+                return DataTypes.W_DOUBLE;
+            case DataTypes.LONG:
+                return DataTypes.W_LONG;
+            case DataTypes.SHORT:
+                return DataTypes.W_SHORT;
+            case DataTypes.BYTE:
+                return DataTypes.W_BYTE;
+            case DataTypes.FLOAT:
+                return DataTypes.W_FLOAT;
+            case DataTypes.CHAR:
+                return DataTypes.W_CHAR;
+            case DataTypes.BOOLEAN:
+                return DataTypes.W_BOOLEAN;
+        }
+        return type;
+    }
+
+    private static Double getNumber(Object in, int type) {
+        if (in == null || in == BlankLiteral.INSTANCE) return 0d;
+        switch (type) {
+            case BIG_DECIMAL:
+                return ((Number) in).doubleValue();
+            case DataTypes.BIG_INTEGER:
+                return ((Number) in).doubleValue();
+            case DataTypes.INTEGER:
+            case DataTypes.W_INTEGER:
+                return ((Number) in).doubleValue();
+            case DataTypes.LONG:
+            case DataTypes.W_LONG:
+                return ((Number) in).doubleValue();
+            case DataTypes.STRING:
+                return Double.parseDouble((String) in);
+            case DataTypes.FLOAT:
+            case DataTypes.W_FLOAT:
+                return ((Number) in).doubleValue();
+            case DataTypes.DOUBLE:
+            case DataTypes.W_DOUBLE:
+                return (Double) in;
+            case DataTypes.SHORT:
+            case DataTypes.W_SHORT:
+                return ((Number) in).doubleValue();
+            case DataTypes.CHAR:
+            case DataTypes.W_CHAR:
+                return Double.parseDouble(String.valueOf((Character) in));
+            case DataTypes.BOOLEAN:
+            case DataTypes.W_BOOLEAN:
+                return ((Boolean) in) ? 1d : 0d;
+            case DataTypes.W_BYTE:
+            case DataTypes.BYTE:
+                return ((Byte) in).doubleValue();
+        }
+
+        throw new RuntimeException("cannot convert <" + in + "> to a numeric type: " + in.getClass() + " [" + type + "]");
+
+    }
+
+    private static InternalNumber getInternalNumberFromType(Object in, int type) {
+        if (in == null || in == BlankLiteral.INSTANCE) return new InternalNumber(0, MATH_CONTEXT);
+        switch (type) {
+            case BIG_DECIMAL:
+                return new InternalNumber(((BigDecimal) in).doubleValue());
+            case DataTypes.BIG_INTEGER:
+                return new InternalNumber((BigInteger) in, MathContext.DECIMAL128);
+            case DataTypes.INTEGER:
+            case DataTypes.W_INTEGER:
+                return new InternalNumber((Integer) in, MathContext.DECIMAL32);
+            case DataTypes.LONG:
+            case DataTypes.W_LONG:
+                return new InternalNumber((Long) in, MathContext.DECIMAL64);
+            case DataTypes.STRING:
+                return new InternalNumber((String) in, MathContext.DECIMAL64);
+            case DataTypes.FLOAT:
+            case DataTypes.W_FLOAT:
+                return new InternalNumber((Float) in, MathContext.DECIMAL64);
+            case DataTypes.DOUBLE:
+            case DataTypes.W_DOUBLE:
+                return new InternalNumber((Double) in, MathContext.DECIMAL64);
+            case DataTypes.SHORT:
+            case DataTypes.W_SHORT:
+                return new InternalNumber((Short) in, MathContext.DECIMAL32);
+            case DataTypes.CHAR:
+            case DataTypes.W_CHAR:
+                return new InternalNumber((Character) in, MathContext.DECIMAL32);
+            case DataTypes.BOOLEAN:
+            case DataTypes.W_BOOLEAN:
+                return new InternalNumber(((Boolean) in) ? 1 : 0);
+            case DataTypes.UNIT:
+                return new InternalNumber(((Unit) in).getValue(), MathContext.DECIMAL64);
+            case DataTypes.W_BYTE:
+            case DataTypes.BYTE:
+                return new InternalNumber(((Byte) in).intValue());
+
+        }
+
+        throw new RuntimeException("cannot convert <" + in + "> to a numeric type: " + in.getClass() + " [" + type + "]");
+    }
+}

--- a/core/src/main/java/org/mvel2/optimizers/AbstractOptimizer.java
+++ b/core/src/main/java/org/mvel2/optimizers/AbstractOptimizer.java
@@ -1,0 +1,304 @@
+/**
+ * MVEL 2.0
+ * Copyright (C) 2007 The Codehaus
+ * Mike Brock, Dhanji Prasanna, John Graham, Mark Proctor
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.mvel2.optimizers;
+
+import static java.lang.Thread.currentThread;
+import static org.mvel2.util.ParseTools.captureStringLiteral;
+import static org.mvel2.util.ParseTools.findInnerClass;
+import static org.mvel2.util.ParseTools.forNameWithInner;
+import static org.mvel2.util.ParseTools.isIdentifierPart;
+import static org.mvel2.util.ParseTools.isWhitespace;
+
+import java.lang.reflect.Method;
+
+import org.mvel2.CompileException;
+import org.mvel2.MVEL;
+import org.mvel2.ParserContext;
+import org.mvel2.compiler.AbstractParser;
+
+/**
+ * @author Christopher Brock
+ */
+public class AbstractOptimizer extends AbstractParser {
+
+    protected static final int BEAN = 0;
+    protected static final int METH = 1;
+    protected static final int COL = 2;
+    protected static final int WITH = 3;
+
+    protected boolean collection = false;
+    protected boolean nullSafe = false;
+    protected Class currType = null;
+    protected boolean staticAccess = false;
+
+    protected int tkStart;
+
+    protected AbstractOptimizer() {
+    }
+
+    protected AbstractOptimizer(ParserContext pCtx) {
+        super(pCtx);
+    }
+
+    /**
+     * Try static access of the property, and return an instance of the Field, Method of Class if successful.
+     *
+     * @return - Field, Method or Class instance.
+     */
+    protected Object tryStaticAccess() {
+        int begin = cursor;
+        try {
+            /**
+             * Try to resolve this *smartly* as a static class reference.
+             *
+             * This starts at the end of the token and starts to step backwards to figure out whether
+             * or not this may be a static class reference.  We search for method calls simply by
+             * inspecting for ()'s.  The first union area we come to where no brackets are present is our
+             * test-point for a class reference.  If we find a class, we pass the reference to the
+             * property accessor along  with trailing methods (if any).
+             *
+             */
+            boolean meth = false;
+            // int end = start + length;
+            int last = end;
+            for (int i = end - 1; i > start; i--) {
+                switch (expr[i]) {
+                    case '.':
+                        if (!meth) {
+                            ClassLoader classLoader = pCtx != null ? pCtx.getClassLoader() : currentThread().getContextClassLoader();
+                            String test = new String(expr, start, (cursor = last) - start);
+                            try {
+                                if (MVEL.COMPILER_OPT_SUPPORT_JAVA_STYLE_CLASS_LITERALS && test.endsWith(".class"))
+                                    test = test.substring(0, test.length() - 6);
+
+                                return Class.forName(test, true, classLoader);
+                            } catch (ClassNotFoundException cnfe) {
+                                try {
+                                    return findInnerClass(test, classLoader, cnfe);
+                                } catch (ClassNotFoundException e) { /* ignore */ }
+                                Class cls = forNameWithInner(new String(expr, start, i - start), classLoader);
+                                String name = new String(expr, i + 1, end - i - 1);
+                                try {
+                                    return cls.getField(name);
+                                } catch (NoSuchFieldException nfe) {
+                                    for (Method m : cls.getMethods()) {
+                                        if (name.equals(m.getName())) return m;
+                                    }
+                                    return null;
+                                }
+                            }
+                        }
+
+                        meth = false;
+                        last = i;
+                        break;
+
+                    case '}':
+                        i--;
+                        for (int d = 1; i > start && d != 0; i--) {
+                            switch (expr[i]) {
+                                case '}':
+                                    d++;
+                                    break;
+                                case '{':
+                                    d--;
+                                    break;
+                                case '"':
+                                case '\'':
+                                    char s = expr[i];
+                                    while (i > start && (expr[i] != s && expr[i - 1] != '\\'))
+                                        i--;
+                            }
+                        }
+                        break;
+
+                    case ')':
+                        i--;
+
+                        for (int d = 1; i > start && d != 0; i--) {
+                            switch (expr[i]) {
+                                case ')':
+                                    d++;
+                                    break;
+                                case '(':
+                                    d--;
+                                    break;
+                                case '"':
+                                case '\'':
+                                    char s = expr[i];
+                                    while (i > start && (expr[i] != s && expr[i - 1] != '\\'))
+                                        i--;
+                            }
+                        }
+
+                        meth = true;
+                        last = i++;
+                        break;
+
+                    case '\'':
+                        while (--i > start) {
+                            if (expr[i] == '\'' && expr[i - 1] != '\\') {
+                                break;
+                            }
+                        }
+                        break;
+
+                    case '"':
+                        while (--i > start) {
+                            if (expr[i] == '"' && expr[i - 1] != '\\') {
+                                break;
+                            }
+                        }
+                        break;
+                }
+            }
+        } catch (Exception cnfe) {
+            cursor = begin;
+        }
+
+        return null;
+    }
+
+    protected int nextSubToken() {
+        skipWhitespace();
+        nullSafe = false;
+
+        switch (expr[tkStart = cursor]) {
+            case '[':
+                return COL;
+            case '{':
+                if (expr[cursor - 1] == '.') {
+                    return WITH;
+                }
+                break;
+            case '.':
+                if ((start + 1) != end) {
+                    switch (expr[cursor = ++tkStart]) {
+                        case '?':
+                            skipWhitespace();
+                            if ((cursor = ++tkStart) == end) {
+                                throw new CompileException("unexpected end of statement", expr, start);
+                            }
+                            nullSafe = true;
+
+                            fields = -1;
+                            break;
+                        case '{':
+                            return WITH;
+                        default:
+                            if (isWhitespace(expr[tkStart])) {
+                                skipWhitespace();
+                                tkStart = cursor;
+                            }
+                    }
+                } else {
+                    throw new CompileException("unexpected end of statement", expr, start);
+                }
+                break;
+            case '?':
+                if (start == cursor) {
+                    tkStart++;
+                    cursor++;
+                    nullSafe = true;
+                }
+        }
+
+        //noinspection StatementWithEmptyBody
+        while (++cursor < end && isIdentifierPart(expr[cursor]));
+
+        skipWhitespace();
+        if (cursor < end) {
+            switch (expr[cursor]) {
+                case '[':
+                    return COL;
+                case '(':
+                    return METH;
+                default:
+                    return BEAN;
+            }
+        }
+
+        return 0;
+    }
+
+    protected String capture() {
+        /**
+         * Trim off any whitespace.
+         */
+        return new String(expr, tkStart = trimRight(tkStart), trimLeft(cursor) - tkStart);
+    }
+
+    /**
+     * Skip to the next non-whitespace position.
+     */
+    protected void whiteSpaceSkip() {
+        if (cursor < length)
+            //noinspection StatementWithEmptyBody
+            while (isWhitespace(expr[cursor]) && ++cursor != length);
+    }
+
+    /**
+     * @param c - character to scan to.
+     * @return - returns true is end of statement is hit, false if the scan scar is countered.
+     */
+    protected boolean scanTo(char c) {
+        for (; cursor < end; cursor++) {
+            switch (expr[cursor]) {
+                case '\'':
+                case '"':
+                    cursor = captureStringLiteral(expr[cursor], expr, cursor, end);
+                default:
+                    if (expr[cursor] == c) {
+                        return false;
+                    }
+            }
+        }
+        return true;
+    }
+
+    protected int findLastUnion() {
+        int split = -1;
+        int depth = 0;
+
+        int end = start + length;
+        for (int i = end - 1; i != start; i--) {
+            switch (expr[i]) {
+                case '}':
+                case ']':
+                    depth++;
+                    break;
+
+                case '{':
+                case '[':
+                    if (--depth == 0) {
+                        split = i;
+                        collection = true;
+                    }
+                    break;
+                case '.':
+                    if (depth == 0) {
+                        split = i;
+                    }
+                    break;
+            }
+            if (split != -1) break;
+        }
+
+        return split;
+    }
+}

--- a/core/src/main/java/org/mvel2/optimizers/AccessorOptimizer.java
+++ b/core/src/main/java/org/mvel2/optimizers/AccessorOptimizer.java
@@ -1,0 +1,46 @@
+/**
+ * MVEL 2.0
+ * Copyright (C) 2007 The Codehaus
+ * Mike Brock, Dhanji Prasanna, John Graham, Mark Proctor
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mvel2.optimizers;
+
+import org.mvel2.ParserContext;
+import org.mvel2.compiler.Accessor;
+import org.mvel2.integration.VariableResolverFactory;
+
+public interface AccessorOptimizer {
+
+    public void init();
+
+    public Accessor optimizeAccessor(ParserContext pCtx, char[] property, int start, int offset, Object ctx, Object thisRef,
+                                     VariableResolverFactory factory, boolean rootThisRef, Class ingressType);
+
+    public Accessor optimizeSetAccessor(ParserContext pCtx, char[] property, int start, int offset, Object ctx, Object thisRef,
+                                        VariableResolverFactory factory, boolean rootThisRef, Object value, Class ingressType);
+
+    public Accessor optimizeCollection(ParserContext pCtx, Object collectionGraph, Class type, char[] property, int start, int offset,
+                                       Object ctx, Object thisRef, VariableResolverFactory factory);
+
+    public Accessor optimizeObjectCreation(ParserContext pCtx, char[] property, int start, int offset, Object ctx, Object thisRef,
+                                           VariableResolverFactory factory);
+
+    public Object getResultOptPass();
+
+    public Class getEgressType();
+
+    public boolean isLiteralOnly();
+}

--- a/core/src/main/java/org/mvel2/optimizers/OptimizationNotSupported.java
+++ b/core/src/main/java/org/mvel2/optimizers/OptimizationNotSupported.java
@@ -1,0 +1,37 @@
+/**
+ * MVEL 2.0
+ * Copyright (C) 2007 The Codehaus
+ * Mike Brock, Dhanji Prasanna, John Graham, Mark Proctor
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.mvel2.optimizers;
+
+public class OptimizationNotSupported extends RuntimeException {
+
+    public OptimizationNotSupported() {
+        super();
+    }
+
+    public OptimizationNotSupported(String message) {
+        super(message);
+    }
+
+    public OptimizationNotSupported(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public OptimizationNotSupported(Throwable cause) {
+        super(cause);
+    }
+}

--- a/core/src/main/java/org/mvel2/optimizers/OptimizerFactory.java
+++ b/core/src/main/java/org/mvel2/optimizers/OptimizerFactory.java
@@ -1,0 +1,115 @@
+/**
+ * MVEL 2.0
+ * Copyright (C) 2007 The Codehaus
+ * Mike Brock, Dhanji Prasanna, John Graham, Mark Proctor
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mvel2.optimizers;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.mvel2.optimizers.dynamic.DynamicOptimizer;
+import org.mvel2.optimizers.impl.asm.ASMAccessorOptimizer;
+import org.mvel2.optimizers.impl.refl.ReflectiveAccessorOptimizer;
+
+public class OptimizerFactory {
+
+    private static final Map<String, AccessorOptimizer> accessorCompilers = new HashMap<String, AccessorOptimizer>();
+    public static String DYNAMIC = "dynamic";
+    public static String SAFE_REFLECTIVE = "reflective";
+    private static String defaultOptimizer;
+    private static ThreadLocal<Class<? extends AccessorOptimizer>> threadOptimizer = new ThreadLocal<Class<? extends AccessorOptimizer>>();
+
+    static {
+        accessorCompilers.put(SAFE_REFLECTIVE, new ReflectiveAccessorOptimizer());
+        accessorCompilers.put(DYNAMIC, new DynamicOptimizer());
+        /**
+         * By default, activate the JIT if ASM is present in the classpath
+         */
+        try {
+            if (OptimizerFactory.class.getClassLoader() != null) {
+                OptimizerFactory.class.getClassLoader().loadClass("org.mvel2.asm.ClassWriter");
+            } else {
+                ClassLoader.getSystemClassLoader().loadClass("org.mvel2.asm.ClassWriter");
+            }
+            accessorCompilers.put("ASM", new ASMAccessorOptimizer());
+        } catch (ClassNotFoundException e) {
+            defaultOptimizer = SAFE_REFLECTIVE;
+        } catch (Throwable e) {
+            e.printStackTrace();
+            System.err.println("[MVEL] Notice: Possible incorrect version of ASM present (3.0 required).  "
+                    + "Disabling JIT compiler.  Reflective Optimizer will be used.");
+            defaultOptimizer = SAFE_REFLECTIVE;
+        }
+
+        if (Boolean.getBoolean("mvel2.disable.jit")) setDefaultOptimizer(SAFE_REFLECTIVE);
+        else setDefaultOptimizer(DYNAMIC);
+    }
+
+    public static AccessorOptimizer getDefaultAccessorCompiler() {
+        try {
+            return accessorCompilers.get(defaultOptimizer).getClass().newInstance();
+        } catch (Exception e) {
+            throw new RuntimeException("unable to instantiate accessor compiler", e);
+        }
+    }
+
+    public static AccessorOptimizer getAccessorCompiler(String name) {
+        try {
+            return accessorCompilers.get(name).getClass().newInstance();
+        } catch (Exception e) {
+            throw new RuntimeException("unable to instantiate accessor compiler", e);
+        }
+    }
+
+    public static AccessorOptimizer getThreadAccessorOptimizer() {
+        if (threadOptimizer.get() == null) {
+            threadOptimizer.set(getDefaultAccessorCompiler().getClass());
+        }
+        try {
+            return threadOptimizer.get().newInstance();
+        } catch (Exception e) {
+            throw new RuntimeException("unable to instantiate accessor compiler", e);
+        }
+    }
+
+    public static void setThreadAccessorOptimizer(Class<? extends AccessorOptimizer> optimizer) {
+        if (optimizer == null) throw new RuntimeException("null optimizer");
+        threadOptimizer.set(optimizer);
+    }
+
+    public static void setDefaultOptimizer(String name) {
+        try {
+            //noinspection unchecked
+            AccessorOptimizer ao = accessorCompilers.get(defaultOptimizer = name);
+            ao.init();
+            //clear optimizer so next call to getThreadAccessorOptimizer uses the default again, don't set thread optimizer
+            //or else static initializers setting the default will unintentionally set up ThreadLocals
+            threadOptimizer.set(null);
+        } catch (Exception e) {
+            throw new RuntimeException("unable to instantiate accessor compiler", e);
+        }
+    }
+
+    public static void clearThreadAccessorOptimizer() {
+        threadOptimizer.set(null);
+        threadOptimizer.remove();
+    }
+
+    public static boolean isThreadAccessorOptimizerInitialized() {
+        return threadOptimizer.get() != null;
+    }
+}

--- a/core/src/main/java/org/mvel2/optimizers/OptimizerHook.java
+++ b/core/src/main/java/org/mvel2/optimizers/OptimizerHook.java
@@ -1,0 +1,45 @@
+/**
+ * MVEL 2.0
+ * Copyright (C) 2007 The Codehaus
+ * Mike Brock, Dhanji Prasanna, John Graham, Mark Proctor
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mvel2.optimizers;
+
+import org.mvel2.compiler.Accessor;
+
+/**
+ * @author Christopher Brock
+ */
+public interface OptimizerHook {
+
+    /**
+     * Should answer back whether or not this hook understands how to work with the current
+     * optimizer.
+     *
+     * @param optimizer - class type of the current optimizer being used
+     * @return boolean
+     */
+    public boolean isOptimizerSupported(Class<? extends AccessorOptimizer> optimizer);
+
+    /**
+     * The optimizer should delegate back to the hook through this method, passing an instance of itself
+     * in the current state.
+     *
+     * @param optimizer - instance of optimizer
+     * @return boolean
+     */
+    public Accessor generateAccessor(AccessorOptimizer optimizer);
+}

--- a/core/src/main/java/org/mvel2/optimizers/dynamic/DynamicAccessor.java
+++ b/core/src/main/java/org/mvel2/optimizers/dynamic/DynamicAccessor.java
@@ -1,0 +1,26 @@
+/**
+ * MVEL 2.0
+ * Copyright (C) 2007 The Codehaus
+ * Mike Brock, Dhanji Prasanna, John Graham, Mark Proctor
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mvel2.optimizers.dynamic;
+
+import org.mvel2.compiler.Accessor;
+
+public interface DynamicAccessor extends Accessor {
+
+    public void deoptimize();
+}

--- a/core/src/main/java/org/mvel2/optimizers/dynamic/DynamicClassLoader.java
+++ b/core/src/main/java/org/mvel2/optimizers/dynamic/DynamicClassLoader.java
@@ -1,0 +1,71 @@
+/**
+ * MVEL 2.0
+ * Copyright (C) 2007 The Codehaus
+ * Mike Brock, Dhanji Prasanna, John Graham, Mark Proctor
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mvel2.optimizers.dynamic;
+
+import java.util.LinkedList;
+
+import org.mvel2.util.MVELClassLoader;
+
+public class DynamicClassLoader extends ClassLoader implements MVELClassLoader {
+
+    private final LinkedList<DynamicAccessor> allAccessors = new LinkedList<DynamicAccessor>();
+    private int totalClasses;
+    private int tenureLimit;
+
+    public DynamicClassLoader(ClassLoader classLoader, int tenureLimit) {
+        super(classLoader);
+        this.tenureLimit = tenureLimit;
+    }
+
+    public Class defineClassX(String className, byte[] b, int start, int end) {
+        totalClasses++;
+        return super.defineClass(className, b, start, end);
+    }
+
+    public int getTotalClasses() {
+        return totalClasses;
+    }
+
+    public DynamicAccessor registerDynamicAccessor(DynamicAccessor accessor) {
+        synchronized (allAccessors) {
+            allAccessors.add(accessor);
+            while (allAccessors.size() > tenureLimit) {
+                DynamicAccessor da = allAccessors.removeFirst();
+                if (da != null) {
+                    da.deoptimize();
+                }
+            }
+            assert accessor != null;
+            return accessor;
+        }
+    }
+
+    public void deoptimizeAll() {
+        synchronized (allAccessors) {
+            for (DynamicAccessor a : allAccessors) {
+                if (a != null) a.deoptimize();
+            }
+            allAccessors.clear();
+        }
+    }
+
+    public boolean isOverloaded() {
+        return tenureLimit < totalClasses;
+    }
+}

--- a/core/src/main/java/org/mvel2/optimizers/dynamic/DynamicCollectionAccessor.java
+++ b/core/src/main/java/org/mvel2/optimizers/dynamic/DynamicCollectionAccessor.java
@@ -1,0 +1,114 @@
+/**
+ * MVEL 2.0
+ * Copyright (C) 2007 The Codehaus
+ * Mike Brock, Dhanji Prasanna, John Graham, Mark Proctor
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mvel2.optimizers.dynamic;
+
+import static java.lang.System.currentTimeMillis;
+
+import org.mvel2.ParserContext;
+import org.mvel2.compiler.Accessor;
+import org.mvel2.integration.VariableResolverFactory;
+import org.mvel2.optimizers.OptimizerFactory;
+
+public class DynamicCollectionAccessor implements DynamicAccessor {
+
+    private ParserContext pCtx;
+    private Object rootObject;
+    private Class colType;
+
+    private char[] property;
+    private int start;
+    private int offset;
+
+    private long stamp;
+    private int type;
+
+    private int runcount;
+
+    private boolean opt = false;
+
+    private Accessor _safeAccessor;
+    private Accessor _accessor;
+
+    public DynamicCollectionAccessor(ParserContext pCtx, Object rootObject, Class colType, char[] property, int start, int offset, int type,
+            Accessor _accessor) {
+        this.pCtx = pCtx;
+        this.rootObject = rootObject;
+        this.colType = colType;
+        this._safeAccessor = this._accessor = _accessor;
+        this.type = type;
+
+        this.property = property;
+        this.start = start;
+        this.offset = offset;
+
+        stamp = currentTimeMillis();
+    }
+
+    public Object getValue(Object ctx, Object elCtx, VariableResolverFactory variableFactory) {
+        if (!opt) {
+            if (++runcount > DynamicOptimizer.tenuringThreshold) {
+                if ((currentTimeMillis() - stamp) < DynamicOptimizer.timeSpan) {
+                    opt = true;
+
+                    return optimize(pCtx, ctx, elCtx, variableFactory);
+                } else {
+                    runcount = 0;
+                    stamp = currentTimeMillis();
+                }
+            }
+        }
+
+        return _accessor.getValue(ctx, elCtx, variableFactory);
+    }
+
+    public Object setValue(Object ctx, Object elCtx, VariableResolverFactory variableFactory, Object value) {
+        runcount++;
+        return _accessor.setValue(ctx, elCtx, variableFactory, value);
+    }
+
+    private Object optimize(ParserContext pCtx, Object ctx, Object elCtx, VariableResolverFactory variableResolverFactory) {
+
+        if (DynamicOptimizer.isOverloaded()) {
+            DynamicOptimizer.enforceTenureLimit();
+        }
+
+        _accessor = OptimizerFactory.getAccessorCompiler("ASM").optimizeCollection(pCtx, rootObject, colType, property, start, offset, ctx,
+                elCtx, variableResolverFactory);
+        return _accessor.getValue(ctx, elCtx, variableResolverFactory);
+    }
+
+    public void deoptimize() {
+        this._accessor = this._safeAccessor;
+        opt = false;
+        runcount = 0;
+        stamp = currentTimeMillis();
+    }
+
+    public long getStamp() {
+        return stamp;
+    }
+
+    public int getRuncount() {
+        return runcount;
+    }
+
+    public Class getKnownEgressType() {
+        return colType;
+    }
+}

--- a/core/src/main/java/org/mvel2/optimizers/dynamic/DynamicGetAccessor.java
+++ b/core/src/main/java/org/mvel2/optimizers/dynamic/DynamicGetAccessor.java
@@ -1,0 +1,132 @@
+/**
+ * MVEL 2.0
+ * Copyright (C) 2007 The Codehaus
+ * Mike Brock, Dhanji Prasanna, John Graham, Mark Proctor
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mvel2.optimizers.dynamic;
+
+import static java.lang.System.currentTimeMillis;
+
+import org.mvel2.ParserContext;
+import org.mvel2.compiler.Accessor;
+import org.mvel2.integration.VariableResolverFactory;
+import org.mvel2.optimizers.AccessorOptimizer;
+import org.mvel2.optimizers.OptimizationNotSupported;
+import org.mvel2.optimizers.OptimizerFactory;
+
+public class DynamicGetAccessor implements DynamicAccessor {
+
+    private char[] expr;
+    private int start;
+    private int offset;
+
+    private long stamp;
+    private int type;
+
+    private int runcount;
+
+    private boolean opt = false;
+
+    private ParserContext pCtx;
+
+    private Accessor _safeAccessor;
+    private Accessor _accessor;
+
+    public DynamicGetAccessor(ParserContext pCtx, char[] expr, int start, int offset, int type, Accessor _accessor) {
+        this._safeAccessor = this._accessor = _accessor;
+        this.type = type;
+
+        this.expr = expr;
+        this.start = start;
+        this.offset = offset;
+
+        this.pCtx = pCtx;
+        stamp = currentTimeMillis();
+    }
+
+    public Object getValue(Object ctx, Object elCtx, VariableResolverFactory variableFactory) {
+        if (!opt) {
+            if (++runcount > DynamicOptimizer.tenuringThreshold) {
+                if ((currentTimeMillis() - stamp) < DynamicOptimizer.timeSpan) {
+                    opt = true;
+                    try {
+                        return optimize(ctx, elCtx, variableFactory);
+                    } catch (OptimizationNotSupported ex) {
+                        // If optimization fails then, rather than fail evaluation, fallback to use safe reflective accessor
+                    }
+                } else {
+                    runcount = 0;
+                    stamp = currentTimeMillis();
+                }
+            }
+        }
+
+        return _accessor.getValue(ctx, elCtx, variableFactory);
+    }
+
+    public Object setValue(Object ctx, Object elCtx, VariableResolverFactory variableFactory, Object value) {
+        runcount++;
+        return _accessor.setValue(ctx, elCtx, variableFactory, value);
+    }
+
+    private Object optimize(Object ctx, Object elCtx, VariableResolverFactory variableResolverFactory) {
+
+        if (DynamicOptimizer.isOverloaded()) {
+            DynamicOptimizer.enforceTenureLimit();
+        }
+
+        AccessorOptimizer ao = OptimizerFactory.getAccessorCompiler("ASM");
+        switch (type) {
+            case DynamicOptimizer.REGULAR_ACCESSOR:
+                _accessor = ao.optimizeAccessor(pCtx, expr, start, offset, ctx, elCtx, variableResolverFactory, false, null);
+                return ao.getResultOptPass();
+            case DynamicOptimizer.OBJ_CREATION:
+                _accessor = ao.optimizeObjectCreation(pCtx, expr, start, offset, ctx, elCtx, variableResolverFactory);
+                return _accessor.getValue(ctx, elCtx, variableResolverFactory);
+            case DynamicOptimizer.COLLECTION:
+                _accessor = ao.optimizeCollection(pCtx, ctx, null, expr, start, offset, ctx, elCtx, variableResolverFactory);
+                return _accessor.getValue(ctx, elCtx, variableResolverFactory);
+        }
+        return null;
+    }
+
+    public void deoptimize() {
+        this._accessor = this._safeAccessor;
+        opt = false;
+        runcount = 0;
+        stamp = currentTimeMillis();
+    }
+
+    public long getStamp() {
+        return stamp;
+    }
+
+    public int getRuncount() {
+        return runcount;
+    }
+
+    public Class getKnownEgressType() {
+        return _safeAccessor.getKnownEgressType();
+    }
+
+    public Accessor getAccessor() {
+        return _accessor;
+    }
+
+    public Accessor getSafeAccessor() {
+        return _safeAccessor;
+    }
+}

--- a/core/src/main/java/org/mvel2/optimizers/dynamic/DynamicOptimizer.java
+++ b/core/src/main/java/org/mvel2/optimizers/dynamic/DynamicOptimizer.java
@@ -1,0 +1,136 @@
+/**
+ * MVEL 2.0
+ * Copyright (C) 2007 The Codehaus
+ * Mike Brock, Dhanji Prasanna, John Graham, Mark Proctor
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mvel2.optimizers.dynamic;
+
+import static java.lang.Thread.currentThread;
+import static org.mvel2.optimizers.OptimizerFactory.SAFE_REFLECTIVE;
+import static org.mvel2.optimizers.OptimizerFactory.getAccessorCompiler;
+import static org.mvel2.optimizers.impl.asm.ASMAccessorOptimizer.setMVELClassLoader;
+
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReadWriteLock;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
+
+import org.mvel2.ParserContext;
+import org.mvel2.compiler.Accessor;
+import org.mvel2.integration.VariableResolverFactory;
+import org.mvel2.optimizers.AbstractOptimizer;
+import org.mvel2.optimizers.AccessorOptimizer;
+
+public class DynamicOptimizer extends AbstractOptimizer implements AccessorOptimizer {
+
+    public static final int REGULAR_ACCESSOR = 0;
+    public static final int SET_ACCESSOR = 1;
+    public static final int COLLECTION = 2;
+    public static final int OBJ_CREATION = 3;
+    private static final Object oLock = new Object();
+    public static int tenuringThreshold = 50;
+    public static long timeSpan = 100;
+    public static int maximumTenure = 1500;
+    public static int totalRecycled = 0;
+    private volatile static DynamicClassLoader classLoader;
+    private static volatile boolean useSafeClassloading = false;
+    private static ReadWriteLock lock = new ReentrantReadWriteLock();
+    private static Lock readLock = lock.readLock();
+    private static Lock writeLock = lock.writeLock();
+    private AccessorOptimizer firstStage = getAccessorCompiler(SAFE_REFLECTIVE);
+
+    private static void _init() {
+        setMVELClassLoader(classLoader = new DynamicClassLoader(currentThread().getContextClassLoader(), maximumTenure));
+    }
+
+    public static void enforceTenureLimit() {
+        writeLock.lock();
+        try {
+            if (classLoader.isOverloaded()) {
+                classLoader.deoptimizeAll();
+                totalRecycled = +classLoader.getTotalClasses();
+                _init();
+            }
+        } finally {
+            writeLock.unlock();
+        }
+    }
+
+    public static boolean isOverloaded() {
+        return classLoader.isOverloaded();
+    }
+
+    public void init() {
+        _init();
+    }
+
+    public Accessor optimizeAccessor(ParserContext pCtx, char[] property, int start, int offset, Object ctx, Object thisRef,
+            VariableResolverFactory factory, boolean rootThisRef, Class ingressType) {
+        readLock.lock();
+        try {
+            pCtx.optimizationNotify();
+            return classLoader.registerDynamicAccessor(new DynamicGetAccessor(pCtx, property, start, offset, 0,
+                    firstStage.optimizeAccessor(pCtx, property, start, offset, ctx, thisRef, factory, rootThisRef, ingressType)));
+        } finally {
+            readLock.unlock();
+        }
+    }
+
+    public Accessor optimizeSetAccessor(ParserContext pCtx, char[] property, int start, int offset, Object ctx, Object thisRef,
+            VariableResolverFactory factory, boolean rootThisRef, Object value, Class valueType) {
+
+        readLock.lock();
+        try {
+            return classLoader.registerDynamicAccessor(new DynamicSetAccessor(pCtx, property, start, offset,
+                    firstStage.optimizeSetAccessor(pCtx, property, start, offset, ctx, thisRef, factory, rootThisRef, value, valueType)));
+        } finally {
+            readLock.unlock();
+        }
+    }
+
+    public Accessor optimizeCollection(ParserContext pCtx, Object rootObject, Class type, char[] property, int start, int offset,
+            Object ctx, Object thisRef, VariableResolverFactory factory) {
+        readLock.lock();
+        try {
+            return classLoader.registerDynamicAccessor(new DynamicCollectionAccessor(pCtx, rootObject, type, property, start, offset, 2,
+                    firstStage.optimizeCollection(pCtx, rootObject, type, property, start, offset, ctx, thisRef, factory)));
+        } finally {
+            readLock.unlock();
+        }
+    }
+
+    public Accessor optimizeObjectCreation(ParserContext pCtx, char[] property, int start, int offset, Object ctx, Object thisRef,
+            VariableResolverFactory factory) {
+        readLock.lock();
+        try {
+            return classLoader.registerDynamicAccessor(new DynamicGetAccessor(pCtx, property, start, offset, 3,
+                    firstStage.optimizeObjectCreation(pCtx, property, start, offset, ctx, thisRef, factory)));
+        } finally {
+            readLock.unlock();
+        }
+    }
+
+    public Object getResultOptPass() {
+        return firstStage.getResultOptPass();
+    }
+
+    public Class getEgressType() {
+        return firstStage.getEgressType();
+    }
+
+    public boolean isLiteralOnly() {
+        return firstStage.isLiteralOnly();
+    }
+}

--- a/core/src/main/java/org/mvel2/optimizers/dynamic/DynamicSetAccessor.java
+++ b/core/src/main/java/org/mvel2/optimizers/dynamic/DynamicSetAccessor.java
@@ -1,0 +1,106 @@
+/**
+ * MVEL 2.0
+ * Copyright (C) 2007 The Codehaus
+ * Mike Brock, Dhanji Prasanna, John Graham, Mark Proctor
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mvel2.optimizers.dynamic;
+
+import static java.lang.System.currentTimeMillis;
+
+import org.mvel2.ParserContext;
+import org.mvel2.compiler.Accessor;
+import org.mvel2.integration.VariableResolverFactory;
+import org.mvel2.optimizers.AccessorOptimizer;
+import org.mvel2.optimizers.OptimizerFactory;
+
+public class DynamicSetAccessor implements DynamicAccessor {
+
+    private final Accessor _safeAccessor;
+    private char[] property;
+    private int start;
+    private int offset;
+    private boolean opt = false;
+    private int runcount = 0;
+    private long stamp;
+    private ParserContext context;
+    private Accessor _accessor;
+    private String description;
+
+    public DynamicSetAccessor(ParserContext context, char[] property, int start, int offset, Accessor _accessor) {
+        assert _accessor != null;
+        this._safeAccessor = this._accessor = _accessor;
+        this.context = context;
+
+        this.property = property;
+        this.start = start;
+        this.offset = offset;
+
+        this.stamp = System.currentTimeMillis();
+    }
+
+    public Object setValue(Object ctx, Object elCtx, VariableResolverFactory variableFactory, Object value) {
+        if (!opt) {
+            if (++runcount > DynamicOptimizer.tenuringThreshold) {
+                if ((currentTimeMillis() - stamp) < DynamicOptimizer.timeSpan) {
+                    opt = true;
+                    return optimize(ctx, elCtx, variableFactory, value);
+                } else {
+                    runcount = 0;
+                    stamp = currentTimeMillis();
+                }
+            }
+        }
+
+        _accessor.setValue(ctx, elCtx, variableFactory, value);
+        return value;
+    }
+
+    public Object getValue(Object ctx, Object elCtx, VariableResolverFactory variableFactory) {
+        throw new RuntimeException("value cannot be read with this accessor");
+    }
+
+    private Object optimize(Object ctx, Object elCtx, VariableResolverFactory variableResolverFactory, Object value) {
+        if (DynamicOptimizer.isOverloaded()) {
+            DynamicOptimizer.enforceTenureLimit();
+        }
+
+        AccessorOptimizer ao = OptimizerFactory.getAccessorCompiler("ASM");
+        _accessor = ao.optimizeSetAccessor(context, property, start, offset, ctx, elCtx, variableResolverFactory, false, value,
+                value != null ? value.getClass() : Object.class);
+        assert _accessor != null;
+
+        return value;
+    }
+
+    public void deoptimize() {
+        this._accessor = this._safeAccessor;
+        opt = false;
+        runcount = 0;
+        stamp = currentTimeMillis();
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    public Class getKnownEgressType() {
+        return _safeAccessor.getKnownEgressType();
+    }
+}

--- a/core/src/main/java/org/mvel2/optimizers/impl/asm/ASMAccessorOptimizer.java
+++ b/core/src/main/java/org/mvel2/optimizers/impl/asm/ASMAccessorOptimizer.java
@@ -1,0 +1,3118 @@
+/**
+ * MVEL 2.0
+ * Copyright (C) 2007 The Codehaus
+ * Mike Brock, Dhanji Prasanna, John Graham, Mark Proctor
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.mvel2.optimizers.impl.asm;
+
+import static java.lang.String.valueOf;
+import static java.lang.System.getProperty;
+import static java.lang.Thread.currentThread;
+import static java.lang.reflect.Array.getLength;
+import static java.lang.reflect.Modifier.FINAL;
+import static java.lang.reflect.Modifier.STATIC;
+import static org.mvel2.DataConversion.canConvert;
+import static org.mvel2.DataConversion.convert;
+import static org.mvel2.MVEL.eval;
+import static org.mvel2.MVEL.isAdvancedDebugging;
+import static org.mvel2.asm.Opcodes.AALOAD;
+import static org.mvel2.asm.Opcodes.AASTORE;
+import static org.mvel2.asm.Opcodes.ACC_PRIVATE;
+import static org.mvel2.asm.Opcodes.ACC_PUBLIC;
+import static org.mvel2.asm.Opcodes.ACONST_NULL;
+import static org.mvel2.asm.Opcodes.ALOAD;
+import static org.mvel2.asm.Opcodes.ANEWARRAY;
+import static org.mvel2.asm.Opcodes.ARETURN;
+import static org.mvel2.asm.Opcodes.ARRAYLENGTH;
+import static org.mvel2.asm.Opcodes.ASTORE;
+import static org.mvel2.asm.Opcodes.ATHROW;
+import static org.mvel2.asm.Opcodes.BALOAD;
+import static org.mvel2.asm.Opcodes.BASTORE;
+import static org.mvel2.asm.Opcodes.BIPUSH;
+import static org.mvel2.asm.Opcodes.CALOAD;
+import static org.mvel2.asm.Opcodes.CASTORE;
+import static org.mvel2.asm.Opcodes.CHECKCAST;
+import static org.mvel2.asm.Opcodes.DALOAD;
+import static org.mvel2.asm.Opcodes.DASTORE;
+import static org.mvel2.asm.Opcodes.DUP;
+import static org.mvel2.asm.Opcodes.DUP_X1;
+import static org.mvel2.asm.Opcodes.DUP_X2;
+import static org.mvel2.asm.Opcodes.FALOAD;
+import static org.mvel2.asm.Opcodes.FASTORE;
+import static org.mvel2.asm.Opcodes.GETFIELD;
+import static org.mvel2.asm.Opcodes.GETSTATIC;
+import static org.mvel2.asm.Opcodes.GOTO;
+import static org.mvel2.asm.Opcodes.IALOAD;
+import static org.mvel2.asm.Opcodes.IASTORE;
+import static org.mvel2.asm.Opcodes.ICONST_0;
+import static org.mvel2.asm.Opcodes.ICONST_1;
+import static org.mvel2.asm.Opcodes.ICONST_2;
+import static org.mvel2.asm.Opcodes.ICONST_3;
+import static org.mvel2.asm.Opcodes.ICONST_4;
+import static org.mvel2.asm.Opcodes.ICONST_5;
+import static org.mvel2.asm.Opcodes.IFEQ;
+import static org.mvel2.asm.Opcodes.IFNONNULL;
+import static org.mvel2.asm.Opcodes.IF_ICMPLT;
+import static org.mvel2.asm.Opcodes.ILOAD;
+import static org.mvel2.asm.Opcodes.INVOKEINTERFACE;
+import static org.mvel2.asm.Opcodes.INVOKESPECIAL;
+import static org.mvel2.asm.Opcodes.INVOKESTATIC;
+import static org.mvel2.asm.Opcodes.INVOKEVIRTUAL;
+import static org.mvel2.asm.Opcodes.ISTORE;
+import static org.mvel2.asm.Opcodes.LALOAD;
+import static org.mvel2.asm.Opcodes.LASTORE;
+import static org.mvel2.asm.Opcodes.NEW;
+import static org.mvel2.asm.Opcodes.POP;
+import static org.mvel2.asm.Opcodes.PUTFIELD;
+import static org.mvel2.asm.Opcodes.RETURN;
+import static org.mvel2.asm.Opcodes.SALOAD;
+import static org.mvel2.asm.Opcodes.SASTORE;
+import static org.mvel2.asm.Opcodes.SIPUSH;
+import static org.mvel2.asm.Opcodes.SWAP;
+import static org.mvel2.asm.Type.getConstructorDescriptor;
+import static org.mvel2.asm.Type.getDescriptor;
+import static org.mvel2.asm.Type.getInternalName;
+import static org.mvel2.asm.Type.getMethodDescriptor;
+import static org.mvel2.asm.Type.getType;
+import static org.mvel2.ast.TypeDescriptor.getClassReference;
+import static org.mvel2.integration.GlobalListenerFactory.hasGetListeners;
+import static org.mvel2.integration.GlobalListenerFactory.notifyGetListeners;
+import static org.mvel2.integration.PropertyHandlerFactory.getNullMethodHandler;
+import static org.mvel2.integration.PropertyHandlerFactory.getNullPropertyHandler;
+import static org.mvel2.integration.PropertyHandlerFactory.getPropertyHandler;
+import static org.mvel2.integration.PropertyHandlerFactory.hasNullMethodHandler;
+import static org.mvel2.integration.PropertyHandlerFactory.hasNullPropertyHandler;
+import static org.mvel2.integration.PropertyHandlerFactory.hasPropertyHandler;
+import static org.mvel2.util.ArrayTools.findFirst;
+import static org.mvel2.util.ParseTools.EMPTY_OBJ_ARR;
+import static org.mvel2.util.ParseTools.balancedCapture;
+import static org.mvel2.util.ParseTools.balancedCaptureWithLineAccounting;
+import static org.mvel2.util.ParseTools.captureContructorAndResidual;
+import static org.mvel2.util.ParseTools.determineActualTargetMethod;
+import static org.mvel2.util.ParseTools.findClass;
+import static org.mvel2.util.ParseTools.getBaseComponentType;
+import static org.mvel2.util.ParseTools.getBestCandidate;
+import static org.mvel2.util.ParseTools.getBestConstructorCandidate;
+import static org.mvel2.util.ParseTools.getSubComponentType;
+import static org.mvel2.util.ParseTools.getWidenedTarget;
+import static org.mvel2.util.ParseTools.isPrimitiveWrapper;
+import static org.mvel2.util.ParseTools.parseMethodOrConstructor;
+import static org.mvel2.util.ParseTools.parseParameterList;
+import static org.mvel2.util.ParseTools.repeatChar;
+import static org.mvel2.util.ParseTools.subCompileExpression;
+import static org.mvel2.util.ParseTools.subset;
+import static org.mvel2.util.PropertyTools.getFieldOrAccessor;
+import static org.mvel2.util.PropertyTools.getFieldOrWriteAccessor;
+import static org.mvel2.util.ReflectionUtil.toNonPrimitiveArray;
+import static org.mvel2.util.ReflectionUtil.toNonPrimitiveType;
+import static org.mvel2.util.Varargs.normalizeArgsForVarArgs;
+import static org.mvel2.util.Varargs.paramTypeVarArgsSafe;
+
+import java.io.FileWriter;
+import java.io.IOException;
+import java.lang.reflect.Array;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Member;
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
+import org.mvel2.CompileException;
+import org.mvel2.DataConversion;
+import org.mvel2.MVEL;
+import org.mvel2.OptimizationFailure;
+import org.mvel2.ParserContext;
+import org.mvel2.PropertyAccessException;
+import org.mvel2.asm.ClassWriter;
+import org.mvel2.asm.Label;
+import org.mvel2.asm.MethodVisitor;
+import org.mvel2.asm.Opcodes;
+import org.mvel2.ast.FunctionInstance;
+import org.mvel2.ast.TypeDescriptor;
+import org.mvel2.ast.WithNode;
+import org.mvel2.compiler.Accessor;
+import org.mvel2.compiler.AccessorNode;
+import org.mvel2.compiler.ExecutableAccessor;
+import org.mvel2.compiler.ExecutableLiteral;
+import org.mvel2.compiler.ExecutableStatement;
+import org.mvel2.compiler.PropertyVerifier;
+import org.mvel2.integration.GlobalListenerFactory;
+import org.mvel2.integration.PropertyHandler;
+import org.mvel2.integration.VariableResolverFactory;
+import org.mvel2.optimizers.AbstractOptimizer;
+import org.mvel2.optimizers.AccessorOptimizer;
+import org.mvel2.optimizers.OptimizationNotSupported;
+import org.mvel2.optimizers.impl.refl.nodes.Union;
+import org.mvel2.util.JITClassLoader;
+import org.mvel2.util.MVELClassLoader;
+import org.mvel2.util.MethodStub;
+import org.mvel2.util.ParseTools;
+import org.mvel2.util.PropertyTools;
+import org.mvel2.util.StringAppender;
+
+/**
+ * Implementation of the MVEL Just-in-Time (JIT) compiler for Property Accessors using the ASM bytecode
+ * engineering library.
+ * <p/>
+ */
+@SuppressWarnings({ "TypeParameterExplicitlyExtendsObject", "unchecked", "UnusedDeclaration" })
+public class ASMAccessorOptimizer extends AbstractOptimizer implements AccessorOptimizer {
+
+    private static final String MAP_IMPL = "java/util/HashMap";
+    private static final int OPCODES_VERSION;
+    private static final Object[] EMPTYARG = new Object[0];
+    private static final Class[] EMPTYCLS = new Class[0];
+    private static final int ARRAY = 0;
+    private static final int LIST = 1;
+    private static final int MAP = 2;
+    private static final int VAL = 3;
+    private static String LIST_IMPL;
+    private static String NAMESPACE;
+    private static MVELClassLoader classLoader;
+
+    static {
+        final String javaVersion = PropertyTools.getJavaVersion();
+        if (javaVersion.startsWith("1.4")) {
+            OPCODES_VERSION = Opcodes.V1_4;
+        } else if (javaVersion.startsWith("1.5")) {
+            OPCODES_VERSION = Opcodes.V1_5;
+        } else if (javaVersion.startsWith("1.6") || javaVersion.startsWith("1.7") || javaVersion.startsWith("1.8")
+                || javaVersion.startsWith("9") || javaVersion.startsWith("10") || javaVersion.startsWith("11")) {
+            OPCODES_VERSION = Opcodes.V1_6;
+        } else {
+            OPCODES_VERSION = Opcodes.V1_2;
+        }
+
+        String defaultNameSapce = getProperty("mvel2.namespace");
+        if (defaultNameSapce == null) NAMESPACE = "org/mvel2/";
+        else NAMESPACE = defaultNameSapce;
+
+        String jitListImpl = getProperty("mvel2.jit.list_impl");
+        if (jitListImpl == null) LIST_IMPL = NAMESPACE + "util/FastList";
+        else LIST_IMPL = jitListImpl;
+    }
+
+    private Object ctx;
+    private Object thisRef;
+    private VariableResolverFactory variableFactory;
+    private boolean first = true;
+    private boolean noinit = false;
+    private boolean deferFinish = false;
+    private boolean literal = false;
+    private boolean propNull = false;
+    private boolean methNull = false;
+    private String className;
+    private ClassWriter cw;
+    private MethodVisitor mv;
+    private Object val;
+    private int stacksize = 1;
+    private int maxlocals = 1;
+    private long time;
+    private ArrayList<ExecutableStatement> compiledInputs;
+    private Class ingressType;
+    private Class returnType;
+    private int compileDepth = 0;
+    @SuppressWarnings({ "StringBufferField" })
+    private StringAppender buildLog;
+
+    public ASMAccessorOptimizer() {
+        //do this to confirm we're running the correct version
+        //otherwise should create a verification error in VM
+        new ClassWriter(ClassWriter.COMPUTE_MAXS);
+    }
+
+    private ASMAccessorOptimizer(ClassWriter cw, MethodVisitor mv, ArrayList<ExecutableStatement> compiledInputs, String className,
+            StringAppender buildLog, int compileDepth) {
+        this.cw = cw;
+        this.mv = mv;
+        this.compiledInputs = compiledInputs;
+        this.className = className;
+        this.buildLog = buildLog;
+        this.compileDepth = compileDepth + 1;
+
+        noinit = true;
+        deferFinish = true;
+    }
+
+    public static MVELClassLoader getMVELClassLoader() {
+        return classLoader;
+    }
+
+    public static void setMVELClassLoader(MVELClassLoader cl) {
+        classLoader = cl;
+    }
+
+    /**
+     * Does all the boilerplate for initiating the JIT.
+     */
+    private void _initJIT() {
+        if (isAdvancedDebugging()) {
+            buildLog = new StringAppender();
+        }
+
+        cw = new ClassWriter(ClassWriter.COMPUTE_MAXS + ClassWriter.COMPUTE_FRAMES);
+
+        synchronized (Runtime.getRuntime()) {
+            cw.visit(OPCODES_VERSION, Opcodes.ACC_PUBLIC + Opcodes.ACC_SUPER, className = "ASMAccessorImpl_"
+                    + valueOf(cw.hashCode()).replaceAll("\\-", "_") + (System.currentTimeMillis() / 10) + ((int) (Math.random() * 100)),
+                    null, "java/lang/Object", new String[] { NAMESPACE + "compiler/Accessor" });
+        }
+
+        MethodVisitor m = cw.visitMethod(ACC_PUBLIC, "<init>", "()V", null, null);
+
+        m.visitCode();
+        m.visitVarInsn(Opcodes.ALOAD, 0);
+        m.visitMethodInsn(INVOKESPECIAL, "java/lang/Object", "<init>", "()V");
+        m.visitInsn(RETURN);
+
+        m.visitMaxs(1, 1);
+        m.visitEnd();
+
+        (mv = cw.visitMethod(ACC_PUBLIC, "getValue",
+                "(Ljava/lang/Object;Ljava/lang/Object;L" + NAMESPACE + "integration/VariableResolverFactory;)Ljava/lang/Object;", null,
+                null)).visitCode();
+    }
+
+    private void _initJIT2() {
+        if (isAdvancedDebugging()) {
+            buildLog = new StringAppender();
+        }
+
+        cw = new ClassWriter(ClassWriter.COMPUTE_MAXS + ClassWriter.COMPUTE_FRAMES);
+
+        synchronized (Runtime.getRuntime()) {
+            cw.visit(OPCODES_VERSION, Opcodes.ACC_PUBLIC + Opcodes.ACC_SUPER, className = "ASMAccessorImpl_"
+                    + valueOf(cw.hashCode()).replaceAll("\\-", "_") + (System.currentTimeMillis() / 10) + ((int) (Math.random() * 100)),
+                    null, "java/lang/Object", new String[] { NAMESPACE + "compiler/Accessor" });
+        }
+
+        MethodVisitor m = cw.visitMethod(ACC_PUBLIC, "<init>", "()V", null, null);
+
+        m.visitCode();
+        m.visitVarInsn(Opcodes.ALOAD, 0);
+        m.visitMethodInsn(INVOKESPECIAL, "java/lang/Object", "<init>", "()V");
+        m.visitInsn(RETURN);
+
+        m.visitMaxs(1, 1);
+        m.visitEnd();
+
+        (mv = cw.visitMethod(ACC_PUBLIC, "setValue", "(Ljava/lang/Object;Ljava/lang/Object;L" + NAMESPACE
+                + "integration/VariableResolverFactory;Ljava/lang/Object;)Ljava/lang/Object;", null, null)).visitCode();
+    }
+
+    public Accessor optimizeAccessor(ParserContext pCtx, char[] property, int start, int offset, Object staticContext, Object thisRef,
+            VariableResolverFactory factory, boolean root, Class ingressType) {
+        time = System.currentTimeMillis();
+
+        if (compiledInputs == null) compiledInputs = new ArrayList<ExecutableStatement>();
+
+        this.start = cursor = start;
+        this.end = start + offset;
+        this.length = end - this.start;
+
+        this.first = true;
+        this.val = null;
+
+        this.pCtx = pCtx;
+        this.expr = property;
+        this.ctx = staticContext;
+        this.thisRef = thisRef;
+        this.variableFactory = factory;
+        this.ingressType = ingressType;
+
+        if (!noinit) _initJIT();
+        return compileAccessor();
+    }
+
+    public Accessor optimizeSetAccessor(ParserContext pCtx, char[] property, int start, int offset, Object ctx, Object thisRef,
+            VariableResolverFactory factory, boolean rootThisRef, Object value, Class ingressType) {
+        this.expr = property;
+        this.start = this.cursor = start;
+        this.end = start + offset;
+        this.length = start + offset;
+
+        this.first = true;
+        this.ingressType = ingressType;
+
+        compiledInputs = new ArrayList<ExecutableStatement>();
+
+        this.pCtx = pCtx;
+        this.ctx = ctx;
+        this.thisRef = thisRef;
+        this.variableFactory = factory;
+
+        char[] root = null;
+
+        PropertyVerifier verifier = new PropertyVerifier(property, this.pCtx = pCtx);
+
+        int split = findLastUnion();
+
+        if (split != -1) {
+            root = subset(property, 0, split);
+        }
+
+        AccessorNode rootAccessor = null;
+
+        _initJIT2();
+
+        if (root != null) {
+            int _length = this.length;
+            int _end = this.end;
+            char[] _expr = this.expr;
+
+            this.length = end = (this.expr = root).length;
+
+            // run the compiler but don't finish building.
+            deferFinish = true;
+            noinit = true;
+
+            compileAccessor();
+            ctx = this.val;
+
+            this.expr = _expr;
+            this.cursor = start + root.length + 1;
+            this.length = _length - root.length - 1;
+            this.end = this.cursor + this.length;
+        } else {
+            assert debug("ALOAD 1");
+            mv.visitVarInsn(ALOAD, 1);
+        }
+
+        try {
+
+            skipWhitespace();
+
+            if (collection) {
+                int st = cursor;
+                whiteSpaceSkip();
+
+                if (st == end) throw new PropertyAccessException("unterminated '['", expr, start, pCtx);
+
+                if (scanTo(']')) throw new PropertyAccessException("unterminated '['", expr, start, pCtx);
+
+                String ex = new String(expr, st, cursor - st).trim();
+
+                assert debug("CHECKCAST " + ctx.getClass().getName());
+                mv.visitTypeInsn(CHECKCAST, getInternalName(ctx.getClass()));
+
+                if (ctx instanceof Map) {
+                    if (MVEL.COMPILER_OPT_ALLOW_OVERRIDE_ALL_PROPHANDLING && hasPropertyHandler(Map.class)) {
+                        propHandlerByteCodePut(ex, ctx, Map.class, value);
+                    } else {
+                        //noinspection unchecked
+                        ((Map) ctx).put(eval(ex, ctx, variableFactory), convert(value, returnType = verifier.analyze()));
+
+                        writeLiteralOrSubexpression(subCompileExpression(ex.toCharArray(), pCtx));
+
+                        assert debug("ALOAD 4");
+                        mv.visitVarInsn(ALOAD, 4);
+
+                        if (value != null && returnType != value.getClass()) {
+                            dataConversion(returnType);
+                            checkcast(returnType);
+                        }
+
+                        assert debug("INVOKEINTERFACE Map.put");
+                        mv.visitMethodInsn(INVOKEINTERFACE, "java/util/Map", "put",
+                                "(Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;");
+
+                        assert debug("POP");
+                        mv.visitInsn(POP);
+
+                        assert debug("ALOAD 4");
+                        mv.visitVarInsn(ALOAD, 4);
+                    }
+                } else if (ctx instanceof List) {
+                    if (MVEL.COMPILER_OPT_ALLOW_OVERRIDE_ALL_PROPHANDLING && hasPropertyHandler(List.class)) {
+                        propHandlerByteCodePut(ex, ctx, List.class, value);
+                    } else {
+                        //noinspection unchecked
+                        ((List) ctx).set(eval(ex, ctx, variableFactory, Integer.class), convert(value, returnType = verifier.analyze()));
+
+                        writeLiteralOrSubexpression(subCompileExpression(ex.toCharArray(), pCtx));
+                        unwrapPrimitive(int.class);
+
+                        assert debug("ALOAD 4");
+                        mv.visitVarInsn(ALOAD, 4);
+
+                        if (value != null && !value.getClass().isAssignableFrom(returnType)) {
+                            dataConversion(returnType);
+                            checkcast(returnType);
+                        }
+
+                        assert debug("INVOKEINTERFACE List.set");
+                        mv.visitMethodInsn(INVOKEINTERFACE, "java/util/List", "set", "(ILjava/lang/Object;)Ljava/lang/Object;");
+
+                        assert debug("ALOAD 4");
+                        mv.visitVarInsn(ALOAD, 4);
+                    }
+                } else if (MVEL.COMPILER_OPT_ALLOW_OVERRIDE_ALL_PROPHANDLING && hasPropertyHandler(ctx.getClass())) {
+                    propHandlerByteCodePut(ex, ctx, ctx.getClass(), value);
+                } else if (ctx.getClass().isArray()) {
+                    if (MVEL.COMPILER_OPT_ALLOW_OVERRIDE_ALL_PROPHANDLING && hasPropertyHandler(Array.class)) {
+                        propHandlerByteCodePut(ex, ctx, Array.class, value);
+                    } else {
+                        Class type = getBaseComponentType(ctx.getClass());
+
+                        Object idx = eval(ex, ctx, variableFactory);
+
+                        writeLiteralOrSubexpression(subCompileExpression(ex.toCharArray(), pCtx), int.class);
+                        if (!(idx instanceof Integer)) {
+                            dataConversion(Integer.class);
+                            idx = DataConversion.convert(idx, Integer.class);
+                            unwrapPrimitive(int.class);
+                        }
+
+                        assert debug("ALOAD 4");
+                        mv.visitVarInsn(ALOAD, 4);
+
+                        if (type.isPrimitive()) unwrapPrimitive(type);
+                        else if (!type.equals(value.getClass())) {
+                            dataConversion(type);
+                        }
+
+                        arrayStore(type);
+
+                        //noinspection unchecked
+                        Array.set(ctx, (Integer) idx, convert(value, type));
+
+                        assert debug("ALOAD 4");
+                        mv.visitVarInsn(ALOAD, 4);
+                    }
+                } else {
+                    throw new PropertyAccessException("cannot bind to collection property: " + new String(expr)
+                            + ": not a recognized collection type: " + ctx.getClass(), expr, start, pCtx);
+                }
+
+                deferFinish = false;
+                noinit = false;
+
+                _finishJIT();
+
+                try {
+                    deferFinish = false;
+                    return _initializeAccessor();
+                } catch (Exception e) {
+                    throw new CompileException("could not generate accessor", expr, start, e);
+                }
+            }
+
+            String tk = new String(expr, this.cursor, this.length);
+            Member member = getFieldOrWriteAccessor(ctx.getClass(), tk, value == null ? null : ingressType);
+
+            if (GlobalListenerFactory.hasSetListeners()) {
+                mv.visitVarInsn(ALOAD, 1);
+                mv.visitLdcInsn(tk);
+                mv.visitVarInsn(ALOAD, 3);
+                mv.visitVarInsn(ALOAD, 4);
+                mv.visitMethodInsn(INVOKESTATIC, NAMESPACE + "integration/GlobalListenerFactory", "notifySetListeners",
+                        "(Ljava/lang/Object;Ljava/lang/String;L" + NAMESPACE + "integration/VariableResolverFactory;Ljava/lang/Object;)V");
+
+                GlobalListenerFactory.notifySetListeners(ctx, tk, variableFactory, value);
+            }
+
+            if (member instanceof Field) {
+                checkcast(ctx.getClass());
+
+                Field fld = (Field) member;
+
+                Label jmp = null;
+                Label jmp2 = new Label();
+
+                if (fld.getType().isPrimitive()) {
+                    assert debug("ASTORE 5");
+                    mv.visitVarInsn(ASTORE, 5);
+
+                    assert debug("ALOAD 4");
+                    mv.visitVarInsn(ALOAD, 4);
+
+                    if (value == null) value = PropertyTools.getPrimitiveInitialValue(fld.getType());
+
+                    jmp = new Label();
+                    assert debug("IFNOTNULL jmp");
+                    mv.visitJumpInsn(IFNONNULL, jmp);
+
+                    assert debug("ALOAD 5");
+                    mv.visitVarInsn(ALOAD, 5);
+
+                    assert debug("ICONST_0");
+                    mv.visitInsn(ICONST_0);
+
+                    assert debug("PUTFIELD " + getInternalName(fld.getDeclaringClass()) + "." + tk);
+                    mv.visitFieldInsn(PUTFIELD, getInternalName(fld.getDeclaringClass()), tk, getDescriptor(fld.getType()));
+
+                    assert debug("GOTO jmp2");
+                    mv.visitJumpInsn(GOTO, jmp2);
+
+                    assert debug("jmp:");
+                    mv.visitLabel(jmp);
+
+                    assert debug("ALOAD 5");
+                    mv.visitVarInsn(ALOAD, 5);
+
+                    assert debug("ALOAD 4");
+                    mv.visitVarInsn(ALOAD, 4);
+
+                    unwrapPrimitive(fld.getType());
+                } else {
+                    assert debug("ALOAD 4");
+                    mv.visitVarInsn(ALOAD, 4);
+                    checkcast(fld.getType());
+                }
+
+                if (jmp == null && value != null && !fld.getType().isAssignableFrom(value.getClass())) {
+                    if (!canConvert(fld.getType(), value.getClass())) {
+                        throw new CompileException("cannot convert type: " + value.getClass() + ": to " + fld.getType(), expr, start);
+                    }
+
+                    dataConversion(fld.getType());
+                    fld.set(ctx, convert(value, fld.getType()));
+                } else {
+                    fld.set(ctx, value);
+                }
+
+                assert debug("PUTFIELD " + getInternalName(fld.getDeclaringClass()) + "." + tk);
+                mv.visitFieldInsn(PUTFIELD, getInternalName(fld.getDeclaringClass()), tk, getDescriptor(fld.getType()));
+
+                assert debug("jmp2:");
+                mv.visitLabel(jmp2);
+
+                assert debug("ALOAD 4");
+                mv.visitVarInsn(ALOAD, 4);
+
+            } else if (member != null) {
+                assert debug("CHECKCAST " + getInternalName(ctx.getClass()));
+                mv.visitTypeInsn(CHECKCAST, getInternalName(ctx.getClass()));
+
+                Method meth = (Method) member;
+
+                assert debug("ALOAD 4");
+                mv.visitVarInsn(ALOAD, 4);
+
+                Class targetType = meth.getParameterTypes()[0];
+
+                Label jmp;
+                Label jmp2 = new Label();
+                if (value != null && !targetType.isAssignableFrom(value.getClass())) {
+                    if (!canConvert(targetType, value.getClass())) {
+                        throw new CompileException("cannot convert type: " + value.getClass() + ": to " + meth.getParameterTypes()[0], expr,
+                                start);
+                    }
+
+                    dataConversion(getWrapperClass(targetType));
+                    if (targetType.isPrimitive()) {
+                        unwrapPrimitive(targetType);
+                    } else checkcast(targetType);
+                    meth.invoke(ctx, convert(value, meth.getParameterTypes()[0]));
+                } else {
+                    if (targetType.isPrimitive()) {
+
+                        if (value == null) value = PropertyTools.getPrimitiveInitialValue(targetType);
+
+                        jmp = new Label();
+                        assert debug("IFNOTNULL jmp");
+                        mv.visitJumpInsn(IFNONNULL, jmp);
+
+                        assert debug("ICONST_0");
+                        mv.visitInsn(ICONST_0);
+
+                        assert debug("INVOKEVIRTUAL " + getInternalName(meth.getDeclaringClass()) + "." + meth.getName());
+                        mv.visitMethodInsn(INVOKEVIRTUAL, getInternalName(meth.getDeclaringClass()), meth.getName(),
+                                getMethodDescriptor(meth));
+
+                        assert debug("GOTO jmp2");
+                        mv.visitJumpInsn(GOTO, jmp2);
+
+                        assert debug("jmp:");
+                        mv.visitLabel(jmp);
+
+                        assert debug("ALOAD 4");
+                        mv.visitVarInsn(ALOAD, 4);
+
+                        unwrapPrimitive(targetType);
+                    } else {
+                        checkcast(targetType);
+                    }
+
+                    meth.invoke(ctx, value);
+                }
+
+                assert debug("INVOKEVIRTUAL " + getInternalName(meth.getDeclaringClass()) + "." + meth.getName());
+                mv.visitMethodInsn(INVOKEVIRTUAL, getInternalName(meth.getDeclaringClass()), meth.getName(), getMethodDescriptor(meth));
+
+                assert debug("jmp2:");
+                mv.visitLabel(jmp2);
+
+                assert debug("ALOAD 4");
+                mv.visitVarInsn(ALOAD, 4);
+            } else if (ctx instanceof Map) {
+                assert debug("CHECKCAST " + getInternalName(ctx.getClass()));
+                mv.visitTypeInsn(CHECKCAST, getInternalName(ctx.getClass()));
+
+                assert debug("LDC '" + tk + "'");
+                mv.visitLdcInsn(tk);
+
+                assert debug("ALOAD 4");
+                mv.visitVarInsn(ALOAD, 4);
+
+                assert debug("INVOKEINTERFACE java/util/Map.put");
+                mv.visitMethodInsn(INVOKEINTERFACE, "java/util/Map", "put", "(Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;");
+
+                assert debug("ALOAD 4");
+                mv.visitVarInsn(ALOAD, 4);
+
+                //noinspection unchecked
+                ((Map) ctx).put(tk, value);
+            } else {
+                throw new PropertyAccessException("could not access property (" + tk + ") in: " + ingressType.getName(), expr, start, pCtx);
+            }
+        } catch (InvocationTargetException e) {
+            throw new PropertyAccessException("could not access property", expr, start, e, pCtx);
+        } catch (IllegalAccessException e) {
+            throw new PropertyAccessException("could not access property", expr, start, e, pCtx);
+        }
+
+        try {
+            deferFinish = false;
+            noinit = false;
+
+            _finishJIT();
+            return _initializeAccessor();
+        } catch (Exception e) {
+
+            throw new CompileException("could not generate accessor", expr, start, e);
+        }
+    }
+
+    private void _finishJIT() {
+        if (deferFinish) {
+            return;
+        }
+
+        if (returnType != null && returnType.isPrimitive()) {
+            //noinspection unchecked
+            wrapPrimitive(returnType);
+        }
+
+        if (returnType == void.class) {
+            assert debug("ACONST_NULL");
+            mv.visitInsn(ACONST_NULL);
+        }
+
+        assert debug("ARETURN");
+        mv.visitInsn(ARETURN);
+
+        assert debug("\n{METHOD STATS (maxstack=" + stacksize + ")}\n");
+
+        dumpAdvancedDebugging(); // dump advanced debugging if necessary
+
+        mv.visitMaxs(stacksize, maxlocals);
+        mv.visitEnd();
+
+        mv = cw.visitMethod(ACC_PUBLIC, "getKnownEgressType", "()Ljava/lang/Class;", null, null);
+        mv.visitCode();
+        visitConstantClass(returnType);
+        mv.visitInsn(ARETURN);
+
+        mv.visitMaxs(1, 1);
+        mv.visitEnd();
+
+        if (propNull) {
+            cw.visitField(ACC_PUBLIC, "nullPropertyHandler", "L" + NAMESPACE + "integration/PropertyHandler;", null, null).visitEnd();
+        }
+
+        if (methNull) {
+            cw.visitField(ACC_PUBLIC, "nullMethodHandler", "L" + NAMESPACE + "integration/PropertyHandler;", null, null).visitEnd();
+        }
+
+        buildInputs();
+
+        if (buildLog != null && buildLog.length() != 0 && expr != null) {
+            mv = cw.visitMethod(ACC_PUBLIC, "toString", "()Ljava/lang/String;", null, null);
+            mv.visitCode();
+            Label l0 = new Label();
+            mv.visitLabel(l0);
+            mv.visitLdcInsn(buildLog.toString() + "\n\n## { " + new String(expr) + " }");
+            mv.visitInsn(ARETURN);
+            Label l1 = new Label();
+            mv.visitLabel(l1);
+            mv.visitMaxs(1, 1);
+            mv.visitEnd();
+        }
+
+        cw.visitEnd();
+    }
+
+    private void visitConstantClass(Class<?> clazz) {
+        if (clazz == null) clazz = Object.class;
+        if (clazz.isPrimitive()) {
+            mv.visitFieldInsn(GETSTATIC, toNonPrimitiveType(clazz).getName().replace(".", "/"), "TYPE", "Ljava/lang/Class;");
+        } else {
+            mv.visitLdcInsn(org.mvel2.asm.Type.getType(clazz));
+        }
+    }
+
+    private Accessor _initializeAccessor() throws Exception {
+        if (deferFinish) {
+            return null;
+        }
+        /**
+         * Hot load the class we just generated.
+         */
+        Class cls = loadClass(className, cw.toByteArray());
+
+        assert debug("[MVEL JIT Completed Optimization <<" + (expr != null ? new String(expr) : "") + ">>]::" + cls + " (time: "
+                + (System.currentTimeMillis() - time) + "ms)");
+
+        Object o;
+
+        try {
+            if (compiledInputs.size() == 0) {
+                o = cls.newInstance();
+            } else {
+                Class[] parms = new Class[compiledInputs.size()];
+                for (int i = 0; i < compiledInputs.size(); i++) {
+                    parms[i] = ExecutableStatement.class;
+                }
+                o = cls.getConstructor(parms).newInstance(compiledInputs.toArray(new ExecutableStatement[compiledInputs.size()]));
+            }
+
+            if (propNull) cls.getField("nullPropertyHandler").set(o, getNullPropertyHandler());
+            if (methNull) cls.getField("nullMethodHandler").set(o, getNullMethodHandler());
+
+        } catch (VerifyError e) {
+            System.out.println("**** COMPILER BUG! REPORT THIS IMMEDIATELY AT http://jira.codehaus.org/browse/MVEL");
+            System.out.println("Expression: " + (expr == null ? null : new String(expr)));
+            throw e;
+        }
+
+        return (Accessor) o;
+    }
+
+    private Accessor compileAccessor() {
+        assert debug("<<INITIATE COMPILE>>");
+
+        Object curr = ctx;
+
+        try {
+            if (!MVEL.COMPILER_OPT_ALLOW_OVERRIDE_ALL_PROPHANDLING) {
+                while (cursor < end) {
+                    switch (nextSubToken()) {
+                        case BEAN:
+                            curr = getBeanProperty(curr, capture());
+                            break;
+                        case METH:
+                            curr = getMethod(curr, capture());
+                            break;
+                        case COL:
+                            curr = getCollectionProperty(curr, capture());
+                            break;
+                        case WITH:
+                            curr = getWithProperty(curr);
+                            break;
+                    }
+
+                    // check to see if a null safety is enabled on this property.
+                    if (fields == -1) {
+                        if (curr == null) {
+                            if (nullSafe) {
+                                throw new OptimizationNotSupported();
+                            }
+                            break;
+                        } else {
+                            fields = 0;
+                        }
+                    }
+
+                    first = false;
+
+                    if (nullSafe && cursor < end) {
+
+                        assert debug("DUP");
+                        mv.visitInsn(DUP);
+
+                        Label j = new Label();
+
+                        assert debug("IFNONNULL : jump");
+                        mv.visitJumpInsn(IFNONNULL, j);
+
+                        assert debug("ARETURN");
+                        mv.visitInsn(ARETURN);
+
+                        assert debug("LABEL:jump");
+                        mv.visitLabel(j);
+                    }
+                }
+            } else {
+                while (cursor < end) {
+                    switch (nextSubToken()) {
+                        case BEAN:
+                            curr = getBeanPropertyAO(curr, capture());
+                            break;
+                        case METH:
+                            curr = getMethod(curr, capture());
+                            break;
+                        case COL:
+                            curr = getCollectionPropertyAO(curr, capture());
+                            break;
+                        case WITH:
+                            curr = getWithProperty(curr);
+                            break;
+                    }
+
+                    // check to see if a null safety is enabled on this property.
+                    if (fields == -1) {
+                        if (curr == null) {
+                            if (nullSafe) {
+                                throw new OptimizationNotSupported();
+                            }
+                            break;
+                        } else {
+                            fields = 0;
+                        }
+                    }
+
+                    first = false;
+
+                    if (nullSafe && cursor < end) {
+
+                        assert debug("DUP");
+                        mv.visitInsn(DUP);
+
+                        Label j = new Label();
+
+                        assert debug("IFNONNULL : jump");
+                        mv.visitJumpInsn(IFNONNULL, j);
+
+                        assert debug("ARETURN");
+                        mv.visitInsn(ARETURN);
+
+                        assert debug("LABEL:jump");
+                        mv.visitLabel(j);
+                    }
+                }
+            }
+
+            val = curr;
+
+            _finishJIT();
+
+            return _initializeAccessor();
+        } catch (InvocationTargetException e) {
+            throw new PropertyAccessException(new String(expr), expr, st, e, pCtx);
+        } catch (IllegalAccessException e) {
+            throw new PropertyAccessException(new String(expr), expr, st, e, pCtx);
+        } catch (IndexOutOfBoundsException e) {
+            throw new PropertyAccessException(new String(expr), expr, st, e, pCtx);
+        } catch (PropertyAccessException e) {
+            throw new CompileException(e.getMessage(), expr, st, e);
+        } catch (CompileException e) {
+            throw e;
+        } catch (NullPointerException e) {
+            throw new PropertyAccessException(new String(expr), expr, st, e, pCtx);
+        } catch (OptimizationNotSupported e) {
+            throw e;
+        } catch (Exception e) {
+            throw new CompileException(e.getMessage(), expr, st, e);
+        }
+    }
+
+    private Object getWithProperty(Object ctx) {
+        assert debug("\n  ** ENTER -> {with}");
+
+        if (first) {
+            assert debug("ALOAD 1");
+            mv.visitVarInsn(ALOAD, 1);
+            first = false;
+        }
+
+        String root = new String(expr, 0, cursor - 1).trim();
+
+        int start = cursor + 1;
+        cursor = balancedCaptureWithLineAccounting(expr, cursor, end, '{', pCtx);
+        this.returnType = ctx != null ? ctx.getClass() : null;
+
+        for (WithNode.ParmValuePair aPvp : WithNode.compileWithExpressions(expr, start, cursor++ - start, root, ingressType, pCtx)) {
+            assert debug("DUP");
+            mv.visitInsn(DUP);
+
+            assert debug("ASTORE " + (5 + compileDepth) + " (withctx)");
+            mv.visitVarInsn(ASTORE, 5 + compileDepth);
+
+            aPvp.eval(ctx, variableFactory);
+
+            if (aPvp.getSetExpression() == null) {
+                addSubstatement(aPvp.getStatement());
+            } else {
+                compiledInputs.add((ExecutableStatement) aPvp.getSetExpression());
+
+                // load set expression
+                assert debug("ALOAD 0");
+                mv.visitVarInsn(ALOAD, 0);
+
+                assert debug("GETFIELD p" + (compiledInputs.size() - 1));
+                mv.visitFieldInsn(GETFIELD, className, "p" + (compiledInputs.size() - 1),
+                        "L" + NAMESPACE + "compiler/ExecutableStatement;");
+
+                // ctx
+                assert debug("ALOAD " + (5 + compileDepth) + "(withctx)");
+                mv.visitVarInsn(ALOAD, (5 + compileDepth));
+
+                // elCtx
+                assert debug("ALOAD 2");
+                mv.visitVarInsn(ALOAD, 2);
+
+                // variable factory
+                assert debug("ALOAD 3");
+                mv.visitVarInsn(ALOAD, 3);
+
+                // the value to set.
+                addSubstatement(aPvp.getStatement());
+
+                assert debug("INVOKEINTERFACE Accessor.setValue");
+                mv.visitMethodInsn(INVOKEINTERFACE, NAMESPACE + "compiler/ExecutableStatement", "setValue",
+                        "(Ljava/lang/Object;Ljava/lang/Object;L" + NAMESPACE
+                                + "integration/VariableResolverFactory;Ljava/lang/Object;)Ljava/lang/Object;");
+
+                assert debug("POP");
+                mv.visitInsn(POP);
+            }
+        }
+
+        return ctx;
+    }
+
+    private Object getBeanPropertyAO(Object ctx, String property) throws IllegalAccessException, InvocationTargetException {
+        if (ctx != null && hasPropertyHandler(ctx.getClass())) {
+            return propHandlerByteCode(property, ctx, ctx.getClass());
+        }
+        return getBeanProperty(ctx, property);
+    }
+
+    private Object getBeanProperty(Object ctx, String property) throws IllegalAccessException, InvocationTargetException {
+
+        assert debug("\n  **  ENTER -> {bean: " + property + "; ctx=" + ctx + "}");
+
+        if ((pCtx == null ? currType : pCtx.getVarOrInputTypeOrNull(property)) == Object.class && !pCtx.isStrongTyping()) {
+            currType = null;
+        }
+
+        if (returnType != null && returnType.isPrimitive()) {
+            //noinspection unchecked
+            wrapPrimitive(returnType);
+        }
+
+        boolean classRef = false;
+
+        Class<?> cls;
+        if (ctx instanceof Class) {
+            if (MVEL.COMPILER_OPT_SUPPORT_JAVA_STYLE_CLASS_LITERALS && "class".equals(property)) {
+                ldcClassConstant((Class<?>) ctx);
+
+                return ctx;
+            }
+
+            cls = (Class<?>) ctx;
+            classRef = true;
+        } else if (ctx != null) {
+            cls = ctx.getClass();
+        } else {
+            cls = null;
+        }
+
+        if (hasPropertyHandler(cls)) {
+            PropertyHandler prop = getPropertyHandler(cls);
+            if (prop instanceof ProducesBytecode) {
+                ((ProducesBytecode) prop).produceBytecodeGet(mv, property, variableFactory);
+                return prop.getProperty(property, ctx, variableFactory);
+            } else {
+                throw new RuntimeException(
+                        "unable to compileShared: custom accessor does not support producing bytecode: " + prop.getClass().getName());
+            }
+        }
+
+        Member member = cls != null ? getFieldOrAccessor(cls, property) : null;
+
+        if (member != null && classRef && (member.getModifiers() & Modifier.STATIC) == 0) {
+            member = null;
+        }
+
+        if (member != null && hasGetListeners()) {
+            mv.visitVarInsn(ALOAD, 1);
+            mv.visitLdcInsn(member.getName());
+            mv.visitVarInsn(ALOAD, 3);
+            mv.visitMethodInsn(INVOKESTATIC, NAMESPACE + "integration/GlobalListenerFactory", "notifyGetListeners",
+                    "(Ljava/lang/Object;Ljava/lang/String;L" + NAMESPACE + "integration/VariableResolverFactory;)V");
+
+            notifyGetListeners(ctx, member.getName(), variableFactory);
+        }
+
+        if (first) {
+            if ("this".equals(property)) {
+                assert debug("ALOAD 2");
+                mv.visitVarInsn(ALOAD, 2);
+                return thisRef;
+            } else if (variableFactory != null && variableFactory.isResolveable(property)) {
+
+                if (variableFactory.isIndexedFactory() && variableFactory.isTarget(property)) {
+                    int idx;
+                    try {
+                        loadVariableByIndex(idx = variableFactory.variableIndexOf(property));
+                    } catch (Exception e) {
+                        throw new OptimizationFailure(property);
+                    }
+
+                    return variableFactory.getIndexedVariableResolver(idx).getValue();
+                } else {
+                    try {
+                        loadVariableByName(property);
+                    } catch (Exception e) {
+                        throw new OptimizationFailure("critical error in JIT", e);
+                    }
+
+                    return variableFactory.getVariableResolver(property).getValue();
+                }
+            } else {
+                assert debug("ALOAD 1");
+                mv.visitVarInsn(ALOAD, 1);
+            }
+        }
+
+        if (member instanceof Field) {
+            return optimizeFieldMethodProperty(ctx, property, cls, member);
+        } else if (member != null) {
+            Object o;
+
+            if (first) {
+                assert debug("ALOAD 1 (B)");
+                mv.visitVarInsn(ALOAD, 1);
+            }
+
+            try {
+                o = ((Method) member).invoke(ctx, EMPTYARG);
+
+                if (returnType != member.getDeclaringClass()) {
+                    assert debug("CHECKCAST " + getInternalName(member.getDeclaringClass()));
+                    mv.visitTypeInsn(CHECKCAST, getInternalName(member.getDeclaringClass()));
+                }
+
+                returnType = ((Method) member).getReturnType();
+
+                assert debug("INVOKEVIRTUAL " + member.getName() + ":" + returnType);
+                mv.visitMethodInsn(INVOKEVIRTUAL, getInternalName(member.getDeclaringClass()), member.getName(),
+                        getMethodDescriptor((Method) member));
+            } catch (IllegalAccessException e) {
+                Method iFaceMeth = determineActualTargetMethod((Method) member);
+                if (iFaceMeth == null)
+                    throw new PropertyAccessException("could not access field: " + cls.getName() + "." + property, expr, st, e, pCtx);
+
+                assert debug("CHECKCAST " + getInternalName(iFaceMeth.getDeclaringClass()));
+                mv.visitTypeInsn(CHECKCAST, getInternalName(iFaceMeth.getDeclaringClass()));
+
+                returnType = iFaceMeth.getReturnType();
+
+                assert debug("INVOKEINTERFACE " + member.getName() + ":" + returnType);
+                mv.visitMethodInsn(INVOKEINTERFACE, getInternalName(iFaceMeth.getDeclaringClass()), member.getName(),
+                        getMethodDescriptor((Method) member));
+
+                o = iFaceMeth.invoke(ctx, EMPTYARG);
+            } catch (IllegalArgumentException e) {
+                if (member.getDeclaringClass().equals(ctx)) {
+                    try {
+                        Class c = Class.forName(member.getDeclaringClass().getName() + "$" + property);
+
+                        throw new CompileException("name collision between innerclass: " + c.getCanonicalName() + "; and bean accessor: "
+                                + property + " (" + member.toString() + ")", expr, tkStart);
+                    } catch (ClassNotFoundException e2) {
+                        //fallthru
+                    }
+                }
+                throw e;
+            }
+
+            if (hasNullPropertyHandler()) {
+                if (o == null) o = getNullPropertyHandler().getProperty(member.getName(), ctx, variableFactory);
+                writeOutNullHandler(member, 0);
+            }
+
+            currType = toNonPrimitiveType(returnType);
+            return o;
+        } else if (ctx instanceof Map && (((Map) ctx).containsKey(property) || nullSafe)) {
+            assert debug("CHECKCAST java/util/Map");
+            mv.visitTypeInsn(CHECKCAST, "java/util/Map");
+
+            assert debug("LDC: \"" + property + "\"");
+            mv.visitLdcInsn(property);
+
+            assert debug("INVOKEINTERFACE: get");
+            mv.visitMethodInsn(INVOKEINTERFACE, "java/util/Map", "get", "(Ljava/lang/Object;)Ljava/lang/Object;");
+            return ((Map) ctx).get(property);
+        } else if (first && "this".equals(property)) {
+            assert debug("ALOAD 2");
+            mv.visitVarInsn(ALOAD, 2); // load the thisRef value.
+
+            return this.thisRef;
+        } else if ("length".equals(property) && ctx.getClass().isArray()) {
+            anyArrayCheck(ctx.getClass());
+
+            assert debug("ARRAYLENGTH");
+            mv.visitInsn(ARRAYLENGTH);
+
+            wrapPrimitive(int.class);
+            return getLength(ctx);
+        } else if (LITERALS.containsKey(property)) {
+            Object lit = LITERALS.get(property);
+
+            if (lit instanceof Class) {
+                ldcClassConstant((Class) lit);
+            }
+
+            return lit;
+        } else {
+            Object ts = tryStaticAccess();
+
+            if (ts != null) {
+                if (ts instanceof Class) {
+                    ldcClassConstant((Class) ts);
+                    return ts;
+                } else if (ts instanceof Method) {
+                    writeFunctionPointerStub(((Method) ts).getDeclaringClass(), (Method) ts);
+                    return ts;
+                } else {
+                    Field f = (Field) ts;
+                    return optimizeFieldMethodProperty(ctx, property, cls, f);
+                }
+            } else if (ctx instanceof Class) {
+                /**
+                 * This is our ugly support for function pointers.  This works but needs to be re-thought out at some
+                 * point.
+                 */
+                Class c = (Class) ctx;
+                for (Method m : c.getMethods()) {
+                    if (property.equals(m.getName())) {
+                        if (pCtx != null && pCtx.getParserConfiguration() != null ? pCtx.getParserConfiguration()
+                                .isAllowNakedMethCall() : MVEL.COMPILER_OPT_ALLOW_NAKED_METH_CALL) {
+                            assert debug("POP");
+                            mv.visitInsn(POP);
+                            assert debug("INVOKESTATIC " + m.getName());
+                            mv.visitMethodInsn(INVOKESTATIC, getInternalName(m.getDeclaringClass()), m.getName(), getMethodDescriptor(m));
+
+                            returnType = m.getReturnType();
+
+                            return m.invoke(null, EMPTY_OBJ_ARR);
+                        } else {
+                            writeFunctionPointerStub(c, m);
+                            return m;
+                        }
+                    }
+                }
+
+                try {
+                    Class subClass = findClass(variableFactory, c.getName() + "$" + property, pCtx);
+                    ldcClassConstant(subClass);
+                    return subClass;
+                } catch (ClassNotFoundException cnfe) {
+                    // fall through.
+                }
+
+            } else if (pCtx != null && pCtx.getParserConfiguration() != null ? pCtx.getParserConfiguration()
+                    .isAllowNakedMethCall() : MVEL.COMPILER_OPT_ALLOW_NAKED_METH_CALL) {
+                return getMethod(ctx, property);
+            }
+
+            if (ctx == null) {
+                throw new PropertyAccessException("unresolvable property or identifier: " + property, expr, st, pCtx);
+            } else {
+                throw new PropertyAccessException("could not access: " + property + "; in class: " + ctx.getClass().getName(), expr, st,
+                        pCtx);
+            }
+        }
+    }
+
+    private Object optimizeFieldMethodProperty(Object ctx, String property, Class<?> cls, Member member) throws IllegalAccessException {
+        Object o = ((Field) member).get(ctx);
+
+        if (((member.getModifiers() & STATIC) != 0)) {
+            // Check if the static field reference is a constant and a primitive.
+            if ((member.getModifiers() & FINAL) != 0 && (o instanceof String || ((Field) member).getType().isPrimitive())) {
+                o = ((Field) member).get(null);
+                assert debug("LDC " + valueOf(o));
+                mv.visitLdcInsn(o);
+                wrapPrimitive(o.getClass());
+
+                if (hasNullPropertyHandler()) {
+                    if (o == null) {
+                        o = getNullPropertyHandler().getProperty(member.getName(), ctx, variableFactory);
+                    }
+
+                    writeOutNullHandler(member, 0);
+                }
+                return o;
+            } else {
+                assert debug("GETSTATIC " + getDescriptor(member.getDeclaringClass()) + "." + member.getName() + "::"
+                        + getDescriptor(((Field) member).getType()));
+
+                mv.visitFieldInsn(GETSTATIC, getInternalName(member.getDeclaringClass()), member.getName(),
+                        getDescriptor(returnType = ((Field) member).getType()));
+            }
+        } else {
+            assert debug("CHECKCAST " + getInternalName(cls));
+            mv.visitTypeInsn(CHECKCAST, getInternalName(cls));
+
+            assert debug("GETFIELD " + property + ":" + getDescriptor(((Field) member).getType()));
+            mv.visitFieldInsn(GETFIELD, getInternalName(cls), property, getDescriptor(returnType = ((Field) member).getType()));
+        }
+
+        returnType = ((Field) member).getType();
+
+        if (hasNullPropertyHandler()) {
+            if (o == null) {
+                o = getNullPropertyHandler().getProperty(member.getName(), ctx, variableFactory);
+            }
+
+            writeOutNullHandler(member, 0);
+        }
+
+        currType = toNonPrimitiveType(returnType);
+        return o;
+    }
+
+    private void writeFunctionPointerStub(Class c, Method m) {
+        ldcClassConstant(c);
+
+        mv.visitMethodInsn(INVOKEVIRTUAL, "java/lang/Class", "getMethods", "()[Ljava/lang/reflect/Method;");
+        mv.visitVarInsn(ASTORE, 7);
+        mv.visitInsn(ICONST_0);
+        mv.visitVarInsn(ISTORE, 5);
+        mv.visitVarInsn(ALOAD, 7);
+        mv.visitInsn(ARRAYLENGTH);
+        mv.visitVarInsn(ISTORE, 6);
+        Label l1 = new Label();
+        mv.visitJumpInsn(GOTO, l1);
+        Label l2 = new Label();
+        mv.visitLabel(l2);
+        mv.visitVarInsn(ALOAD, 7);
+        mv.visitVarInsn(ILOAD, 5);
+        mv.visitInsn(AALOAD);
+        mv.visitVarInsn(ASTORE, 4);
+        Label l3 = new Label();
+        mv.visitLabel(l3);
+        mv.visitLdcInsn(m.getName());
+        mv.visitVarInsn(ALOAD, 4);
+        mv.visitMethodInsn(INVOKEVIRTUAL, "java/lang/reflect/Method", "getName", "()Ljava/lang/String;");
+        mv.visitMethodInsn(INVOKEVIRTUAL, "java/lang/String", "equals", "(Ljava/lang/Object;)Z");
+        Label l4 = new Label();
+        mv.visitJumpInsn(IFEQ, l4);
+        Label l5 = new Label();
+        mv.visitLabel(l5);
+        mv.visitVarInsn(ALOAD, 4);
+        mv.visitInsn(ARETURN);
+        mv.visitLabel(l4);
+        mv.visitIincInsn(5, 1);
+        mv.visitLabel(l1);
+        mv.visitVarInsn(ILOAD, 5);
+        mv.visitVarInsn(ILOAD, 6);
+        mv.visitJumpInsn(IF_ICMPLT, l2);
+        Label l6 = new Label();
+        mv.visitLabel(l6);
+        mv.visitInsn(ACONST_NULL);
+        mv.visitInsn(ARETURN);
+
+        //   deferFinish = true;
+    }
+
+    private Object getCollectionProperty(Object ctx, String prop) throws IllegalAccessException, InvocationTargetException {
+        if (prop.trim().length() > 0) {
+            ctx = getBeanProperty(ctx, prop);
+            first = false;
+        }
+
+        currType = null;
+
+        assert debug("\n  **  ENTER -> {collection:<<" + prop + ">>; ctx=" + ctx + "}");
+
+        int start = ++cursor;
+
+        skipWhitespace();
+
+        if (cursor == end) throw new CompileException("unterminated '['", expr, st);
+
+        if (scanTo(']')) throw new CompileException("unterminated '['", expr, st);
+
+        String tk = new String(expr, start, cursor - start);
+
+        assert debug("{collection token: [" + tk + "]}");
+
+        if (ctx == null) return null;
+        if (first) {
+            assert debug("ALOAD 1");
+            mv.visitVarInsn(ALOAD, 1);
+        }
+
+        ExecutableStatement compiled = (ExecutableStatement) subCompileExpression(tk.toCharArray(), pCtx);
+        Object item = compiled.getValue(ctx, variableFactory);
+
+        ++cursor;
+
+        if (ctx instanceof Map) {
+            assert debug("CHECKCAST java/util/Map");
+            mv.visitTypeInsn(CHECKCAST, "java/util/Map");
+
+            Class c = writeLiteralOrSubexpression(compiled);
+            if (c != null && c.isPrimitive()) {
+                wrapPrimitive(c);
+            }
+
+            assert debug("INVOKEINTERFACE: get");
+            mv.visitMethodInsn(INVOKEINTERFACE, "java/util/Map", "get", "(Ljava/lang/Object;)Ljava/lang/Object;");
+
+            return ((Map) ctx).get(item);
+        } else if (ctx instanceof List) {
+            assert debug("CHECKCAST java/util/List");
+            mv.visitTypeInsn(CHECKCAST, "java/util/List");
+
+            writeLiteralOrSubexpression(compiled, int.class);
+
+            assert debug("INVOKEINTERFACE: java/util/List.get");
+            mv.visitMethodInsn(INVOKEINTERFACE, "java/util/List", "get", "(I)Ljava/lang/Object;");
+
+            return ((List) ctx).get(convert(item, Integer.class));
+
+        } else if (ctx.getClass().isArray()) {
+            assert debug("CHECKCAST " + getDescriptor(ctx.getClass()));
+            mv.visitTypeInsn(CHECKCAST, getDescriptor(ctx.getClass()));
+
+            writeLiteralOrSubexpression(compiled, int.class, item.getClass());
+
+            Class cls = getBaseComponentType(ctx.getClass());
+            if (cls.isPrimitive()) {
+                if (cls == int.class) {
+                    assert debug("IALOAD");
+                    mv.visitInsn(IALOAD);
+                } else if (cls == char.class) {
+                    assert debug("CALOAD");
+                    mv.visitInsn(CALOAD);
+                } else if (cls == boolean.class) {
+                    assert debug("BALOAD");
+                    mv.visitInsn(BALOAD);
+                } else if (cls == double.class) {
+                    assert debug("DALOAD");
+                    mv.visitInsn(DALOAD);
+                } else if (cls == float.class) {
+                    assert debug("FALOAD");
+                    mv.visitInsn(FALOAD);
+                } else if (cls == short.class) {
+                    assert debug("SALOAD");
+                    mv.visitInsn(SALOAD);
+                } else if (cls == long.class) {
+                    assert debug("LALOAD");
+                    mv.visitInsn(LALOAD);
+                } else if (cls == byte.class) {
+                    assert debug("BALOAD");
+                    mv.visitInsn(BALOAD);
+                }
+
+                wrapPrimitive(cls);
+            } else {
+                assert debug("AALOAD");
+                mv.visitInsn(AALOAD);
+            }
+
+            return Array.get(ctx, convert(item, Integer.class));
+        } else if (ctx instanceof CharSequence) {
+            assert debug("CHECKCAST java/lang/CharSequence");
+            mv.visitTypeInsn(CHECKCAST, "java/lang/CharSequence");
+
+            if (item instanceof Integer) {
+                intPush((Integer) item);
+
+                assert debug("INVOKEINTERFACE java/lang/CharSequence.charAt");
+                mv.visitMethodInsn(INVOKEINTERFACE, "java/lang/CharSequence", "charAt", "(I)C");
+
+                wrapPrimitive(char.class);
+
+                return ((CharSequence) ctx).charAt((Integer) item);
+            } else {
+                writeLiteralOrSubexpression(compiled, Integer.class);
+                unwrapPrimitive(int.class);
+
+                assert debug("INVOKEINTERFACE java/lang/CharSequence.charAt");
+                mv.visitMethodInsn(INVOKEINTERFACE, "java/lang/CharSequence", "charAt", "(I)C");
+
+                wrapPrimitive(char.class);
+
+                return ((CharSequence) ctx).charAt(convert(item, Integer.class));
+            }
+        } else {
+            TypeDescriptor tDescr = new TypeDescriptor(expr, this.start, length, 0);
+            if (tDescr.isArray()) {
+                try {
+                    Class cls = getClassReference((Class) ctx, tDescr, variableFactory, pCtx);
+                    //   rootNode = new StaticReferenceAccessor(cls);
+                    ldcClassConstant(cls);
+                    return cls;
+                } catch (Exception e) {
+                    //fall through
+                }
+            }
+
+            throw new CompileException("illegal use of []: unknown type: " + (ctx == null ? null : ctx.getClass().getName()), expr, st);
+        }
+    }
+
+    private Object getCollectionPropertyAO(Object ctx, String prop) throws IllegalAccessException, InvocationTargetException {
+        if (prop.length() > 0) {
+            ctx = getBeanProperty(ctx, prop);
+            first = false;
+        }
+
+        currType = null;
+
+        assert debug("\n  **  ENTER -> {collection:<<" + prop + ">>; ctx=" + ctx + "}");
+
+        int _start = ++cursor;
+
+        skipWhitespace();
+
+        if (cursor == end) throw new CompileException("unterminated '['", expr, st);
+
+        if (scanTo(']')) throw new CompileException("unterminated '['", expr, st);
+
+        String tk = new String(expr, _start, cursor - _start);
+
+        assert debug("{collection token:<<" + tk + ">>}");
+
+        if (ctx == null) return null;
+
+        ExecutableStatement compiled = (ExecutableStatement) subCompileExpression(tk.toCharArray());
+        Object item = compiled.getValue(ctx, variableFactory);
+
+        ++cursor;
+
+        if (ctx instanceof Map) {
+            if (hasPropertyHandler(Map.class)) {
+                return propHandlerByteCode(tk, ctx, Map.class);
+            } else {
+                if (first) {
+                    assert debug("ALOAD 1");
+                    mv.visitVarInsn(ALOAD, 1);
+                }
+
+                assert debug("CHECKCAST java/util/Map");
+                mv.visitTypeInsn(CHECKCAST, "java/util/Map");
+
+                Class c = writeLiteralOrSubexpression(compiled);
+                if (c != null && c.isPrimitive()) {
+                    wrapPrimitive(c);
+                }
+
+                assert debug("INVOKEINTERFACE: Map.get");
+                mv.visitMethodInsn(INVOKEINTERFACE, "java/util/Map", "get", "(Ljava/lang/Object;)Ljava/lang/Object;");
+            }
+
+            return ((Map) ctx).get(item);
+        } else if (ctx instanceof List) {
+            if (hasPropertyHandler(List.class)) {
+                return propHandlerByteCode(tk, ctx, List.class);
+            } else {
+                if (first) {
+                    assert debug("ALOAD 1");
+                    mv.visitVarInsn(ALOAD, 1);
+                }
+
+                assert debug("CHECKCAST java/util/List");
+                mv.visitTypeInsn(CHECKCAST, "java/util/List");
+
+                writeLiteralOrSubexpression(compiled, int.class);
+
+                assert debug("INVOKEINTERFACE: java/util/List.get");
+                mv.visitMethodInsn(INVOKEINTERFACE, "java/util/List", "get", "(I)Ljava/lang/Object;");
+
+                return ((List) ctx).get(convert(item, Integer.class));
+            }
+        } else if (ctx.getClass().isArray()) {
+            if (hasPropertyHandler(Array.class)) {
+                return propHandlerByteCode(tk, ctx, Array.class);
+            } else {
+                if (first) {
+                    assert debug("ALOAD 1");
+                    mv.visitVarInsn(ALOAD, 1);
+                }
+
+                assert debug("CHECKCAST " + getDescriptor(ctx.getClass()));
+                mv.visitTypeInsn(CHECKCAST, getDescriptor(ctx.getClass()));
+
+                writeLiteralOrSubexpression(compiled, int.class, item.getClass());
+
+                Class cls = getBaseComponentType(ctx.getClass());
+                if (cls.isPrimitive()) {
+                    if (cls == int.class) {
+                        assert debug("IALOAD");
+                        mv.visitInsn(IALOAD);
+                    } else if (cls == char.class) {
+                        assert debug("CALOAD");
+                        mv.visitInsn(CALOAD);
+                    } else if (cls == boolean.class) {
+                        assert debug("BALOAD");
+                        mv.visitInsn(BALOAD);
+                    } else if (cls == double.class) {
+                        assert debug("DALOAD");
+                        mv.visitInsn(DALOAD);
+                    } else if (cls == float.class) {
+                        assert debug("FALOAD");
+                        mv.visitInsn(FALOAD);
+                    } else if (cls == short.class) {
+                        assert debug("SALOAD");
+                        mv.visitInsn(SALOAD);
+                    } else if (cls == long.class) {
+                        assert debug("LALOAD");
+                        mv.visitInsn(LALOAD);
+                    } else if (cls == byte.class) {
+                        assert debug("BALOAD");
+                        mv.visitInsn(BALOAD);
+                    }
+
+                    wrapPrimitive(cls);
+                } else {
+                    assert debug("AALOAD");
+                    mv.visitInsn(AALOAD);
+                }
+
+                return Array.get(ctx, convert(item, Integer.class));
+            }
+        } else if (ctx instanceof CharSequence) {
+            if (hasPropertyHandler(CharSequence.class)) {
+                return propHandlerByteCode(tk, ctx, CharSequence.class);
+            } else {
+                if (first) {
+                    assert debug("ALOAD 1");
+                    mv.visitVarInsn(ALOAD, 1);
+                }
+
+                assert debug("CHECKCAST java/lang/CharSequence");
+                mv.visitTypeInsn(CHECKCAST, "java/lang/CharSequence");
+
+                if (item instanceof Integer) {
+                    intPush((Integer) item);
+
+                    assert debug("INVOKEINTERFACE java/lang/CharSequence.charAt");
+                    mv.visitMethodInsn(INVOKEINTERFACE, "java/lang/CharSequence", "charAt", "(I)C");
+
+                    wrapPrimitive(char.class);
+
+                    return ((CharSequence) ctx).charAt((Integer) item);
+                } else {
+                    writeLiteralOrSubexpression(compiled, Integer.class);
+                    unwrapPrimitive(int.class);
+
+                    assert debug("INVOKEINTERFACE java/lang/CharSequence.charAt");
+                    mv.visitMethodInsn(INVOKEINTERFACE, "java/lang/CharSequence", "charAt", "(I)C");
+
+                    wrapPrimitive(char.class);
+
+                    return ((CharSequence) ctx).charAt(convert(item, Integer.class));
+                }
+            }
+        } else {
+            TypeDescriptor tDescr = new TypeDescriptor(expr, start, end - start, 0);
+            if (tDescr.isArray()) {
+                try {
+                    Class cls = getClassReference((Class) ctx, tDescr, variableFactory, pCtx);
+                    //   rootNode = new StaticReferenceAccessor(cls);
+                    ldcClassConstant(cls);
+                    return cls;
+                } catch (Exception e) {
+                    //fall through
+                }
+            }
+
+            throw new CompileException("illegal use of []: unknown type: " + (ctx == null ? null : ctx.getClass().getName()), expr, st);
+        }
+    }
+
+    @SuppressWarnings({ "unchecked" })
+    private Object getMethod(Object ctx, String name) throws IllegalAccessException, InvocationTargetException {
+        assert debug("\n  **  {method: " + name + "}");
+
+        int st = cursor;
+        String tk = cursor != end && expr[cursor] == '(' && ((cursor = balancedCapture(expr, cursor, '(')) - st) > 1 ? new String(expr,
+                st + 1, cursor - st - 1) : "";
+        cursor++;
+
+        Object[] preConvArgs;
+        Object[] args;
+        Class[] argTypes;
+        ExecutableStatement[] es;
+        List<char[]> subtokens;
+
+        if (tk.length() == 0) {
+            args = preConvArgs = ParseTools.EMPTY_OBJ_ARR;
+            argTypes = ParseTools.EMPTY_CLS_ARR;
+            es = null;
+            subtokens = null;
+        } else {
+            subtokens = parseParameterList(tk.toCharArray(), 0, -1);
+
+            es = new ExecutableStatement[subtokens.size()];
+            args = new Object[subtokens.size()];
+            argTypes = new Class[subtokens.size()];
+            preConvArgs = new Object[es.length];
+
+            for (int i = 0; i < subtokens.size(); i++) {
+                assert debug("subtoken[" + i + "] { " + new String(subtokens.get(i)) + " }");
+                preConvArgs[i] = args[i] = (es[i] = (ExecutableStatement) subCompileExpression(subtokens.get(i), pCtx))
+                        .getValue(this.thisRef, this.thisRef, variableFactory);
+
+                if (es[i].isExplicitCast()) argTypes[i] = es[i].getKnownEgressType();
+            }
+
+            if (pCtx.isStrictTypeEnforcement()) {
+                for (int i = 0; i < args.length; i++) {
+                    argTypes[i] = es[i].getKnownEgressType();
+                }
+            } else {
+                for (int i = 0; i < args.length; i++) {
+                    if (argTypes[i] != null) continue;
+
+                    if (es[i].getKnownEgressType() == Object.class) {
+                        argTypes[i] = args[i] == null ? null : args[i].getClass();
+                    } else {
+                        argTypes[i] = es[i].getKnownEgressType();
+                    }
+                }
+            }
+        }
+
+        if (first && variableFactory != null && variableFactory.isResolveable(name)) {
+            Object ptr = variableFactory.getVariableResolver(name).getValue();
+
+            if (ptr instanceof Method) {
+                ctx = ((Method) ptr).getDeclaringClass();
+                name = ((Method) ptr).getName();
+            } else if (ptr instanceof MethodStub) {
+                ctx = ((MethodStub) ptr).getClassReference();
+                name = ((MethodStub) ptr).getMethodName();
+            } else if (ptr instanceof FunctionInstance) {
+
+                if (es != null && es.length != 0) {
+                    compiledInputs.addAll(Arrays.asList(es));
+
+                    intPush(es.length);
+
+                    assert debug("ANEWARRAY [" + es.length + "]");
+                    mv.visitTypeInsn(ANEWARRAY, "java/lang/Object");
+
+                    assert debug("ASTORE 4");
+                    mv.visitVarInsn(ASTORE, 4);
+
+                    for (int i = 0; i < es.length; i++) {
+                        assert debug("ALOAD 4");
+                        mv.visitVarInsn(ALOAD, 4);
+                        intPush(i);
+                        loadField(i);
+
+                        assert debug("ALOAD 1");
+                        mv.visitVarInsn(ALOAD, 1);
+
+                        assert debug("ALOAD 3");
+                        mv.visitIntInsn(ALOAD, 3);
+
+                        assert debug("INVOKEINTERFACE ExecutableStatement.getValue");
+                        mv.visitMethodInsn(INVOKEINTERFACE, NAMESPACE + "compiler/ExecutableStatement", "getValue",
+                                "(Ljava/lang/Object;L" + NAMESPACE + "integration/VariableResolverFactory;)Ljava/lang/Object;");
+
+                        assert debug("AASTORE");
+                        mv.visitInsn(AASTORE);
+                    }
+                } else {
+                    assert debug("ACONST_NULL");
+                    mv.visitInsn(ACONST_NULL);
+
+                    assert debug("CHECKCAST java/lang/Object");
+                    mv.visitTypeInsn(CHECKCAST, "[Ljava/lang/Object;");
+
+                    assert debug("ASTORE 4");
+                    mv.visitVarInsn(ASTORE, 4);
+                }
+
+                if (variableFactory.isIndexedFactory() && variableFactory.isTarget(name)) {
+                    loadVariableByIndex(variableFactory.variableIndexOf(name));
+                } else {
+                    loadVariableByName(name);
+                }
+
+                checkcast(FunctionInstance.class);
+
+                assert debug("ALOAD 1");
+                mv.visitVarInsn(ALOAD, 1);
+
+                assert debug("ALOAD 2");
+                mv.visitVarInsn(ALOAD, 2);
+
+                assert debug("ALOAD 3");
+                mv.visitVarInsn(ALOAD, 3);
+
+                assert debug("ALOAD 4");
+                mv.visitVarInsn(ALOAD, 4);
+
+                assert debug("INVOKEVIRTUAL Function.call");
+                mv.visitMethodInsn(INVOKEVIRTUAL, getInternalName(FunctionInstance.class), "call", "(Ljava/lang/Object;Ljava/lang/Object;L"
+                        + NAMESPACE + "integration/VariableResolverFactory;[Ljava/lang/Object;)Ljava/lang/Object;");
+
+                return ((FunctionInstance) ptr).call(ctx, thisRef, variableFactory, args);
+            } else {
+                throw new OptimizationFailure("attempt to optimize a method call for a reference that does not point to a method: " + name
+                        + " (reference is type: " + (ctx != null ? ctx.getClass().getName() : null) + ")");
+            }
+
+            first = false;
+        } else if (returnType != null && returnType.isPrimitive()) {
+            //noinspection unchecked
+            wrapPrimitive(returnType);
+        }
+
+        /**
+         * If the target object is an instance of java.lang.Class itself then do not
+         * adjust the Class scope target.
+         */
+
+        boolean classTarget = false;
+        Class<?> cls = currType != null ? currType : ((classTarget = ctx instanceof Class) ? (Class<?>) ctx : ctx.getClass());
+
+        currType = null;
+
+        Method m;
+        Class[] parameterTypes = null;
+
+        /**
+         * Try to find an instance method from the class target.
+         */
+        if ((m = getBestCandidate(argTypes, name, cls, cls.getMethods(), false, classTarget)) != null) {
+            parameterTypes = m.getParameterTypes();
+        }
+
+        if (m == null && classTarget) {
+            /**
+             * If we didn't find anything, maybe we're looking for the actual java.lang.Class methods.
+             */
+            if ((m = getBestCandidate(argTypes, name, cls, Class.class.getMethods(), false)) != null) {
+                parameterTypes = m.getParameterTypes();
+            }
+        }
+
+        // If we didn't find anything and the declared class is different from the actual one try also with the actual one
+        if (m == null && cls != ctx.getClass() && !(ctx instanceof Class)) {
+            cls = ctx.getClass();
+            if ((m = getBestCandidate(argTypes, name, cls, cls.getMethods(), false, classTarget)) != null) {
+                parameterTypes = m.getParameterTypes();
+            }
+        }
+
+        if (es != null && m != null && m.isVarArgs()
+                && (es.length != parameterTypes.length || !(es[es.length - 1] instanceof ExecutableAccessor))) {
+            // normalize ExecutableStatement for varargs
+            ExecutableStatement[] varArgEs = new ExecutableStatement[parameterTypes.length];
+            int varArgStart = parameterTypes.length - 1;
+            for (int i = 0; i < varArgStart; i++)
+                varArgEs[i] = es[i];
+
+            String varargsTypeName = parameterTypes[parameterTypes.length - 1].getComponentType().getName();
+            String varArgExpr;
+            if ("null".equals(tk)) { //if null is the token no need for wrapping
+                varArgExpr = tk;
+            } else {
+                StringBuilder sb = new StringBuilder("new ").append(varargsTypeName).append("[] {");
+                for (int i = varArgStart; i < subtokens.size(); i++) {
+                    sb.append(subtokens.get(i));
+                    if (i < subtokens.size() - 1) sb.append(",");
+                }
+                varArgExpr = sb.append("}").toString();
+            }
+            char[] token = varArgExpr.toCharArray();
+            varArgEs[varArgStart] = ((ExecutableStatement) subCompileExpression(token, pCtx));
+            es = varArgEs;
+
+            if (preConvArgs.length == parameterTypes.length - 1) {
+                // empty vararg
+                Object[] preConvArgsForVarArg = new Object[parameterTypes.length];
+                for (int i = 0; i < preConvArgs.length; i++)
+                    preConvArgsForVarArg[i] = preConvArgs[i];
+                preConvArgsForVarArg[parameterTypes.length - 1] = Array
+                        .newInstance(parameterTypes[parameterTypes.length - 1].getComponentType(), 0);
+                preConvArgs = preConvArgsForVarArg;
+            }
+        }
+
+        int inputsOffset = compiledInputs.size();
+
+        if (es != null) {
+            for (ExecutableStatement e : es) {
+                if (e instanceof ExecutableLiteral) {
+                    continue;
+                }
+
+                compiledInputs.add(e);
+            }
+        }
+
+        if (first) {
+            assert debug("ALOAD 1 (D) ");
+            mv.visitVarInsn(ALOAD, 1);
+        }
+
+        if (m == null) {
+            StringAppender errorBuild = new StringAppender();
+
+            if (parameterTypes != null) {
+                for (int i = 0; i < args.length; i++) {
+                    errorBuild.append(parameterTypes[i] != null ? parameterTypes[i].getClass().getName() : null);
+                    if (i < args.length - 1) errorBuild.append(", ");
+                }
+            }
+
+            if ("size".equals(name) && args.length == 0 && cls.isArray()) {
+                anyArrayCheck(cls);
+
+                assert debug("ARRAYLENGTH");
+                mv.visitInsn(ARRAYLENGTH);
+
+                wrapPrimitive(int.class);
+                return getLength(ctx);
+            }
+
+            throw new CompileException("unable to resolve method: " + cls.getName() + "." + name + "(" + errorBuild.toString()
+                    + ") [arglength=" + args.length + "]", expr, st);
+        } else {
+            m = getWidenedTarget(m);
+
+            if (es != null) {
+                ExecutableStatement cExpr;
+                for (int i = 0; i < es.length; i++) {
+                    if ((cExpr = es[i]).getKnownIngressType() == null) {
+                        cExpr.setKnownIngressType(parameterTypes[i]);
+                        cExpr.computeTypeConversionRule();
+                    }
+                    if (!cExpr.isConvertableIngressEgress() && i < args.length) {
+                        args[i] = convert(args[i], paramTypeVarArgsSafe(parameterTypes, i, m.isVarArgs()));
+                    }
+                }
+            } else {
+                /**
+                 * Coerce any types if required.
+                 */
+                for (int i = 0; i < args.length; i++) {
+                    args[i] = convert(args[i], paramTypeVarArgsSafe(parameterTypes, i, m.isVarArgs()));
+                }
+            }
+
+            if (m.getParameterTypes().length == 0) {
+                if ((m.getModifiers() & STATIC) != 0) {
+                    assert debug("INVOKESTATIC " + m.getName());
+                    mv.visitMethodInsn(INVOKESTATIC, getInternalName(m.getDeclaringClass()), m.getName(), getMethodDescriptor(m));
+                } else {
+                    assert debug("CHECKCAST " + getInternalName(m.getDeclaringClass()));
+                    mv.visitTypeInsn(CHECKCAST, getInternalName(m.getDeclaringClass()));
+
+                    if (m.getDeclaringClass().isInterface()) {
+                        assert debug("INVOKEINTERFACE " + m.getName());
+                        mv.visitMethodInsn(INVOKEINTERFACE, getInternalName(m.getDeclaringClass()), m.getName(), getMethodDescriptor(m));
+
+                    } else {
+                        assert debug("INVOKEVIRTUAL " + m.getName());
+                        mv.visitMethodInsn(INVOKEVIRTUAL, getInternalName(m.getDeclaringClass()), m.getName(), getMethodDescriptor(m));
+                    }
+                }
+
+                returnType = m.getReturnType();
+
+                stacksize++;
+            } else {
+                if ((m.getModifiers() & STATIC) == 0) {
+                    assert debug("CHECKCAST " + getInternalName(cls));
+                    mv.visitTypeInsn(CHECKCAST, getInternalName(cls));
+                }
+
+                Class<?> aClass = m.getParameterTypes()[m.getParameterTypes().length - 1];
+                if (m.isVarArgs()) {
+                    if (es == null || es.length == (m.getParameterTypes().length - 1)) {
+                        ExecutableStatement[] executableStatements = new ExecutableStatement[m.getParameterTypes().length];
+                        if (es != null) {
+                            System.arraycopy(es, 0, executableStatements, 0, es.length);
+                        }
+                        executableStatements[executableStatements.length - 1] = new ExecutableLiteral(Array.newInstance(aClass, 0));
+                        es = executableStatements;
+                    }
+                }
+
+                for (int i = 0; es != null && i < es.length; i++) {
+                    if (es[i] instanceof ExecutableLiteral) {
+                        ExecutableLiteral literal = (ExecutableLiteral) es[i];
+
+                        if (literal.getLiteral() == null) {
+                            assert debug("ICONST_NULL");
+                            mv.visitInsn(ACONST_NULL);
+                            continue;
+                        } else if (parameterTypes[i] == int.class && literal.intOptimized()) {
+                            intPush(literal.getInteger32());
+                            continue;
+                        } else if (parameterTypes[i] == int.class && preConvArgs[i] instanceof Integer) {
+                            intPush((Integer) preConvArgs[i]);
+                            continue;
+                        } else if (parameterTypes[i] == boolean.class) {
+                            boolean bool = DataConversion.convert(literal.getLiteral(), Boolean.class);
+                            assert debug(bool ? "ICONST_1" : "ICONST_0");
+                            mv.visitInsn(bool ? ICONST_1 : ICONST_0);
+                            continue;
+                        } else {
+                            Object lit = literal.getLiteral();
+
+                            if (parameterTypes[i] == Object.class) {
+                                if (isPrimitiveWrapper(lit.getClass())) {
+                                    if (lit.getClass() == Integer.class) {
+                                        intPush((Integer) lit);
+                                    } else {
+                                        assert debug("LDC " + lit);
+                                        mv.visitLdcInsn(lit);
+                                    }
+
+                                    wrapPrimitive(lit.getClass());
+                                } else if (lit instanceof String) {
+                                    mv.visitLdcInsn(lit);
+                                    checkcast(Object.class);
+                                }
+                                continue;
+                            } else if (canConvert(parameterTypes[i], lit.getClass())) {
+                                Object c = convert(lit, parameterTypes[i]);
+                                if (c instanceof Class) {
+                                    ldcClassConstant((Class) c);
+                                } else {
+                                    assert debug("LDC " + lit + " (" + lit.getClass().getName() + ")");
+
+                                    mv.visitLdcInsn(convert(lit, parameterTypes[i]));
+
+                                    if (isPrimitiveWrapper(parameterTypes[i])) {
+                                        wrapPrimitive(lit.getClass());
+                                    }
+                                }
+                                continue;
+                            } else {
+                                throw new OptimizationNotSupported();
+                            }
+                        }
+                    }
+
+                    assert debug("ALOAD 0");
+                    mv.visitVarInsn(ALOAD, 0);
+
+                    assert debug("GETFIELD p" + inputsOffset);
+                    mv.visitFieldInsn(GETFIELD, className, "p" + inputsOffset, "L" + NAMESPACE + "compiler/ExecutableStatement;");
+
+                    inputsOffset++;
+
+                    assert debug("ALOAD 2");
+                    mv.visitVarInsn(ALOAD, 2);
+
+                    assert debug("ALOAD 3");
+                    mv.visitVarInsn(ALOAD, 3);
+
+                    assert debug("INVOKEINTERFACE ExecutableStatement.getValue");
+                    mv.visitMethodInsn(INVOKEINTERFACE, getInternalName(ExecutableStatement.class), "getValue",
+                            "(Ljava/lang/Object;L" + NAMESPACE + "integration/VariableResolverFactory;)Ljava/lang/Object;");
+
+                    if (parameterTypes[i].isPrimitive()) {
+                        if (preConvArgs[i] == null
+                                || (parameterTypes[i] != String.class && !parameterTypes[i].isAssignableFrom(preConvArgs[i].getClass()))) {
+
+                            ldcClassConstant(getWrapperClass(parameterTypes[i]));
+
+                            assert debug("INVOKESTATIC DataConversion.convert");
+                            mv.visitMethodInsn(INVOKESTATIC, NAMESPACE + "DataConversion", "convert",
+                                    "(Ljava/lang/Object;Ljava/lang/Class;)Ljava/lang/Object;");
+                        }
+
+                        unwrapPrimitive(parameterTypes[i]);
+                    } else if (preConvArgs[i] == null
+                            || (parameterTypes[i] != String.class && !parameterTypes[i].isAssignableFrom(preConvArgs[i].getClass()))) {
+
+                        ldcClassConstant(parameterTypes[i]);
+
+                        assert debug("INVOKESTATIC DataConversion.convert");
+                        mv.visitMethodInsn(INVOKESTATIC, NAMESPACE + "DataConversion", "convert",
+                                "(Ljava/lang/Object;Ljava/lang/Class;)Ljava/lang/Object;");
+
+                        assert debug("CHECKCAST " + getInternalName(parameterTypes[i]));
+                        mv.visitTypeInsn(CHECKCAST, getInternalName(parameterTypes[i]));
+                    } else if (parameterTypes[i] == String.class) {
+                        assert debug("<<<DYNAMIC TYPE OPTIMIZATION STRING>>");
+                        mv.visitMethodInsn(INVOKESTATIC, "java/lang/String", "valueOf", "(Ljava/lang/Object;)Ljava/lang/String;");
+                    } else {
+                        assert debug("<<<DYNAMIC TYPING BYPASS>>>");
+                        assert debug("<<<OPT. JUSTIFICATION " + parameterTypes[i] + "=" + preConvArgs[i].getClass() + ">>>");
+
+                        assert debug("CHECKCAST " + getInternalName(parameterTypes[i]));
+                        mv.visitTypeInsn(CHECKCAST, getInternalName(parameterTypes[i]));
+                    }
+                }
+
+                if ((m.getModifiers() & STATIC) != 0) {
+                    assert debug("INVOKESTATIC: " + m.getName());
+                    mv.visitMethodInsn(INVOKESTATIC, getInternalName(m.getDeclaringClass()), m.getName(), getMethodDescriptor(m));
+                } else {
+                    if (m.getDeclaringClass().isInterface()
+                            && (m.getDeclaringClass() != cls || (ctx != null && ctx.getClass() != m.getDeclaringClass()))) {
+                        assert debug("INVOKEINTERFACE: " + getInternalName(m.getDeclaringClass()) + "." + m.getName());
+                        mv.visitMethodInsn(INVOKEINTERFACE, getInternalName(m.getDeclaringClass()), m.getName(), getMethodDescriptor(m));
+                    } else {
+                        assert debug("INVOKEVIRTUAL: " + getInternalName(cls) + "." + m.getName());
+                        mv.visitMethodInsn(INVOKEVIRTUAL, getInternalName(cls), m.getName(), getMethodDescriptor(m));
+                    }
+                }
+
+                returnType = m.getReturnType();
+
+                stacksize++;
+            }
+
+            Object o = m.invoke(ctx, normalizeArgsForVarArgs(parameterTypes, args, m.isVarArgs()));
+
+            if (hasNullMethodHandler()) {
+                writeOutNullHandler(m, 1);
+                if (o == null) o = getNullMethodHandler().getProperty(m.getName(), ctx, variableFactory);
+            }
+
+            currType = toNonPrimitiveType(m.getReturnType());
+            return o;
+
+        }
+    }
+
+    private void dataConversion(Class target) {
+        if (target.equals(Object.class)) return;
+
+        ldcClassConstant(target);
+        assert debug("INVOKESTATIC " + NAMESPACE + "DataConversion.convert");
+        mv.visitMethodInsn(INVOKESTATIC, NAMESPACE + "DataConversion", "convert",
+                "(Ljava/lang/Object;Ljava/lang/Class;)Ljava/lang/Object;");
+    }
+
+    public void init() {
+        try {
+            classLoader = new JITClassLoader(currentThread().getContextClassLoader());
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private ContextClassLoader getContextClassLoader() {
+        return pCtx == null ? null : new ContextClassLoader(pCtx.getClassLoader());
+    }
+
+    private Class loadClass(String className, byte[] b) throws Exception {
+        /**
+         * This must be synchronized.  Two classes cannot be simultaneously deployed in the JVM.
+         */
+        ContextClassLoader contextClassLoader = getContextClassLoader();
+        return contextClassLoader == null ? classLoader.defineClassX(className, b, 0, b.length) : contextClassLoader.defineClass(className,
+                b);
+    }
+
+    private boolean debug(String instruction) {
+        if (buildLog != null) {
+            buildLog.append(instruction).append("\n");
+        }
+        return true;
+    }
+
+    @SuppressWarnings({ "SameReturnValue" })
+    public String getName() {
+        return "ASM";
+    }
+
+    public Object getResultOptPass() {
+        return val;
+    }
+
+    private Class getWrapperClass(Class cls) {
+        if (cls == boolean.class) {
+            return Boolean.class;
+        } else if (cls == int.class) {
+            return Integer.class;
+        } else if (cls == float.class) {
+            return Float.class;
+        } else if (cls == double.class) {
+            return Double.class;
+        } else if (cls == short.class) {
+            return Short.class;
+        } else if (cls == long.class) {
+            return Long.class;
+        } else if (cls == byte.class) {
+            return Byte.class;
+        } else if (cls == char.class) {
+            return Character.class;
+        }
+
+        return cls;
+    }
+
+    private void unwrapPrimitive(Class cls) {
+        if (cls == boolean.class) {
+            assert debug("CHECKCAST java/lang/Boolean");
+            mv.visitTypeInsn(CHECKCAST, "java/lang/Boolean");
+            assert debug("INVOKEVIRTUAL java/lang/Boolean.booleanValue");
+            mv.visitMethodInsn(INVOKEVIRTUAL, "java/lang/Boolean", "booleanValue", "()Z");
+        } else if (cls == int.class) {
+            assert debug("CHECKCAST java/lang/Integer");
+            mv.visitTypeInsn(CHECKCAST, "java/lang/Integer");
+            assert debug("INVOKEVIRTUAL java/lang/Integer.intValue");
+            mv.visitMethodInsn(INVOKEVIRTUAL, "java/lang/Integer", "intValue", "()I");
+        } else if (cls == float.class) {
+            assert debug("CHECKCAST java/lang/Float");
+            mv.visitTypeInsn(CHECKCAST, "java/lang/Float");
+            assert debug("INVOKEVIRTUAL java/lang/Float.floatValue");
+            mv.visitMethodInsn(INVOKEVIRTUAL, "java/lang/Float", "floatValue", "()F");
+        } else if (cls == double.class) {
+            assert debug("CHECKCAST java/lang/Double");
+            mv.visitTypeInsn(CHECKCAST, "java/lang/Double");
+            assert debug("INVOKEVIRTUAL java/lang/Double.doubleValue");
+            mv.visitMethodInsn(INVOKEVIRTUAL, "java/lang/Double", "doubleValue", "()D");
+        } else if (cls == short.class) {
+            assert debug("CHECKCAST java/lang/Short");
+            mv.visitTypeInsn(CHECKCAST, "java/lang/Short");
+            assert debug("INVOKEVIRTUAL java/lang/Short.shortValue");
+            mv.visitMethodInsn(INVOKEVIRTUAL, "java/lang/Short", "shortValue", "()S");
+        } else if (cls == long.class) {
+            assert debug("CHECKCAST java/lang/Long");
+            mv.visitTypeInsn(CHECKCAST, "java/lang/Long");
+            assert debug("INVOKEVIRTUAL java/lang/Long.longValue");
+            mv.visitMethodInsn(INVOKEVIRTUAL, "java/lang/Long", "longValue", "()J");
+        } else if (cls == byte.class) {
+            assert debug("CHECKCAST java/lang/Byte");
+            mv.visitTypeInsn(CHECKCAST, "java/lang/Byte");
+            assert debug("INVOKEVIRTUAL java/lang/Byte.byteValue");
+            mv.visitMethodInsn(INVOKEVIRTUAL, "java/lang/Byte", "byteValue", "()B");
+        } else if (cls == char.class) {
+            assert debug("CHECKCAST java/lang/Character");
+            mv.visitTypeInsn(CHECKCAST, "java/lang/Character");
+            assert debug("INVOKEVIRTUAL java/lang/Character.charValue");
+            mv.visitMethodInsn(INVOKEVIRTUAL, "java/lang/Character", "charValue", "()C");
+        }
+    }
+
+    private void wrapPrimitive(Class<? extends Object> cls) {
+        if (OPCODES_VERSION == Opcodes.V1_4) {
+            /**
+             * JAVA 1.4 SUCKS!  DIE 1.4 DIE!!!
+             */
+
+            debug("** Using 1.4 Bytecode **");
+
+            if (cls == boolean.class || cls == Boolean.class) {
+                debug("NEW java/lang/Boolean");
+                mv.visitTypeInsn(NEW, "java/lang/Boolean");
+
+                debug("DUP X1");
+                mv.visitInsn(DUP_X1);
+
+                debug("SWAP");
+                mv.visitInsn(SWAP);
+
+                debug("INVOKESPECIAL java/lang/Boolean.<init>::(Z)V");
+                mv.visitMethodInsn(INVOKESPECIAL, "java/lang/Boolean", "<init>", "(Z)V");
+            } else if (cls == int.class || cls == Integer.class) {
+                debug("NEW java/lang/Integer");
+                mv.visitTypeInsn(NEW, "java/lang/Integer");
+
+                debug("DUP X1");
+                mv.visitInsn(DUP_X1);
+
+                debug("SWAP");
+                mv.visitInsn(SWAP);
+
+                debug("INVOKESPECIAL java/lang/Integer.<init>::(I)V");
+                mv.visitMethodInsn(INVOKESPECIAL, "java/lang/Integer", "<init>", "(I)V");
+            } else if (cls == float.class || cls == Float.class) {
+                debug("NEW java/lang/Float");
+                mv.visitTypeInsn(NEW, "java/lang/Float");
+
+                debug("DUP X1");
+                mv.visitInsn(DUP_X1);
+
+                debug("SWAP");
+                mv.visitInsn(SWAP);
+
+                debug("INVOKESPECIAL java/lang/Float.<init>::(F)V");
+                mv.visitMethodInsn(INVOKESPECIAL, "java/lang/Float", "<init>", "(F)V");
+            } else if (cls == double.class || cls == Double.class) {
+                debug("NEW java/lang/Double");
+                mv.visitTypeInsn(NEW, "java/lang/Double");
+
+                debug("DUP X2");
+                mv.visitInsn(DUP_X2);
+
+                debug("DUP X2");
+                mv.visitInsn(DUP_X2);
+
+                debug("POP");
+                mv.visitInsn(POP);
+
+                debug("INVOKESPECIAL java/lang/Double.<init>::(D)V");
+                mv.visitMethodInsn(INVOKESPECIAL, "java/lang/Double", "<init>", "(D)V");
+            } else if (cls == short.class || cls == Short.class) {
+                debug("NEW java/lang/Short");
+                mv.visitTypeInsn(NEW, "java/lang/Short");
+
+                debug("DUP X1");
+                mv.visitInsn(DUP_X1);
+
+                debug("SWAP");
+                mv.visitInsn(SWAP);
+
+                debug("INVOKESPECIAL java/lang/Short.<init>::(S)V");
+                mv.visitMethodInsn(INVOKESPECIAL, "java/lang/Short", "<init>", "(S)V");
+            } else if (cls == long.class || cls == Long.class) {
+                debug("NEW java/lang/Long");
+                mv.visitTypeInsn(NEW, "java/lang/Long");
+
+                debug("DUP X1");
+                mv.visitInsn(DUP_X1);
+
+                debug("SWAP");
+                mv.visitInsn(SWAP);
+
+                debug("INVOKESPECIAL java/lang/Long.<init>::(L)V");
+                mv.visitMethodInsn(INVOKESPECIAL, "java/lang/Float", "<init>", "(L)V");
+            } else if (cls == byte.class || cls == Byte.class) {
+                debug("NEW java/lang/Byte");
+                mv.visitTypeInsn(NEW, "java/lang/Byte");
+
+                debug("DUP X1");
+                mv.visitInsn(DUP_X1);
+
+                debug("SWAP");
+                mv.visitInsn(SWAP);
+
+                debug("INVOKESPECIAL java/lang/Byte.<init>::(B)V");
+                mv.visitMethodInsn(INVOKESPECIAL, "java/lang/Byte", "<init>", "(B)V");
+            } else if (cls == char.class || cls == Character.class) {
+                debug("NEW java/lang/Character");
+                mv.visitTypeInsn(NEW, "java/lang/Character");
+
+                debug("DUP X1");
+                mv.visitInsn(DUP_X1);
+
+                debug("SWAP");
+                mv.visitInsn(SWAP);
+
+                debug("INVOKESPECIAL java/lang/Character.<init>::(C)V");
+                mv.visitMethodInsn(INVOKESPECIAL, "java/lang/Character", "<init>", "(C)V");
+            }
+        } else {
+            if (cls == boolean.class || cls == Boolean.class) {
+                debug("INVOKESTATIC java/lang/Boolean.valueOf");
+                mv.visitMethodInsn(INVOKESTATIC, "java/lang/Boolean", "valueOf", "(Z)Ljava/lang/Boolean;");
+            } else if (cls == int.class || cls == Integer.class) {
+                debug("INVOKESTATIC java/lang/Integer.valueOf");
+                mv.visitMethodInsn(INVOKESTATIC, "java/lang/Integer", "valueOf", "(I)Ljava/lang/Integer;");
+            } else if (cls == float.class || cls == Float.class) {
+                debug("INVOKESTATIC java/lang/Float.valueOf");
+                mv.visitMethodInsn(INVOKESTATIC, "java/lang/Float", "valueOf", "(F)Ljava/lang/Float;");
+            } else if (cls == double.class || cls == Double.class) {
+                debug("INVOKESTATIC java/lang/Double.valueOf");
+                mv.visitMethodInsn(INVOKESTATIC, "java/lang/Double", "valueOf", "(D)Ljava/lang/Double;");
+            } else if (cls == short.class || cls == Short.class) {
+                debug("INVOKESTATIC java/lang/Short.valueOf");
+                mv.visitMethodInsn(INVOKESTATIC, "java/lang/Short", "valueOf", "(S)Ljava/lang/Short;");
+            } else if (cls == long.class || cls == Long.class) {
+                debug("INVOKESTATIC java/lang/Long.valueOf");
+                mv.visitMethodInsn(INVOKESTATIC, "java/lang/Long", "valueOf", "(J)Ljava/lang/Long;");
+            } else if (cls == byte.class || cls == Byte.class) {
+                debug("INVOKESTATIC java/lang/Byte.valueOf");
+                mv.visitMethodInsn(INVOKESTATIC, "java/lang/Byte", "valueOf", "(B)Ljava/lang/Byte;");
+            } else if (cls == char.class || cls == Character.class) {
+                debug("INVOKESTATIC java/lang/Character.valueOf");
+                mv.visitMethodInsn(INVOKESTATIC, "java/lang/Character", "valueOf", "(C)Ljava/lang/Character;");
+            }
+        }
+    }
+
+    private void anyArrayCheck(Class cls) {
+        if (cls == boolean[].class) {
+            assert debug("CHECKCAST [Z");
+            mv.visitTypeInsn(CHECKCAST, "[Z");
+        } else if (cls == int[].class) {
+            assert debug("CHECKCAST [I");
+            mv.visitTypeInsn(CHECKCAST, "[I");
+        } else if (cls == float[].class) {
+            assert debug("CHECKCAST [F");
+            mv.visitTypeInsn(CHECKCAST, "[F");
+        } else if (cls == double[].class) {
+            assert debug("CHECKCAST [D");
+            mv.visitTypeInsn(CHECKCAST, "[D");
+        } else if (cls == short[].class) {
+            assert debug("CHECKCAST [S");
+            mv.visitTypeInsn(CHECKCAST, "[S");
+        } else if (cls == long[].class) {
+            assert debug("CHECKCAST [J");
+            mv.visitTypeInsn(CHECKCAST, "[J");
+        } else if (cls == byte[].class) {
+            assert debug("CHECKCAST [B");
+            mv.visitTypeInsn(CHECKCAST, "[B");
+        } else if (cls == char[].class) {
+            assert debug("CHECKCAST [C");
+            mv.visitTypeInsn(CHECKCAST, "[C");
+        } else {
+            assert debug("CHECKCAST [Ljava/lang/Object;");
+            mv.visitTypeInsn(CHECKCAST, "[Ljava/lang/Object;");
+        }
+    }
+
+    private void writeOutLiteralWrapped(Object lit) {
+        if (lit instanceof Integer) {
+            intPush((Integer) lit);
+            wrapPrimitive(int.class);
+            return;
+        }
+
+        assert debug("LDC " + lit);
+        if (lit instanceof String) {
+            mv.visitLdcInsn(lit);
+        } else if (lit instanceof Long) {
+            mv.visitLdcInsn(lit);
+            wrapPrimitive(long.class);
+        } else if (lit instanceof Float) {
+            mv.visitLdcInsn(lit);
+            wrapPrimitive(float.class);
+        } else if (lit instanceof Double) {
+            mv.visitLdcInsn(lit);
+            wrapPrimitive(double.class);
+        } else if (lit instanceof Short) {
+            mv.visitLdcInsn(lit);
+            wrapPrimitive(short.class);
+        } else if (lit instanceof Character) {
+            mv.visitLdcInsn(lit);
+            wrapPrimitive(char.class);
+        } else if (lit instanceof Boolean) {
+            mv.visitLdcInsn(lit);
+            wrapPrimitive(boolean.class);
+        } else if (lit instanceof Byte) {
+            mv.visitLdcInsn(lit);
+            wrapPrimitive(byte.class);
+        }
+    }
+
+    public void arrayStore(Class cls) {
+        if (cls.isPrimitive()) {
+            if (cls == int.class) {
+                assert debug("IASTORE");
+                mv.visitInsn(IASTORE);
+            } else if (cls == char.class) {
+                assert debug("CASTORE");
+                mv.visitInsn(CASTORE);
+            } else if (cls == boolean.class) {
+                assert debug("BASTORE");
+                mv.visitInsn(BASTORE);
+            } else if (cls == double.class) {
+                assert debug("DASTORE");
+                mv.visitInsn(DASTORE);
+            } else if (cls == float.class) {
+                assert debug("FASTORE");
+                mv.visitInsn(FASTORE);
+            } else if (cls == short.class) {
+                assert debug("SASTORE");
+                mv.visitInsn(SASTORE);
+            } else if (cls == long.class) {
+                assert debug("LASTORE");
+                mv.visitInsn(LASTORE);
+            } else if (cls == byte.class) {
+                assert debug("BASTORE");
+                mv.visitInsn(BASTORE);
+            }
+        } else {
+            assert debug("AASTORE");
+            mv.visitInsn(AASTORE);
+        }
+
+    }
+
+    public void wrapRuntimeConverstion(Class toType) {
+        ldcClassConstant(getWrapperClass(toType));
+
+        assert debug("INVOKESTATIC DataConversion.convert");
+        mv.visitMethodInsn(INVOKESTATIC, "" + NAMESPACE + "DataConversion", "convert",
+                "(Ljava/lang/Object;Ljava/lang/Class;)Ljava/lang/Object;");
+    }
+
+    private Object addSubstatement(ExecutableStatement stmt) {
+        if (stmt instanceof ExecutableAccessor) {
+            ExecutableAccessor ea = (ExecutableAccessor) stmt;
+            if (ea.getNode().isIdentifier() && !ea.getNode().isDeepProperty()) {
+                loadVariableByName(ea.getNode().getName());
+                return null;
+            }
+        }
+
+        compiledInputs.add(stmt);
+
+        assert debug("ALOAD 0");
+        mv.visitVarInsn(ALOAD, 0);
+
+        assert debug("GETFIELD p" + (compiledInputs.size() - 1));
+        mv.visitFieldInsn(GETFIELD, className, "p" + (compiledInputs.size() - 1), "L" + NAMESPACE + "compiler/ExecutableStatement;");
+
+        assert debug("ALOAD 2");
+        mv.visitVarInsn(ALOAD, 2);
+
+        assert debug("ALOAD 3");
+        mv.visitVarInsn(ALOAD, 3);
+
+        assert debug("INVOKEINTERFACE ExecutableStatement.getValue");
+        mv.visitMethodInsn(INVOKEINTERFACE, getInternalName(ExecutableStatement.class), "getValue",
+                "(Ljava/lang/Object;L" + NAMESPACE + "integration/VariableResolverFactory;)Ljava/lang/Object;");
+
+        return null;
+    }
+
+    private void loadVariableByName(String name) {
+        assert debug("ALOAD 3");
+        mv.visitVarInsn(ALOAD, 3);
+
+        assert debug("LDC \"" + name + "\"");
+        mv.visitLdcInsn(name);
+
+        assert debug("INVOKEINTERFACE " + NAMESPACE + "integration/VariableResolverFactory.getVariableResolver");
+        mv.visitMethodInsn(INVOKEINTERFACE, "" + NAMESPACE + "integration/VariableResolverFactory", "getVariableResolver",
+                "(Ljava/lang/String;)L" + NAMESPACE + "integration/VariableResolver;");
+
+        assert debug("INVOKEINTERFACE " + NAMESPACE + "integration/VariableResolver.getValue");
+        mv.visitMethodInsn(INVOKEINTERFACE, "" + NAMESPACE + "integration/VariableResolver", "getValue", "()Ljava/lang/Object;");
+
+        returnType = Object.class;
+    }
+
+    private void loadVariableByIndex(int pos) {
+        assert debug("ALOAD 3");
+        mv.visitVarInsn(ALOAD, 3);
+
+        assert debug("PUSH IDX VAL =" + pos);
+        intPush(pos);
+
+        assert debug("INVOKEINTERFACE " + NAMESPACE + "integration/VariableResolverFactory.getIndexedVariableResolver");
+        mv.visitMethodInsn(INVOKEINTERFACE, "" + NAMESPACE + "integration/VariableResolverFactory", "getIndexedVariableResolver",
+                "(I)L" + NAMESPACE + "integration/VariableResolver;");
+
+        assert debug("INVOKEINTERFACE " + NAMESPACE + "integration/VariableResolver.getValue");
+        mv.visitMethodInsn(INVOKEINTERFACE, "" + NAMESPACE + "integration/VariableResolver", "getValue", "()Ljava/lang/Object;");
+
+        returnType = Object.class;
+    }
+
+    private void loadField(int number) {
+        assert debug("ALOAD 0");
+        mv.visitVarInsn(ALOAD, 0);
+
+        assert debug("GETFIELD p" + number);
+        mv.visitFieldInsn(GETFIELD, className, "p" + number, "L" + NAMESPACE + "compiler/ExecutableStatement;");
+    }
+
+    private void ldcClassConstant(Class cls) {
+        if (OPCODES_VERSION == Opcodes.V1_4) {
+            assert debug("LDC \"" + cls.getName() + "\"");
+            mv.visitLdcInsn(cls.getName());
+            mv.visitMethodInsn(INVOKESTATIC, "java/lang/Class", "forName", "(Ljava/lang/String;)Ljava/lang/Class;");
+            Label l4 = new Label();
+            mv.visitJumpInsn(GOTO, l4);
+            mv.visitTypeInsn(NEW, "java/lang/NoClassDefFoundError");
+            mv.visitInsn(DUP_X1);
+            mv.visitInsn(SWAP);
+            mv.visitMethodInsn(INVOKEVIRTUAL, "java/lang/Throwable", "getMessage", "()Ljava/lang/String;");
+            mv.visitMethodInsn(INVOKESPECIAL, "java/lang/NoClassDefFoundError", "<init>", "(Ljava/lang/String;)V");
+            mv.visitInsn(ATHROW);
+            mv.visitLabel(l4);
+        } else {
+            assert debug("LDC " + getType(cls));
+            mv.visitLdcInsn(getType(cls));
+        }
+    }
+
+    private void buildInputs() {
+        if (compiledInputs.size() == 0) return;
+
+        assert debug("\n{SETTING UP MEMBERS...}\n");
+
+        StringAppender constSig = new StringAppender("(");
+        int size = compiledInputs.size();
+
+        for (int i = 0; i < size; i++) {
+            assert debug("ACC_PRIVATE p" + i);
+            cw.visitField(ACC_PRIVATE, "p" + i, "L" + NAMESPACE + "compiler/ExecutableStatement;", null, null).visitEnd();
+
+            constSig.append("L" + NAMESPACE + "compiler/ExecutableStatement;");
+        }
+        constSig.append(")V");
+
+        assert debug("\n{CREATING INJECTION CONSTRUCTOR}\n");
+
+        MethodVisitor cv = cw.visitMethod(ACC_PUBLIC, "<init>", constSig.toString(), null, null);
+        cv.visitCode();
+        assert debug("ALOAD 0");
+        cv.visitVarInsn(ALOAD, 0);
+        assert debug("INVOKESPECIAL java/lang/Object.<init>");
+        cv.visitMethodInsn(INVOKESPECIAL, "java/lang/Object", "<init>", "()V");
+
+        for (int i = 0; i < size; i++) {
+            assert debug("ALOAD 0");
+            cv.visitVarInsn(ALOAD, 0);
+            assert debug("ALOAD " + (i + 1));
+            cv.visitVarInsn(ALOAD, i + 1);
+            assert debug("PUTFIELD p" + i);
+            cv.visitFieldInsn(PUTFIELD, className, "p" + i, "L" + NAMESPACE + "compiler/ExecutableStatement;");
+        }
+
+        assert debug("RETURN");
+        cv.visitInsn(RETURN);
+        cv.visitMaxs(0, 0);
+        cv.visitEnd();
+
+        assert debug("}");
+    }
+
+    private int _getAccessor(Object o, Class type) {
+        if (o instanceof List) {
+            assert debug("NEW " + LIST_IMPL);
+            mv.visitTypeInsn(NEW, LIST_IMPL);
+
+            assert debug("DUP");
+            mv.visitInsn(DUP);
+
+            assert debug("DUP");
+            mv.visitInsn(DUP);
+
+            intPush(((List) o).size());
+            assert debug("INVOKESPECIAL " + LIST_IMPL + ".<init>");
+            mv.visitMethodInsn(INVOKESPECIAL, LIST_IMPL, "<init>", "(I)V");
+
+            for (Object item : (List) o) {
+                if (_getAccessor(item, type) != VAL) {
+                    assert debug("POP");
+                    mv.visitInsn(POP);
+                }
+
+                assert debug("INVOKEINTERFACE java/util/List.add");
+                mv.visitMethodInsn(INVOKEINTERFACE, "java/util/List", "add", "(Ljava/lang/Object;)Z");
+
+                assert debug("POP");
+                mv.visitInsn(POP);
+
+                assert debug("DUP");
+                mv.visitInsn(DUP);
+            }
+
+            returnType = List.class;
+
+            return LIST;
+        } else if (o instanceof Map) {
+            assert debug("NEW " + MAP_IMPL);
+            mv.visitTypeInsn(NEW, MAP_IMPL);
+
+            assert debug("DUP");
+            mv.visitInsn(DUP);
+
+            assert debug("DUP");
+            mv.visitInsn(DUP);
+
+            intPush(((Map) o).size());
+
+            assert debug("INVOKESPECIAL " + MAP_IMPL + ".<init>");
+            mv.visitMethodInsn(INVOKESPECIAL, MAP_IMPL, "<init>", "(I)V");
+
+            for (Object item : ((Map) o).keySet()) {
+                mv.visitTypeInsn(CHECKCAST, "java/util/Map");
+
+                if (_getAccessor(item, type) != VAL) {
+                    assert debug("POP");
+                    mv.visitInsn(POP);
+                }
+                if (_getAccessor(((Map) o).get(item), type) != VAL) {
+                    assert debug("POP");
+                    mv.visitInsn(POP);
+                }
+
+                assert debug("INVOKEINTERFACE java/util/Map.put");
+                mv.visitMethodInsn(INVOKEINTERFACE, "java/util/Map", "put", "(Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;");
+
+                assert debug("POP");
+                mv.visitInsn(POP);
+
+                assert debug("DUP");
+                mv.visitInsn(DUP);
+            }
+
+            returnType = Map.class;
+
+            return MAP;
+        } else if (o instanceof Object[]) {
+            Accessor[] a = new Accessor[((Object[]) o).length];
+            int i = 0;
+            int dim = 0;
+
+            if (type != null) {
+                String nm = type.getName();
+                while (nm.charAt(dim) == '[')
+                    dim++;
+            } else {
+                type = Object[].class;
+                dim = 1;
+            }
+
+            try {
+                intPush(((Object[]) o).length);
+                assert debug("ANEWARRAY " + getInternalName(getSubComponentType(type)) + " (" + ((Object[]) o).length + ")");
+                mv.visitTypeInsn(ANEWARRAY, getInternalName(getSubComponentType(type)));
+
+                Class cls = dim > 1 ? findClass(null, repeatChar('[', dim - 1) + "L" + getBaseComponentType(type).getName() + ";",
+                        pCtx) : type;
+
+                assert debug("DUP");
+                mv.visitInsn(DUP);
+
+                for (Object item : (Object[]) o) {
+                    intPush(i);
+
+                    if (_getAccessor(item, cls) != VAL) {
+                        assert debug("POP");
+                        mv.visitInsn(POP);
+                    }
+
+                    assert debug("AASTORE (" + o.hashCode() + ")");
+                    mv.visitInsn(AASTORE);
+
+                    assert debug("DUP");
+                    mv.visitInsn(DUP);
+
+                    i++;
+                }
+
+            } catch (ClassNotFoundException e) {
+                throw new RuntimeException("this error should never throw:" + getBaseComponentType(type).getName(), e);
+            }
+
+            return ARRAY;
+        } else {
+            if (type.isArray()) {
+                writeLiteralOrSubexpression(subCompileExpression(((String) o).toCharArray(), pCtx), getSubComponentType(type));
+            } else {
+                writeLiteralOrSubexpression(subCompileExpression(((String) o).toCharArray(), pCtx));
+            }
+            return VAL;
+        }
+    }
+
+    private Class writeLiteralOrSubexpression(Object stmt) {
+        return writeLiteralOrSubexpression(stmt, null, null);
+    }
+
+    private Class writeLiteralOrSubexpression(Object stmt, Class desiredTarget) {
+        return writeLiteralOrSubexpression(stmt, desiredTarget, null);
+    }
+
+    private Class writeLiteralOrSubexpression(Object stmt, Class desiredTarget, Class knownIngressType) {
+        if (stmt instanceof ExecutableLiteral) {
+            Object literalValue = ((ExecutableLiteral) stmt).getLiteral();
+
+            // Handle the case when the literal is null MVEL-312
+            if (literalValue == null) {
+                mv.visitInsn(ACONST_NULL);
+                return null;
+            }
+
+            Class type = literalValue == null ? desiredTarget : literalValue.getClass();
+
+            assert debug("*** type:" + type + ";desired:" + desiredTarget);
+
+            if (type == Integer.class && desiredTarget == int.class) {
+                intPush(((ExecutableLiteral) stmt).getInteger32());
+                type = int.class;
+            } else if (desiredTarget != null && desiredTarget != type) {
+                assert debug("*** Converting because desiredType(" + desiredTarget.getClass() + ") is not: " + type);
+
+                if (!DataConversion.canConvert(type, desiredTarget)) {
+                    throw new CompileException("was expecting type: " + desiredTarget.getName() + "; but found type: " + type.getName(),
+                            expr, st);
+                }
+                writeOutLiteralWrapped(convert(literalValue, desiredTarget));
+            } else {
+                writeOutLiteralWrapped(literalValue);
+            }
+
+            return type;
+        } else {
+            literal = false;
+
+            addSubstatement((ExecutableStatement) stmt);
+
+            Class type;
+            if (knownIngressType == null) {
+                type = ((ExecutableStatement) stmt).getKnownEgressType();
+            } else {
+                type = knownIngressType;
+            }
+
+            if (desiredTarget != null && type != desiredTarget) {
+                if (desiredTarget.isPrimitive()) {
+                    if (type == null) throw new OptimizationFailure(
+                            "cannot optimize expression: " + new String(expr) + ": cannot determine ingress type for primitive output");
+
+                    checkcast(type);
+                    unwrapPrimitive(desiredTarget);
+                }
+            }
+
+            return type;
+        }
+    }
+
+    private void addPrintOut(String text) {
+        mv.visitFieldInsn(GETSTATIC, "java/lang/System", "out", "Ljava/io/PrintStream;");
+        mv.visitLdcInsn(text);
+        mv.visitMethodInsn(INVOKEVIRTUAL, "java/io/PrintStream", "println", "(Ljava/lang/String;)V");
+    }
+
+    public Accessor optimizeCollection(ParserContext pCtx, Object o, Class type, char[] property, int start, int offset, Object ctx,
+            Object thisRef, VariableResolverFactory factory) {
+        this.expr = property;
+        this.cursor = this.start = start;
+        this.end = start + offset;
+        this.length = offset;
+
+        type = toNonPrimitiveArray(type);
+        this.returnType = type;
+
+        this.compiledInputs = new ArrayList<ExecutableStatement>();
+
+        this.ctx = ctx;
+        this.thisRef = thisRef;
+        this.variableFactory = factory;
+        this.pCtx = pCtx;
+
+        _initJIT();
+
+        literal = true;
+
+        _getAccessor(o, type);
+
+        _finishJIT();
+
+        try {
+            Accessor compiledAccessor = _initializeAccessor();
+
+            if (property != null && length > start) {
+                return new Union(pCtx, compiledAccessor, property, start, length);
+            } else {
+                return compiledAccessor;
+            }
+
+        } catch (Exception e) {
+            throw new OptimizationFailure("could not optimize collection", e);
+        }
+    }
+
+    private void checkcast(Class cls) {
+        assert debug("CHECKCAST " + getInternalName(cls));
+        mv.visitTypeInsn(CHECKCAST, getInternalName(cls));
+    }
+
+    private void intPush(int index) {
+        if (index >= 0 && index < 6) {
+            switch (index) {
+                case 0:
+                    assert debug("ICONST_0");
+                    mv.visitInsn(ICONST_0);
+                    break;
+                case 1:
+                    assert debug("ICONST_1");
+                    mv.visitInsn(ICONST_1);
+                    break;
+                case 2:
+                    assert debug("ICONST_2");
+                    mv.visitInsn(ICONST_2);
+                    break;
+                case 3:
+                    assert debug("ICONST_3");
+                    mv.visitInsn(ICONST_3);
+                    break;
+                case 4:
+                    assert debug("ICONST_4");
+                    mv.visitInsn(ICONST_4);
+                    break;
+                case 5:
+                    assert debug("ICONST_5");
+                    mv.visitInsn(ICONST_5);
+                    break;
+            }
+        } else if (index > -127 && index < 128) {
+            assert debug("BIPUSH " + index);
+            mv.visitIntInsn(BIPUSH, index);
+        } else if (index > Short.MAX_VALUE) {
+            assert debug("LDC " + index);
+            mv.visitLdcInsn(index);
+        } else {
+            assert debug("SIPUSH " + index);
+            mv.visitIntInsn(SIPUSH, index);
+        }
+    }
+
+    public Accessor optimizeObjectCreation(ParserContext pCtx, char[] property, int start, int offset, Object ctx, Object thisRef,
+            VariableResolverFactory factory) {
+        _initJIT();
+
+        compiledInputs = new ArrayList<ExecutableStatement>();
+        this.start = cursor = start;
+        this.end = start + offset;
+        this.length = this.end - this.start;
+        this.ctx = ctx;
+        this.thisRef = thisRef;
+        this.variableFactory = factory;
+        this.pCtx = pCtx;
+
+        String[] cnsRes = captureContructorAndResidual(property, start, offset);
+        List<char[]> constructorParms = parseMethodOrConstructor(cnsRes[0].toCharArray());
+
+        try {
+            if (constructorParms != null) {
+                for (char[] constructorParm : constructorParms) {
+                    compiledInputs.add((ExecutableStatement) subCompileExpression(constructorParm, pCtx));
+                }
+
+                Class cls = findClass(factory, new String(subset(property, 0, findFirst('(', start, length, property))), pCtx);
+
+                assert debug("NEW " + getInternalName(cls));
+                mv.visitTypeInsn(NEW, getInternalName(cls));
+                assert debug("DUP");
+                mv.visitInsn(DUP);
+
+                Object[] parms = new Object[constructorParms.size()];
+
+                int i = 0;
+                for (ExecutableStatement es : compiledInputs) {
+                    parms[i++] = es.getValue(ctx, factory);
+                }
+
+                Constructor cns = getBestConstructorCandidate(parms, cls, pCtx.isStrongTyping());
+
+                if (cns == null) {
+                    StringBuilder error = new StringBuilder();
+                    for (int x = 0; x < parms.length; x++) {
+                        error.append(parms[x].getClass().getName());
+                        if (x + 1 < parms.length) error.append(", ");
+                    }
+
+                    throw new CompileException("unable to find constructor: " + cls.getName() + "(" + error.toString() + ")", expr, st);
+                }
+
+                this.returnType = cns.getDeclaringClass();
+
+                Class tg;
+                for (i = 0; i < constructorParms.size(); i++) {
+                    assert debug("ALOAD 0");
+                    mv.visitVarInsn(ALOAD, 0);
+                    assert debug("GETFIELD p" + i);
+                    mv.visitFieldInsn(GETFIELD, className, "p" + i, "L" + NAMESPACE + "compiler/ExecutableStatement;");
+                    assert debug("ALOAD 2");
+                    mv.visitVarInsn(ALOAD, 2);
+                    assert debug("ALOAD 3");
+                    mv.visitVarInsn(ALOAD, 3);
+                    assert debug("INVOKEINTERFACE " + NAMESPACE + "compiler/ExecutableStatement.getValue");
+                    mv.visitMethodInsn(INVOKEINTERFACE, "" + NAMESPACE + "compiler/ExecutableStatement", "getValue",
+                            "(Ljava/lang/Object;L" + NAMESPACE + "integration/VariableResolverFactory;)Ljava/lang/Object;");
+
+                    tg = cns.getParameterTypes()[i]
+                            .isPrimitive() ? getWrapperClass(cns.getParameterTypes()[i]) : cns.getParameterTypes()[i];
+
+                    if (parms[i] != null && !parms[i].getClass().isAssignableFrom(cns.getParameterTypes()[i])) {
+                        ldcClassConstant(tg);
+
+                        assert debug("INVOKESTATIC " + NAMESPACE + "DataConversion.convert");
+                        mv.visitMethodInsn(INVOKESTATIC, "" + NAMESPACE + "DataConversion", "convert",
+                                "(Ljava/lang/Object;Ljava/lang/Class;)Ljava/lang/Object;");
+
+                        if (cns.getParameterTypes()[i].isPrimitive()) {
+                            unwrapPrimitive(cns.getParameterTypes()[i]);
+                        } else {
+                            assert debug("CHECKCAST " + getInternalName(tg));
+                            mv.visitTypeInsn(CHECKCAST, getInternalName(tg));
+                        }
+
+                    } else {
+                        assert debug("CHECKCAST " + getInternalName(cns.getParameterTypes()[i]));
+                        mv.visitTypeInsn(CHECKCAST, getInternalName(cns.getParameterTypes()[i]));
+                    }
+
+                }
+
+                assert debug("INVOKESPECIAL " + getInternalName(cls) + ".<init> : " + getConstructorDescriptor(cns));
+                mv.visitMethodInsn(INVOKESPECIAL, getInternalName(cls), "<init>", getConstructorDescriptor(cns));
+
+                _finishJIT();
+
+                Accessor acc = _initializeAccessor();
+
+                if (cnsRes.length > 1 && cnsRes[1] != null && !cnsRes[1].trim().equals("")) {
+                    return new Union(pCtx, acc, cnsRes[1].toCharArray(), 0, cnsRes[1].length());
+                }
+
+                return acc;
+            } else {
+                Class cls = findClass(factory, new String(property), pCtx);
+
+                assert debug("NEW " + getInternalName(cls));
+                mv.visitTypeInsn(NEW, getInternalName(cls));
+                assert debug("DUP");
+                mv.visitInsn(DUP);
+
+                Constructor cns = cls.getConstructor(EMPTYCLS);
+
+                assert debug("INVOKESPECIAL <init>");
+
+                mv.visitMethodInsn(INVOKESPECIAL, getInternalName(cls), "<init>", getConstructorDescriptor(cns));
+
+                _finishJIT();
+                Accessor acc = _initializeAccessor();
+
+                if (cnsRes.length > 1 && cnsRes[1] != null && !cnsRes[1].trim().equals("")) {
+                    return new Union(pCtx, acc, cnsRes[1].toCharArray(), 0, cnsRes[1].length());
+                }
+
+                return acc;
+            }
+        } catch (ClassNotFoundException e) {
+            throw new CompileException("class or class reference not found: " + new String(property), property, st);
+        } catch (Exception e) {
+            throw new OptimizationFailure("could not optimize construtor: " + new String(property), e);
+        }
+    }
+
+    public Class getEgressType() {
+        return returnType;
+    }
+
+    private void dumpAdvancedDebugging() {
+        if (buildLog == null) return;
+
+        System.out
+                .println("JIT Compiler Dump for: <<" + (expr == null ? null : new String(expr)) + ">>\n-------------------------------\n");
+        System.out.println(buildLog.toString());
+        System.out.println("\n<END OF DUMP>\n");
+        if (MVEL.isFileDebugging()) {
+            try {
+                FileWriter writer = ParseTools.getDebugFileWriter();
+                writer.write(buildLog.toString());
+                writer.flush();
+                writer.close();
+            } catch (IOException e) {
+                //empty
+            }
+        }
+    }
+
+    private Object propHandlerByteCode(String property, Object ctx, Class handler) {
+        PropertyHandler ph = getPropertyHandler(handler);
+        if (ph instanceof ProducesBytecode) {
+            assert debug("<<3rd-Party Code Generation>>");
+            ((ProducesBytecode) ph).produceBytecodeGet(mv, property, variableFactory);
+            return ph.getProperty(property, ctx, variableFactory);
+        } else {
+            throw new RuntimeException(
+                    "unable to compileShared: custom accessor does not support producing bytecode: " + ph.getClass().getName());
+        }
+    }
+
+    private void propHandlerByteCodePut(String property, Object ctx, Class handler, Object value) {
+        PropertyHandler ph = getPropertyHandler(handler);
+        if (ph instanceof ProducesBytecode) {
+            assert debug("<<3rd-Party Code Generation>>");
+            ((ProducesBytecode) ph).produceBytecodePut(mv, property, variableFactory);
+            ph.setProperty(property, ctx, variableFactory, value);
+        } else {
+            throw new RuntimeException(
+                    "unable to compileShared: custom accessor does not support producing bytecode: " + ph.getClass().getName());
+        }
+    }
+
+    private void writeOutNullHandler(Member member, int type) {
+
+        assert debug("DUP");
+        mv.visitInsn(DUP);
+
+        Label j = new Label();
+
+        assert debug("IFNONNULL : jump");
+        mv.visitJumpInsn(IFNONNULL, j);
+
+        assert debug("POP");
+        mv.visitInsn(POP);
+
+        assert debug("ALOAD 0");
+        mv.visitVarInsn(ALOAD, 0);
+
+        if (type == 0) {
+            this.propNull = true;
+
+            assert debug("GETFIELD 'nullPropertyHandler'");
+            mv.visitFieldInsn(GETFIELD, className, "nullPropertyHandler", "L" + NAMESPACE + "integration/PropertyHandler;");
+        } else {
+            this.methNull = true;
+
+            assert debug("GETFIELD 'nullMethodHandler'");
+            mv.visitFieldInsn(GETFIELD, className, "nullMethodHandler", "L" + NAMESPACE + "integration/PropertyHandler;");
+        }
+
+        assert debug("LDC '" + member.getName() + "'");
+        mv.visitLdcInsn(member.getName());
+
+        assert debug("ALOAD 1");
+        mv.visitVarInsn(ALOAD, 1);
+
+        assert debug("ALOAD 3");
+        mv.visitVarInsn(ALOAD, 3);
+
+        assert debug("INVOKEINTERFACE PropertyHandler.getProperty");
+        mv.visitMethodInsn(INVOKEINTERFACE, NAMESPACE + "integration/PropertyHandler", "getProperty",
+                "(Ljava/lang/String;Ljava/lang/Object;L" + NAMESPACE + "integration/VariableResolverFactory;)Ljava/lang/Object;");
+
+        assert debug("LABEL:jump");
+        mv.visitLabel(j);
+
+    }
+
+    public boolean isLiteralOnly() {
+        return literal;
+    }
+
+    private static class ContextClassLoader extends ClassLoader {
+
+        ContextClassLoader(ClassLoader classLoader) {
+            super(classLoader);
+        }
+
+        Class<?> defineClass(String name, byte[] b) {
+            return defineClass(name, b, 0, b.length);
+        }
+    }
+}

--- a/core/src/main/java/org/mvel2/optimizers/impl/asm/ProducesBytecode.java
+++ b/core/src/main/java/org/mvel2/optimizers/impl/asm/ProducesBytecode.java
@@ -1,0 +1,53 @@
+/**
+ * MVEL 2.0
+ * Copyright (C) 2007 The Codehaus
+ * Mike Brock, Dhanji Prasanna, John Graham, Mark Proctor
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mvel2.optimizers.impl.asm;
+
+import org.mvel2.asm.MethodVisitor;
+import org.mvel2.integration.VariableResolverFactory;
+
+/**
+ * A {@link org.mvel2.integration.PropertyHandler} that implements this class advertises the to the
+ * {@link ASMAccessorOptimizer} that it is able to generate bytecode for it's custom resolvers.<br/>
+ * <br/>
+ * The two methods defined by this interface (one for get, and one for set accessors) are passed an
+ * ASM MethodVistor object.  It is to be assumed by the implementor that the JIT has already produced
+ * the necessary bytecode up until this point.  The implementor most only implement the necessary bytecode
+ * instructions to retrieve the property, leaving the resultant value on the stack.  <b>DO NOT</b> implement
+ * bytecode that calls a return instruction such as ARETURN.  This will be done automatically by the JIT.<br/>
+ * <br/>
+ * See the following example:<br/>
+ * <pre><code>
+ *   public void produceBytecodeGet(MethodVisitor mv, String propertyName, VariableResolverFactory variableResolverFactory) {
+ * mv.visitTypeInsn(CHECKCAST, "org/mvel/tests/main/res/SampleBean");
+ * mv.visitLdcInsn(propertyName);
+ * mv.visitMethodInsn(INVOKEVIRTUAL, "org/mvel/tests/main/res/SampleBean", "getProperty", "(Ljava/lang/String;)Ljava/lang/Object;");
+ * }
+ * </code></pre><br/>
+ * This example (correctly) presumes that the property of interest exists on the stack, and simply performs the necessary
+ * CHECKCAST, and call to the needed method in the accessor to translate the property call. <br/>
+ * <br/>
+ * This is taken from a working example which you can examine in the MVEL unit tests.
+ * The class is: org.mvel.tests.main.res.SampleBeanAccessor
+ */
+public interface ProducesBytecode {
+
+    public void produceBytecodeGet(MethodVisitor mv, String propertyName, VariableResolverFactory factory);
+
+    public void produceBytecodePut(MethodVisitor mv, String propertyName, VariableResolverFactory factory);
+}

--- a/core/src/main/java/org/mvel2/optimizers/impl/refl/ReflectiveAccessorOptimizer.java
+++ b/core/src/main/java/org/mvel2/optimizers/impl/refl/ReflectiveAccessorOptimizer.java
@@ -1,0 +1,1255 @@
+/**
+ * MVEL 2.0
+ * Copyright (C) 2007 The Codehaus
+ * Mike Brock, Dhanji Prasanna, John Graham, Mark Proctor
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.mvel2.optimizers.impl.refl;
+
+import static java.lang.Integer.parseInt;
+import static java.lang.Thread.currentThread;
+import static java.lang.reflect.Array.getLength;
+import static org.mvel2.DataConversion.canConvert;
+import static org.mvel2.DataConversion.convert;
+import static org.mvel2.MVEL.eval;
+import static org.mvel2.ast.TypeDescriptor.getClassReference;
+import static org.mvel2.integration.GlobalListenerFactory.hasSetListeners;
+import static org.mvel2.integration.GlobalListenerFactory.notifyGetListeners;
+import static org.mvel2.integration.GlobalListenerFactory.notifySetListeners;
+import static org.mvel2.integration.PropertyHandlerFactory.getNullMethodHandler;
+import static org.mvel2.integration.PropertyHandlerFactory.getNullPropertyHandler;
+import static org.mvel2.integration.PropertyHandlerFactory.getPropertyHandler;
+import static org.mvel2.integration.PropertyHandlerFactory.hasNullMethodHandler;
+import static org.mvel2.integration.PropertyHandlerFactory.hasNullPropertyHandler;
+import static org.mvel2.integration.PropertyHandlerFactory.hasPropertyHandler;
+import static org.mvel2.util.CompilerTools.expectType;
+import static org.mvel2.util.ParseTools.EMPTY_OBJ_ARR;
+import static org.mvel2.util.ParseTools.balancedCapture;
+import static org.mvel2.util.ParseTools.balancedCaptureWithLineAccounting;
+import static org.mvel2.util.ParseTools.captureContructorAndResidual;
+import static org.mvel2.util.ParseTools.determineActualTargetMethod;
+import static org.mvel2.util.ParseTools.findClass;
+import static org.mvel2.util.ParseTools.getBaseComponentType;
+import static org.mvel2.util.ParseTools.getBestCandidate;
+import static org.mvel2.util.ParseTools.getBestConstructorCandidate;
+import static org.mvel2.util.ParseTools.getSubComponentType;
+import static org.mvel2.util.ParseTools.getWidenedTarget;
+import static org.mvel2.util.ParseTools.parseMethodOrConstructor;
+import static org.mvel2.util.ParseTools.parseParameterList;
+import static org.mvel2.util.ParseTools.repeatChar;
+import static org.mvel2.util.ParseTools.subCompileExpression;
+import static org.mvel2.util.ParseTools.subset;
+import static org.mvel2.util.PropertyTools.getFieldOrAccessor;
+import static org.mvel2.util.PropertyTools.getFieldOrWriteAccessor;
+import static org.mvel2.util.ReflectionUtil.toNonPrimitiveType;
+import static org.mvel2.util.Varargs.normalizeArgsForVarArgs;
+import static org.mvel2.util.Varargs.paramTypeVarArgsSafe;
+
+import java.lang.reflect.Array;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Member;
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.util.List;
+import java.util.Map;
+
+import org.mvel2.CompileException;
+import org.mvel2.MVEL;
+import org.mvel2.OptimizationFailure;
+import org.mvel2.ParserContext;
+import org.mvel2.PropertyAccessException;
+import org.mvel2.ast.FunctionInstance;
+import org.mvel2.ast.TypeDescriptor;
+import org.mvel2.compiler.Accessor;
+import org.mvel2.compiler.AccessorNode;
+import org.mvel2.compiler.ExecutableLiteral;
+import org.mvel2.compiler.ExecutableStatement;
+import org.mvel2.compiler.PropertyVerifier;
+import org.mvel2.integration.GlobalListenerFactory;
+import org.mvel2.integration.PropertyHandler;
+import org.mvel2.integration.VariableResolver;
+import org.mvel2.integration.VariableResolverFactory;
+import org.mvel2.optimizers.AbstractOptimizer;
+import org.mvel2.optimizers.AccessorOptimizer;
+import org.mvel2.optimizers.impl.refl.collection.ArrayCreator;
+import org.mvel2.optimizers.impl.refl.collection.ExprValueAccessor;
+import org.mvel2.optimizers.impl.refl.collection.ListCreator;
+import org.mvel2.optimizers.impl.refl.collection.MapCreator;
+import org.mvel2.optimizers.impl.refl.nodes.ArrayAccessor;
+import org.mvel2.optimizers.impl.refl.nodes.ArrayAccessorNest;
+import org.mvel2.optimizers.impl.refl.nodes.ArrayLength;
+import org.mvel2.optimizers.impl.refl.nodes.ConstructorAccessor;
+import org.mvel2.optimizers.impl.refl.nodes.DynamicFieldAccessor;
+import org.mvel2.optimizers.impl.refl.nodes.DynamicFunctionAccessor;
+import org.mvel2.optimizers.impl.refl.nodes.FieldAccessor;
+import org.mvel2.optimizers.impl.refl.nodes.FieldAccessorNH;
+import org.mvel2.optimizers.impl.refl.nodes.FunctionAccessor;
+import org.mvel2.optimizers.impl.refl.nodes.GetterAccessor;
+import org.mvel2.optimizers.impl.refl.nodes.GetterAccessorNH;
+import org.mvel2.optimizers.impl.refl.nodes.IndexedCharSeqAccessor;
+import org.mvel2.optimizers.impl.refl.nodes.IndexedCharSeqAccessorNest;
+import org.mvel2.optimizers.impl.refl.nodes.IndexedVariableAccessor;
+import org.mvel2.optimizers.impl.refl.nodes.ListAccessor;
+import org.mvel2.optimizers.impl.refl.nodes.ListAccessorNest;
+import org.mvel2.optimizers.impl.refl.nodes.MapAccessor;
+import org.mvel2.optimizers.impl.refl.nodes.MapAccessorNest;
+import org.mvel2.optimizers.impl.refl.nodes.MethodAccessor;
+import org.mvel2.optimizers.impl.refl.nodes.MethodAccessorNH;
+import org.mvel2.optimizers.impl.refl.nodes.Notify;
+import org.mvel2.optimizers.impl.refl.nodes.NullSafe;
+import org.mvel2.optimizers.impl.refl.nodes.PropertyHandlerAccessor;
+import org.mvel2.optimizers.impl.refl.nodes.SetterAccessor;
+import org.mvel2.optimizers.impl.refl.nodes.StaticReferenceAccessor;
+import org.mvel2.optimizers.impl.refl.nodes.StaticVarAccessor;
+import org.mvel2.optimizers.impl.refl.nodes.StaticVarAccessorNH;
+import org.mvel2.optimizers.impl.refl.nodes.ThisValueAccessor;
+import org.mvel2.optimizers.impl.refl.nodes.Union;
+import org.mvel2.optimizers.impl.refl.nodes.VariableAccessor;
+import org.mvel2.optimizers.impl.refl.nodes.WithAccessor;
+import org.mvel2.util.ArrayTools;
+import org.mvel2.util.ErrorUtil;
+import org.mvel2.util.MethodStub;
+import org.mvel2.util.NullType;
+import org.mvel2.util.ParseTools;
+import org.mvel2.util.PropertyTools;
+import org.mvel2.util.StringAppender;
+
+public class ReflectiveAccessorOptimizer extends AbstractOptimizer implements AccessorOptimizer {
+
+    private static final int DONE = -1;
+    private static final Object[] EMPTYARG = new Object[0];
+    private static final Class[] EMPTYCLS = new Class[0];
+    private AccessorNode rootNode;
+    private AccessorNode currNode;
+    private Object ctx;
+    private Object thisRef;
+    private Object val;
+    private VariableResolverFactory variableFactory;
+    private boolean first = true;
+
+    private Class ingressType;
+    private Class returnType;
+
+    public ReflectiveAccessorOptimizer() {
+    }
+
+    private ReflectiveAccessorOptimizer(ParserContext pCtx, char[] property, int start, int offset, Object ctx, Object thisRef,
+            VariableResolverFactory variableFactory) {
+        super(pCtx);
+        this.expr = property;
+        this.start = start;
+        this.length = property != null ? offset : start;
+        this.end = start + length;
+        this.ctx = ctx;
+        this.variableFactory = variableFactory;
+        this.thisRef = thisRef;
+    }
+
+    public void init() {
+    }
+
+    public Accessor optimizeAccessor(ParserContext pCtx, char[] property, int start, int offset, Object ctx, Object thisRef,
+            VariableResolverFactory factory, boolean root, Class ingressType) {
+        this.rootNode = this.currNode = null;
+        this.expr = property;
+        this.start = start;
+        this.end = start + offset;
+        this.length = end - start;
+
+        this.first = true;
+        this.ctx = ctx;
+        this.thisRef = thisRef;
+        this.variableFactory = factory;
+        this.ingressType = ingressType;
+
+        this.pCtx = pCtx;
+
+        return compileGetChain();
+    }
+
+    public Accessor optimizeSetAccessor(ParserContext pCtx, char[] property, int start, int offset, Object ctx, Object thisRef,
+            VariableResolverFactory factory, boolean rootThisRef, Object value, Class ingressType) {
+        this.rootNode = this.currNode = null;
+        this.expr = property;
+        this.start = start;
+        this.first = true;
+
+        this.length = start + offset;
+        this.ctx = ctx;
+        this.thisRef = thisRef;
+        this.variableFactory = factory;
+        this.ingressType = ingressType;
+
+        char[] root = null;
+
+        int split = findLastUnion();
+
+        PropertyVerifier verifier = new PropertyVerifier(property, this.pCtx = pCtx);
+
+        if (split != -1) {
+            root = subset(property, 0, split++);
+            //todo: must use the property verifier.
+            property = subset(property, split, property.length - split);
+        }
+
+        if (root != null) {
+            this.length = end = (this.expr = root).length;
+
+            compileGetChain();
+            ctx = this.val;
+        }
+
+        if (ctx == null) {
+            throw new PropertyAccessException("could not access property: "
+                    + new String(property, this.start, Math.min(length, property.length)) + "; parent is null: " + new String(expr), expr,
+                    this.start, pCtx);
+        }
+
+        try {
+            this.length = end = (this.expr = property).length;
+            int st;
+            this.cursor = st = 0;
+
+            skipWhitespace();
+
+            if (collection) {
+                st = cursor;
+
+                if (cursor == end) throw new PropertyAccessException("unterminated '['", expr, this.start, pCtx);
+
+                if (scanTo(']')) throw new PropertyAccessException("unterminated '['", expr, this.start, pCtx);
+
+                String ex = new String(property, st, cursor - st);
+
+                if (ctx instanceof Map) {
+                    if (MVEL.COMPILER_OPT_ALLOW_OVERRIDE_ALL_PROPHANDLING && hasPropertyHandler(Map.class)) {
+                        propHandlerSet(ex, ctx, Map.class, value);
+                    } else {
+                        //noinspection unchecked
+                        ((Map) ctx).put(eval(ex, ctx, variableFactory), convert(value, returnType = verifier.analyze()));
+
+                        addAccessorNode(new MapAccessorNest(ex, returnType));
+                    }
+
+                    return rootNode;
+                } else if (ctx instanceof List) {
+                    if (MVEL.COMPILER_OPT_ALLOW_OVERRIDE_ALL_PROPHANDLING && hasPropertyHandler(List.class)) {
+                        propHandlerSet(ex, ctx, List.class, value);
+                    } else {
+                        //noinspection unchecked
+                        ((List) ctx).set(eval(ex, ctx, variableFactory, Integer.class), convert(value, returnType = verifier.analyze()));
+
+                        addAccessorNode(new ListAccessorNest(ex, returnType));
+                    }
+
+                    return rootNode;
+                } else if (MVEL.COMPILER_OPT_ALLOW_OVERRIDE_ALL_PROPHANDLING && hasPropertyHandler(ctx.getClass())) {
+                    propHandlerSet(ex, ctx, ctx.getClass(), value);
+                    return rootNode;
+                } else if (ctx.getClass().isArray()) {
+                    if (MVEL.COMPILER_OPT_ALLOW_OVERRIDE_ALL_PROPHANDLING && hasPropertyHandler(Array.class)) {
+                        propHandlerSet(ex, ctx, Array.class, value);
+                    } else {
+                        //noinspection unchecked
+                        Array.set(ctx, eval(ex, ctx, variableFactory, Integer.class), convert(value, getBaseComponentType(ctx.getClass())));
+                        addAccessorNode(new ArrayAccessorNest(ex));
+                    }
+                    return rootNode;
+                } else {
+                    throw new PropertyAccessException("cannot bind to collection property: " + new String(property)
+                            + ": not a recognized collection type: " + ctx.getClass(), expr, this.st, pCtx);
+                }
+            } else if (MVEL.COMPILER_OPT_ALLOW_OVERRIDE_ALL_PROPHANDLING && hasPropertyHandler(ctx.getClass())) {
+                propHandlerSet(new String(property), ctx, ctx.getClass(), value);
+                return rootNode;
+            }
+
+            String tk = new String(property, 0, length).trim();
+
+            if (hasSetListeners()) {
+                notifySetListeners(ctx, tk, variableFactory, value);
+                addAccessorNode(new Notify(tk));
+            }
+
+            Member member = getFieldOrWriteAccessor(ctx.getClass(), tk, value == null ? null : ingressType);
+
+            if (member instanceof Field) {
+                Field fld = (Field) member;
+
+                if (value != null && !fld.getType().isAssignableFrom(value.getClass())) {
+                    if (!canConvert(fld.getType(), value.getClass())) {
+                        throw new CompileException("cannot convert type: " + value.getClass() + ": to " + fld.getType(), this.expr,
+                                this.start);
+                    }
+
+                    fld.set(ctx, convert(value, fld.getType()));
+                    addAccessorNode(new DynamicFieldAccessor(fld));
+                } else if (value == null && fld.getType().isPrimitive()) {
+                    fld.set(ctx, PropertyTools.getPrimitiveInitialValue(fld.getType()));
+                    addAccessorNode(new FieldAccessor(fld));
+                } else {
+                    fld.set(ctx, value);
+                    addAccessorNode(new FieldAccessor(fld));
+                }
+            } else if (member != null) {
+                Method meth = (Method) member;
+
+                if (value != null && !meth.getParameterTypes()[0].isAssignableFrom(value.getClass())) {
+                    if (!canConvert(meth.getParameterTypes()[0], value.getClass())) {
+                        throw new CompileException("cannot convert type: " + value.getClass() + ": to " + meth.getParameterTypes()[0],
+                                this.expr, this.start);
+                    }
+
+                    meth.invoke(ctx, convert(value, meth.getParameterTypes()[0]));
+                } else if (value == null && meth.getParameterTypes()[0].isPrimitive()) {
+                    meth.invoke(ctx, PropertyTools.getPrimitiveInitialValue(meth.getParameterTypes()[0]));
+                } else {
+                    meth.invoke(ctx, value);
+                }
+
+                addAccessorNode(new SetterAccessor(meth));
+            } else if (ctx instanceof Map) {
+                //noinspection unchecked
+                ((Map) ctx).put(tk, value);
+
+                addAccessorNode(new MapAccessor(tk));
+            } else {
+                throw new PropertyAccessException("could not access property (" + tk + ") in: " + ingressType.getName(), this.expr,
+                        this.start, pCtx);
+            }
+        } catch (InvocationTargetException e) {
+            throw new PropertyAccessException("could not access property: " + new String(property), this.expr, st, e, pCtx);
+        } catch (IllegalAccessException e) {
+            throw new PropertyAccessException("could not access property: " + new String(property), this.expr, st, e, pCtx);
+        } catch (IllegalArgumentException e) {
+            throw new PropertyAccessException("error binding property: " + new String(property) + " (value <<" + value + ">>::"
+                    + (value == null ? "null" : value.getClass().getCanonicalName()) + ")", this.expr, st, e, pCtx);
+        }
+
+        return rootNode;
+    }
+
+    private Accessor compileGetChain() {
+        Object curr = ctx;
+        cursor = start;
+
+        try {
+            if (!MVEL.COMPILER_OPT_ALLOW_OVERRIDE_ALL_PROPHANDLING) {
+                while (cursor < end) {
+                    switch (nextSubToken()) {
+                        case BEAN:
+                            curr = getBeanProperty(curr, capture());
+                            break;
+                        case METH:
+                            curr = getMethod(curr, capture());
+                            break;
+                        case COL:
+                            curr = getCollectionProperty(curr, capture());
+                            break;
+                        case WITH:
+                            curr = getWithProperty(curr);
+                            break;
+                        case DONE:
+                            break;
+                    }
+
+                    first = false;
+                    if (curr != null) returnType = curr.getClass();
+                    if (cursor < end) {
+                        if (nullSafe) {
+                            int os = expr[cursor] == '.' ? 1 : 0;
+                            addAccessorNode(new NullSafe(expr, cursor + os, end - cursor - os, pCtx));
+                            if (curr == null) break;
+                        }
+                        if (curr == null) throw new NullPointerException();
+                    }
+                    staticAccess = false;
+                }
+
+            } else {
+                while (cursor < end) {
+                    switch (nextSubToken()) {
+                        case BEAN:
+                            curr = getBeanPropertyAO(curr, capture());
+                            break;
+                        case METH:
+                            curr = getMethod(curr, capture());
+                            break;
+                        case COL:
+                            curr = getCollectionPropertyAO(curr, capture());
+                            break;
+                        case WITH:
+                            curr = getWithProperty(curr);
+                            break;
+                        case DONE:
+                            break;
+                    }
+
+                    first = false;
+                    if (curr != null) returnType = curr.getClass();
+                    if (cursor < end) {
+                        if (nullSafe) {
+                            int os = expr[cursor] == '.' ? 1 : 0;
+                            addAccessorNode(new NullSafe(expr, cursor + os, length - cursor - os, pCtx));
+                            if (curr == null) break;
+                        }
+                        if (curr == null) throw new NullPointerException();
+                    }
+                    staticAccess = false;
+                }
+            }
+
+            val = curr;
+            return rootNode;
+        } catch (InvocationTargetException e) {
+            if (MVEL.INVOKED_METHOD_EXCEPTIONS_BUBBLE) {
+                if (e.getTargetException() instanceof RuntimeException) {
+                    throw (RuntimeException) e.getTargetException();
+                } else {
+                    throw new RuntimeException(e);
+                }
+            }
+
+            throw new PropertyAccessException(new String(expr, start, length) + ": " + e.getTargetException().getMessage(), this.expr,
+                    this.st, e, pCtx);
+        } catch (IllegalAccessException e) {
+            throw new PropertyAccessException(new String(expr, start, length) + ": " + e.getMessage(), this.expr, this.st, e, pCtx);
+        } catch (IndexOutOfBoundsException e) {
+            throw new PropertyAccessException(new String(expr, start, length) + ": array index out of bounds.", this.expr, this.st, e,
+                    pCtx);
+        } catch (CompileException e) {
+            throw e;
+        } catch (NullPointerException e) {
+            throw new PropertyAccessException("null pointer: " + new String(expr, start, length), this.expr, this.st, e, pCtx);
+        } catch (Exception e) {
+            e.printStackTrace();
+            throw new CompileException(e.getMessage(), this.expr, st, e);
+        }
+    }
+
+    private void addAccessorNode(AccessorNode an) {
+        if (rootNode == null) rootNode = currNode = an;
+        else {
+            currNode = currNode.setNextNode(an);
+        }
+    }
+
+    private Object getWithProperty(Object ctx) {
+        currType = null;
+        String root = start == cursor ? null : new String(expr, start, cursor - 1).trim();
+
+        int st = cursor + 1;
+        cursor = balancedCaptureWithLineAccounting(expr, cursor, end, '{', pCtx);
+
+        WithAccessor wa = new WithAccessor(pCtx, root, expr, st, cursor++ - st, ingressType);
+        addAccessorNode(wa);
+        return wa.getValue(ctx, thisRef, variableFactory);
+    }
+
+    private Object getBeanPropertyAO(Object ctx, String property) throws Exception {
+
+        if (GlobalListenerFactory.hasGetListeners()) {
+            notifyGetListeners(ctx, property, variableFactory);
+            addAccessorNode(new Notify(property));
+        }
+
+        if (ctx != null && hasPropertyHandler(ctx.getClass())) return propHandler(property, ctx, ctx.getClass());
+
+        return getBeanProperty(ctx, property);
+    }
+
+    private Object getBeanProperty(Object ctx, String property) throws Exception {
+        if ((pCtx == null ? currType : pCtx.getVarOrInputTypeOrNull(property)) == Object.class && !pCtx.isStrongTyping()) {
+            currType = null;
+        }
+
+        if (first) {
+            if ("this".equals(property)) {
+                addAccessorNode(new ThisValueAccessor());
+                return this.thisRef;
+            } else if (variableFactory != null && variableFactory.isResolveable(property)) {
+
+                if (variableFactory.isIndexedFactory() && variableFactory.isTarget(property)) {
+                    int idx;
+                    addAccessorNode(new IndexedVariableAccessor(idx = variableFactory.variableIndexOf(property)));
+
+                    VariableResolver vr = variableFactory.getIndexedVariableResolver(idx);
+                    if (vr == null) {
+                        variableFactory.setIndexedVariableResolver(idx, variableFactory.getVariableResolver(property));
+                    }
+
+                    return variableFactory.getIndexedVariableResolver(idx).getValue();
+                } else {
+                    addAccessorNode(new VariableAccessor(property));
+
+                    return variableFactory.getVariableResolver(property).getValue();
+                }
+            }
+        }
+
+        boolean classRef = false;
+
+        Class<?> cls;
+        if (ctx instanceof Class) {
+            if (MVEL.COMPILER_OPT_SUPPORT_JAVA_STYLE_CLASS_LITERALS && "class".equals(property)) {
+                return ctx;
+            }
+
+            cls = (Class<?>) ctx;
+
+            classRef = true;
+        } else if (ctx != null) {
+            cls = ctx.getClass();
+        } else {
+            cls = currType;
+        }
+
+        if (hasPropertyHandler(cls)) {
+            PropertyHandlerAccessor acc = new PropertyHandlerAccessor(property, cls, getPropertyHandler(cls));
+            addAccessorNode(acc);
+            return acc.getValue(ctx, thisRef, variableFactory);
+        }
+
+        Member member = cls != null ? getFieldOrAccessor(cls, property) : null;
+
+        if (member != null && classRef && (member.getModifiers() & Modifier.STATIC) == 0) {
+            member = null;
+        }
+
+        Object o;
+
+        if (member instanceof Method) {
+            try {
+                o = ctx != null ? ((Method) member).invoke(ctx, EMPTYARG) : null;
+
+                if (hasNullPropertyHandler()) {
+                    addAccessorNode(new GetterAccessorNH((Method) member, getNullPropertyHandler()));
+                    if (o == null) o = getNullPropertyHandler().getProperty(member.getName(), ctx, variableFactory);
+                } else {
+                    addAccessorNode(new GetterAccessor((Method) member));
+                }
+            } catch (IllegalAccessException e) {
+                Method iFaceMeth = determineActualTargetMethod((Method) member);
+
+                if (iFaceMeth == null) throw new PropertyAccessException("could not access field: " + cls.getName() + "." + property,
+                        this.expr, this.start, pCtx);
+
+                o = iFaceMeth.invoke(ctx, EMPTYARG);
+
+                if (hasNullPropertyHandler()) {
+                    addAccessorNode(new GetterAccessorNH((Method) member, getNullMethodHandler()));
+                    if (o == null) o = getNullMethodHandler().getProperty(member.getName(), ctx, variableFactory);
+                } else {
+                    addAccessorNode(new GetterAccessor(iFaceMeth));
+                }
+            } catch (IllegalArgumentException e) {
+                if (member.getDeclaringClass().equals(ctx)) {
+                    try {
+                        Class c = Class.forName(member.getDeclaringClass().getName() + "$" + property);
+
+                        throw new CompileException("name collision between innerclass: " + c.getCanonicalName() + "; and bean accessor: "
+                                + property + " (" + member.toString() + ")", expr, tkStart);
+                    } catch (ClassNotFoundException e2) {
+                        //fallthru
+                    }
+                }
+                throw e;
+            }
+            currType = toNonPrimitiveType(((Method) member).getReturnType());
+            return o;
+        } else if (member != null) {
+            Field f = (Field) member;
+
+            if ((f.getModifiers() & Modifier.STATIC) != 0) {
+                o = f.get(null);
+
+                if (hasNullPropertyHandler()) {
+                    addAccessorNode(new StaticVarAccessorNH((Field) member, getNullMethodHandler()));
+                    if (o == null) o = getNullMethodHandler().getProperty(member.getName(), ctx, variableFactory);
+                } else {
+                    addAccessorNode(new StaticVarAccessor((Field) member));
+                }
+            } else {
+                o = ctx != null ? f.get(ctx) : null;
+                if (hasNullPropertyHandler()) {
+                    addAccessorNode(new FieldAccessorNH((Field) member, getNullMethodHandler()));
+                    if (o == null) o = getNullMethodHandler().getProperty(member.getName(), ctx, variableFactory);
+                } else {
+                    addAccessorNode(new FieldAccessor((Field) member));
+                }
+            }
+            currType = toNonPrimitiveType(f.getType());
+            return o;
+        } else if (ctx instanceof Map && (((Map) ctx).containsKey(property) || nullSafe)) {
+            addAccessorNode(new MapAccessor(property));
+            return ((Map) ctx).get(property);
+        } else if (ctx != null && "length".equals(property) && ctx.getClass().isArray()) {
+            addAccessorNode(new ArrayLength());
+            return getLength(ctx);
+        } else if (LITERALS.containsKey(property)) {
+            addAccessorNode(new StaticReferenceAccessor(ctx = LITERALS.get(property)));
+            return ctx;
+        } else {
+            Object tryStaticMethodRef = tryStaticAccess();
+            staticAccess = true;
+            if (tryStaticMethodRef != null) {
+                if (tryStaticMethodRef instanceof Class) {
+                    addAccessorNode(new StaticReferenceAccessor(tryStaticMethodRef));
+                    return tryStaticMethodRef;
+                } else if (tryStaticMethodRef instanceof Field) {
+                    addAccessorNode(new StaticVarAccessor((Field) tryStaticMethodRef));
+                    return ((Field) tryStaticMethodRef).get(null);
+                } else {
+                    addAccessorNode(new StaticReferenceAccessor(tryStaticMethodRef));
+                    return tryStaticMethodRef;
+                }
+            } else if (ctx instanceof Class) {
+                Class c = (Class) ctx;
+                for (Method m : c.getMethods()) {
+                    if (property.equals(m.getName())) {
+                        if (pCtx != null && pCtx.getParserConfiguration() != null ? pCtx.getParserConfiguration()
+                                .isAllowNakedMethCall() : MVEL.COMPILER_OPT_ALLOW_NAKED_METH_CALL) {
+                            o = m.invoke(null, EMPTY_OBJ_ARR);
+                            if (hasNullMethodHandler()) {
+                                addAccessorNode(new MethodAccessorNH(m, new ExecutableStatement[0], getNullMethodHandler()));
+                                if (o == null) o = getNullMethodHandler().getProperty(m.getName(), ctx, variableFactory);
+                            } else {
+                                addAccessorNode(new MethodAccessor(m, new ExecutableStatement[0]));
+                            }
+                            return o;
+                        } else {
+                            addAccessorNode(new StaticReferenceAccessor(m));
+                            return m;
+                        }
+                    }
+                }
+
+                try {
+                    Class subClass = findClass(variableFactory, c.getName() + "$" + property, pCtx);
+                    addAccessorNode(new StaticReferenceAccessor(subClass));
+                    return subClass;
+                } catch (ClassNotFoundException cnfe) {
+                    // fall through.
+                }
+            } else if (pCtx != null && pCtx.getParserConfiguration() != null ? pCtx.getParserConfiguration()
+                    .isAllowNakedMethCall() : MVEL.COMPILER_OPT_ALLOW_NAKED_METH_CALL) {
+                return getMethod(ctx, property);
+            }
+
+            // if it is not already using this as context try to read the property value from this
+            if (ctx != this.thisRef && this.thisRef != null) {
+                addAccessorNode(new ThisValueAccessor());
+                return getBeanProperty(this.thisRef, property);
+            }
+
+            if (ctx == null) {
+                throw new PropertyAccessException("unresolvable property or identifier: " + property, expr, start, pCtx);
+            } else {
+                throw new PropertyAccessException("could not access: " + property + "; in class: " + ctx.getClass().getName(), expr, start,
+                        pCtx);
+            }
+        }
+    }
+
+    /**
+     * Handle accessing a property embedded in a collections, map, or array
+     *
+     * @param ctx  -
+     * @param prop -
+     * @return -
+     * @throws Exception -
+     */
+    private Object getCollectionProperty(Object ctx, String prop) throws Exception {
+        if (prop.length() > 0) {
+            ctx = getBeanProperty(ctx, prop);
+        }
+
+        currType = null;
+        if (ctx == null) return null;
+
+        int start = ++cursor;
+
+        skipWhitespace();
+
+        if (cursor == end) throw new CompileException("unterminated '['", this.expr, this.start);
+
+        String item;
+
+        if (scanTo(']')) throw new CompileException("unterminated '['", this.expr, this.start);
+
+        item = new String(expr, start, cursor - start);
+
+        boolean itemSubExpr = true;
+
+        Object idx = null;
+
+        try {
+            idx = parseInt(item);
+            itemSubExpr = false;
+        } catch (Exception e) {
+            // not a number;
+        }
+
+        ExecutableStatement itemStmt = null;
+        if (itemSubExpr) {
+            try {
+                idx = (itemStmt = (ExecutableStatement) subCompileExpression(item.toCharArray(), pCtx)).getValue(ctx, thisRef,
+                        variableFactory);
+            } catch (CompileException e) {
+                e.setExpr(this.expr);
+                e.setCursor(start);
+                throw e;
+            }
+        }
+
+        ++cursor;
+
+        if (ctx instanceof Map) {
+            if (itemSubExpr) {
+                addAccessorNode(new MapAccessorNest(itemStmt, null));
+            } else {
+                addAccessorNode(new MapAccessor(parseInt(item)));
+            }
+
+            return ((Map) ctx).get(idx);
+        } else if (ctx instanceof List) {
+            if (itemSubExpr) {
+                addAccessorNode(new ListAccessorNest(itemStmt, null));
+            } else {
+                addAccessorNode(new ListAccessor(parseInt(item)));
+            }
+
+            return ((List) ctx).get((Integer) idx);
+        } else if (ctx.getClass().isArray()) {
+            if (itemSubExpr) {
+                addAccessorNode(new ArrayAccessorNest(itemStmt));
+            } else {
+                addAccessorNode(new ArrayAccessor(parseInt(item)));
+            }
+
+            return Array.get(ctx, (Integer) idx);
+        } else if (ctx instanceof CharSequence) {
+            if (itemSubExpr) {
+                addAccessorNode(new IndexedCharSeqAccessorNest(itemStmt));
+            } else {
+                addAccessorNode(new IndexedCharSeqAccessor(parseInt(item)));
+            }
+
+            return ((CharSequence) ctx).charAt((Integer) idx);
+        } else if (ctx instanceof Class) {
+            TypeDescriptor tDescr = new TypeDescriptor(expr, this.start, length, 0);
+            if (tDescr.isArray()) {
+                Class cls = getClassReference((Class) ctx, tDescr, variableFactory, pCtx);
+                rootNode = new StaticReferenceAccessor(cls);
+                return cls;
+            }
+        }
+        throw new CompileException("illegal use of []: unknown type: " + ctx.getClass().getName(), this.expr, this.start);
+    }
+
+    private Object getCollectionPropertyAO(Object ctx, String prop) throws Exception {
+        if (prop.length() > 0) {
+            ctx = getBeanPropertyAO(ctx, prop);
+        }
+
+        currType = null;
+        if (ctx == null) return null;
+
+        int _start = ++cursor;
+
+        skipWhitespace();
+
+        if (cursor == end) throw new CompileException("unterminated '['", this.expr, this.start);
+
+        String item;
+
+        if (scanTo(']')) throw new CompileException("unterminated '['", this.expr, this.start);
+
+        item = new String(expr, _start, cursor - _start);
+
+        boolean itemSubExpr = true;
+
+        Object idx = null;
+
+        try {
+            idx = parseInt(item);
+            itemSubExpr = false;
+        } catch (Exception e) {
+            // not a number;
+        }
+
+        ExecutableStatement itemStmt = null;
+        if (itemSubExpr) {
+            idx = (itemStmt = (ExecutableStatement) subCompileExpression(item.toCharArray(), pCtx)).getValue(ctx, thisRef, variableFactory);
+        }
+
+        ++cursor;
+
+        if (ctx instanceof Map) {
+            if (hasPropertyHandler(Map.class)) {
+                return propHandler(item, ctx, Map.class);
+            } else {
+                if (itemSubExpr) {
+                    addAccessorNode(new MapAccessorNest(itemStmt, null));
+                } else {
+                    addAccessorNode(new MapAccessor(parseInt(item)));
+                }
+
+                return ((Map) ctx).get(idx);
+            }
+        } else if (ctx instanceof List) {
+            if (hasPropertyHandler(List.class)) {
+                return propHandler(item, ctx, List.class);
+            } else {
+                if (itemSubExpr) {
+                    addAccessorNode(new ListAccessorNest(itemStmt, null));
+                } else {
+                    addAccessorNode(new ListAccessor(parseInt(item)));
+                }
+
+                return ((List) ctx).get((Integer) idx);
+            }
+        } else if (ctx.getClass().isArray()) {
+            if (hasPropertyHandler(Array.class)) {
+                return propHandler(item, ctx, Array.class);
+            } else {
+                if (itemSubExpr) {
+                    addAccessorNode(new ArrayAccessorNest(itemStmt));
+                } else {
+                    addAccessorNode(new ArrayAccessor(parseInt(item)));
+                }
+
+                return Array.get(ctx, (Integer) idx);
+            }
+        } else if (ctx instanceof CharSequence) {
+            if (hasPropertyHandler(CharSequence.class)) {
+                return propHandler(item, ctx, CharSequence.class);
+            } else {
+                if (itemSubExpr) {
+                    addAccessorNode(new IndexedCharSeqAccessorNest(itemStmt));
+                } else {
+                    addAccessorNode(new IndexedCharSeqAccessor(parseInt(item)));
+                }
+
+                return ((CharSequence) ctx).charAt((Integer) idx);
+            }
+        } else {
+            TypeDescriptor tDescr = new TypeDescriptor(expr, this.start, end - this.start, 0);
+            if (tDescr.isArray()) {
+                Class cls = getClassReference((Class) ctx, tDescr, variableFactory, pCtx);
+                rootNode = new StaticReferenceAccessor(cls);
+                return cls;
+            }
+
+            throw new CompileException("illegal use of []: unknown type: " + ctx.getClass().getName(), this.expr, this.st);
+        }
+    }
+
+    /**
+     * Find an appropriate method, execute it, and return it's response.
+     *
+     * @param ctx  -
+     * @param name -
+     * @return -
+     * @throws Exception -
+     */
+    @SuppressWarnings({ "unchecked" })
+    private Object getMethod(Object ctx, String name) throws Exception {
+        int st = cursor;
+        String tk = cursor != end && expr[cursor] == '(' && ((cursor = balancedCapture(expr, cursor, '(')) - st) > 1 ? new String(expr,
+                st + 1, cursor - st - 1) : "";
+        cursor++;
+
+        Object[] args;
+        Class[] argTypes;
+        ExecutableStatement[] es;
+
+        if (tk.length() == 0) {
+            args = ParseTools.EMPTY_OBJ_ARR;
+            argTypes = ParseTools.EMPTY_CLS_ARR;
+            es = null;
+        } else {
+            List<char[]> subtokens = parseParameterList(tk.toCharArray(), 0, -1);
+            es = new ExecutableStatement[subtokens.size()];
+            args = new Object[subtokens.size()];
+            argTypes = new Class[subtokens.size()];
+
+            for (int i = 0; i < subtokens.size(); i++) {
+                try {
+                    args[i] = (es[i] = (ExecutableStatement) subCompileExpression(subtokens.get(i), pCtx)).getValue(this.thisRef, thisRef,
+                            variableFactory);
+                } catch (CompileException e) {
+                    throw ErrorUtil.rewriteIfNeeded(e, this.expr, this.start);
+                }
+
+                if (es[i].isExplicitCast()) argTypes[i] = es[i].getKnownEgressType();
+            }
+
+            if (pCtx.isStrictTypeEnforcement()) {
+                for (int i = 0; i < args.length; i++) {
+                    argTypes[i] = es[i].getKnownEgressType();
+                    if (es[i] instanceof ExecutableLiteral && ((ExecutableLiteral) es[i]).getLiteral() == null) {
+                        argTypes[i] = NullType.class;
+                    }
+                }
+            } else {
+                for (int i = 0; i < args.length; i++) {
+                    if (argTypes[i] != null) continue;
+
+                    if (es[i].getKnownEgressType() == Object.class) {
+                        argTypes[i] = args[i] == null ? null : args[i].getClass();
+                    } else {
+                        argTypes[i] = es[i].getKnownEgressType();
+                    }
+                }
+            }
+        }
+
+        return getMethod(ctx, name, args, argTypes, es);
+    }
+
+    @SuppressWarnings({ "unchecked" })
+    private Object getMethod(Object ctx, String name, Object[] args, Class[] argTypes, ExecutableStatement[] es) throws Exception {
+        if (first && variableFactory != null && variableFactory.isResolveable(name)) {
+            Object ptr = variableFactory.getVariableResolver(name).getValue();
+            if (ptr instanceof Method) {
+                ctx = ((Method) ptr).getDeclaringClass();
+                name = ((Method) ptr).getName();
+            } else if (ptr instanceof MethodStub) {
+                ctx = ((MethodStub) ptr).getClassReference();
+                name = ((MethodStub) ptr).getMethodName();
+            } else if (ptr instanceof FunctionInstance) {
+                FunctionInstance func = (FunctionInstance) ptr;
+                if (!name.equals(func.getFunction().getName())) {
+                    getBeanProperty(ctx, name);
+                    addAccessorNode(new DynamicFunctionAccessor(es));
+                } else {
+                    addAccessorNode(new FunctionAccessor(func, es));
+                }
+                return func.call(ctx, thisRef, variableFactory, args);
+            } else {
+                throw new OptimizationFailure("attempt to optimize a method call for a reference that does not point to a method: " + name
+                        + " (reference is type: " + (ctx != null ? ctx.getClass().getName() : null) + ")");
+            }
+
+            first = false;
+        }
+
+        if (ctx == null && currType == null) {
+            throw new PropertyAccessException("null pointer or function not found: " + name, this.expr, this.start, pCtx);
+        }
+
+        boolean classTarget = false;
+        Class<?> cls = currType != null ? currType : ((classTarget = ctx instanceof Class) ? (Class<?>) ctx : ctx.getClass());
+        currType = null;
+
+        Method m;
+        Class[] parameterTypes = null;
+
+        /**
+         * If we have not cached the method then we need to go ahead and try to resolve it.
+         */
+
+        /**
+         * Try to find an instance method from the class target.
+         */
+        if ((m = getBestCandidate(argTypes, name, cls, cls.getMethods(), false, classTarget)) != null) {
+            parameterTypes = m.getParameterTypes();
+        }
+
+        if (m == null && classTarget) {
+            /**
+             * If we didn't find anything, maybe we're looking for the actual java.lang.Class methods.
+             */
+            if ((m = getBestCandidate(argTypes, name, cls, Class.class.getMethods(), false)) != null) {
+                parameterTypes = m.getParameterTypes();
+            }
+        }
+
+        // If we didn't find anything and the declared class is different from the actual one try also with the actual one
+        if (m == null && ctx != null && cls != ctx.getClass() && !(ctx instanceof Class)) {
+            cls = ctx.getClass();
+            if ((m = getBestCandidate(argTypes, name, cls, cls.getMethods(), false, classTarget)) != null) {
+                parameterTypes = m.getParameterTypes();
+            }
+        }
+
+        if (m == null) {
+            StringAppender errorBuild = new StringAppender();
+            if ("size".equals(name) && args.length == 0 && cls.isArray()) {
+                addAccessorNode(new ArrayLength());
+                return getLength(ctx);
+            }
+
+            // if it is not already using this as context try to access the method this
+            if (ctx != this.thisRef && this.thisRef != null) {
+                addAccessorNode(new ThisValueAccessor());
+                return getMethod(this.thisRef, name, args, argTypes, es);
+            }
+
+            for (int i = 0; i < args.length; i++) {
+                errorBuild.append(args[i] != null ? args[i].getClass().getName() : null);
+                if (i < args.length - 1) errorBuild.append(", ");
+            }
+
+            throw new PropertyAccessException("unable to resolve method: " + cls.getName() + "." + name + "(" + errorBuild.toString()
+                    + ") [arglength=" + args.length + "]", this.expr, this.st, pCtx);
+        }
+
+        if (es != null) {
+            ExecutableStatement cExpr;
+            for (int i = 0; i < es.length; i++) {
+                cExpr = es[i];
+                if (cExpr.getKnownIngressType() == null) {
+                    cExpr.setKnownIngressType(paramTypeVarArgsSafe(parameterTypes, i, m.isVarArgs()));
+                    cExpr.computeTypeConversionRule();
+                }
+                if (!cExpr.isConvertableIngressEgress()) {
+                    args[i] = convert(args[i], paramTypeVarArgsSafe(parameterTypes, i, m.isVarArgs()));
+                }
+            }
+        } else {
+            /**
+             * Coerce any types if required.
+             */
+            for (int i = 0; i < args.length; i++)
+                args[i] = convert(args[i], paramTypeVarArgsSafe(parameterTypes, i, m.isVarArgs()));
+        }
+
+        Method method = getWidenedTarget(cls, m);
+        Object o = ctx != null ? method.invoke(ctx, normalizeArgsForVarArgs(parameterTypes, args, m.isVarArgs())) : null;
+
+        if (hasNullMethodHandler()) {
+            addAccessorNode(new MethodAccessorNH(method, (ExecutableStatement[]) es, getNullMethodHandler()));
+            if (o == null) o = getNullMethodHandler().getProperty(m.getName(), ctx, variableFactory);
+        } else {
+            addAccessorNode(new MethodAccessor(method, (ExecutableStatement[]) es));
+        }
+
+        /**
+         * return the response.
+         */
+        currType = toNonPrimitiveType(method.getReturnType());
+        return o;
+    }
+
+    public Object getValue(Object ctx, Object elCtx, VariableResolverFactory variableFactory) throws Exception {
+        return rootNode.getValue(ctx, elCtx, variableFactory);
+    }
+
+    private Accessor _getAccessor(Object o, Class type) {
+        if (o instanceof List) {
+            Accessor[] a = new Accessor[((List) o).size()];
+            int i = 0;
+
+            for (Object item : (List) o) {
+                a[i++] = _getAccessor(item, type);
+            }
+
+            returnType = List.class;
+
+            return new ListCreator(a);
+        } else if (o instanceof Map) {
+            Accessor[] k = new Accessor[((Map) o).size()];
+            Accessor[] v = new Accessor[k.length];
+            int i = 0;
+
+            for (Object item : ((Map) o).keySet()) {
+                k[i] = _getAccessor(item, type); // key
+                v[i++] = _getAccessor(((Map) o).get(item), type); // value
+            }
+
+            returnType = Map.class;
+
+            return new MapCreator(k, v);
+        } else if (o instanceof Object[]) {
+            Accessor[] a = new Accessor[((Object[]) o).length];
+            int i = 0;
+            int dim = 0;
+
+            if (type != null) {
+                String nm = type.getName();
+                while (nm.charAt(dim) == '[')
+                    dim++;
+            } else {
+                type = Object[].class;
+                dim = 1;
+            }
+
+            try {
+                Class base = getBaseComponentType(type);
+                Class cls = dim > 1 ? findClass(null, repeatChar('[', dim - 1) + "L" + base.getName() + ";", pCtx) : type;
+
+                for (Object item : (Object[]) o) {
+                    expectType(pCtx, a[i++] = _getAccessor(item, cls), base, true);
+                }
+
+                return new ArrayCreator(a, getSubComponentType(type));
+            } catch (ClassNotFoundException e) {
+                throw new RuntimeException("this error should never throw:" + getBaseComponentType(type).getName(), e);
+            }
+        } else {
+            if (returnType == null) returnType = Object.class;
+            if (type.isArray()) {
+                return new ExprValueAccessor((String) o, type, ctx, variableFactory, pCtx);
+            } else {
+                return new ExprValueAccessor((String) o, Object.class, ctx, variableFactory, pCtx);
+            }
+        }
+    }
+
+    public Accessor optimizeCollection(ParserContext pCtx, Object o, Class type, char[] property, int start, int offset, Object ctx,
+            Object thisRef, VariableResolverFactory factory) {
+        this.start = this.cursor = start;
+        this.length = start + offset;
+        this.returnType = type;
+        this.ctx = ctx;
+        this.variableFactory = factory;
+        this.pCtx = pCtx;
+
+        Accessor root = _getAccessor(o, returnType);
+
+        if (property != null && length > start) {
+            return new Union(pCtx, root, property, cursor, offset);
+        } else {
+            return root;
+        }
+    }
+
+    public Accessor optimizeObjectCreation(ParserContext pCtx, char[] property, int start, int offset, Object ctx, Object thisRef,
+            VariableResolverFactory factory) {
+        this.length = start + offset;
+        this.cursor = this.start = start;
+        this.pCtx = pCtx;
+
+        try {
+            return compileConstructor(property, ctx, factory);
+        } catch (CompileException e) {
+            throw ErrorUtil.rewriteIfNeeded(e, property, this.start);
+        } catch (ClassNotFoundException e) {
+            throw new CompileException("could not resolve class: " + e.getMessage(), property, this.start, e);
+        } catch (Exception e) {
+            throw new CompileException("could not create constructor: " + e.getMessage(), property, this.start, e);
+        }
+    }
+
+    private AccessorNode getRootNode() {
+        return rootNode;
+    }
+
+    private void setRootNode(AccessorNode rootNode) {
+        this.rootNode = this.currNode = rootNode;
+    }
+
+    public Object getResultOptPass() {
+        return val;
+    }
+
+    @SuppressWarnings({ "WeakerAccess" })
+    private AccessorNode compileConstructor(char[] expression, Object ctx, VariableResolverFactory vars) throws InstantiationException,
+            IllegalAccessException, InvocationTargetException, ClassNotFoundException, NoSuchMethodException {
+
+        String[] cnsRes = captureContructorAndResidual(expression, start, length);
+        List<char[]> constructorParms = parseMethodOrConstructor(cnsRes[0].toCharArray());
+
+        if (constructorParms != null) {
+            String s = new String(subset(expression, 0, ArrayTools.findFirst('(', start, length, expression)));
+            Class cls = ParseTools.findClass(vars, s, pCtx);
+
+            ExecutableStatement[] cStmts = new ExecutableStatement[constructorParms.size()];
+
+            for (int i = 0; i < constructorParms.size(); i++) {
+                cStmts[i] = (ExecutableStatement) subCompileExpression(constructorParms.get(i), pCtx);
+            }
+
+            Object[] parms = new Object[constructorParms.size()];
+            for (int i = 0; i < constructorParms.size(); i++) {
+                parms[i] = cStmts[i].getValue(ctx, vars);
+            }
+
+            Constructor cns = getBestConstructorCandidate(parms, cls, pCtx.isStrongTyping());
+
+            if (cns == null) {
+                StringBuilder error = new StringBuilder();
+                for (int i = 0; i < parms.length; i++) {
+                    error.append(parms[i].getClass().getName());
+                    if (i + 1 < parms.length) error.append(", ");
+                }
+
+                throw new CompileException("unable to find constructor: " + cls.getName() + "(" + error.toString() + ")", this.expr,
+                        this.start);
+            }
+            for (int i = 0; i < parms.length; i++) {
+                //noinspection unchecked
+                parms[i] = convert(parms[i], paramTypeVarArgsSafe(cns.getParameterTypes(), i, cns.isVarArgs()));
+            }
+            parms = normalizeArgsForVarArgs(cns.getParameterTypes(), parms, cns.isVarArgs());
+
+            AccessorNode ca = new ConstructorAccessor(cns, cStmts);
+
+            if (cnsRes.length > 1) {
+                ReflectiveAccessorOptimizer compiledOptimizer = new ReflectiveAccessorOptimizer(pCtx, cnsRes[1].toCharArray(), 0,
+                        cnsRes[1].length(), cns.newInstance(parms), ctx, vars);
+                compiledOptimizer.ingressType = cns.getDeclaringClass();
+
+                compiledOptimizer.setRootNode(ca);
+                compiledOptimizer.compileGetChain();
+                ca = compiledOptimizer.getRootNode();
+
+                this.val = compiledOptimizer.getResultOptPass();
+            }
+
+            return ca;
+        } else {
+            ClassLoader classLoader = pCtx != null ? pCtx.getClassLoader() : currentThread().getContextClassLoader();
+            Constructor<?> cns = Class.forName(new String(expression), true, classLoader).getConstructor(EMPTYCLS);
+            AccessorNode ca = new ConstructorAccessor(cns, null);
+
+            if (cnsRes.length > 1) {
+                //noinspection NullArgumentToVariableArgMethod
+                ReflectiveAccessorOptimizer compiledOptimizer = new ReflectiveAccessorOptimizer(pCtx, cnsRes[1].toCharArray(), 0,
+                        cnsRes[1].length(), cns.newInstance(null), ctx, vars);
+                compiledOptimizer.setRootNode(ca);
+                compiledOptimizer.compileGetChain();
+                ca = compiledOptimizer.getRootNode();
+
+                this.val = compiledOptimizer.getResultOptPass();
+            }
+
+            return ca;
+        }
+    }
+
+    public Class getEgressType() {
+        return returnType;
+    }
+
+    public boolean isLiteralOnly() {
+        return false;
+    }
+
+    private Object propHandler(String property, Object ctx, Class handler) {
+        PropertyHandler ph = getPropertyHandler(handler);
+        addAccessorNode(new PropertyHandlerAccessor(property, handler, ph));
+        return ph.getProperty(property, ctx, variableFactory);
+    }
+
+    public void propHandlerSet(String property, Object ctx, Class handler, Object value) {
+        PropertyHandler ph = getPropertyHandler(handler);
+        addAccessorNode(new PropertyHandlerAccessor(property, handler, ph));
+        ph.setProperty(property, ctx, variableFactory, value);
+    }
+}

--- a/core/src/main/java/org/mvel2/optimizers/impl/refl/collection/ArrayCreator.java
+++ b/core/src/main/java/org/mvel2/optimizers/impl/refl/collection/ArrayCreator.java
@@ -1,0 +1,71 @@
+/**
+ * MVEL (The MVFLEX Expression Language)
+ *
+ * Copyright (C) 2007 Christopher Brock, MVFLEX/Valhalla Project and the Codehaus
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package org.mvel2.optimizers.impl.refl.collection;
+
+import static java.lang.reflect.Array.newInstance;
+
+import java.lang.reflect.Array;
+
+import org.mvel2.compiler.Accessor;
+import org.mvel2.integration.VariableResolverFactory;
+
+/**
+ * @author Christopher Brock
+ */
+public class ArrayCreator implements Accessor {
+
+    public Accessor[] template;
+    private Class arrayType;
+
+    public ArrayCreator(Accessor[] template, Class arrayType) {
+        this.template = template;
+        this.arrayType = arrayType;
+    }
+
+    public Object getValue(Object ctx, Object elCtx, VariableResolverFactory variableFactory) {
+        if (Object.class.equals(arrayType)) {
+            Object[] newArray = new Object[template.length];
+
+            for (int i = 0; i < newArray.length; i++) {
+                newArray[i] = template[i].getValue(ctx, elCtx, variableFactory);
+            }
+
+            return newArray;
+        } else {
+            Object newArray = newInstance(arrayType, template.length);
+            for (int i = 0; i < template.length; i++) {
+                Array.set(newArray, i, template[i].getValue(ctx, elCtx, variableFactory));
+            }
+
+            return newArray;
+        }
+    }
+
+    public Accessor[] getTemplate() {
+        return template;
+    }
+
+    public Object setValue(Object ctx, Object elCtx, VariableResolverFactory variableFactory, Object value) {
+        return null;
+    }
+
+    public Class getKnownEgressType() {
+        return arrayType;
+    }
+}

--- a/core/src/main/java/org/mvel2/optimizers/impl/refl/collection/ExprValueAccessor.java
+++ b/core/src/main/java/org/mvel2/optimizers/impl/refl/collection/ExprValueAccessor.java
@@ -1,0 +1,80 @@
+/**
+ * MVEL (The MVFLEX Expression Language)
+ *
+ * Copyright (C) 2007 Christopher Brock, MVFLEX/Valhalla Project and the Codehaus
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package org.mvel2.optimizers.impl.refl.collection;
+
+import static org.mvel2.DataConversion.canConvert;
+import static org.mvel2.DataConversion.convert;
+import static org.mvel2.util.ParseTools.getSubComponentType;
+import static org.mvel2.util.ReflectionUtil.isAssignableFrom;
+
+import org.mvel2.ParserContext;
+import org.mvel2.compiler.Accessor;
+import org.mvel2.compiler.ExecutableLiteral;
+import org.mvel2.compiler.ExecutableStatement;
+import org.mvel2.integration.VariableResolverFactory;
+import org.mvel2.util.ParseTools;
+
+/**
+ * @author Christopher Brock
+ */
+public class ExprValueAccessor implements Accessor {
+
+    public ExecutableStatement stmt;
+
+    public ExprValueAccessor(String ex, Class expectedType, Object ctx, VariableResolverFactory factory, ParserContext pCtx) {
+        stmt = (ExecutableStatement) ParseTools.subCompileExpression(ex.toCharArray(), pCtx);
+
+        //if (expectedType.isArray()) {
+        Class tt = getSubComponentType(expectedType);
+        Class et = stmt.getKnownEgressType();
+        if (stmt.getKnownEgressType() != null && !isAssignableFrom(tt, et)) {
+            if ((stmt instanceof ExecutableLiteral) && canConvert(et, tt)) {
+                try {
+                    stmt = new ExecutableLiteral(convert(stmt.getValue(ctx, factory), tt));
+                    return;
+                } catch (IllegalArgumentException e) {
+                    // fall through;
+                }
+            }
+            if (pCtx != null && pCtx.isStrongTyping())
+                throw new RuntimeException("was expecting type: " + tt + "; but found type: " + (et == null ? "null" : et.getName()));
+        }
+    }
+
+    public Object getValue(Object ctx, Object elCtx, VariableResolverFactory variableFactory) {
+        return stmt.getValue(elCtx, variableFactory);
+    }
+
+    public Object setValue(Object ctx, Object elCtx, VariableResolverFactory variableFactory, Object value) {
+        // not implemented
+        return null;
+    }
+
+    public ExecutableStatement getStmt() {
+        return stmt;
+    }
+
+    public void setStmt(ExecutableStatement stmt) {
+        this.stmt = stmt;
+    }
+
+    public Class getKnownEgressType() {
+        return stmt.getKnownEgressType();
+    }
+}

--- a/core/src/main/java/org/mvel2/optimizers/impl/refl/collection/ListCreator.java
+++ b/core/src/main/java/org/mvel2/optimizers/impl/refl/collection/ListCreator.java
@@ -1,0 +1,58 @@
+/**
+ * MVEL (The MVFLEX Expression Language)
+ *
+ * Copyright (C) 2007 Christopher Brock, MVFLEX/Valhalla Project and the Codehaus
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package org.mvel2.optimizers.impl.refl.collection;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import org.mvel2.compiler.Accessor;
+import org.mvel2.integration.VariableResolverFactory;
+
+/**
+ * @author Christopher Brock
+ */
+public class ListCreator implements Accessor {
+
+    private Accessor[] values;
+
+    public ListCreator(Accessor[] values) {
+        this.values = values;
+    }
+
+    public Object getValue(Object ctx, Object elCtx, VariableResolverFactory variableFactory) {
+        Object[] template = new Object[getValues().length];
+        for (int i = 0; i < getValues().length; i++) {
+            template[i] = getValues()[i].getValue(ctx, elCtx, variableFactory);
+        }
+        return new ArrayList<Object>(Arrays.asList(template));
+    }
+
+    public Object setValue(Object ctx, Object elCtx, VariableResolverFactory variableFactory, Object value) {
+        return null;
+    }
+
+    public Class getKnownEgressType() {
+        return List.class;
+    }
+
+    public Accessor[] getValues() {
+        return values;
+    }
+}

--- a/core/src/main/java/org/mvel2/optimizers/impl/refl/collection/MDArrayCreator.java
+++ b/core/src/main/java/org/mvel2/optimizers/impl/refl/collection/MDArrayCreator.java
@@ -1,0 +1,70 @@
+/**
+ * MVEL (The MVFLEX Expression Language)
+ *
+ * Copyright (C) 2007 Christopher Brock, MVFLEX/Valhalla Project and the Codehaus
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package org.mvel2.optimizers.impl.refl.collection;
+
+import static java.lang.reflect.Array.newInstance;
+
+import java.lang.reflect.Array;
+
+import org.mvel2.compiler.Accessor;
+import org.mvel2.integration.VariableResolverFactory;
+
+/**
+ * @author Christopher Brock
+ */
+public class MDArrayCreator implements Accessor {
+
+    public Accessor[] template;
+    private Class arrayType;
+    private int dimension;
+
+    public MDArrayCreator(Accessor[] template, Class arrayType, int dimension) {
+        this.template = template;
+        this.arrayType = arrayType;
+        this.dimension = dimension;
+    }
+
+    public Object getValue(Object ctx, Object elCtx, VariableResolverFactory variableFactory) {
+        if (Object.class.equals(arrayType)) {
+            Object[] newArray = new Object[template.length];
+
+            for (int i = 0; i < newArray.length; i++)
+                newArray[i] = template[i].getValue(ctx, elCtx, variableFactory);
+
+            return newArray;
+        } else {
+            Object newArray = newInstance(arrayType, template.length);
+
+            for (int i = 0; i < template.length; i++) {
+                Object o = template[i].getValue(ctx, elCtx, variableFactory);
+                Array.set(newArray, i, o);
+            }
+
+            return newArray;
+        }
+    }
+
+    public Object setValue(Object ctx, Object elCtx, VariableResolverFactory variableFactory, Object value) {
+        return null;
+    }
+
+    public Class getKnownEgressType() {
+        return arrayType;
+    }
+}

--- a/core/src/main/java/org/mvel2/optimizers/impl/refl/collection/MapCreator.java
+++ b/core/src/main/java/org/mvel2/optimizers/impl/refl/collection/MapCreator.java
@@ -1,0 +1,58 @@
+/**
+ * MVEL (The MVFLEX Expression Language)
+ *
+ * Copyright (C) 2007 Christopher Brock, MVFLEX/Valhalla Project and the Codehaus
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package org.mvel2.optimizers.impl.refl.collection;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.mvel2.compiler.Accessor;
+import org.mvel2.integration.VariableResolverFactory;
+
+/**
+ * @author Christopher Brock
+ */
+public class MapCreator implements Accessor {
+
+    private Accessor[] keys;
+    private Accessor[] vals;
+    private int size;
+
+    public MapCreator(Accessor[] keys, Accessor[] vals) {
+        this.size = (this.keys = keys).length;
+        this.vals = vals;
+    }
+
+    public Object getValue(Object ctx, Object elCtx, VariableResolverFactory variableFactory) {
+        Map map = new HashMap(size * 2);
+        for (int i = size - 1; i != -1; i--) {
+            //noinspection unchecked
+            map.put(keys[i].getValue(ctx, elCtx, variableFactory), vals[i].getValue(ctx, elCtx, variableFactory));
+        }
+        return map;
+    }
+
+    public Object setValue(Object ctx, Object elCtx, VariableResolverFactory variableFactory, Object value) {
+        // not implemented
+        return null;
+    }
+
+    public Class getKnownEgressType() {
+        return Map.class;
+    }
+}

--- a/core/src/main/java/org/mvel2/optimizers/impl/refl/nodes/ArrayAccessor.java
+++ b/core/src/main/java/org/mvel2/optimizers/impl/refl/nodes/ArrayAccessor.java
@@ -1,0 +1,86 @@
+/**
+ * MVEL (The MVFLEX Expression Language)
+ *
+ * Copyright (C) 2007 Christopher Brock, MVFLEX/Valhalla Project and the Codehaus
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package org.mvel2.optimizers.impl.refl.nodes;
+
+import java.lang.reflect.Array;
+
+import org.mvel2.compiler.AccessorNode;
+import org.mvel2.integration.VariableResolverFactory;
+
+public class ArrayAccessor implements AccessorNode {
+
+    private AccessorNode nextNode;
+    private int index;
+
+    public ArrayAccessor() {
+    }
+
+    public ArrayAccessor(int index) {
+        this.index = index;
+    }
+
+    public Object getValue(Object ctx, Object elCtx, VariableResolverFactory vars) {
+        if (nextNode != null) {
+            return nextNode.getValue(Array.get(ctx, index), elCtx, vars);
+        } else {
+            try {
+                return Array.get(ctx, index);
+            } catch (IllegalArgumentException e) {
+                // This isn't great, but the mechanism for deoptimizing a stale accessor is currently based on 
+                //  Accessor's  throwing a ClassCastException.  Catching  IllegalArgumentException in 
+                // org.mvel2.ast.ASTNode.getReducedValueAccelerated(Object, Object, VariableResolverFactory)
+                // is a bad idea and currently there is nowhere to easily introduce pre-emptive accessor validity.
+                throw new ClassCastException("Argument of type '" + ctx.getClass() + "' is not an Array");
+            }
+        }
+    }
+
+    public Object setValue(Object ctx, Object elCtx, VariableResolverFactory variableFactory, Object value) {
+        if (nextNode != null) {
+            return nextNode.setValue(Array.get(ctx, index), elCtx, variableFactory, value);
+        } else {
+            Array.set(ctx, index, value);
+            return value;
+        }
+    }
+
+    public int getIndex() {
+        return index;
+    }
+
+    public void setIndex(int index) {
+        this.index = index;
+    }
+
+    public AccessorNode getNextNode() {
+        return nextNode;
+    }
+
+    public AccessorNode setNextNode(AccessorNode nextNode) {
+        return this.nextNode = nextNode;
+    }
+
+    public Class getKnownEgressType() {
+        return Object[].class;
+    }
+
+    public String toString() {
+        return "Array Accessor -> [" + index + "]";
+    }
+}

--- a/core/src/main/java/org/mvel2/optimizers/impl/refl/nodes/ArrayAccessorNest.java
+++ b/core/src/main/java/org/mvel2/optimizers/impl/refl/nodes/ArrayAccessorNest.java
@@ -1,0 +1,100 @@
+/**
+ * MVEL (The MVFLEX Expression Language)
+ *
+ * Copyright (C) 2007 Christopher Brock, MVFLEX/Valhalla Project and the Codehaus
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package org.mvel2.optimizers.impl.refl.nodes;
+
+import static org.mvel2.DataConversion.convert;
+
+import java.lang.reflect.Array;
+
+import org.mvel2.compiler.AccessorNode;
+import org.mvel2.compiler.ExecutableStatement;
+import org.mvel2.integration.VariableResolverFactory;
+import org.mvel2.util.ParseTools;
+
+public class ArrayAccessorNest implements AccessorNode {
+
+    private AccessorNode nextNode;
+    private ExecutableStatement index;
+
+    private Class baseComponentType;
+    private boolean requireConversion;
+
+    public ArrayAccessorNest() {
+    }
+
+    public ArrayAccessorNest(String index) {
+        this.index = (ExecutableStatement) ParseTools.subCompileExpression(index.toCharArray());
+    }
+
+    public ArrayAccessorNest(ExecutableStatement stmt) {
+        this.index = stmt;
+    }
+
+    public Object getValue(Object ctx, Object elCtx, VariableResolverFactory vars) {
+        if (nextNode != null) {
+            return nextNode.getValue(((Object[]) ctx)[(Integer) index.getValue(ctx, elCtx, vars)], elCtx, vars);
+        } else {
+            return ((Object[]) ctx)[(Integer) index.getValue(ctx, elCtx, vars)];
+        }
+    }
+
+    public Object setValue(Object ctx, Object elCtx, VariableResolverFactory vars, Object value) {
+        if (nextNode != null) {
+            return nextNode.setValue(((Object[]) ctx)[(Integer) index.getValue(ctx, elCtx, vars)], elCtx, vars, value);
+        } else {
+            if (baseComponentType == null) {
+                baseComponentType = ParseTools.getBaseComponentType(ctx.getClass());
+                requireConversion = baseComponentType != value.getClass() && !baseComponentType.isAssignableFrom(value.getClass());
+            }
+
+            if (requireConversion) {
+                Object o = convert(value, baseComponentType);
+                Array.set(ctx, (Integer) index.getValue(ctx, elCtx, vars), o);
+                return o;
+            } else {
+                Array.set(ctx, (Integer) index.getValue(ctx, elCtx, vars), value);
+                return value;
+            }
+        }
+    }
+
+    public ExecutableStatement getIndex() {
+        return index;
+    }
+
+    public void setIndex(ExecutableStatement index) {
+        this.index = index;
+    }
+
+    public AccessorNode getNextNode() {
+        return nextNode;
+    }
+
+    public AccessorNode setNextNode(AccessorNode nextNode) {
+        return this.nextNode = nextNode;
+    }
+
+    public Class getKnownEgressType() {
+        return baseComponentType;
+    }
+
+    public String toString() {
+        return "Array Accessor -> [" + index + "]";
+    }
+}

--- a/core/src/main/java/org/mvel2/optimizers/impl/refl/nodes/ArrayLength.java
+++ b/core/src/main/java/org/mvel2/optimizers/impl/refl/nodes/ArrayLength.java
@@ -1,0 +1,45 @@
+/**
+ * MVEL (The MVFLEX Expression Language)
+ *
+ * Copyright (C) 2007 Christopher Brock, MVFLEX/Valhalla Project and the Codehaus
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package org.mvel2.optimizers.impl.refl.nodes;
+
+import static java.lang.reflect.Array.getLength;
+
+import org.mvel2.integration.VariableResolverFactory;
+
+/**
+ * @author Christopher Brock
+ */
+public class ArrayLength extends BaseAccessor {
+
+    public Object getValue(Object ctx, Object elCtx, VariableResolverFactory variableFactory) {
+        if (nextNode != null) {
+            return nextNode.getValue(getLength(ctx), elCtx, variableFactory);
+        } else {
+            return getLength(ctx);
+        }
+    }
+
+    public Object setValue(Object ctx, Object elCtx, VariableResolverFactory variableFactory, Object value) {
+        return null;
+    }
+
+    public Class getKnownEgressType() {
+        return Integer.class;
+    }
+}

--- a/core/src/main/java/org/mvel2/optimizers/impl/refl/nodes/BaseAccessor.java
+++ b/core/src/main/java/org/mvel2/optimizers/impl/refl/nodes/BaseAccessor.java
@@ -1,0 +1,34 @@
+/**
+ * MVEL (The MVFLEX Expression Language)
+ *
+ * Copyright (C) 2007 Christopher Brock, MVFLEX/Valhalla Project and the Codehaus
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package org.mvel2.optimizers.impl.refl.nodes;
+
+import org.mvel2.compiler.AccessorNode;
+
+public abstract class BaseAccessor implements AccessorNode {
+
+    protected AccessorNode nextNode;
+
+    public AccessorNode setNextNode(AccessorNode accessorNode) {
+        return this.nextNode = accessorNode;
+    }
+
+    public AccessorNode getNextNode() {
+        return this.nextNode;
+    }
+}

--- a/core/src/main/java/org/mvel2/optimizers/impl/refl/nodes/ConstructorAccessor.java
+++ b/core/src/main/java/org/mvel2/optimizers/impl/refl/nodes/ConstructorAccessor.java
@@ -1,0 +1,89 @@
+/**
+ * MVEL (The MVFLEX Expression Language)
+ *
+ * Copyright (C) 2007 Christopher Brock, MVFLEX/Valhalla Project and the Codehaus
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package org.mvel2.optimizers.impl.refl.nodes;
+
+import java.lang.reflect.Constructor;
+
+import org.mvel2.compiler.ExecutableStatement;
+import org.mvel2.integration.VariableResolverFactory;
+
+public class ConstructorAccessor extends InvokableAccessor {
+
+    private Constructor constructor;
+
+    public ConstructorAccessor(Constructor constructor, ExecutableStatement[] parms) {
+        this.constructor = constructor;
+        this.length = (this.parameterTypes = constructor.getParameterTypes()).length;
+        this.parms = parms;
+    }
+
+    public Object getValue(Object ctx, Object elCtx, VariableResolverFactory variableFactory) {
+        try {
+            if (!coercionNeeded) {
+                try {
+                    if (nextNode != null) {
+                        return nextNode.getValue(constructor.newInstance(executeAll(elCtx, variableFactory)), elCtx, variableFactory);
+                    } else {
+                        return constructor.newInstance(executeAll(elCtx, variableFactory));
+                    }
+                } catch (IllegalArgumentException e) {
+                    coercionNeeded = true;
+                    return getValue(ctx, elCtx, variableFactory);
+                }
+
+            } else {
+                if (nextNode != null) {
+                    return nextNode.getValue(
+                            constructor.newInstance(executeAndCoerce(parameterTypes, elCtx, variableFactory, constructor.isVarArgs())),
+                            elCtx, variableFactory);
+                } else {
+                    return constructor.newInstance(executeAndCoerce(parameterTypes, elCtx, variableFactory, constructor.isVarArgs()));
+                }
+            }
+        } catch (Exception e) {
+            throw new RuntimeException("cannot construct object", e);
+        }
+    }
+
+    public Object setValue(Object ctx, Object elCtx, VariableResolverFactory variableFactory, Object value) {
+        return null;
+    }
+
+    private Object[] executeAll(Object ctx, VariableResolverFactory vars) {
+        if (length == 0) return GetterAccessor.EMPTY;
+
+        Object[] vals = new Object[length];
+        for (int i = 0; i < length; i++) {
+            vals[i] = parms[i].getValue(ctx, vars);
+        }
+        return vals;
+    }
+
+    public Class getKnownEgressType() {
+        return constructor.getClass();
+    }
+
+    public Constructor getConstructor() {
+        return constructor;
+    }
+
+    public ExecutableStatement[] getParameters() {
+        return parms;
+    }
+}

--- a/core/src/main/java/org/mvel2/optimizers/impl/refl/nodes/DynamicFieldAccessor.java
+++ b/core/src/main/java/org/mvel2/optimizers/impl/refl/nodes/DynamicFieldAccessor.java
@@ -1,0 +1,87 @@
+/**
+ * MVEL (The MVFLEX Expression Language)
+ *
+ * Copyright (C) 2007 Christopher Brock, MVFLEX/Valhalla Project and the Codehaus
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package org.mvel2.optimizers.impl.refl.nodes;
+
+import java.lang.reflect.Field;
+
+import org.mvel2.DataConversion;
+import org.mvel2.compiler.AccessorNode;
+import org.mvel2.integration.VariableResolverFactory;
+
+@SuppressWarnings({ "unchecked" })
+public class DynamicFieldAccessor implements AccessorNode {
+
+    private AccessorNode nextNode;
+    private Field field;
+    private Class targetType;
+
+    public DynamicFieldAccessor() {
+    }
+
+    public DynamicFieldAccessor(Field field) {
+        setField(field);
+    }
+
+    public Object getValue(Object ctx, Object elCtx, VariableResolverFactory vars) {
+        try {
+            if (nextNode != null) {
+                return nextNode.getValue(field.get(ctx), elCtx, vars);
+            } else {
+                return field.get(ctx);
+            }
+        } catch (Exception e) {
+            throw new RuntimeException("unable to access field", e);
+        }
+
+    }
+
+    public Object setValue(Object ctx, Object elCtx, VariableResolverFactory variableFactory, Object value) {
+        try {
+            if (nextNode != null) {
+                return nextNode.setValue(field.get(ctx), elCtx, variableFactory, value);
+            } else {
+                field.set(ctx, DataConversion.convert(value, targetType));
+                return value;
+            }
+        } catch (Exception e) {
+            throw new RuntimeException("unable to access field", e);
+        }
+    }
+
+    public Field getField() {
+        return field;
+    }
+
+    public void setField(Field field) {
+        this.field = field;
+        this.targetType = field.getType();
+    }
+
+    public AccessorNode getNextNode() {
+        return nextNode;
+    }
+
+    public AccessorNode setNextNode(AccessorNode nextNode) {
+        return this.nextNode = nextNode;
+    }
+
+    public Class getKnownEgressType() {
+        return targetType;
+    }
+}

--- a/core/src/main/java/org/mvel2/optimizers/impl/refl/nodes/DynamicFunctionAccessor.java
+++ b/core/src/main/java/org/mvel2/optimizers/impl/refl/nodes/DynamicFunctionAccessor.java
@@ -1,0 +1,66 @@
+/**
+ * MVEL (The MVFLEX Expression Language)
+ *
+ * Copyright (C) 2007 Christopher Brock, MVFLEX/Valhalla Project and the Codehaus
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package org.mvel2.optimizers.impl.refl.nodes;
+
+import org.mvel2.ast.Function;
+import org.mvel2.ast.FunctionInstance;
+import org.mvel2.compiler.Accessor;
+import org.mvel2.integration.VariableResolverFactory;
+
+public class DynamicFunctionAccessor extends BaseAccessor {
+
+    // private Function function;
+    private Accessor[] parameters;
+
+    public DynamicFunctionAccessor(Accessor[] parms) {
+        this.parameters = parms;
+    }
+
+    public Object getValue(Object ctx, Object elCtx, VariableResolverFactory variableFactory) {
+        Object[] parms = null;
+
+        Function function;
+        if (ctx instanceof FunctionInstance) {
+            function = ((FunctionInstance) ctx).getFunction();
+        } else {
+            function = (Function) ctx;
+        }
+
+        if (parameters != null && parameters.length != 0) {
+            parms = new Object[parameters.length];
+            for (int i = 0; i < parms.length; i++) {
+                parms[i] = parameters[i].getValue(ctx, elCtx, variableFactory);
+            }
+        }
+
+        if (nextNode != null) {
+            return nextNode.getValue(function.call(ctx, elCtx, variableFactory, parms), elCtx, variableFactory);
+        } else {
+            return function.call(ctx, elCtx, variableFactory, parms);
+        }
+    }
+
+    public Object setValue(Object ctx, Object elCtx, VariableResolverFactory variableFactory, Object value) {
+        throw new RuntimeException("can't write to function");
+    }
+
+    public Class getKnownEgressType() {
+        return Object.class;
+    }
+}

--- a/core/src/main/java/org/mvel2/optimizers/impl/refl/nodes/DynamicSetterAccessor.java
+++ b/core/src/main/java/org/mvel2/optimizers/impl/refl/nodes/DynamicSetterAccessor.java
@@ -1,0 +1,72 @@
+/**
+ * MVEL (The MVFLEX Expression Language)
+ *
+ * Copyright (C) 2007 Christopher Brock, MVFLEX/Valhalla Project and the Codehaus
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package org.mvel2.optimizers.impl.refl.nodes;
+
+import static org.mvel2.DataConversion.convert;
+
+import java.lang.reflect.Method;
+
+import org.mvel2.compiler.AccessorNode;
+import org.mvel2.integration.VariableResolverFactory;
+
+@SuppressWarnings({ "unchecked" })
+public class DynamicSetterAccessor implements AccessorNode {
+    //  private AccessorNode nextNode;
+
+    public static final Object[] EMPTY = new Object[0];
+    private final Method method;
+    private Class targetType;
+
+    public DynamicSetterAccessor(Method method) {
+        this.method = method;
+        this.targetType = method.getParameterTypes()[0];
+    }
+
+    public Object setValue(Object ctx, Object elCtx, VariableResolverFactory variableFactory, Object value) {
+        try {
+            return method.invoke(ctx, convert(value, targetType));
+        } catch (Exception e) {
+            throw new RuntimeException("error binding property", e);
+        }
+    }
+
+    public Object getValue(Object ctx, Object elCtx, VariableResolverFactory vars) {
+        return null;
+    }
+
+    public Method getMethod() {
+        return method;
+    }
+
+    public AccessorNode setNextNode(AccessorNode nextNode) {
+        return null;
+    }
+
+    public AccessorNode getNextNode() {
+        return null;
+    }
+
+    public String toString() {
+        return method.getDeclaringClass().getName() + "." + method.getName();
+    }
+
+    public Class getKnownEgressType() {
+        return targetType;
+    }
+}

--- a/core/src/main/java/org/mvel2/optimizers/impl/refl/nodes/FieldAccessor.java
+++ b/core/src/main/java/org/mvel2/optimizers/impl/refl/nodes/FieldAccessor.java
@@ -1,0 +1,107 @@
+/**
+ * MVEL (The MVFLEX Expression Language)
+ *
+ * Copyright (C) 2007 Christopher Brock, MVFLEX/Valhalla Project and the Codehaus
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package org.mvel2.optimizers.impl.refl.nodes;
+
+import static org.mvel2.DataConversion.convert;
+
+import java.lang.reflect.Field;
+
+import org.mvel2.compiler.AccessorNode;
+import org.mvel2.integration.VariableResolverFactory;
+import org.mvel2.util.PropertyTools;
+
+public class FieldAccessor implements AccessorNode {
+
+    private AccessorNode nextNode;
+    private Field field;
+    private boolean coercionRequired = false;
+    private boolean primitive;
+
+    public FieldAccessor() {
+    }
+
+    public FieldAccessor(Field field) {
+        primitive = (this.field = field).getType().isPrimitive();
+    }
+
+    public Object getValue(Object ctx, Object elCtx, VariableResolverFactory vars) {
+        try {
+            if (nextNode != null) {
+                return nextNode.getValue(field.get(ctx), elCtx, vars);
+            } else {
+                return field.get(ctx);
+            }
+        } catch (Exception e) {
+            throw new RuntimeException("unable to access field: " + field.getName(), e);
+        }
+    }
+
+    public Object setValue(Object ctx, Object elCtx, VariableResolverFactory variableFactory, Object value) {
+        if (nextNode != null) {
+            try {
+                return nextNode.setValue(field.get(ctx), elCtx, variableFactory,
+                        value == null && primitive ? PropertyTools.getPrimitiveInitialValue(field.getType()) : value);
+            } catch (Exception e) {
+                throw new RuntimeException("unable to access field", e);
+            }
+        }
+
+        // this local field is required to make sure exception block works with the same coercionRequired value
+        // and it is not changed by another thread while setter is invoked 
+        boolean attemptedCoercion = coercionRequired;
+        try {
+
+            if (coercionRequired) {
+                field.set(ctx, value = convert(ctx, field.getClass()));
+                return value;
+            } else {
+                field.set(ctx, value);
+                return value;
+            }
+        } catch (IllegalArgumentException e) {
+            if (!attemptedCoercion) {
+                coercionRequired = true;
+                return setValue(ctx, elCtx, variableFactory, value);
+            }
+            throw new RuntimeException("unable to bind property", e);
+        } catch (Exception e) {
+            throw new RuntimeException("unable to access field", e);
+        }
+    }
+
+    public Field getField() {
+        return field;
+    }
+
+    public void setField(Field field) {
+        this.field = field;
+    }
+
+    public AccessorNode getNextNode() {
+        return nextNode;
+    }
+
+    public AccessorNode setNextNode(AccessorNode nextNode) {
+        return this.nextNode = nextNode;
+    }
+
+    public Class getKnownEgressType() {
+        return field.getClass();
+    }
+}

--- a/core/src/main/java/org/mvel2/optimizers/impl/refl/nodes/FieldAccessorNH.java
+++ b/core/src/main/java/org/mvel2/optimizers/impl/refl/nodes/FieldAccessorNH.java
@@ -1,0 +1,100 @@
+/**
+ * MVEL (The MVFLEX Expression Language)
+ *
+ * Copyright (C) 2007 Christopher Brock, MVFLEX/Valhalla Project and the Codehaus
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package org.mvel2.optimizers.impl.refl.nodes;
+
+import static org.mvel2.DataConversion.convert;
+
+import java.lang.reflect.Field;
+
+import org.mvel2.compiler.AccessorNode;
+import org.mvel2.integration.PropertyHandler;
+import org.mvel2.integration.VariableResolverFactory;
+
+public class FieldAccessorNH implements AccessorNode {
+
+    private AccessorNode nextNode;
+    private Field field;
+    private boolean coercionRequired = false;
+    private PropertyHandler nullHandler;
+
+    public FieldAccessorNH(Field field, PropertyHandler handler) {
+        this.field = field;
+        this.nullHandler = handler;
+    }
+
+    public Object getValue(Object ctx, Object elCtx, VariableResolverFactory vars) {
+        try {
+            Object v = field.get(ctx);
+            if (v == null) v = nullHandler.getProperty(field.getName(), elCtx, vars);
+
+            if (nextNode != null) {
+                return nextNode.getValue(v, elCtx, vars);
+            } else {
+                return v;
+            }
+        } catch (Exception e) {
+            throw new RuntimeException("unable to access field", e);
+        }
+    }
+
+    public Object setValue(Object ctx, Object elCtx, VariableResolverFactory variableFactory, Object value) {
+        // this local field is required to make sure exception block works with the same coercionRequired value
+        // and it is not changed by another thread while setter is invoked 
+        boolean attemptedCoercion = coercionRequired;
+        try {
+            if (nextNode != null) {
+                return nextNode.setValue(ctx, elCtx, variableFactory, value);
+            } else if (coercionRequired) {
+                field.set(ctx, value = convert(ctx, field.getClass()));
+                return value;
+            } else {
+                field.set(ctx, value);
+                return value;
+            }
+        } catch (IllegalArgumentException e) {
+            if (!attemptedCoercion) {
+                coercionRequired = true;
+                return setValue(ctx, elCtx, variableFactory, value);
+            }
+            throw new RuntimeException("unable to bind property", e);
+        } catch (Exception e) {
+            throw new RuntimeException("unable to access field", e);
+        }
+    }
+
+    public Field getField() {
+        return field;
+    }
+
+    public void setField(Field field) {
+        this.field = field;
+    }
+
+    public AccessorNode getNextNode() {
+        return nextNode;
+    }
+
+    public AccessorNode setNextNode(AccessorNode nextNode) {
+        return this.nextNode = nextNode;
+    }
+
+    public Class getKnownEgressType() {
+        return field.getClass();
+    }
+}

--- a/core/src/main/java/org/mvel2/optimizers/impl/refl/nodes/FunctionAccessor.java
+++ b/core/src/main/java/org/mvel2/optimizers/impl/refl/nodes/FunctionAccessor.java
@@ -1,0 +1,59 @@
+/**
+ * MVEL (The MVFLEX Expression Language)
+ *
+ * Copyright (C) 2007 Christopher Brock, MVFLEX/Valhalla Project and the Codehaus
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package org.mvel2.optimizers.impl.refl.nodes;
+
+import org.mvel2.ast.FunctionInstance;
+import org.mvel2.compiler.Accessor;
+import org.mvel2.integration.VariableResolverFactory;
+
+public class FunctionAccessor extends BaseAccessor {
+
+    private FunctionInstance function;
+    private Accessor[] parameters;
+
+    public FunctionAccessor(FunctionInstance function, Accessor[] parms) {
+        this.function = function;
+        this.parameters = parms;
+    }
+
+    public Object getValue(Object ctx, Object elCtx, VariableResolverFactory variableFactory) {
+        Object[] parms = null;
+
+        if (parameters != null && parameters.length != 0) {
+            parms = new Object[parameters.length];
+            for (int i = 0; i < parms.length; i++) {
+                parms[i] = parameters[i].getValue(ctx, elCtx, variableFactory);
+            }
+        }
+
+        if (nextNode != null) {
+            return nextNode.getValue(function.call(ctx, elCtx, variableFactory, parms), elCtx, variableFactory);
+        } else {
+            return function.call(ctx, elCtx, variableFactory, parms);
+        }
+    }
+
+    public Object setValue(Object ctx, Object elCtx, VariableResolverFactory variableFactory, Object value) {
+        throw new RuntimeException("can't write to function");
+    }
+
+    public Class getKnownEgressType() {
+        return Object.class;
+    }
+}

--- a/core/src/main/java/org/mvel2/optimizers/impl/refl/nodes/GetterAccessor.java
+++ b/core/src/main/java/org/mvel2/optimizers/impl/refl/nodes/GetterAccessor.java
@@ -1,0 +1,134 @@
+/**
+ * MVEL (The MVFLEX Expression Language)
+ *
+ * Copyright (C) 2007 Christopher Brock, MVFLEX/Valhalla Project and the Codehaus
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package org.mvel2.optimizers.impl.refl.nodes;
+
+import static org.mvel2.MVEL.getProperty;
+import static org.mvel2.util.ParseTools.getBestCandidate;
+import static org.mvel2.util.ReflectionUtil.getPropertyFromAccessor;
+
+import java.lang.reflect.Method;
+
+import org.mvel2.CompileException;
+import org.mvel2.compiler.AccessorNode;
+import org.mvel2.integration.VariableResolverFactory;
+
+public class GetterAccessor implements AccessorNode {
+
+    public static final Object[] EMPTY = new Object[0];
+    private final Method method;
+    private AccessorNode nextNode;
+
+    public GetterAccessor(Method method) {
+        this.method = method;
+    }
+
+    public Object getValue(Object ctx, Object elCtx, VariableResolverFactory vars) {
+        try {
+            if (nextNode != null) {
+                return nextNode.getValue(method.invoke(ctx, EMPTY), elCtx, vars);
+            } else {
+                return method.invoke(ctx, EMPTY);
+            }
+        } catch (IllegalArgumentException e) {
+            if (ctx != null && method.getDeclaringClass() != ctx.getClass()) {
+                Method o = getBestCandidate(EMPTY, method.getName(), ctx.getClass(), ctx.getClass().getMethods(), true);
+                if (o != null) {
+                    return executeOverrideTarget(o, ctx, elCtx, vars);
+                }
+            }
+
+            /**
+             * HACK: Try to access this another way.
+             */
+            if (nextNode != null) {
+                return nextNode.getValue(getProperty(getPropertyFromAccessor(method.getName()), ctx), elCtx, vars);
+            } else {
+                return getProperty(getPropertyFromAccessor(method.getName()), ctx);
+            }
+        } catch (NullPointerException e) {
+            if (ctx == null) {
+                throw new RuntimeException("unable to invoke method: " + method.getDeclaringClass().getName() + "." + method.getName()
+                        + ": " + "target of method is null", e);
+            } else {
+                throw new RuntimeException("cannot invoke getter: " + method.getName() + " (see trace)", e);
+            }
+        } catch (Exception e) {
+            throw new RuntimeException(
+                    "cannot invoke getter: " + method.getName() + " [declr.class: " + method.getDeclaringClass().getName() + "; act.class: "
+                            + (ctx != null ? ctx.getClass().getName() : "null") + "] (see trace)",
+                    e);
+        }
+    }
+
+    public Method getMethod() {
+        return method;
+    }
+
+    public AccessorNode setNextNode(AccessorNode nextNode) {
+        return this.nextNode = nextNode;
+    }
+
+    public AccessorNode getNextNode() {
+        return nextNode;
+    }
+
+    public String toString() {
+        return method.getDeclaringClass().getName() + "." + method.getName();
+    }
+
+    public Object setValue(Object ctx, Object elCtx, VariableResolverFactory vars, Object value) {
+        try {
+            if (nextNode != null) {
+                return nextNode.setValue(method.invoke(ctx, EMPTY), elCtx, vars, value);
+            } else {
+                throw new RuntimeException("bad payload");
+            }
+        } catch (IllegalArgumentException e) {
+            /**
+             * HACK: Try to access this another way.
+             */
+
+            if (nextNode != null) {
+                return nextNode.setValue(getProperty(getPropertyFromAccessor(method.getName()), ctx), elCtx, vars, value);
+            } else {
+                return getProperty(getPropertyFromAccessor(method.getName()), ctx);
+            }
+        } catch (CompileException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new RuntimeException("error " + method.getName() + ": " + e.getClass().getName() + ":" + e.getMessage(), e);
+        }
+    }
+
+    public Class getKnownEgressType() {
+        return method.getReturnType();
+    }
+
+    private Object executeOverrideTarget(Method o, Object ctx, Object elCtx, VariableResolverFactory vars) {
+        try {
+            if (nextNode != null) {
+                return nextNode.getValue(o.invoke(ctx, EMPTY), elCtx, vars);
+            } else {
+                return o.invoke(ctx, EMPTY);
+            }
+        } catch (Exception e2) {
+            throw new RuntimeException("unable to invoke method", e2);
+        }
+    }
+}

--- a/core/src/main/java/org/mvel2/optimizers/impl/refl/nodes/GetterAccessorNH.java
+++ b/core/src/main/java/org/mvel2/optimizers/impl/refl/nodes/GetterAccessorNH.java
@@ -1,0 +1,128 @@
+/**
+ * MVEL (The MVFLEX Expression Language)
+ *
+ * Copyright (C) 2007 Christopher Brock, MVFLEX/Valhalla Project and the Codehaus
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package org.mvel2.optimizers.impl.refl.nodes;
+
+import static org.mvel2.MVEL.getProperty;
+import static org.mvel2.util.ParseTools.getBestCandidate;
+
+import java.lang.reflect.Method;
+
+import org.mvel2.CompileException;
+import org.mvel2.compiler.AccessorNode;
+import org.mvel2.integration.PropertyHandler;
+import org.mvel2.integration.VariableResolverFactory;
+
+public class GetterAccessorNH implements AccessorNode {
+
+    public static final Object[] EMPTY = new Object[0];
+    private final Method method;
+    private AccessorNode nextNode;
+    private PropertyHandler nullHandler;
+
+    public GetterAccessorNH(Method method, PropertyHandler nullHandler) {
+        this.method = method;
+        this.nullHandler = nullHandler;
+    }
+
+    public Object getValue(Object ctx, Object elCtx, VariableResolverFactory vars) {
+        try {
+            return nullHandle(method.getName(), method.invoke(ctx, EMPTY), ctx, elCtx, vars);
+        } catch (IllegalArgumentException e) {
+            if (ctx != null && method.getDeclaringClass() != ctx.getClass()) {
+                Method o = getBestCandidate(EMPTY, method.getName(), ctx.getClass(), ctx.getClass().getMethods(), true);
+                if (o != null) {
+                    return executeOverrideTarget(o, ctx, elCtx, vars);
+                }
+            }
+            /**
+             * HACK: Try to access this another way.
+             */
+
+            return nullHandle(method.getName(), getProperty(method.getName() + "()", ctx), ctx, elCtx, vars);
+        } catch (Exception e) {
+            throw new RuntimeException("cannot invoke getter: " + method.getName() + " [declr.class: "
+                    + method.getDeclaringClass().getName() + "; act.class: " + (ctx != null ? ctx.getClass().getName() : "null") + "]", e);
+        }
+    }
+
+    public Method getMethod() {
+        return method;
+    }
+
+    public AccessorNode setNextNode(AccessorNode nextNode) {
+        return this.nextNode = nextNode;
+    }
+
+    public AccessorNode getNextNode() {
+        return nextNode;
+    }
+
+    public String toString() {
+        return method.getDeclaringClass().getName() + "." + method.getName();
+    }
+
+    public Object setValue(Object ctx, Object elCtx, VariableResolverFactory vars, Object value) {
+        try {
+            Object v = method.invoke(ctx, EMPTY);
+            if (v == null) v = nullHandler.getProperty(method.getName(), ctx, vars);
+            return nextNode.setValue(v, elCtx, vars, value);
+
+        } catch (IllegalArgumentException e) {
+            /**
+             * HACK: Try to access this another way.
+             */
+
+            Object v = getProperty(method.getName() + "()", ctx);
+            if (v == null) v = nullHandler.getProperty(method.getName(), ctx, vars);
+            return nextNode.setValue(v, elCtx, vars, value);
+        } catch (CompileException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new RuntimeException("error " + method.getName() + ": " + e.getClass().getName() + ":" + e.getMessage(), e);
+        }
+    }
+
+    public Class getKnownEgressType() {
+        return method.getReturnType();
+    }
+
+    private Object executeOverrideTarget(Method o, Object ctx, Object elCtx, VariableResolverFactory vars) {
+        try {
+            return nullHandle(o.getName(), o.invoke(ctx, EMPTY), ctx, elCtx, vars);
+        } catch (Exception e2) {
+            throw new RuntimeException("unable to invoke method", e2);
+        }
+    }
+
+    private Object nullHandle(String name, Object v, Object ctx, Object elCtx, VariableResolverFactory vars) {
+        if (v != null) {
+            if (nextNode != null) {
+                return nextNode.getValue(v, elCtx, vars);
+            } else {
+                return v;
+            }
+        } else {
+            if (nextNode != null) {
+                return nextNode.getValue(nullHandler.getProperty(name, ctx, vars), elCtx, vars);
+            } else {
+                return nullHandler.getProperty(name, ctx, vars);
+            }
+        }
+    }
+}

--- a/core/src/main/java/org/mvel2/optimizers/impl/refl/nodes/IndexedCharSeqAccessor.java
+++ b/core/src/main/java/org/mvel2/optimizers/impl/refl/nodes/IndexedCharSeqAccessor.java
@@ -1,0 +1,72 @@
+/**
+ * MVEL (The MVFLEX Expression Language)
+ *
+ * Copyright (C) 2007 Christopher Brock, MVFLEX/Valhalla Project and the Codehaus
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package org.mvel2.optimizers.impl.refl.nodes;
+
+import org.mvel2.compiler.AccessorNode;
+import org.mvel2.integration.VariableResolverFactory;
+
+public class IndexedCharSeqAccessor implements AccessorNode {
+
+    private AccessorNode nextNode;
+
+    private int index;
+
+    public IndexedCharSeqAccessor() {
+    }
+
+    public IndexedCharSeqAccessor(int index) {
+        this.index = index;
+    }
+
+    public Object getValue(Object ctx, Object elCtx, VariableResolverFactory vars) {
+        if (nextNode != null) {
+            return nextNode.getValue(((String) ctx).charAt(index), elCtx, vars);
+        } else {
+            return ((String) ctx).charAt(index);
+        }
+    }
+
+    public Object setValue(Object ctx, Object elCtx, VariableResolverFactory variableFactory, Object value) {
+        return nextNode.setValue(((String) ctx).charAt(index), elCtx, variableFactory, value);
+    }
+
+    public int getIndex() {
+        return index;
+    }
+
+    public void setIndex(int index) {
+        this.index = index;
+    }
+
+    public AccessorNode getNextNode() {
+        return nextNode;
+    }
+
+    public AccessorNode setNextNode(AccessorNode nextNode) {
+        return this.nextNode = nextNode;
+    }
+
+    public String toString() {
+        return "Array Accessor -> [" + index + "]";
+    }
+
+    public Class getKnownEgressType() {
+        return Character.class;
+    }
+}

--- a/core/src/main/java/org/mvel2/optimizers/impl/refl/nodes/IndexedCharSeqAccessorNest.java
+++ b/core/src/main/java/org/mvel2/optimizers/impl/refl/nodes/IndexedCharSeqAccessorNest.java
@@ -1,0 +1,73 @@
+/**
+ * MVEL (The MVFLEX Expression Language)
+ *
+ * Copyright (C) 2007 Christopher Brock, MVFLEX/Valhalla Project and the Codehaus
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package org.mvel2.optimizers.impl.refl.nodes;
+
+import org.mvel2.compiler.AccessorNode;
+import org.mvel2.compiler.ExecutableStatement;
+import org.mvel2.integration.VariableResolverFactory;
+
+public class IndexedCharSeqAccessorNest implements AccessorNode {
+
+    private AccessorNode nextNode;
+    private ExecutableStatement index;
+
+    public IndexedCharSeqAccessorNest() {
+    }
+
+    public IndexedCharSeqAccessorNest(ExecutableStatement index) {
+        this.index = index;
+    }
+
+    public Object getValue(Object ctx, Object elCtx, VariableResolverFactory vars) {
+        if (nextNode != null) {
+            return nextNode.getValue(((String) ctx).charAt((Integer) index.getValue(ctx, elCtx, vars)), elCtx, vars);
+        } else {
+            return ((String) ctx).charAt((Integer) index.getValue(ctx, elCtx, vars));
+        }
+    }
+
+    public Object setValue(Object ctx, Object elCtx, VariableResolverFactory variableFactory, Object value) {
+        return nextNode.setValue(((String) ctx).charAt((Integer) index.getValue(ctx, elCtx, variableFactory)), elCtx, variableFactory,
+                value);
+    }
+
+    public ExecutableStatement getIndex() {
+        return index;
+    }
+
+    public void setIndex(ExecutableStatement index) {
+        this.index = index;
+    }
+
+    public AccessorNode getNextNode() {
+        return nextNode;
+    }
+
+    public AccessorNode setNextNode(AccessorNode nextNode) {
+        return this.nextNode = nextNode;
+    }
+
+    public String toString() {
+        return "Array Accessor -> [" + index + "]";
+    }
+
+    public Class getKnownEgressType() {
+        return Character.class;
+    }
+}

--- a/core/src/main/java/org/mvel2/optimizers/impl/refl/nodes/IndexedVariableAccessor.java
+++ b/core/src/main/java/org/mvel2/optimizers/impl/refl/nodes/IndexedVariableAccessor.java
@@ -1,0 +1,61 @@
+/**
+ * MVEL (The MVFLEX Expression Language)
+ *
+ * Copyright (C) 2007 Christopher Brock, MVFLEX/Valhalla Project and the Codehaus
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package org.mvel2.optimizers.impl.refl.nodes;
+
+import org.mvel2.compiler.AccessorNode;
+import org.mvel2.integration.VariableResolverFactory;
+
+public class IndexedVariableAccessor implements AccessorNode {
+
+    private AccessorNode nextNode;
+    private int register;
+
+    public IndexedVariableAccessor(int register) {
+        this.register = register;
+    }
+
+    public Object getValue(Object ctx, Object elCtx, VariableResolverFactory vrf) {
+        if (nextNode != null) {
+            return nextNode.getValue(vrf.getIndexedVariableResolver(register).getValue(), elCtx, vrf);
+        } else {
+            return vrf.getIndexedVariableResolver(register).getValue();
+        }
+    }
+
+    public Object setValue(Object ctx, Object elCtx, VariableResolverFactory variableFactory, Object value) {
+        if (nextNode != null) {
+            return nextNode.setValue(variableFactory.getIndexedVariableResolver(register).getValue(), elCtx, variableFactory, value);
+        } else {
+            variableFactory.getIndexedVariableResolver(register).setValue(value);
+            return value;
+        }
+    }
+
+    public AccessorNode getNextNode() {
+        return nextNode;
+    }
+
+    public AccessorNode setNextNode(AccessorNode nextNode) {
+        return this.nextNode = nextNode;
+    }
+
+    public Class getKnownEgressType() {
+        return Object.class;
+    }
+}

--- a/core/src/main/java/org/mvel2/optimizers/impl/refl/nodes/InvokableAccessor.java
+++ b/core/src/main/java/org/mvel2/optimizers/impl/refl/nodes/InvokableAccessor.java
@@ -1,0 +1,42 @@
+package org.mvel2.optimizers.impl.refl.nodes;
+
+import static org.mvel2.DataConversion.convert;
+
+import java.lang.reflect.Array;
+
+import org.mvel2.compiler.ExecutableStatement;
+import org.mvel2.integration.VariableResolverFactory;
+
+public abstract class InvokableAccessor extends BaseAccessor {
+
+    protected int length;
+    protected ExecutableStatement[] parms;
+    protected Class[] parameterTypes;
+    protected boolean coercionNeeded = false;
+
+    protected Object[] executeAndCoerce(Class[] target, Object elCtx, VariableResolverFactory vars, boolean isVarargs) {
+        Object[] values = new Object[length];
+        for (int i = 0; i < length && !(isVarargs && i >= length - 1); i++) {
+            //noinspection unchecked
+            values[i] = convert(parms[i].getValue(elCtx, vars), target[i]);
+        }
+        if (isVarargs) {
+            Class<?> componentType = target[length - 1].getComponentType();
+            Object vararg;
+            if (parms == null) {
+                vararg = Array.newInstance(componentType, 0);
+            } else {
+                vararg = Array.newInstance(componentType, parms.length - length + 1);
+                for (int i = length - 1; i < parms.length; i++) {
+                    Array.set(vararg, i - length + 1, convert(parms[i].getValue(elCtx, vars), componentType));
+                }
+            }
+            values[length - 1] = vararg;
+        }
+        return values;
+    }
+
+    public Class[] getParameterTypes() {
+        return parameterTypes;
+    }
+}

--- a/core/src/main/java/org/mvel2/optimizers/impl/refl/nodes/ListAccessor.java
+++ b/core/src/main/java/org/mvel2/optimizers/impl/refl/nodes/ListAccessor.java
@@ -1,0 +1,79 @@
+/**
+ * MVEL (The MVFLEX Expression Language)
+ *
+ * Copyright (C) 2007 Christopher Brock, MVFLEX/Valhalla Project and the Codehaus
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package org.mvel2.optimizers.impl.refl.nodes;
+
+import java.util.List;
+
+import org.mvel2.compiler.AccessorNode;
+import org.mvel2.integration.VariableResolverFactory;
+
+public class ListAccessor implements AccessorNode {
+
+    private AccessorNode nextNode;
+    private int index;
+
+    public ListAccessor() {
+    }
+
+    public ListAccessor(int index) {
+        this.index = index;
+    }
+
+    public Object getValue(Object ctx, Object elCtx, VariableResolverFactory vars) {
+        if (nextNode != null) {
+            return nextNode.getValue(((List) ctx).get(index), elCtx, vars);
+        } else {
+            return ((List) ctx).get(index);
+        }
+    }
+
+    public Object setValue(Object ctx, Object elCtx, VariableResolverFactory vars, Object value) {
+        if (nextNode != null) {
+            return nextNode.setValue(((List) ctx).get(index), elCtx, vars, value);
+        } else {
+            //noinspection unchecked
+            ((List) ctx).set(index, value);
+            return value;
+        }
+    }
+
+    public int getIndex() {
+        return index;
+    }
+
+    public void setIndex(int index) {
+        this.index = index;
+    }
+
+    public AccessorNode getNextNode() {
+        return nextNode;
+    }
+
+    public AccessorNode setNextNode(AccessorNode nextNode) {
+        return this.nextNode = nextNode;
+    }
+
+    public String toString() {
+        return "Array Accessor -> [" + index + "]";
+    }
+
+    public Class getKnownEgressType() {
+        return Object.class;
+    }
+}

--- a/core/src/main/java/org/mvel2/optimizers/impl/refl/nodes/ListAccessorNest.java
+++ b/core/src/main/java/org/mvel2/optimizers/impl/refl/nodes/ListAccessorNest.java
@@ -1,0 +1,96 @@
+/**
+ * MVEL (The MVFLEX Expression Language)
+ *
+ * Copyright (C) 2007 Christopher Brock, MVFLEX/Valhalla Project and the Codehaus
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package org.mvel2.optimizers.impl.refl.nodes;
+
+import static org.mvel2.util.ParseTools.subCompileExpression;
+
+import java.util.List;
+
+import org.mvel2.DataConversion;
+import org.mvel2.compiler.AccessorNode;
+import org.mvel2.compiler.ExecutableStatement;
+import org.mvel2.integration.VariableResolverFactory;
+
+public class ListAccessorNest implements AccessorNode {
+
+    private AccessorNode nextNode;
+    private ExecutableStatement index;
+    private Class conversionType;
+
+    public ListAccessorNest() {
+    }
+
+    public ListAccessorNest(String index, Class conversionType) {
+        this.index = (ExecutableStatement) subCompileExpression(index.toCharArray());
+        this.conversionType = conversionType;
+    }
+
+    public ListAccessorNest(ExecutableStatement index, Class conversionType) {
+        this.index = index;
+        this.conversionType = conversionType;
+    }
+
+    public Object getValue(Object ctx, Object elCtx, VariableResolverFactory vars) {
+        if (nextNode != null) {
+            return nextNode.getValue(((List) ctx).get((Integer) index.getValue(ctx, elCtx, vars)), elCtx, vars);
+        } else {
+            return ((List) ctx).get((Integer) index.getValue(ctx, elCtx, vars));
+        }
+    }
+
+    public Object setValue(Object ctx, Object elCtx, VariableResolverFactory vars, Object value) {
+        //noinspection unchecked
+
+        if (nextNode != null) {
+            return nextNode.setValue(((List) ctx).get((Integer) index.getValue(ctx, elCtx, vars)), elCtx, vars, value);
+        } else {
+            if (conversionType != null) {
+                ((List) ctx).set((Integer) index.getValue(ctx, elCtx, vars), value = DataConversion.convert(value, conversionType));
+            } else {
+                ((List) ctx).set((Integer) index.getValue(ctx, elCtx, vars), value);
+            }
+            return value;
+        }
+
+    }
+
+    public ExecutableStatement getIndex() {
+        return index;
+    }
+
+    public void setIndex(ExecutableStatement index) {
+        this.index = index;
+    }
+
+    public AccessorNode getNextNode() {
+        return nextNode;
+    }
+
+    public AccessorNode setNextNode(AccessorNode nextNode) {
+        return this.nextNode = nextNode;
+    }
+
+    public String toString() {
+        return "Array Accessor -> [" + index + "]";
+    }
+
+    public Class getKnownEgressType() {
+        return Object.class;
+    }
+}

--- a/core/src/main/java/org/mvel2/optimizers/impl/refl/nodes/MapAccessor.java
+++ b/core/src/main/java/org/mvel2/optimizers/impl/refl/nodes/MapAccessor.java
@@ -1,0 +1,79 @@
+/**
+ * MVEL (The MVFLEX Expression Language)
+ *
+ * Copyright (C) 2007 Christopher Brock, MVFLEX/Valhalla Project and the Codehaus
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package org.mvel2.optimizers.impl.refl.nodes;
+
+import java.util.Map;
+
+import org.mvel2.compiler.AccessorNode;
+import org.mvel2.integration.VariableResolverFactory;
+
+public class MapAccessor implements AccessorNode {
+
+    private AccessorNode nextNode;
+    private Object property;
+
+    public MapAccessor() {
+    }
+
+    public MapAccessor(Object property) {
+        this.property = property;
+    }
+
+    public Object getValue(Object ctx, Object elCtx, VariableResolverFactory vrf) {
+        if (nextNode != null) {
+            return nextNode.getValue(((Map) ctx).get(property), elCtx, vrf);
+        } else {
+            return ((Map) ctx).get(property);
+        }
+    }
+
+    public Object setValue(Object ctx, Object elCtx, VariableResolverFactory vars, Object value) {
+        if (nextNode != null) {
+            return nextNode.setValue(((Map) ctx).get(property), elCtx, vars, value);
+        } else {
+            //noinspection unchecked
+            ((Map) ctx).put(property, value);
+            return value;
+        }
+    }
+
+    public Object getProperty() {
+        return property;
+    }
+
+    public void setProperty(Object property) {
+        this.property = property;
+    }
+
+    public AccessorNode getNextNode() {
+        return nextNode;
+    }
+
+    public AccessorNode setNextNode(AccessorNode nextNode) {
+        return this.nextNode = nextNode;
+    }
+
+    public String toString() {
+        return "Map Accessor -> [" + property + "]";
+    }
+
+    public Class getKnownEgressType() {
+        return Object.class;
+    }
+}

--- a/core/src/main/java/org/mvel2/optimizers/impl/refl/nodes/MapAccessorNest.java
+++ b/core/src/main/java/org/mvel2/optimizers/impl/refl/nodes/MapAccessorNest.java
@@ -1,0 +1,96 @@
+/**
+ * MVEL (The MVFLEX Expression Language)
+ *
+ * Copyright (C) 2007 Christopher Brock, MVFLEX/Valhalla Project and the Codehaus
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package org.mvel2.optimizers.impl.refl.nodes;
+
+import static org.mvel2.util.ParseTools.subCompileExpression;
+
+import java.util.Map;
+
+import org.mvel2.DataConversion;
+import org.mvel2.compiler.AccessorNode;
+import org.mvel2.compiler.ExecutableStatement;
+import org.mvel2.integration.VariableResolverFactory;
+
+/**
+ * @author Christopher Brock
+ */
+public class MapAccessorNest implements AccessorNode {
+
+    private AccessorNode nextNode;
+    private ExecutableStatement property;
+    private Class conversionType;
+
+    public MapAccessorNest() {
+    }
+
+    public MapAccessorNest(ExecutableStatement property, Class conversionType) {
+        this.property = property;
+        this.conversionType = conversionType;
+    }
+
+    public MapAccessorNest(String property, Class conversionType) {
+        this.property = (ExecutableStatement) subCompileExpression(property.toCharArray());
+        this.conversionType = conversionType;
+    }
+
+    public Object getValue(Object ctx, Object elCtx, VariableResolverFactory vrf) {
+        if (nextNode != null) {
+            return nextNode.getValue(((Map) ctx).get(property.getValue(ctx, elCtx, vrf)), elCtx, vrf);
+        } else {
+            return ((Map) ctx).get(property.getValue(ctx, elCtx, vrf));
+        }
+    }
+
+    public Object setValue(Object ctx, Object elCtx, VariableResolverFactory vars, Object value) {
+        if (nextNode != null) {
+            return nextNode.setValue(((Map) ctx).get(property.getValue(ctx, elCtx, vars)), elCtx, vars, value);
+        } else {
+            if (conversionType != null) {
+                ((Map) ctx).put(property.getValue(ctx, elCtx, vars), value = DataConversion.convert(value, conversionType));
+            } else {
+                ((Map) ctx).put(property.getValue(ctx, elCtx, vars), value);
+            }
+            return value;
+        }
+    }
+
+    public ExecutableStatement getProperty() {
+        return property;
+    }
+
+    public void setProperty(ExecutableStatement property) {
+        this.property = property;
+    }
+
+    public AccessorNode getNextNode() {
+        return nextNode;
+    }
+
+    public AccessorNode setNextNode(AccessorNode nextNode) {
+        return this.nextNode = nextNode;
+    }
+
+    public String toString() {
+        return "Map Accessor -> [" + property + "]";
+    }
+
+    public Class getKnownEgressType() {
+        return Object.class;
+    }
+}

--- a/core/src/main/java/org/mvel2/optimizers/impl/refl/nodes/MethodAccessor.java
+++ b/core/src/main/java/org/mvel2/optimizers/impl/refl/nodes/MethodAccessor.java
@@ -1,0 +1,190 @@
+/**
+ * MVEL (The MVFLEX Expression Language)
+ *
+ * Copyright (C) 2007 Christopher Brock, MVFLEX/Valhalla Project and the Codehaus
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package org.mvel2.optimizers.impl.refl.nodes;
+
+import static org.mvel2.util.ParseTools.getBestCandidate;
+import static org.mvel2.util.ParseTools.getWidenedTarget;
+
+import java.lang.reflect.Method;
+
+import org.mvel2.compiler.ExecutableStatement;
+import org.mvel2.integration.VariableResolverFactory;
+
+public class MethodAccessor extends InvokableAccessor {
+
+    private Method method;
+
+    public MethodAccessor() {
+    }
+
+    public MethodAccessor(Method method, ExecutableStatement[] parms) {
+        setMethod(method);
+        this.parms = parms;
+    }
+
+    public Object getValue(Object ctx, Object elCtx, VariableResolverFactory vars) {
+        if (!coercionNeeded) {
+            try {
+                if (nextNode != null) {
+                    return nextNode.getValue(method.invoke(ctx, executeAll(elCtx, vars, method)), elCtx, vars);
+                } else {
+                    return method.invoke(ctx, executeAll(elCtx, vars, method));
+                }
+            } catch (IllegalArgumentException e) {
+                if (ctx != null && method.getDeclaringClass() != ctx.getClass()) {
+                    Method o = getBestCandidate(parameterTypes, method.getName(), ctx.getClass(), ctx.getClass().getMethods(), true);
+                    if (o != null) {
+                        return executeOverrideTarget(getWidenedTarget(o), ctx, elCtx, vars);
+                    }
+                }
+
+                coercionNeeded = true;
+                return getValue(ctx, elCtx, vars);
+            } catch (Exception e) {
+                throw new RuntimeException("cannot invoke method: " + method.getName(), e);
+            }
+
+        } else {
+            try {
+                if (nextNode != null) {
+                    return nextNode.getValue(method.invoke(ctx, executeAndCoerce(parameterTypes, elCtx, vars, method.isVarArgs())), elCtx,
+                            vars);
+                } else {
+                    return method.invoke(ctx, executeAndCoerce(parameterTypes, elCtx, vars, method.isVarArgs()));
+                }
+            } catch (IllegalArgumentException e) {
+                Object[] vs = executeAndCoerce(parameterTypes, elCtx, vars, false);
+                Method newMeth;
+                if ((newMeth = getWidenedTarget(
+                        getBestCandidate(vs, method.getName(), ctx.getClass(), ctx.getClass().getMethods(), false))) != null) {
+                    return executeOverrideTarget(newMeth, ctx, elCtx, vars);
+                } else {
+                    throw e;
+                }
+            } catch (Exception e) {
+                throw new RuntimeException("cannot invoke method: " + method.getName(), e);
+            }
+        }
+    }
+
+    private Object executeOverrideTarget(Method o, Object ctx, Object elCtx, VariableResolverFactory vars) {
+        // this local field is required to make sure exception block works with the same coercionNeeded value
+        // and it is not changed by another thread while setter is invoked
+        boolean attemptedCoercion = coercionNeeded;
+        if (!coercionNeeded) {
+            try {
+                try {
+                    if (nextNode != null) {
+                        return nextNode.getValue(o.invoke(ctx, executeAll(elCtx, vars, o)), elCtx, vars);
+                    } else {
+                        return o.invoke(ctx, executeAll(elCtx, vars, o));
+                    }
+                } catch (IllegalArgumentException e) {
+                    if (attemptedCoercion) throw e;
+
+                    coercionNeeded = true;
+                    return executeOverrideTarget(o, ctx, elCtx, vars);
+                }
+            } catch (Exception e2) {
+                throw new RuntimeException("unable to invoke method", e2);
+            }
+        } else {
+            try {
+                if (nextNode != null) {
+                    return nextNode.getValue(o.invoke(ctx, executeAndCoerce(o.getParameterTypes(), elCtx, vars, o.isVarArgs())), elCtx,
+                            vars);
+                } else {
+                    return o.invoke(ctx, executeAndCoerce(o.getParameterTypes(), elCtx, vars, o.isVarArgs()));
+                }
+            } catch (IllegalAccessException e) {
+                throw new RuntimeException("unable to invoke method (expected target: " + method.getDeclaringClass().getName() + "::"
+                        + method.getName() + "; " + "actual target: " + ctx.getClass().getName() + "::" + method.getName()
+                        + "; coercionNeeded=" + (coercionNeeded ? "yes" : "no") + ")");
+            } catch (Exception e2) {
+                throw new RuntimeException("unable to invoke method (expected target: " + method.getDeclaringClass().getName() + "::"
+                        + method.getName() + "; " + "actual target: " + ctx.getClass().getName() + "::" + method.getName()
+                        + "; coercionNeeded=" + (coercionNeeded ? "yes" : "no") + ")");
+            }
+        }
+    }
+
+    private Object[] executeAll(Object ctx, VariableResolverFactory vars, Method m) {
+        if (length == 0) return GetterAccessor.EMPTY;
+
+        Object[] vals = new Object[length];
+        for (int i = 0; i < length - (m.isVarArgs() ? 1 : 0); i++) {
+            vals[i] = parms[i].getValue(ctx, vars);
+        }
+
+        if (m.isVarArgs()) {
+            if (parms == null) {
+                vals[length - 1] = new Object[0];
+            } else if (parms.length == length) {
+                Object lastParam = parms[length - 1].getValue(ctx, vars);
+                vals[length - 1] = lastParam == null || lastParam.getClass().isArray() ? lastParam : new Object[] { lastParam };
+            } else {
+                Object[] vararg = new Object[parms.length - length + 1];
+                for (int i = 0; i < vararg.length; i++)
+                    vararg[i] = parms[length - 1 + i].getValue(ctx, vars);
+                vals[length - 1] = vararg;
+            }
+        }
+
+        return vals;
+    }
+
+    public Method getMethod() {
+        return method;
+    }
+
+    public void setMethod(Method method) {
+        this.method = method;
+        this.length = (this.parameterTypes = this.method.getParameterTypes()).length;
+    }
+
+    public ExecutableStatement[] getParms() {
+        return parms;
+    }
+
+    public void setParms(ExecutableStatement[] parms) {
+        this.parms = parms;
+    }
+
+    public Object setValue(Object ctx, Object elCtx, VariableResolverFactory variableFactory, Object value) {
+        try {
+            return nextNode.setValue(method.invoke(ctx, executeAll(elCtx, variableFactory, method)), elCtx, variableFactory, value);
+        } catch (IllegalArgumentException e) {
+            if (ctx != null && method.getDeclaringClass() != ctx.getClass()) {
+                Method o = getBestCandidate(parameterTypes, method.getName(), ctx.getClass(), ctx.getClass().getMethods(), true);
+                if (o != null) {
+                    return nextNode.setValue(executeOverrideTarget(o, ctx, elCtx, variableFactory), elCtx, variableFactory, value);
+                }
+            }
+
+            coercionNeeded = true;
+            return setValue(ctx, elCtx, variableFactory, value);
+        } catch (Exception e) {
+            throw new RuntimeException("cannot invoke method", e);
+        }
+    }
+
+    public Class getKnownEgressType() {
+        return method.getReturnType();
+    }
+}

--- a/core/src/main/java/org/mvel2/optimizers/impl/refl/nodes/MethodAccessorNH.java
+++ b/core/src/main/java/org/mvel2/optimizers/impl/refl/nodes/MethodAccessorNH.java
@@ -1,0 +1,158 @@
+/**
+ * MVEL (The MVFLEX Expression Language)
+ *
+ * Copyright (C) 2007 Christopher Brock, MVFLEX/Valhalla Project and the Codehaus
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package org.mvel2.optimizers.impl.refl.nodes;
+
+import static org.mvel2.DataConversion.convert;
+import static org.mvel2.util.ParseTools.getBestCandidate;
+
+import java.lang.reflect.Method;
+
+import org.mvel2.compiler.AccessorNode;
+import org.mvel2.compiler.ExecutableStatement;
+import org.mvel2.integration.PropertyHandler;
+import org.mvel2.integration.VariableResolverFactory;
+
+public class MethodAccessorNH implements AccessorNode {
+
+    private AccessorNode nextNode;
+
+    private Method method;
+    private Class[] parameterTypes;
+    private ExecutableStatement[] parms;
+    private int length;
+    private boolean coercionNeeded = false;
+
+    private PropertyHandler nullHandler;
+
+    public MethodAccessorNH() {
+    }
+
+    public MethodAccessorNH(Method method, ExecutableStatement[] parms, PropertyHandler handler) {
+        this.method = method;
+        this.length = (this.parameterTypes = this.method.getParameterTypes()).length;
+
+        this.parms = parms;
+        this.nullHandler = handler;
+    }
+
+    public Object getValue(Object ctx, Object elCtx, VariableResolverFactory vars) {
+        if (!coercionNeeded) {
+            try {
+                Object v = method.invoke(ctx, executeAll(elCtx, vars));
+                if (v == null) nullHandler.getProperty(method.getName(), ctx, vars);
+
+                if (nextNode != null) {
+                    return nextNode.getValue(v, elCtx, vars);
+                } else {
+                    return v;
+                }
+            } catch (IllegalArgumentException e) {
+                if (ctx != null && method.getDeclaringClass() != ctx.getClass()) {
+                    Method o = getBestCandidate(parameterTypes, method.getName(), ctx.getClass(), ctx.getClass().getMethods(), true);
+                    if (o != null) {
+                        return executeOverrideTarget(o, ctx, elCtx, vars);
+                    }
+                }
+
+                coercionNeeded = true;
+                return getValue(ctx, elCtx, vars);
+            } catch (Exception e) {
+                throw new RuntimeException("cannot invoke method", e);
+            }
+
+        } else {
+            try {
+                if (nextNode != null) {
+                    return nextNode.getValue(method.invoke(ctx, executeAndCoerce(parameterTypes, elCtx, vars)), elCtx, vars);
+                } else {
+                    return method.invoke(ctx, executeAndCoerce(parameterTypes, elCtx, vars));
+                }
+            } catch (Exception e) {
+                throw new RuntimeException("cannot invoke method", e);
+            }
+        }
+    }
+
+    private Object executeOverrideTarget(Method o, Object ctx, Object elCtx, VariableResolverFactory vars) {
+        try {
+            Object v = o.invoke(ctx, executeAll(elCtx, vars));
+            if (v == null) v = nullHandler.getProperty(o.getName(), ctx, vars);
+
+            if (nextNode != null) {
+                return nextNode.getValue(v, elCtx, vars);
+            } else {
+                return v;
+            }
+        } catch (Exception e2) {
+            throw new RuntimeException("unable to invoke method", e2);
+        }
+    }
+
+    private Object[] executeAll(Object ctx, VariableResolverFactory vars) {
+        if (length == 0) return GetterAccessor.EMPTY;
+
+        Object[] vals = new Object[length];
+        for (int i = 0; i < length; i++) {
+            vals[i] = parms[i].getValue(ctx, vars);
+        }
+        return vals;
+    }
+
+    private Object[] executeAndCoerce(Class[] target, Object elCtx, VariableResolverFactory vars) {
+        Object[] values = new Object[length];
+        for (int i = 0; i < length; i++) {
+            //noinspection unchecked
+            values[i] = convert(parms[i].getValue(elCtx, vars), target[i]);
+        }
+        return values;
+    }
+
+    public Method getMethod() {
+        return method;
+    }
+
+    public void setMethod(Method method) {
+        this.method = method;
+        this.length = (this.parameterTypes = this.method.getParameterTypes()).length;
+    }
+
+    public ExecutableStatement[] getParms() {
+        return parms;
+    }
+
+    public void setParms(ExecutableStatement[] parms) {
+        this.parms = parms;
+    }
+
+    public AccessorNode getNextNode() {
+        return nextNode;
+    }
+
+    public AccessorNode setNextNode(AccessorNode nextNode) {
+        return this.nextNode = nextNode;
+    }
+
+    public Object setValue(Object ctx, Object elCtx, VariableResolverFactory variableFactory, Object value) {
+        return nextNode.setValue(ctx, elCtx, variableFactory, value);
+    }
+
+    public Class getKnownEgressType() {
+        return method.getReturnType();
+    }
+}

--- a/core/src/main/java/org/mvel2/optimizers/impl/refl/nodes/Notify.java
+++ b/core/src/main/java/org/mvel2/optimizers/impl/refl/nodes/Notify.java
@@ -1,0 +1,37 @@
+package org.mvel2.optimizers.impl.refl.nodes;
+
+import org.mvel2.compiler.AccessorNode;
+import org.mvel2.integration.GlobalListenerFactory;
+import org.mvel2.integration.VariableResolverFactory;
+
+public class Notify implements AccessorNode {
+
+    private String name;
+    private AccessorNode nextNode;
+
+    public Notify(String name) {
+        this.name = name;
+    }
+
+    public Object getValue(Object ctx, Object elCtx, VariableResolverFactory vrf) {
+        GlobalListenerFactory.notifyGetListeners(ctx, name, vrf);
+        return nextNode.getValue(ctx, elCtx, vrf);
+    }
+
+    public Object setValue(Object ctx, Object elCtx, VariableResolverFactory variableFactory, Object value) {
+        GlobalListenerFactory.notifySetListeners(ctx, name, variableFactory, value);
+        return nextNode.setValue(ctx, elCtx, variableFactory, value);
+    }
+
+    public AccessorNode getNextNode() {
+        return nextNode;
+    }
+
+    public AccessorNode setNextNode(AccessorNode nextNode) {
+        return this.nextNode = nextNode;
+    }
+
+    public Class getKnownEgressType() {
+        return Object.class;
+    }
+}

--- a/core/src/main/java/org/mvel2/optimizers/impl/refl/nodes/NullSafe.java
+++ b/core/src/main/java/org/mvel2/optimizers/impl/refl/nodes/NullSafe.java
@@ -1,0 +1,75 @@
+package org.mvel2.optimizers.impl.refl.nodes;
+
+import org.mvel2.ParserContext;
+import org.mvel2.compiler.Accessor;
+import org.mvel2.compiler.AccessorNode;
+import org.mvel2.integration.VariableResolverFactory;
+import org.mvel2.optimizers.OptimizerFactory;
+
+public class NullSafe implements AccessorNode {
+
+    private AccessorNode nextNode;
+    private char[] expr;
+    private int start;
+    private int offset;
+    private ParserContext pCtx;
+
+    public NullSafe(char[] expr, int start, int offset, ParserContext pCtx) {
+        this.expr = expr;
+        this.start = start;
+        this.offset = offset;
+        this.pCtx = pCtx;
+    }
+
+    public Object getValue(Object ctx, Object elCtx, VariableResolverFactory variableFactory) {
+        if (ctx == null) return null;
+        if (nextNode == null) {
+            final Accessor a = OptimizerFactory.getAccessorCompiler(OptimizerFactory.SAFE_REFLECTIVE).optimizeAccessor(pCtx, expr, start,
+                    offset, ctx, elCtx, variableFactory, true, ctx.getClass());
+
+            nextNode = new AccessorNode() {
+
+                public AccessorNode getNextNode() {
+                    return null;
+                }
+
+                public AccessorNode setNextNode(AccessorNode accessorNode) {
+                    return null;
+                }
+
+                public Object getValue(Object ctx, Object elCtx, VariableResolverFactory variableFactory) {
+                    return a.getValue(ctx, elCtx, variableFactory);
+                }
+
+                public Object setValue(Object ctx, Object elCtx, VariableResolverFactory variableFactory, Object value) {
+                    return a.setValue(ctx, elCtx, variableFactory, value);
+                }
+
+                public Class getKnownEgressType() {
+                    return a.getKnownEgressType();
+                }
+            };
+
+        }
+        //   else {
+        return nextNode.getValue(ctx, elCtx, variableFactory);
+        //    }
+    }
+
+    public Object setValue(Object ctx, Object elCtx, VariableResolverFactory variableFactory, Object value) {
+        if (ctx == null) return null;
+        return nextNode.setValue(ctx, elCtx, variableFactory, value);
+    }
+
+    public AccessorNode getNextNode() {
+        return nextNode;
+    }
+
+    public AccessorNode setNextNode(AccessorNode accessorNode) {
+        return this.nextNode = accessorNode;
+    }
+
+    public Class getKnownEgressType() {
+        return Object.class;
+    }
+}

--- a/core/src/main/java/org/mvel2/optimizers/impl/refl/nodes/PropertyHandlerAccessor.java
+++ b/core/src/main/java/org/mvel2/optimizers/impl/refl/nodes/PropertyHandlerAccessor.java
@@ -1,0 +1,49 @@
+package org.mvel2.optimizers.impl.refl.nodes;
+
+import org.mvel2.MVEL;
+import org.mvel2.integration.PropertyHandler;
+import org.mvel2.integration.VariableResolverFactory;
+
+public class PropertyHandlerAccessor extends BaseAccessor {
+
+    private String propertyName;
+    private PropertyHandler propertyHandler;
+    private Class conversionType;
+
+    public PropertyHandlerAccessor(String propertyName, Class conversionType, PropertyHandler propertyHandler) {
+        this.propertyName = propertyName;
+        this.conversionType = conversionType;
+        this.propertyHandler = propertyHandler;
+    }
+
+    public Object getValue(Object ctx, Object elCtx, VariableResolverFactory variableFactory) {
+        if (!conversionType.isAssignableFrom(ctx.getClass())) {
+            if (nextNode != null) {
+                return nextNode.getValue(MVEL.getProperty(propertyName, ctx), elCtx, variableFactory);
+            } else {
+                return MVEL.getProperty(propertyName, ctx);
+            }
+        }
+        try {
+            if (nextNode != null) {
+                return nextNode.getValue(propertyHandler.getProperty(propertyName, ctx, variableFactory), elCtx, variableFactory);
+            } else {
+                return propertyHandler.getProperty(propertyName, ctx, variableFactory);
+            }
+        } catch (Exception e) {
+            throw new RuntimeException("unable to access field", e);
+        }
+    }
+
+    public Object setValue(Object ctx, Object elCtx, VariableResolverFactory variableFactory, Object value) {
+        if (nextNode != null) {
+            return nextNode.setValue(propertyHandler.getProperty(propertyName, ctx, variableFactory), ctx, variableFactory, value);
+        } else {
+            return propertyHandler.setProperty(propertyName, ctx, variableFactory, value);
+        }
+    }
+
+    public Class getKnownEgressType() {
+        return Object.class;
+    }
+}

--- a/core/src/main/java/org/mvel2/optimizers/impl/refl/nodes/SetterAccessor.java
+++ b/core/src/main/java/org/mvel2/optimizers/impl/refl/nodes/SetterAccessor.java
@@ -1,0 +1,86 @@
+package org.mvel2.optimizers.impl.refl.nodes;
+
+import static org.mvel2.DataConversion.convert;
+import static org.mvel2.util.ParseTools.getBestCandidate;
+
+import java.lang.reflect.Method;
+
+import org.mvel2.compiler.AccessorNode;
+import org.mvel2.integration.VariableResolverFactory;
+import org.mvel2.util.PropertyTools;
+
+public class SetterAccessor implements AccessorNode {
+
+    public static final Object[] EMPTY = new Object[0];
+    private final Method method;
+    private AccessorNode nextNode;
+    private Class<?> targetType;
+    private boolean primitive;
+    private boolean coercionRequired = false;
+
+    public SetterAccessor(Method method) {
+        this.method = method;
+        assert method != null;
+        primitive = (this.targetType = method.getParameterTypes()[0]).isPrimitive();
+    }
+
+    public Object setValue(Object ctx, Object elCtx, VariableResolverFactory variableFactory, Object value) {
+        // this local field is required to make sure exception block works with the same coercionRequired value
+        // and it is not changed by another thread while setter is invoked
+        boolean attemptedCoercion = coercionRequired;
+        try {
+            if (coercionRequired) {
+                return method.invoke(ctx, convert(value, targetType));
+            } else {
+                return method.invoke(ctx, value == null && primitive ? PropertyTools.getPrimitiveInitialValue(targetType) : value);
+            }
+        } catch (IllegalArgumentException e) {
+            if (ctx != null && method.getDeclaringClass() != ctx.getClass()) {
+                Method o = getBestCandidate(EMPTY, method.getName(), ctx.getClass(), ctx.getClass().getMethods(), true);
+                if (o != null) {
+                    return executeOverrideTarget(o, ctx, value);
+                }
+            }
+
+            if (!attemptedCoercion) {
+                coercionRequired = true;
+                return setValue(ctx, elCtx, variableFactory, value);
+            }
+            throw new RuntimeException("unable to bind property", e);
+        } catch (Exception e) {
+            throw new RuntimeException("error calling method: " + method.getDeclaringClass().getName() + "." + method.getName(), e);
+        }
+    }
+
+    public Object getValue(Object ctx, Object elCtx, VariableResolverFactory vars) {
+        return null;
+    }
+
+    public Method getMethod() {
+        return method;
+    }
+
+    public AccessorNode setNextNode(AccessorNode nextNode) {
+        return this.nextNode = nextNode;
+    }
+
+    public AccessorNode getNextNode() {
+        return nextNode;
+    }
+
+    public String toString() {
+        return method.getDeclaringClass().getName() + "." + method.getName();
+    }
+
+    public Class getKnownEgressType() {
+        return method.getReturnType();
+    }
+
+    private Object executeOverrideTarget(Method o, Object ctx, Object value) {
+        try {
+            return o.invoke(ctx, convert(value, targetType));
+        } catch (Exception e2) {
+            throw new RuntimeException("unable to invoke method", e2);
+        }
+    }
+}

--- a/core/src/main/java/org/mvel2/optimizers/impl/refl/nodes/StaticReferenceAccessor.java
+++ b/core/src/main/java/org/mvel2/optimizers/impl/refl/nodes/StaticReferenceAccessor.java
@@ -1,0 +1,67 @@
+/**
+ * MVEL (The MVFLEX Expression Language)
+ *
+ * Copyright (C) 2007 Christopher Brock, MVFLEX/Valhalla Project and the Codehaus
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package org.mvel2.optimizers.impl.refl.nodes;
+
+import org.mvel2.compiler.AccessorNode;
+import org.mvel2.integration.VariableResolverFactory;
+
+public class StaticReferenceAccessor implements AccessorNode {
+
+    Object literal;
+    private AccessorNode nextNode;
+
+    public StaticReferenceAccessor() {
+    }
+
+    public StaticReferenceAccessor(Object literal) {
+        this.literal = literal;
+    }
+
+    public Object getValue(Object ctx, Object elCtx, VariableResolverFactory vars) {
+        if (nextNode != null) {
+            return nextNode.getValue(literal, elCtx, vars);
+        } else {
+            return literal;
+        }
+    }
+
+    public Object setValue(Object ctx, Object elCtx, VariableResolverFactory variableFactory, Object value) {
+        return nextNode.setValue(literal, elCtx, variableFactory, value);
+    }
+
+    public Object getLiteral() {
+        return literal;
+    }
+
+    public void setLiteral(Object literal) {
+        this.literal = literal;
+    }
+
+    public AccessorNode getNextNode() {
+        return nextNode;
+    }
+
+    public AccessorNode setNextNode(AccessorNode nextNode) {
+        return this.nextNode = nextNode;
+    }
+
+    public Class getKnownEgressType() {
+        return literal.getClass();
+    }
+}

--- a/core/src/main/java/org/mvel2/optimizers/impl/refl/nodes/StaticVarAccessor.java
+++ b/core/src/main/java/org/mvel2/optimizers/impl/refl/nodes/StaticVarAccessor.java
@@ -1,0 +1,76 @@
+/**
+ * MVEL (The MVFLEX Expression Language)
+ *
+ * Copyright (C) 2007 Christopher Brock, MVFLEX/Valhalla Project and the Codehaus
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package org.mvel2.optimizers.impl.refl.nodes;
+
+import java.lang.reflect.Field;
+
+import org.mvel2.OptimizationFailure;
+import org.mvel2.compiler.AccessorNode;
+import org.mvel2.integration.VariableResolverFactory;
+
+public class StaticVarAccessor implements AccessorNode {
+
+    Field field;
+    private AccessorNode nextNode;
+
+    public StaticVarAccessor(Field field) {
+        this.field = field;
+    }
+
+    public Object getValue(Object ctx, Object elCtx, VariableResolverFactory vars) {
+        try {
+            if (nextNode != null) {
+                return nextNode.getValue(field.get(null), elCtx, vars);
+            } else {
+                return field.get(null);
+            }
+        } catch (Exception e) {
+            throw new OptimizationFailure("unable to access static field", e);
+        }
+    }
+
+    public AccessorNode getNextNode() {
+        return nextNode;
+    }
+
+    public AccessorNode setNextNode(AccessorNode nextNode) {
+        return this.nextNode = nextNode;
+    }
+
+    public Object setValue(Object ctx, Object elCtx, VariableResolverFactory variableFactory, Object value) {
+        try {
+            if (nextNode == null) {
+                field.set(null, value);
+            } else {
+                return nextNode.setValue(field.get(null), elCtx, variableFactory, value);
+            }
+        } catch (Exception e) {
+            throw new RuntimeException("error accessing static variable", e);
+        }
+        return value;
+    }
+
+    public Field getField() {
+        return field;
+    }
+
+    public Class getKnownEgressType() {
+        return field.getClass();
+    }
+}

--- a/core/src/main/java/org/mvel2/optimizers/impl/refl/nodes/StaticVarAccessorNH.java
+++ b/core/src/main/java/org/mvel2/optimizers/impl/refl/nodes/StaticVarAccessorNH.java
@@ -1,0 +1,78 @@
+/**
+ * MVEL (The MVFLEX Expression Language)
+ *
+ * Copyright (C) 2007 Christopher Brock, MVFLEX/Valhalla Project and the Codehaus
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package org.mvel2.optimizers.impl.refl.nodes;
+
+import java.lang.reflect.Field;
+
+import org.mvel2.OptimizationFailure;
+import org.mvel2.compiler.AccessorNode;
+import org.mvel2.integration.PropertyHandler;
+import org.mvel2.integration.VariableResolverFactory;
+
+public class StaticVarAccessorNH implements AccessorNode {
+
+    Field field;
+    private AccessorNode nextNode;
+    private PropertyHandler nullHandler;
+
+    public StaticVarAccessorNH(Field field, PropertyHandler handler) {
+        this.field = field;
+        this.nullHandler = handler;
+    }
+
+    public Object getValue(Object ctx, Object elCtx, VariableResolverFactory vars) {
+        try {
+            Object v = field.get(ctx);
+            if (v == null) v = nullHandler.getProperty(field.getName(), elCtx, vars);
+
+            if (nextNode != null) {
+                return nextNode.getValue(v, elCtx, vars);
+            } else {
+                return v;
+            }
+        } catch (Exception e) {
+            throw new OptimizationFailure("unable to access static field", e);
+        }
+    }
+
+    public AccessorNode getNextNode() {
+        return nextNode;
+    }
+
+    public AccessorNode setNextNode(AccessorNode nextNode) {
+        return this.nextNode = nextNode;
+    }
+
+    public Object setValue(Object ctx, Object elCtx, VariableResolverFactory variableFactory, Object value) {
+        try {
+            if (nextNode == null) {
+                field.set(null, value);
+            } else {
+                return nextNode.setValue(field.get(null), elCtx, variableFactory, value);
+            }
+        } catch (Exception e) {
+            throw new RuntimeException("error accessing static variable", e);
+        }
+        return value;
+    }
+
+    public Class getKnownEgressType() {
+        return field.getClass();
+    }
+}

--- a/core/src/main/java/org/mvel2/optimizers/impl/refl/nodes/ThisValueAccessor.java
+++ b/core/src/main/java/org/mvel2/optimizers/impl/refl/nodes/ThisValueAccessor.java
@@ -1,0 +1,56 @@
+/**
+ * MVEL (The MVFLEX Expression Language)
+ *
+ * Copyright (C) 2007 Christopher Brock, MVFLEX/Valhalla Project and the Codehaus
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package org.mvel2.optimizers.impl.refl.nodes;
+
+import org.mvel2.compiler.AccessorNode;
+import org.mvel2.integration.VariableResolverFactory;
+
+public class ThisValueAccessor implements AccessorNode {
+
+    private AccessorNode nextNode;
+
+    public ThisValueAccessor() {
+    }
+
+    public Object getValue(Object ctx, Object elCtx, VariableResolverFactory vars) {
+        if (nextNode != null) {
+            return this.nextNode.getValue(elCtx, elCtx, vars);
+        } else {
+            return elCtx;
+        }
+    }
+
+    public AccessorNode getNextNode() {
+        return nextNode;
+    }
+
+    public AccessorNode setNextNode(AccessorNode nextNode) {
+        return this.nextNode = nextNode;
+    }
+
+    public Object setValue(Object ctx, Object elCtx, VariableResolverFactory variableFactory, Object value) {
+        if (nextNode == null) throw new RuntimeException("assignment to reserved variable 'this' not permitted");
+        return this.nextNode.setValue(elCtx, elCtx, variableFactory, value);
+
+    }
+
+    public Class getKnownEgressType() {
+        return Object.class;
+    }
+}

--- a/core/src/main/java/org/mvel2/optimizers/impl/refl/nodes/Union.java
+++ b/core/src/main/java/org/mvel2/optimizers/impl/refl/nodes/Union.java
@@ -1,0 +1,79 @@
+/**
+ * MVEL (The MVFLEX Expression Language)
+ *
+ * Copyright (C) 2007 Christopher Brock, MVFLEX/Valhalla Project and the Codehaus
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package org.mvel2.optimizers.impl.refl.nodes;
+
+import org.mvel2.ParserContext;
+import org.mvel2.compiler.Accessor;
+import org.mvel2.integration.VariableResolverFactory;
+import org.mvel2.optimizers.AccessorOptimizer;
+import org.mvel2.optimizers.OptimizerFactory;
+
+/**
+ * @author Christopher Brock
+ */
+public class Union implements Accessor {
+
+    private Accessor accessor;
+    private char[] nextExpr;
+    private int start;
+    private int offset;
+    private Accessor nextAccessor;
+    private ParserContext pCtx;
+
+    public Union(ParserContext pCtx, Accessor accessor, char[] nextAccessor, int start, int offset) {
+        this.accessor = accessor;
+        this.start = start;
+        this.offset = offset;
+        this.nextExpr = nextAccessor;
+        this.pCtx = pCtx;
+    }
+
+    public Object getValue(Object ctx, Object elCtx, VariableResolverFactory variableFactory) {
+        if (nextAccessor == null) {
+            return get(ctx, elCtx, variableFactory);
+        } else {
+            return nextAccessor.getValue(get(ctx, elCtx, variableFactory), elCtx, variableFactory);
+        }
+    }
+
+    public Object setValue(Object ctx, Object elCtx, VariableResolverFactory variableFactory, Object value) {
+        return nextAccessor.setValue(get(ctx, elCtx, variableFactory), elCtx, variableFactory, value);
+    }
+
+    private Object get(Object ctx, Object elCtx, VariableResolverFactory variableFactory) {
+        if (nextAccessor == null) {
+            Object o = accessor.getValue(ctx, elCtx, variableFactory);
+            AccessorOptimizer ao = OptimizerFactory.getDefaultAccessorCompiler();
+            Class ingress = accessor.getKnownEgressType();
+
+            nextAccessor = ao.optimizeAccessor(pCtx, nextExpr, start, offset, o, elCtx, variableFactory, false, ingress);
+            return ao.getResultOptPass();
+        } else {
+            return accessor.getValue(ctx, elCtx, variableFactory);
+        }
+    }
+
+    public Class getLeftIngressType() {
+        return accessor.getKnownEgressType();
+    }
+
+    public Class getKnownEgressType() {
+        return nextAccessor.getKnownEgressType();
+    }
+}

--- a/core/src/main/java/org/mvel2/optimizers/impl/refl/nodes/VariableAccessor.java
+++ b/core/src/main/java/org/mvel2/optimizers/impl/refl/nodes/VariableAccessor.java
@@ -1,0 +1,72 @@
+/**
+ * MVEL (The MVFLEX Expression Language)
+ *
+ * Copyright (C) 2007 Christopher Brock, MVFLEX/Valhalla Project and the Codehaus
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package org.mvel2.optimizers.impl.refl.nodes;
+
+import org.mvel2.compiler.AccessorNode;
+import org.mvel2.integration.VariableResolverFactory;
+
+public class VariableAccessor implements AccessorNode {
+
+    private AccessorNode nextNode;
+    private String property;
+
+    public VariableAccessor(String property) {
+        this.property = property;
+    }
+
+    public Object getValue(Object ctx, Object elCtx, VariableResolverFactory vrf) {
+        if (vrf == null) throw new RuntimeException("cannot access property in optimized accessor: " + property);
+
+        if (nextNode != null) {
+            return nextNode.getValue(vrf.getVariableResolver(property).getValue(), elCtx, vrf);
+        } else {
+            return vrf.getVariableResolver(property).getValue();
+        }
+    }
+
+    public Object setValue(Object ctx, Object elCtx, VariableResolverFactory variableFactory, Object value) {
+        if (nextNode != null) {
+            return nextNode.setValue(variableFactory.getVariableResolver(property).getValue(), elCtx, variableFactory, value);
+        } else {
+            variableFactory.getVariableResolver(property).setValue(value);
+        }
+
+        return value;
+    }
+
+    public Object getProperty() {
+        return property;
+    }
+
+    public void setProperty(String property) {
+        this.property = property;
+    }
+
+    public AccessorNode getNextNode() {
+        return nextNode;
+    }
+
+    public AccessorNode setNextNode(AccessorNode nextNode) {
+        return this.nextNode = nextNode;
+    }
+
+    public Class getKnownEgressType() {
+        return Object.class;
+    }
+}

--- a/core/src/main/java/org/mvel2/optimizers/impl/refl/nodes/WithAccessor.java
+++ b/core/src/main/java/org/mvel2/optimizers/impl/refl/nodes/WithAccessor.java
@@ -1,0 +1,99 @@
+package org.mvel2.optimizers.impl.refl.nodes;
+
+import static org.mvel2.MVEL.executeSetExpression;
+import static org.mvel2.util.PropertyTools.getReturnType;
+
+import java.io.Serializable;
+
+import org.mvel2.MVEL;
+import org.mvel2.ParserContext;
+import org.mvel2.ast.WithNode;
+import org.mvel2.compiler.AccessorNode;
+import org.mvel2.compiler.ExecutableStatement;
+import org.mvel2.integration.VariableResolverFactory;
+
+public class WithAccessor implements AccessorNode {
+
+    protected String nestParm;
+    protected ExecutableStatement nestedStatement;
+    protected WithNode.ParmValuePair[] withExpressions;
+    private AccessorNode nextNode;
+
+    public WithAccessor(ParserContext pCtx, String property, char[] expr, int start, int offset, Class ingressType) {
+        pCtx.setBlockSymbols(true);
+
+        withExpressions = WithNode.compileWithExpressions(expr, start, offset, property, ingressType, pCtx);
+
+        pCtx.setBlockSymbols(false);
+    }
+
+    public AccessorNode getNextNode() {
+        return this.nextNode;
+    }
+
+    public AccessorNode setNextNode(AccessorNode accessorNode) {
+        return this.nextNode = accessorNode;
+    }
+
+    public Object getValue(Object ctx, Object elCtx, VariableResolverFactory variableFactory) {
+        if (this.nextNode == null) {
+            return processWith(ctx, elCtx, variableFactory);
+        } else {
+            return this.nextNode.getValue(processWith(ctx, elCtx, variableFactory), elCtx, variableFactory);
+        }
+    }
+
+    public Object setValue(Object ctx, Object elCtx, VariableResolverFactory variableFactory, Object value) {
+        return this.nextNode.setValue(processWith(ctx, elCtx, variableFactory), elCtx, variableFactory, value);
+    }
+
+    public Object processWith(Object ctx, Object thisValue, VariableResolverFactory factory) {
+        for (WithNode.ParmValuePair pvp : withExpressions) {
+            if (pvp.getSetExpression() != null) {
+                executeSetExpression(pvp.getSetExpression(), ctx, factory, pvp.getStatement().getValue(ctx, thisValue, factory));
+            } else {
+                pvp.getStatement().getValue(ctx, thisValue, factory);
+            }
+        }
+
+        return ctx;
+    }
+
+    public Class getKnownEgressType() {
+        return Object.class;
+    }
+
+    public static final class ExecutablePairs implements Serializable {
+
+        private Serializable setExpression;
+        private ExecutableStatement statement;
+
+        public ExecutablePairs() {
+        }
+
+        public ExecutablePairs(String parameter, ExecutableStatement statement, Class ingressType, ParserContext pCtx) {
+            if (parameter != null && parameter.length() != 0) {
+                this.setExpression = MVEL.compileSetExpression(parameter,
+                        ingressType != null ? getReturnType(ingressType, parameter, pCtx) : Object.class, pCtx);
+
+            }
+            this.statement = statement;
+        }
+
+        public Serializable getSetExpression() {
+            return setExpression;
+        }
+
+        public void setSetExpression(Serializable setExpression) {
+            this.setExpression = setExpression;
+        }
+
+        public ExecutableStatement getStatement() {
+            return statement;
+        }
+
+        public void setStatement(ExecutableStatement statement) {
+            this.statement = statement;
+        }
+    }
+}

--- a/core/src/main/java/org/mvel2/sh/Command.java
+++ b/core/src/main/java/org/mvel2/sh/Command.java
@@ -1,0 +1,28 @@
+/**
+ * MVEL 2.0
+ * Copyright (C) 2007 The Codehaus
+ * Mike Brock, Dhanji Prasanna, John Graham, Mark Proctor
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mvel2.sh;
+
+public interface Command {
+
+    public Object execute(ShellSession session, String[] args);
+
+    public String getDescription();
+
+    public String getHelp();
+}

--- a/core/src/main/java/org/mvel2/sh/CommandException.java
+++ b/core/src/main/java/org/mvel2/sh/CommandException.java
@@ -1,0 +1,38 @@
+/**
+ * MVEL 2.0
+ * Copyright (C) 2007 The Codehaus
+ * Mike Brock, Dhanji Prasanna, John Graham, Mark Proctor
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mvel2.sh;
+
+public class CommandException extends RuntimeException {
+
+    public CommandException() {
+        super();
+    }
+
+    public CommandException(String message) {
+        super(message);
+    }
+
+    public CommandException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public CommandException(Throwable cause) {
+        super(cause);
+    }
+}

--- a/core/src/main/java/org/mvel2/sh/CommandSet.java
+++ b/core/src/main/java/org/mvel2/sh/CommandSet.java
@@ -1,0 +1,26 @@
+/**
+ * MVEL 2.0
+ * Copyright (C) 2007 The Codehaus
+ * Mike Brock, Dhanji Prasanna, John Graham, Mark Proctor
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mvel2.sh;
+
+import java.util.Map;
+
+public interface CommandSet {
+
+    public Map<String, Command> load();
+}

--- a/core/src/main/java/org/mvel2/sh/DefaultEnvironment.java
+++ b/core/src/main/java/org/mvel2/sh/DefaultEnvironment.java
@@ -1,0 +1,25 @@
+/**
+ * MVEL 2.0
+ * Copyright (C) 2007 The Codehaus
+ * Mike Brock, Dhanji Prasanna, John Graham, Mark Proctor
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mvel2.sh;
+
+public interface DefaultEnvironment {
+
+    public static final String PROMPT = "[@{ new java.text.SimpleDateFormat('hh:mmaa').format(new java.util.Date(System.currentTimeMillis()))}] mvel2$ ";
+
+}

--- a/core/src/main/java/org/mvel2/sh/Main.java
+++ b/core/src/main/java/org/mvel2/sh/Main.java
@@ -1,0 +1,42 @@
+/**
+ * MVEL 2.0
+ * Copyright (C) 2007 The Codehaus
+ * Mike Brock, Dhanji Prasanna, John Graham, Mark Proctor
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mvel2.sh;
+
+import java.io.File;
+import java.io.IOException;
+
+import org.mvel2.MVEL;
+
+public class Main {
+
+    public static void main(String[] args) throws IOException {
+        if (args.length != 0) {
+            MVEL.evalFile(new File(args[0]));
+        } else {
+            showSplash();
+            new ShellSession().run();
+        }
+    }
+
+    private static void showSplash() {
+        System.out.println("\nMVEL-Shell (MVELSH)");
+        System.out.println("Copyright (C) 2010, Christopher Brock, The Codehaus");
+        System.out.println("Version " + MVEL.VERSION + "." + MVEL.VERSION_SUB + "\n");
+    }
+}

--- a/core/src/main/java/org/mvel2/sh/ShellSession.java
+++ b/core/src/main/java/org/mvel2/sh/ShellSession.java
@@ -1,0 +1,477 @@
+/**
+ * MVEL 2.0
+ * Copyright (C) 2007 The Codehaus
+ * Mike Brock, Dhanji Prasanna, John Graham, Mark Proctor
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mvel2.sh;
+
+import static java.lang.Boolean.parseBoolean;
+import static java.lang.Runtime.getRuntime;
+import static java.lang.System.arraycopy;
+import static java.lang.System.getProperty;
+import static java.util.ResourceBundle.getBundle;
+import static org.mvel2.MVEL.compileExpression;
+import static org.mvel2.MVEL.executeExpression;
+import static org.mvel2.util.PropertyTools.contains;
+
+import java.io.BufferedReader;
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.OutputStream;
+import java.io.PrintStream;
+import java.util.Arrays;
+import java.util.Enumeration;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.MissingResourceException;
+import java.util.ResourceBundle;
+
+import org.mvel2.MVELInterpretedRuntime;
+import org.mvel2.ParserContext;
+import org.mvel2.integration.VariableResolverFactory;
+import org.mvel2.integration.impl.MapVariableResolverFactory;
+import org.mvel2.sh.command.basic.BasicCommandSet;
+import org.mvel2.sh.command.file.FileCommandSet;
+import org.mvel2.templates.TemplateRuntime;
+import org.mvel2.util.PropertyTools;
+import org.mvel2.util.StringAppender;
+
+/**
+ * A shell session.
+ */
+public class ShellSession {
+
+    public static final String PROMPT_VAR = "$PROMPT";
+    private static final String[] EMPTY = new String[0];
+    final BufferedReader readBuffer = new BufferedReader(new InputStreamReader(System.in));
+    private final Map<String, Command> commands = new HashMap<String, Command>();
+    ParserContext pCtx = new ParserContext();
+    VariableResolverFactory lvrf;
+    StringAppender inBuffer = new StringAppender();
+    private Map<String, Object> variables;
+    private Map<String, String> env;
+    private Object ctxObject;
+    private int depth;
+    private int cdepth;
+    private boolean multi = false;
+    private int multiIndentSize = 0;
+    private PrintStream out = System.out;
+    private String prompt;
+    private String commandBuffer;
+
+    public ShellSession() {
+        System.out.println("Starting session...");
+
+        variables = new HashMap<String, Object>();
+        env = new HashMap<String, String>();
+
+        commands.putAll(new BasicCommandSet().load());
+        commands.putAll(new FileCommandSet().load());
+
+        env.put(PROMPT_VAR, DefaultEnvironment.PROMPT);
+        env.put("$OS_NAME", getProperty("os.name"));
+        env.put("$OS_VERSION", getProperty("os.version"));
+        env.put("$JAVA_VERSION", PropertyTools.getJavaVersion());
+        env.put("$CWD", new File(".").getAbsolutePath());
+        env.put("$COMMAND_PASSTRU", "false");
+        env.put("$PRINTOUTPUT", "true");
+        env.put("$ECHO", "false");
+        env.put("$SHOW_TRACES", "true");
+        env.put("$USE_OPTIMIZER_ALWAYS", "false");
+        env.put("$PATH", "");
+
+        try {
+            ResourceBundle bundle = getBundle(".mvelsh.properties");
+
+            Enumeration<String> enumer = bundle.getKeys();
+            String key;
+            while (enumer.hasMoreElements()) {
+                env.put(key = enumer.nextElement(), bundle.getString(key));
+            }
+        } catch (MissingResourceException e) {
+            System.out.println("No config file found.  Loading default config.");
+
+            if (!contains(getProperty("os.name").toLowerCase(), "windows")) {
+                env.put("$PATH", "/bin:/usr/bin:/sbin:/usr/sbin");
+            }
+
+        }
+
+        lvrf = new MapVariableResolverFactory(variables, new MapVariableResolverFactory(env));
+
+    }
+
+    public ShellSession(String init) {
+        this();
+        exec(init);
+    }
+
+    private void _exec() {
+        String[] inTokens;
+        Object outputBuffer;
+
+        final PrintStream sysPrintStream = System.out;
+        final PrintStream sysErrorStream = System.err;
+        final InputStream sysInputStream = System.in;
+
+        File execFile;
+
+        if ("true".equals(env.get("$ECHO"))) {
+            out.println(">" + commandBuffer);
+            out.flush();
+        }
+
+        inTokens = inBuffer.append(commandBuffer).toString().split("\\s");
+
+        if (inTokens.length != 0 && commands.containsKey(inTokens[0])) {
+
+            commandBuffer = null;
+
+            String[] passParameters;
+            if (inTokens.length > 1) {
+                arraycopy(inTokens, 1, passParameters = new String[inTokens.length - 1], 0, passParameters.length);
+            } else {
+                passParameters = EMPTY;
+            }
+
+            try {
+                commands.get(inTokens[0]).execute(this, passParameters);
+            } catch (CommandException e) {
+                out.append("Error: ").append(e.getMessage()).append("\n");
+            }
+        } else {
+            commandBuffer = null;
+
+            try {
+                if (shouldDefer(inBuffer)) {
+                    multi = true;
+                    return;
+                } else {
+                    multi = false;
+                }
+
+                if (parseBoolean(env.get("$USE_OPTIMIZER_ALWAYS"))) {
+                    outputBuffer = executeExpression(compileExpression(inBuffer.toString()), ctxObject, lvrf);
+                } else {
+                    MVELInterpretedRuntime runtime = new MVELInterpretedRuntime(inBuffer.toString(), ctxObject, lvrf, pCtx);
+                    outputBuffer = runtime.parse();
+                }
+            } catch (Exception e) {
+                if ("true".equals(env.get("$COMMAND_PASSTHRU"))) {
+
+                    String[] paths;
+                    String s;
+                    if ((s = inTokens[0]).startsWith("./")) {
+                        s = new File(env.get("$CWD")).getAbsolutePath() + s.substring(s.indexOf('/'));
+
+                        paths = new String[] { s };
+                    } else {
+                        paths = env.get("$PATH").split("(:|;)");
+                    }
+
+                    boolean successfulExec = false;
+
+                    for (String execPath : paths) {
+                        if ((execFile = new File(execPath + "/" + s)).exists() && execFile.isFile()) {
+                            successfulExec = true;
+
+                            String[] execString = new String[inTokens.length];
+                            execString[0] = execFile.getAbsolutePath();
+
+                            System.arraycopy(inTokens, 1, execString, 1, inTokens.length - 1);
+
+                            try {
+                                final Process p = getRuntime().exec(execString);
+                                final OutputStream outStream = p.getOutputStream();
+
+                                final InputStream inStream = p.getInputStream();
+                                final InputStream errStream = p.getErrorStream();
+
+                                final RunState runState = new RunState(this);
+
+                                final Thread pollingThread = new Thread(new Runnable() {
+
+                                    public void run() {
+                                        byte[] buf = new byte[25];
+                                        int read;
+
+                                        while (true) {
+                                            try {
+                                                while ((read = inStream.read(buf)) > 0) {
+                                                    for (int i = 0; i < read; i++) {
+                                                        sysPrintStream.print((char) buf[i]);
+                                                    }
+                                                    sysPrintStream.flush();
+                                                }
+
+                                                if (!runState.isRunning()) break;
+                                            } catch (Exception e) {
+                                                break;
+                                            }
+                                        }
+
+                                        sysPrintStream.flush();
+
+                                        if (!multi) {
+                                            multiIndentSize = (prompt = String.valueOf(TemplateRuntime.eval(env.get("$PROMPT"), variables)))
+                                                    .length();
+                                            out.append(prompt);
+                                        } else {
+                                            out.append(">").append(indent((multiIndentSize - 1) + (depth * 4)));
+                                        }
+
+                                    }
+                                });
+
+                                final Thread watchThread = new Thread(new Runnable() {
+
+                                    public void run() {
+
+                                        Thread runningThread = new Thread(new Runnable() {
+
+                                            public void run() {
+                                                try {
+                                                    String read;
+                                                    while (runState.isRunning()) {
+                                                        while ((read = readBuffer.readLine()) != null) {
+                                                            if (runState.isRunning()) {
+                                                                for (char c : read.toCharArray()) {
+                                                                    outStream.write((byte) c);
+                                                                }
+                                                            } else {
+                                                                runState.getSession().setCommandBuffer(read);
+                                                                break;
+                                                            }
+                                                        }
+                                                    }
+
+                                                    outStream.write((byte) '\n');
+                                                    outStream.flush();
+                                                } catch (Exception e2) {
+
+                                                }
+                                            }
+
+                                        });
+
+                                        runningThread.setPriority(Thread.MIN_PRIORITY);
+                                        runningThread.start();
+
+                                        try {
+                                            p.waitFor();
+                                        } catch (InterruptedException e) {
+                                            // nothing;
+                                        }
+
+                                        sysPrintStream.flush();
+                                        runState.setRunning(false);
+
+                                        try {
+                                            runningThread.join();
+                                        } catch (InterruptedException e) {
+                                            // nothing;�
+                                        }
+                                    }
+                                });
+
+                                pollingThread.setPriority(Thread.MIN_PRIORITY);
+                                pollingThread.start();
+
+                                watchThread.setPriority(Thread.MIN_PRIORITY);
+                                watchThread.start();
+                                watchThread.join();
+
+                                try {
+                                    pollingThread.notify();
+                                } catch (Exception ne) {
+
+                                }
+
+                            } catch (Exception e2) {
+                                // fall through;
+                            }
+                        }
+                    }
+
+                    if (successfulExec) {
+                        inBuffer.reset();
+                        return;
+                    }
+                }
+
+                ByteArrayOutputStream stackTraceCap = new ByteArrayOutputStream();
+                PrintStream capture = new PrintStream(stackTraceCap);
+
+                e.printStackTrace(capture);
+                capture.flush();
+
+                env.put("$LAST_STACK_TRACE", new String(stackTraceCap.toByteArray()));
+                if (parseBoolean(env.get("$SHOW_TRACE"))) {
+                    out.println(env.get("$LAST_STACK_TRACE"));
+                } else {
+                    out.println(e.toString());
+                }
+
+                inBuffer.reset();
+
+                return;
+            }
+
+            if (outputBuffer != null && "true".equals(env.get("$PRINTOUTPUT"))) {
+                if (outputBuffer.getClass().isArray()) {
+                    out.println(Arrays.toString((Object[]) outputBuffer));
+                } else {
+                    out.println(String.valueOf(outputBuffer));
+                }
+            }
+
+        }
+
+        inBuffer.reset();
+
+    }
+
+    //todo: fix this
+    public void run() {
+        final BufferedReader readBuffer = new BufferedReader(new InputStreamReader(System.in));
+
+        try {
+            //noinspection InfiniteLoopStatement
+            while (true) {
+                printPrompt();
+
+                if (commandBuffer == null) {
+                    commandBuffer = readBuffer.readLine();
+                }
+
+                _exec();
+            }
+        } catch (Exception e) {
+            e.printStackTrace();
+            System.out.println("unexpected exception. exiting.");
+        }
+
+    }
+
+    public void printPrompt() {
+        if (!multi) {
+            multiIndentSize = (prompt = String.valueOf(TemplateRuntime.eval(env.get("$PROMPT"), variables))).length();
+            out.append(prompt);
+        } else {
+            out.append(">").append(indent((multiIndentSize - 1) + (depth * 4)));
+        }
+    }
+
+    public boolean shouldDefer(StringAppender inBuf) {
+        char[] buffer = new char[inBuf.length()];
+        inBuf.getChars(0, inBuf.length(), buffer, 0);
+
+        depth = cdepth = 0;
+        for (int i = 0; i < buffer.length; i++) {
+            switch (buffer[i]) {
+                case '/':
+                    if (i + 1 < buffer.length && buffer[i + 1] == '*') {
+                        cdepth++;
+                    }
+                    break;
+                case '*':
+                    if (i + 1 < buffer.length && buffer[i + 1] == '/') {
+                        cdepth--;
+                    }
+                    break;
+
+                case '{':
+                    depth++;
+                    break;
+                case '}':
+                    depth--;
+                    break;
+            }
+        }
+
+        return depth + cdepth > 0;
+    }
+
+    public String indent(int size) {
+        StringBuffer sbuf = new StringBuffer();
+        for (int i = 0; i < size; i++)
+            sbuf.append(" ");
+        return sbuf.toString();
+    }
+
+    public Map<String, Command> getCommands() {
+        return commands;
+    }
+
+    public Map<String, Object> getVariables() {
+        return variables;
+    }
+
+    public Map<String, String> getEnv() {
+        return env;
+    }
+
+    public Object getCtxObject() {
+        return ctxObject;
+    }
+
+    public void setCtxObject(Object ctxObject) {
+        this.ctxObject = ctxObject;
+    }
+
+    public String getCommandBuffer() {
+        return commandBuffer;
+    }
+
+    public void setCommandBuffer(String commandBuffer) {
+        this.commandBuffer = commandBuffer;
+    }
+
+    public void exec(String command) {
+        for (String c : command.split("\n")) {
+            inBuffer.append(c);
+            _exec();
+        }
+    }
+
+    public static final class RunState {
+
+        private boolean running = true;
+        private ShellSession session;
+
+        public RunState(ShellSession session) {
+            this.session = session;
+        }
+
+        public ShellSession getSession() {
+            return session;
+        }
+
+        public void setSession(ShellSession session) {
+            this.session = session;
+        }
+
+        public boolean isRunning() {
+            return running;
+        }
+
+        public void setRunning(boolean running) {
+            this.running = running;
+        }
+    }
+}

--- a/core/src/main/java/org/mvel2/sh/command/basic/BasicCommandSet.java
+++ b/core/src/main/java/org/mvel2/sh/command/basic/BasicCommandSet.java
@@ -1,0 +1,41 @@
+/**
+ * MVEL 2.0
+ * Copyright (C) 2007 The Codehaus
+ * Mike Brock, Dhanji Prasanna, John Graham, Mark Proctor
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mvel2.sh.command.basic;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.mvel2.sh.Command;
+import org.mvel2.sh.CommandSet;
+
+public class BasicCommandSet implements CommandSet {
+
+    public Map<String, Command> load() {
+        Map<String, Command> cmds = new HashMap<String, Command>();
+
+        cmds.put("set", new Set());
+        cmds.put("push", new PushContext());
+        cmds.put("help", new Help());
+        cmds.put("showvars", new ShowVars());
+        cmds.put("inspect", new ObjectInspector());
+        cmds.put("exit", new Exit());
+
+        return cmds;
+    }
+}

--- a/core/src/main/java/org/mvel2/sh/command/basic/Exit.java
+++ b/core/src/main/java/org/mvel2/sh/command/basic/Exit.java
@@ -1,0 +1,38 @@
+/**
+ * MVEL 2.0
+ * Copyright (C) 2007 The Codehaus
+ * Mike Brock, Dhanji Prasanna, John Graham, Mark Proctor
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mvel2.sh.command.basic;
+
+import org.mvel2.sh.Command;
+import org.mvel2.sh.ShellSession;
+
+public class Exit implements Command {
+
+    public Object execute(ShellSession session, String[] args) {
+        System.exit(0);
+        return null;
+    }
+
+    public String getDescription() {
+        return "exits the command shell";
+    }
+
+    public String getHelp() {
+        return "No help yet.";
+    }
+}

--- a/core/src/main/java/org/mvel2/sh/command/basic/Help.java
+++ b/core/src/main/java/org/mvel2/sh/command/basic/Help.java
@@ -1,0 +1,43 @@
+/**
+ * MVEL 2.0
+ * Copyright (C) 2007 The Codehaus
+ * Mike Brock, Dhanji Prasanna, John Graham, Mark Proctor
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mvel2.sh.command.basic;
+
+import static org.mvel2.sh.text.TextUtil.pad;
+
+import org.mvel2.sh.Command;
+import org.mvel2.sh.ShellSession;
+
+public class Help implements Command {
+
+    public Object execute(ShellSession session, String[] args) {
+        for (String command : session.getCommands().keySet()) {
+            System.out.println(command + pad(command.length(), 25) + "- " + session.getCommands().get(command).getDescription());
+        }
+
+        return null;
+    }
+
+    public String getDescription() {
+        return "displays help for available shell commands";
+    }
+
+    public String getHelp() {
+        return "No help yet";
+    }
+}

--- a/core/src/main/java/org/mvel2/sh/command/basic/ObjectInspector.java
+++ b/core/src/main/java/org/mvel2/sh/command/basic/ObjectInspector.java
@@ -1,0 +1,169 @@
+/**
+ * MVEL 2.0
+ * Copyright (C) 2007 The Codehaus
+ * Mike Brock, Dhanji Prasanna, John Graham, Mark Proctor
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mvel2.sh.command.basic;
+
+import static org.mvel2.sh.text.TextUtil.padTwo;
+
+import java.io.BufferedOutputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.ObjectOutputStream;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.util.LinkedList;
+import java.util.List;
+
+import org.mvel2.sh.Command;
+import org.mvel2.sh.ShellSession;
+import org.mvel2.sh.text.TextUtil;
+import org.mvel2.util.StringAppender;
+
+public class ObjectInspector implements Command {
+
+    private static final int PADDING = 17;
+
+    private static String renderClassHeirarchy(Class cls) {
+        List<String> list = new LinkedList<String>();
+        list.add(cls.getName());
+
+        while ((cls = cls.getSuperclass()) != null) {
+            list.add(cls.getName());
+        }
+
+        StringAppender output = new StringAppender();
+
+        for (int i = list.size() - 1; i != -1; i--) {
+            output.append(list.get(i));
+            if ((i - 1) != -1) output.append(" -> ");
+        }
+
+        return output.toString();
+    }
+
+    private static void renderFields(Class cls) {
+        Field[] fields = cls.getFields();
+
+        for (int i = 0; i < fields.length; i++) {
+            write("", fields[i].getType().getName() + " " + fields[i].getName());
+        }
+    }
+
+    private static void renderMethods(Class cls) {
+        Method[] methods = cls.getMethods();
+
+        Method m;
+        StringAppender appender = new StringAppender();
+        int mf;
+        for (int i = 0; i < methods.length; i++) {
+            appender.append(TextUtil.paint(' ', PADDING + 2));
+            if (((mf = (m = methods[i]).getModifiers()) & Modifier.PUBLIC) != 0) appender.append("public");
+            else if ((mf & Modifier.PRIVATE) != 0) appender.append("private");
+            else if ((mf & Modifier.PROTECTED) != 0) appender.append("protected");
+
+            appender.append(' ').append(m.getReturnType().getName()).append(' ').append(m.getName()).append("(");
+            Class[] parmTypes = m.getParameterTypes();
+            for (int y = 0; y < parmTypes.length; y++) {
+                if (parmTypes[y].isArray()) {
+                    appender.append(parmTypes[y].getComponentType().getName() + "[]");
+                } else {
+                    appender.append(parmTypes[y].getName());
+                }
+                if ((y + 1) < parmTypes.length) appender.append(", ");
+            }
+            appender.append(")");
+
+            if (m.getDeclaringClass() != cls) {
+                appender.append("    [inherited from: ").append(m.getDeclaringClass().getName()).append("]");
+            }
+
+            if ((i + 1) < methods.length) appender.append('\n');
+        }
+
+        System.out.println(appender.toString());
+    }
+
+    private static void write(Object first, Object second) {
+        System.out.println(padTwo(first, ": " + second, PADDING));
+    }
+
+    public Object execute(ShellSession session, String[] args) {
+
+        if (args.length == 0) {
+            System.out.println("inspect: requires an argument.");
+            return null;
+        }
+
+        if (!session.getVariables().containsKey(args[0])) {
+            System.out.println("inspect: no such variable: " + args[0]);
+            return null;
+        }
+
+        Object val = session.getVariables().get(args[0]);
+
+        System.out.println("Object Inspector");
+        System.out.println(TextUtil.paint('-', PADDING));
+
+        if (val == null) {
+            System.out.println("[Value is Null]");
+            return null;
+        }
+
+        Class cls = val.getClass();
+        boolean serialized = true;
+        long serializedSize = 0;
+
+        try {
+            ByteArrayOutputStream outStream = new ByteArrayOutputStream();
+            ObjectOutputStream objectOut = new ObjectOutputStream(new BufferedOutputStream(outStream));
+            objectOut.writeObject(val);
+            objectOut.flush();
+            outStream.flush();
+
+            serializedSize = outStream.size();
+        } catch (Exception e) {
+            serialized = false;
+        }
+
+        write("VariableName", args[0]);
+        write("Hashcode", val.hashCode());
+        write("ClassType", cls.getName());
+        write("Serializable", serialized);
+        if (serialized) {
+            write("SerializedSize", serializedSize + " bytes");
+        }
+        write("ClassHierarchy", renderClassHeirarchy(cls));
+        write("Fields", cls.getFields().length);
+        renderFields(cls);
+
+        write("Methods", cls.getMethods().length);
+        renderMethods(cls);
+
+        System.out.println();
+
+        return null;
+    }
+
+    public String getDescription() {
+        return "inspects an object";
+    }
+
+    public String getHelp() {
+        return "No help yet";
+    }
+}

--- a/core/src/main/java/org/mvel2/sh/command/basic/PushContext.java
+++ b/core/src/main/java/org/mvel2/sh/command/basic/PushContext.java
@@ -1,0 +1,39 @@
+/**
+ * MVEL 2.0
+ * Copyright (C) 2007 The Codehaus
+ * Mike Brock, Dhanji Prasanna, John Graham, Mark Proctor
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mvel2.sh.command.basic;
+
+import org.mvel2.MVEL;
+import org.mvel2.sh.Command;
+import org.mvel2.sh.ShellSession;
+
+public class PushContext implements Command {
+
+    public Object execute(ShellSession session, String[] args) {
+        session.setCtxObject(MVEL.eval(args[0], session.getCtxObject(), session.getVariables()));
+        return "Changed Context";
+    }
+
+    public String getDescription() {
+        return null;
+    }
+
+    public String getHelp() {
+        return null;
+    }
+}

--- a/core/src/main/java/org/mvel2/sh/command/basic/Set.java
+++ b/core/src/main/java/org/mvel2/sh/command/basic/Set.java
@@ -1,0 +1,60 @@
+/**
+ * MVEL 2.0
+ * Copyright (C) 2007 The Codehaus
+ * Mike Brock, Dhanji Prasanna, John Graham, Mark Proctor
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mvel2.sh.command.basic;
+
+import java.util.Map;
+
+import org.mvel2.sh.Command;
+import org.mvel2.sh.CommandException;
+import org.mvel2.sh.ShellSession;
+import org.mvel2.util.StringAppender;
+
+public class Set implements Command {
+
+    public Object execute(ShellSession session, String[] args) {
+
+        Map<String, String> env = session.getEnv();
+
+        if (args.length == 0) {
+            for (String var : env.keySet()) {
+                System.out.println(var + " = " + env.get(var));
+            }
+        } else if (args.length == 1) {
+            throw new CommandException("incorrect number of parameters");
+        } else {
+            StringAppender sbuf = new StringAppender();
+            for (int i = 1; i < args.length; i++) {
+                sbuf.append(args[i]);
+                if (i < args.length) sbuf.append(" ");
+            }
+
+            env.put(args[0], sbuf.toString().trim());
+        }
+
+        return null;
+    }
+
+    public String getDescription() {
+        return "sets an environment variable";
+    }
+
+    public String getHelp() {
+        return null;
+    }
+}

--- a/core/src/main/java/org/mvel2/sh/command/basic/ShowVars.java
+++ b/core/src/main/java/org/mvel2/sh/command/basic/ShowVars.java
@@ -1,0 +1,62 @@
+/**
+ * MVEL 2.0
+ * Copyright (C) 2007 The Codehaus
+ * Mike Brock, Dhanji Prasanna, John Graham, Mark Proctor
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mvel2.sh.command.basic;
+
+import java.util.Map;
+
+import org.mvel2.sh.Command;
+import org.mvel2.sh.CommandException;
+import org.mvel2.sh.ShellSession;
+
+public class ShowVars implements Command {
+
+    public Object execute(ShellSession session, String[] args) {
+        boolean values = false;
+
+        Map<String, Object> vars = session.getVariables();
+
+        for (int i = 0; i < args.length; i++) {
+            if ("-values".equals(args[i])) values = true;
+            else throw new CommandException("unknown argument: " + args[i]);
+        }
+
+        System.out.println("Printing Variables ...");
+        if (values) {
+            for (String key : vars.keySet()) {
+                System.out.println(key + " => " + String.valueOf(vars.get(key)));
+            }
+        } else {
+            for (String key : vars.keySet()) {
+                System.out.println(key);
+            }
+        }
+
+        System.out.println(" ** " + vars.size() + " variables total.");
+
+        return null;
+    }
+
+    public String getDescription() {
+        return "shows current variables";
+    }
+
+    public String getHelp() {
+        return "no help yet";
+    }
+}

--- a/core/src/main/java/org/mvel2/sh/command/file/ChangeWorkingDir.java
+++ b/core/src/main/java/org/mvel2/sh/command/file/ChangeWorkingDir.java
@@ -1,0 +1,64 @@
+/**
+ * MVEL 2.0
+ * Copyright (C) 2007 The Codehaus
+ * Mike Brock, Dhanji Prasanna, John Graham, Mark Proctor
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mvel2.sh.command.file;
+
+import java.io.File;
+
+import org.mvel2.sh.Command;
+import org.mvel2.sh.CommandException;
+import org.mvel2.sh.ShellSession;
+
+public class ChangeWorkingDir implements Command {
+
+    public Object execute(ShellSession session, String[] args) {
+        File cwd = new File(session.getEnv().get("$CWD"));
+
+        if (args.length == 0 || ".".equals(args[0])) return null;
+        else if ("..".equals(args[0])) {
+            if (cwd.getParentFile() != null) {
+                cwd = cwd.getParentFile();
+            } else {
+                throw new CommandException("already at top-level directory");
+            }
+        } else if (args[0].charAt(0) == '/') {
+            cwd = new File(args[0]);
+            if (!cwd.exists()) {
+                throw new CommandException("no such directory: " + args[0]);
+            }
+        } else {
+            cwd = new File(cwd.getAbsolutePath() + "/" + args[0]);
+            if (!cwd.exists()) {
+                throw new CommandException("no such directory: " + args[0]);
+            }
+        }
+
+        session.getEnv().put("$CWD", cwd.getAbsolutePath());
+
+        return null;
+
+    }
+
+    public String getDescription() {
+        return "changes the working directory";
+    }
+
+    public String getHelp() {
+        return "no help yet";
+    }
+}

--- a/core/src/main/java/org/mvel2/sh/command/file/DirList.java
+++ b/core/src/main/java/org/mvel2/sh/command/file/DirList.java
@@ -1,0 +1,62 @@
+/**
+ * MVEL 2.0
+ * Copyright (C) 2007 The Codehaus
+ * Mike Brock, Dhanji Prasanna, John Graham, Mark Proctor
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mvel2.sh.command.file;
+
+import java.io.File;
+
+import org.mvel2.sh.Command;
+import org.mvel2.sh.CommandException;
+import org.mvel2.sh.ShellSession;
+
+public class DirList implements Command {
+
+    public Object execute(ShellSession session, String[] args) {
+        File current = new File(session.getEnv().get("$CWD"));
+
+        if (!current.isDirectory())
+            throw new CommandException("cannot list directory : " + session.getEnv().get("$CWD") + " is not a directory");
+
+        File[] files = current.listFiles();
+
+        if (files.length == 0) return null;
+        else {
+            System.out.append("Total ").append(String.valueOf(files.length)).append("\n");
+        }
+
+        for (File file : current.listFiles()) {
+            if (file.isDirectory()) {
+                System.out.append(file.getName()).append("/");
+            } else {
+                System.out.append(file.getName());
+            }
+            System.out.append("\n");
+        }
+        System.out.flush();
+
+        return null;
+    }
+
+    public String getDescription() {
+        return "performs a list of files and directories in the current working dir.";
+    }
+
+    public String getHelp() {
+        return "no help yet";
+    }
+}

--- a/core/src/main/java/org/mvel2/sh/command/file/FileCommandSet.java
+++ b/core/src/main/java/org/mvel2/sh/command/file/FileCommandSet.java
@@ -1,0 +1,38 @@
+/**
+ * MVEL 2.0
+ * Copyright (C) 2007 The Codehaus
+ * Mike Brock, Dhanji Prasanna, John Graham, Mark Proctor
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mvel2.sh.command.file;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.mvel2.sh.Command;
+import org.mvel2.sh.CommandSet;
+
+public class FileCommandSet implements CommandSet {
+
+    public Map<String, Command> load() {
+        Map<String, Command> cmd = new HashMap<String, Command>();
+
+        cmd.put("ls", new DirList());
+        cmd.put("cd", new ChangeWorkingDir());
+        cmd.put("pwd", new PrintWorkingDirectory());
+
+        return cmd;
+    }
+}

--- a/core/src/main/java/org/mvel2/sh/command/file/PrintWorkingDirectory.java
+++ b/core/src/main/java/org/mvel2/sh/command/file/PrintWorkingDirectory.java
@@ -1,0 +1,38 @@
+/**
+ * MVEL 2.0
+ * Copyright (C) 2007 The Codehaus
+ * Mike Brock, Dhanji Prasanna, John Graham, Mark Proctor
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mvel2.sh.command.file;
+
+import org.mvel2.sh.Command;
+import org.mvel2.sh.ShellSession;
+
+public class PrintWorkingDirectory implements Command {
+
+    public Object execute(ShellSession session, String[] args) {
+        System.out.println(session.getEnv().get("$CWD"));
+        return null;
+    }
+
+    public String getDescription() {
+        return "prints the current working directory";
+    }
+
+    public String getHelp() {
+        return "no help yet.";
+    }
+}

--- a/core/src/main/java/org/mvel2/sh/text/TextUtil.java
+++ b/core/src/main/java/org/mvel2/sh/text/TextUtil.java
@@ -1,0 +1,45 @@
+/**
+ * MVEL 2.0
+ * Copyright (C) 2007 The Codehaus
+ * Mike Brock, Dhanji Prasanna, John Graham, Mark Proctor
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mvel2.sh.text;
+
+import static java.lang.String.valueOf;
+
+public class TextUtil {
+
+    public static String pad(int colLength, int tabPos) {
+        StringBuilder sAppend = new StringBuilder();
+        for (int len = tabPos - colLength; len != -1; len--) {
+            sAppend.append(' ');
+        }
+
+        return sAppend.toString();
+    }
+
+    public static String paint(char c, int amount) {
+        StringBuilder append = new StringBuilder();
+        for (; amount != -1; amount--) {
+            append.append(c);
+        }
+        return append.toString();
+    }
+
+    public static String padTwo(Object first, Object second, int tab) {
+        return new StringBuilder(valueOf(first)).append(pad(valueOf(first).length(), tab)).append(second).toString();
+    }
+}

--- a/core/src/main/java/org/mvel2/templates/CompiledTemplate.java
+++ b/core/src/main/java/org/mvel2/templates/CompiledTemplate.java
@@ -1,0 +1,50 @@
+/**
+ * MVEL 2.0
+ * Copyright (C) 2007 The Codehaus
+ * Mike Brock, Dhanji Prasanna, John Graham, Mark Proctor
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mvel2.templates;
+
+import java.io.Serializable;
+
+import org.mvel2.templates.res.Node;
+
+public class CompiledTemplate implements Serializable {
+
+    private char[] template;
+    private Node root;
+
+    public CompiledTemplate(char[] template, Node root) {
+        this.template = template;
+        this.root = root;
+    }
+
+    public char[] getTemplate() {
+        return template;
+    }
+
+    public void setTemplate(char[] template) {
+        this.template = template;
+    }
+
+    public Node getRoot() {
+        return root;
+    }
+
+    public void setRoot(Node root) {
+        this.root = root;
+    }
+}

--- a/core/src/main/java/org/mvel2/templates/SimpleTemplateRegistry.java
+++ b/core/src/main/java/org/mvel2/templates/SimpleTemplateRegistry.java
@@ -1,0 +1,51 @@
+/**
+ * MVEL 2.0
+ * Copyright (C) 2007 The Codehaus
+ * Mike Brock, Dhanji Prasanna, John Graham, Mark Proctor
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mvel2.templates;
+
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Set;
+
+public class SimpleTemplateRegistry implements TemplateRegistry {
+
+    private Map<String, CompiledTemplate> NAMED_TEMPLATES = new HashMap<String, CompiledTemplate>();
+
+    public void addNamedTemplate(String name, CompiledTemplate template) {
+        NAMED_TEMPLATES.put(name, template);
+    }
+
+    public CompiledTemplate getNamedTemplate(String name) {
+        CompiledTemplate t = NAMED_TEMPLATES.get(name);
+        if (t == null) throw new TemplateError("no named template exists '" + name + "'");
+        return t;
+    }
+
+    public Iterator iterator() {
+        return NAMED_TEMPLATES.keySet().iterator();
+    }
+
+    public Set<String> getNames() {
+        return NAMED_TEMPLATES.keySet();
+    }
+
+    public boolean contains(String name) {
+        return NAMED_TEMPLATES.containsKey(name);
+    }
+}

--- a/core/src/main/java/org/mvel2/templates/TemplateCompiler.java
+++ b/core/src/main/java/org/mvel2/templates/TemplateCompiler.java
@@ -1,0 +1,531 @@
+/**
+ * MVEL 2.0
+ * Copyright (C) 2007 The Codehaus
+ * Mike Brock, Dhanji Prasanna, John Graham, Mark Proctor
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mvel2.templates;
+
+import static org.mvel2.util.ParseTools.balancedCaptureWithLineAccounting;
+import static org.mvel2.util.ParseTools.subset;
+
+import java.io.File;
+import java.io.InputStream;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.mvel2.CompileException;
+import org.mvel2.ParserContext;
+import org.mvel2.templates.res.CodeNode;
+import org.mvel2.templates.res.CommentNode;
+import org.mvel2.templates.res.CompiledCodeNode;
+import org.mvel2.templates.res.CompiledDeclareNode;
+import org.mvel2.templates.res.CompiledEvalNode;
+import org.mvel2.templates.res.CompiledExpressionNode;
+import org.mvel2.templates.res.CompiledForEachNode;
+import org.mvel2.templates.res.CompiledIfNode;
+import org.mvel2.templates.res.CompiledIncludeNode;
+import org.mvel2.templates.res.CompiledNamedIncludeNode;
+import org.mvel2.templates.res.CompiledTerminalExpressionNode;
+import org.mvel2.templates.res.DeclareNode;
+import org.mvel2.templates.res.EndNode;
+import org.mvel2.templates.res.EvalNode;
+import org.mvel2.templates.res.ExpressionNode;
+import org.mvel2.templates.res.ForEachNode;
+import org.mvel2.templates.res.IfNode;
+import org.mvel2.templates.res.IncludeNode;
+import org.mvel2.templates.res.NamedIncludeNode;
+import org.mvel2.templates.res.Node;
+import org.mvel2.templates.res.Opcodes;
+import org.mvel2.templates.res.TerminalExpressionNode;
+import org.mvel2.templates.res.TerminalNode;
+import org.mvel2.templates.res.TextNode;
+import org.mvel2.templates.util.TemplateTools;
+import org.mvel2.util.ExecutionStack;
+import org.mvel2.util.ParseTools;
+
+/**
+ * The TemplateCompiler class is used for pre-compiling MVEL Templates.  To execute a compiled template see
+ * {@link TemplateRuntime}
+ *
+ * @author Mike Brock
+ */
+@SuppressWarnings({ "ManualArrayCopy" })
+public class TemplateCompiler {
+
+    private static final Map<String, Integer> OPCODES = new HashMap<String, Integer>();
+
+    static {
+        OPCODES.put("if", Opcodes.IF);
+        OPCODES.put("else", Opcodes.ELSE);
+        OPCODES.put("elseif", Opcodes.ELSE);
+        OPCODES.put("end", Opcodes.END);
+        OPCODES.put("foreach", Opcodes.FOREACH);
+
+        OPCODES.put("includeNamed", Opcodes.INCLUDE_NAMED);
+        OPCODES.put("include", Opcodes.INCLUDE_FILE);
+        OPCODES.put("comment", Opcodes.COMMENT);
+        OPCODES.put("code", Opcodes.CODE);
+        OPCODES.put("eval", Opcodes.EVAL);
+
+        OPCODES.put("declare", Opcodes.DECLARE);
+
+        OPCODES.put("stop", Opcodes.STOP);
+    }
+
+    private char[] template;
+    private int length;
+    private int start;
+    private int cursor;
+    private int lastTextRangeEnding;
+    private int line;
+    private int colStart;
+    private boolean codeCache = false;
+    private Map<String, Class<? extends Node>> customNodes;
+    private ParserContext parserContext;
+
+    public TemplateCompiler(String template) {
+        this.length = (this.template = template.toCharArray()).length;
+    }
+
+    public TemplateCompiler(char[] template) {
+        this.length = (this.template = template).length;
+    }
+
+    // Parse Utilities Start Here
+
+    public TemplateCompiler(String template, boolean codeCache) {
+        this.length = (this.template = template.toCharArray()).length;
+        this.codeCache = codeCache;
+    }
+
+    public TemplateCompiler(char[] template, boolean codeCache) {
+        this.length = (this.template = template).length;
+        this.codeCache = codeCache;
+    }
+
+    public TemplateCompiler(char[] template, boolean codeCache, ParserContext context) {
+        this.length = (this.template = template).length;
+        this.codeCache = codeCache;
+        this.parserContext = context;
+    }
+
+    public TemplateCompiler(CharSequence sequence) {
+        this.length = (this.template = sequence.toString().toCharArray()).length;
+    }
+
+    public TemplateCompiler(CharSequence sequence, boolean codeCache) {
+        this.length = (this.template = sequence.toString().toCharArray()).length;
+        this.codeCache = codeCache;
+    }
+
+    public TemplateCompiler(CharSequence sequence, boolean codeCache, ParserContext context) {
+        this.length = (this.template = sequence.toString().toCharArray()).length;
+        this.codeCache = codeCache;
+        this.parserContext = context;
+    }
+
+    public TemplateCompiler(String template, Map<String, Class<? extends Node>> customNodes) {
+        this.length = (this.template = template.toCharArray()).length;
+        this.customNodes = customNodes;
+    }
+
+    public TemplateCompiler(char[] template, Map<String, Class<? extends Node>> customNodes) {
+        this.length = (this.template = template).length;
+        this.customNodes = customNodes;
+    }
+
+    public TemplateCompiler(CharSequence sequence, Map<String, Class<? extends Node>> customNodes) {
+        this.length = (this.template = sequence.toString().toCharArray()).length;
+        this.customNodes = customNodes;
+    }
+
+    public TemplateCompiler(String template, Map<String, Class<? extends Node>> customNodes, boolean codeCache) {
+        this.length = (this.template = template.toCharArray()).length;
+        this.customNodes = customNodes;
+        this.codeCache = codeCache;
+    }
+
+    public TemplateCompiler(char[] template, Map<String, Class<? extends Node>> customNodes, boolean codeCache) {
+        this.length = (this.template = template).length;
+        this.customNodes = customNodes;
+        this.codeCache = codeCache;
+    }
+
+    public TemplateCompiler(CharSequence sequence, Map<String, Class<? extends Node>> customNodes, boolean codeCache) {
+        this.length = (this.template = sequence.toString().toCharArray()).length;
+        this.customNodes = customNodes;
+        this.codeCache = codeCache;
+    }
+
+    public TemplateCompiler(String template, Map<String, Class<? extends Node>> customNodes, boolean codeCache, ParserContext context) {
+        this.length = (this.template = template.toCharArray()).length;
+        this.customNodes = customNodes;
+        this.codeCache = codeCache;
+        this.parserContext = context;
+    }
+
+    public TemplateCompiler(char[] template, Map<String, Class<? extends Node>> customNodes, boolean codeCache, ParserContext context) {
+        this.length = (this.template = template).length;
+        this.customNodes = customNodes;
+        this.codeCache = codeCache;
+        this.parserContext = context;
+    }
+
+    public TemplateCompiler(CharSequence sequence, Map<String, Class<? extends Node>> customNodes, boolean codeCache,
+            ParserContext context) {
+        this.length = (this.template = sequence.toString().toCharArray()).length;
+        this.customNodes = customNodes;
+        this.codeCache = codeCache;
+        this.parserContext = context;
+    }
+
+    public static CompiledTemplate compileTemplate(String template) {
+        return new TemplateCompiler(template, true, ParserContext.create()).compile();
+    }
+
+    public static CompiledTemplate compileTemplate(char[] template) {
+        return new TemplateCompiler(template, true, ParserContext.create()).compile();
+    }
+
+    public static CompiledTemplate compileTemplate(CharSequence template) {
+        return new TemplateCompiler(template, true, ParserContext.create()).compile();
+    }
+
+    public static CompiledTemplate compileTemplate(String template, ParserContext context) {
+        return new TemplateCompiler(template, true, context).compile();
+    }
+
+    public static CompiledTemplate compileTemplate(char[] template, ParserContext context) {
+        return new TemplateCompiler(template, true, context).compile();
+    }
+
+    public static CompiledTemplate compileTemplate(CharSequence template, ParserContext context) {
+        return new TemplateCompiler(template, true, context).compile();
+    }
+
+    public static CompiledTemplate compileTemplate(String template, Map<String, Class<? extends Node>> customNodes) {
+        return new TemplateCompiler(template, customNodes, true, ParserContext.create()).compile();
+    }
+
+    public static CompiledTemplate compileTemplate(char[] template, Map<String, Class<? extends Node>> customNodes) {
+        return new TemplateCompiler(template, customNodes, true, ParserContext.create()).compile();
+    }
+
+    public static CompiledTemplate compileTemplate(CharSequence template, Map<String, Class<? extends Node>> customNodes) {
+        return new TemplateCompiler(template, customNodes, true, ParserContext.create()).compile();
+    }
+
+    public static CompiledTemplate compileTemplate(String template, Map<String, Class<? extends Node>> customNodes, ParserContext context) {
+        return new TemplateCompiler(template, customNodes, true, context).compile();
+    }
+
+    public static CompiledTemplate compileTemplate(char[] template, Map<String, Class<? extends Node>> customNodes, ParserContext context) {
+        return new TemplateCompiler(template, customNodes, true, context).compile();
+    }
+
+    public static CompiledTemplate compileTemplate(CharSequence template, Map<String, Class<? extends Node>> customNodes,
+            ParserContext context) {
+        return new TemplateCompiler(template, customNodes, true, context).compile();
+    }
+
+    public static CompiledTemplate compileTemplate(InputStream stream) {
+        return compileTemplate(stream, ParserContext.create());
+    }
+
+    public static CompiledTemplate compileTemplate(InputStream stream, ParserContext context) {
+        return compileTemplate(stream, null, context);
+    }
+
+    public static CompiledTemplate compileTemplate(InputStream stream, Map<String, Class<? extends Node>> customNodes) {
+        return new TemplateCompiler(TemplateTools.readStream(stream), customNodes, true, ParserContext.create()).compile();
+    }
+
+    public static CompiledTemplate compileTemplate(InputStream stream, Map<String, Class<? extends Node>> customNodes,
+            ParserContext context) {
+        return new TemplateCompiler(TemplateTools.readStream(stream), customNodes, true, context).compile();
+    }
+
+    public static CompiledTemplate compileTemplate(File file) {
+        return compileTemplate(file, ParserContext.create());
+    }
+
+    public static CompiledTemplate compileTemplate(File file, ParserContext context) {
+        return compileTemplate(file, null, context);
+    }
+
+    public static CompiledTemplate compileTemplate(File file, Map<String, Class<? extends Node>> customNodes) {
+        return new TemplateCompiler(TemplateTools.readInFile(file), customNodes, true, ParserContext.create()).compile();
+    }
+
+    public static CompiledTemplate compileTemplate(File file, Map<String, Class<? extends Node>> customNodes, ParserContext context) {
+        return new TemplateCompiler(TemplateTools.readInFile(file), customNodes, true, context).compile();
+    }
+
+    public CompiledTemplate compile() {
+        return new CompiledTemplate(template, compileFrom(null, new ExecutionStack()));
+    }
+
+    public Node compileFrom(Node root, ExecutionStack stack) {
+        line = 1;
+
+        Node n = root;
+        if (root == null) {
+            n = root = new TextNode(0, 0);
+        }
+
+        IfNode last;
+        Integer opcode;
+        String name;
+        int x;
+
+        try {
+            while (cursor < length) {
+                switch (template[cursor]) {
+                    case '\n':
+                        line++;
+                        colStart = cursor + 1;
+                        break;
+                    case '@':
+                    case '$':
+                        if (isNext(template[cursor])) {
+                            start = ++cursor;
+                            (n = markTextNode(n)).setEnd(n.getEnd() + 1);
+                            start = lastTextRangeEnding = ++cursor;
+
+                            continue;
+                        }
+                        if ((x = captureOrbToken()) != -1) {
+                            start = x;
+                            switch ((opcode = OPCODES.get(name = new String(capture()))) == null ? 0 : opcode) {
+                                case Opcodes.IF:
+                                    /**
+                                     * Capture any residual text node, and push the if statement on the nesting stack.
+                                     */
+                                    stack.push(n = markTextNode(n).next = codeCache ? new CompiledIfNode(start, name, template,
+                                            captureOrbInternal(), start,
+                                            parserContext) : new IfNode(start, name, template, captureOrbInternal(), start));
+
+                                    n.setTerminus(new TerminalNode());
+
+                                    break;
+
+                                case Opcodes.ELSE:
+                                    if (!stack.isEmpty() && stack.peek() instanceof IfNode) {
+                                        markTextNode(n).next = (last = (IfNode) stack.pop()).getTerminus();
+
+                                        last.demarcate(last.getTerminus(), template);
+                                        last.next = n = codeCache ? new CompiledIfNode(start, name, template, captureOrbInternal(), start,
+                                                parserContext) : new IfNode(start, name, template, captureOrbInternal(), start);
+                                        n.setTerminus(last.getTerminus());
+
+                                        stack.push(n);
+                                    }
+                                    break;
+
+                                case Opcodes.FOREACH:
+                                    stack.push(n = markTextNode(n).next = codeCache ? new CompiledForEachNode(start, name, template,
+                                            captureOrbInternal(), start,
+                                            parserContext) : new ForEachNode(start, name, template, captureOrbInternal(), start));
+
+                                    n.setTerminus(new TerminalNode());
+
+                                    break;
+
+                                case Opcodes.INCLUDE_FILE:
+                                    n = markTextNode(n).next = codeCache ? new CompiledIncludeNode(start, name, template,
+                                            captureOrbInternal(), start = cursor + 1, parserContext) : new IncludeNode(start, name,
+                                                    template, captureOrbInternal(), start = cursor + 1);
+                                    break;
+
+                                case Opcodes.INCLUDE_NAMED:
+                                    n = markTextNode(n).next = codeCache ? new CompiledNamedIncludeNode(start, name, template,
+                                            captureOrbInternal(), start = cursor + 1, parserContext) : new NamedIncludeNode(start, name,
+                                                    template, captureOrbInternal(), start = cursor + 1);
+                                    break;
+
+                                case Opcodes.CODE:
+                                    n = markTextNode(n).next = codeCache ? new CompiledCodeNode(start, name, template, captureOrbInternal(),
+                                            start = cursor + 1,
+                                            parserContext) : new CodeNode(start, name, template, captureOrbInternal(), start = cursor + 1);
+                                    break;
+
+                                case Opcodes.EVAL:
+                                    n = markTextNode(n).next = codeCache ? new CompiledEvalNode(start, name, template, captureOrbInternal(),
+                                            start = cursor + 1,
+                                            parserContext) : new EvalNode(start, name, template, captureOrbInternal(), start = cursor + 1);
+                                    break;
+
+                                case Opcodes.COMMENT:
+                                    n = markTextNode(n).next = new CommentNode(start, name, template, captureOrbInternal(),
+                                            start = cursor + 1);
+
+                                    break;
+
+                                case Opcodes.DECLARE:
+                                    stack.push(n = markTextNode(n).next = codeCache ? new CompiledDeclareNode(start, name, template,
+                                            captureOrbInternal(), start = cursor + 1, parserContext) : new DeclareNode(start, name,
+                                                    template, captureOrbInternal(), start = cursor + 1));
+
+                                    n.setTerminus(new TerminalNode());
+
+                                    break;
+
+                                case Opcodes.END:
+                                    n = markTextNode(n);
+
+                                    Node end = (Node) stack.pop();
+                                    Node terminal = end.getTerminus();
+
+                                    terminal.setCStart(captureOrbInternal());
+                                    terminal.setEnd((lastTextRangeEnding = start) - 1);
+                                    terminal.calculateContents(template);
+
+                                    if (end.demarcate(terminal, template)) n = n.next = terminal;
+                                    else n = terminal;
+
+                                    break;
+
+                                default:
+                                    if (name.length() == 0) {
+                                        n = markTextNode(n).next = codeCache ? new CompiledExpressionNode(start, name, template,
+                                                captureOrbInternal(), start = cursor + 1, parserContext) : new ExpressionNode(start, name,
+                                                        template, captureOrbInternal(), start = cursor + 1);
+                                    } else if (customNodes != null && customNodes.containsKey(name)) {
+                                        Class<? extends Node> customNode = customNodes.get(name);
+
+                                        try {
+                                            (n = markTextNode(n).next = (customNode.newInstance())).setBegin(start);
+                                            n.setName(name);
+                                            n.setCStart(captureOrbInternal());
+                                            n.setCEnd(start = cursor + 1);
+                                            n.setEnd(n.getCEnd());
+
+                                            n.setContents(subset(template, n.getCStart(), n.getCEnd() - n.getCStart() - 1));
+
+                                            if (n.isOpenNode()) {
+                                                stack.push(n);
+                                            }
+                                        } catch (InstantiationException e) {
+                                            throw new RuntimeException("unable to instantiate custom node class: " + customNode.getName());
+                                        } catch (IllegalAccessException e) {
+                                            throw new RuntimeException("unable to instantiate custom node class: " + customNode.getName());
+                                        }
+                                    } else {
+                                        throw new RuntimeException("unknown token type: " + name);
+                                    }
+                            }
+                        }
+
+                        break;
+                }
+                cursor++;
+            }
+        } catch (RuntimeException e) {
+            CompileException ce = new CompileException(e.getMessage(), template, cursor, e);
+            ce.setExpr(template);
+
+            if (e instanceof CompileException) {
+                CompileException ce2 = (CompileException) e;
+                if (ce2.getCursor() != -1) {
+                    ce.setCursor(ce2.getCursor());
+                    if (ce2.getColumn() == -1) ce.setColumn(ce.getCursor() - colStart);
+                    else ce.setColumn(ce2.getColumn());
+                }
+            }
+            ce.setLineNumber(line);
+
+            throw ce;
+        }
+
+        if (!stack.isEmpty()) {
+            CompileException ce = new CompileException("unclosed @" + ((Node) stack.peek()).getName() + "{} block. expected @end{}",
+                    template, cursor);
+            ce.setColumn(cursor - colStart);
+            ce.setLineNumber(line);
+            throw ce;
+        }
+
+        if (start < template.length) {
+            n = n.next = new TextNode(start, template.length);
+        }
+        n.next = new EndNode();
+
+        n = root;
+        do {
+            if (n.getLength() != 0) {
+                break;
+            }
+        } while ((n = n.getNext()) != null);
+
+        if (n != null && n.getLength() == template.length - 1) {
+            if (n instanceof ExpressionNode) {
+                return codeCache ? new CompiledTerminalExpressionNode(n, parserContext) : new TerminalExpressionNode(n);
+            } else {
+                return n;
+            }
+        }
+
+        return root;
+    }
+
+    private boolean isNext(char c) {
+        return cursor != length && template[cursor + 1] == c;
+    }
+
+    private int captureOrbToken() {
+        int newStart = ++cursor;
+        while ((cursor != length) && ParseTools.isIdentifierPart(template[cursor]))
+            cursor++;
+        if (cursor != length && template[cursor] == '{') return newStart;
+        return -1;
+    }
+
+    private int captureOrbInternal() {
+        try {
+            ParserContext pCtx = new ParserContext();
+            cursor = balancedCaptureWithLineAccounting(template, start = cursor, length, '{', pCtx);
+            line += pCtx.getLineCount();
+            int ret = start + 1;
+            start = cursor + 1;
+            return ret;
+        } catch (CompileException e) {
+            e.setLineNumber(line);
+            e.setColumn((cursor - colStart) + 1);
+            throw e;
+        }
+    }
+
+    private char[] capture() {
+        char[] newChar = new char[cursor - start];
+        for (int i = 0; i < newChar.length; i++) {
+            newChar[i] = template[i + start];
+        }
+        return newChar;
+    }
+
+    private Node markTextNode(Node n) {
+        int s = (n.getEnd() > lastTextRangeEnding ? n.getEnd() : lastTextRangeEnding);
+
+        if (s < start) {
+            return n.next = new TextNode(s, lastTextRangeEnding = start - 1);
+        }
+        return n;
+    }
+
+    public ParserContext getParserContext() {
+        return parserContext;
+    }
+}

--- a/core/src/main/java/org/mvel2/templates/TemplateDebug.java
+++ b/core/src/main/java/org/mvel2/templates/TemplateDebug.java
@@ -1,0 +1,32 @@
+/**
+ * MVEL 2.0
+ * Copyright (C) 2007 The Codehaus
+ * Mike Brock, Dhanji Prasanna, John Graham, Mark Proctor
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mvel2.templates;
+
+import org.mvel2.templates.res.Node;
+
+public class TemplateDebug {
+
+    public static void decompile(CompiledTemplate t, char[] template) {
+        int i = 1;
+        for (Node n = t.getRoot(); n != null; n = n.getNext()) {
+            System.out.println((i++) + "> " + n.toString() + "['" + new String(template, n.getBegin(), n.getEnd() - n.getBegin()) + "']");
+        }
+    }
+
+}

--- a/core/src/main/java/org/mvel2/templates/TemplateError.java
+++ b/core/src/main/java/org/mvel2/templates/TemplateError.java
@@ -1,0 +1,38 @@
+/**
+ * MVEL 2.0
+ * Copyright (C) 2007 The Codehaus
+ * Mike Brock, Dhanji Prasanna, John Graham, Mark Proctor
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mvel2.templates;
+
+public class TemplateError extends RuntimeException {
+
+    public TemplateError() {
+        super(); //To change body of overridden methods use File | Settings | File Templates.
+    }
+
+    public TemplateError(String s) {
+        super(s); //To change body of overridden methods use File | Settings | File Templates.
+    }
+
+    public TemplateError(String s, Throwable throwable) {
+        super(s, throwable); //To change body of overridden methods use File | Settings | File Templates.
+    }
+
+    public TemplateError(Throwable throwable) {
+        super(throwable); //To change body of overridden methods use File | Settings | File Templates.
+    }
+}

--- a/core/src/main/java/org/mvel2/templates/TemplateRegistry.java
+++ b/core/src/main/java/org/mvel2/templates/TemplateRegistry.java
@@ -1,0 +1,35 @@
+/**
+ * MVEL 2.0
+ * Copyright (C) 2007 The Codehaus
+ * Mike Brock, Dhanji Prasanna, John Graham, Mark Proctor
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mvel2.templates;
+
+import java.util.Iterator;
+import java.util.Set;
+
+public interface TemplateRegistry {
+
+    Iterator iterator();
+
+    Set<String> getNames();
+
+    boolean contains(String name);
+
+    void addNamedTemplate(String name, CompiledTemplate template);
+
+    CompiledTemplate getNamedTemplate(String name);
+}

--- a/core/src/main/java/org/mvel2/templates/TemplateRuntime.java
+++ b/core/src/main/java/org/mvel2/templates/TemplateRuntime.java
@@ -1,0 +1,323 @@
+/**
+ * MVEL 2.0
+ * Copyright (C) 2007 The Codehaus
+ * Mike Brock, Dhanji Prasanna, John Graham, Mark Proctor
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mvel2.templates;
+
+import static org.mvel2.templates.TemplateCompiler.compileTemplate;
+
+import java.io.File;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.util.Map;
+
+import org.mvel2.integration.VariableResolverFactory;
+import org.mvel2.integration.impl.ImmutableDefaultFactory;
+import org.mvel2.integration.impl.MapVariableResolverFactory;
+import org.mvel2.templates.res.Node;
+import org.mvel2.templates.util.TemplateOutputStream;
+import org.mvel2.templates.util.TemplateTools;
+import org.mvel2.templates.util.io.StandardOutputStream;
+import org.mvel2.templates.util.io.StringAppenderStream;
+import org.mvel2.templates.util.io.StringBuilderStream;
+import org.mvel2.util.ExecutionStack;
+import org.mvel2.util.StringAppender;
+
+/**
+ * This is the root of the template runtime, and contains various utility methods for executing templates.
+ */
+public class TemplateRuntime {
+
+    private char[] template;
+    private TemplateRegistry namedTemplateRegistry;
+    private Node rootNode;
+    private String baseDir;
+    private ExecutionStack relPath;
+
+    public TemplateRuntime(char[] template, TemplateRegistry namedTemplateRegistry, Node rootNode, String baseDir) {
+        this.template = template;
+        this.namedTemplateRegistry = namedTemplateRegistry;
+        this.rootNode = rootNode;
+        this.baseDir = baseDir;
+    }
+
+    public static Object eval(File file, Object ctx, VariableResolverFactory vars, TemplateRegistry registry) {
+        return execute(compileTemplate(TemplateTools.readInFile(file)), ctx, vars, registry);
+    }
+
+    public static Object eval(InputStream instream) {
+        return eval(instream, null, new ImmutableDefaultFactory(), null);
+    }
+
+    public static Object eval(InputStream instream, Object ctx) {
+        return eval(instream, ctx, new ImmutableDefaultFactory(), null);
+    }
+
+    public static Object eval(InputStream instream, Object ctx, VariableResolverFactory vars) {
+        return eval(instream, ctx, vars);
+    }
+
+    public static Object eval(InputStream instream, Object ctx, Map vars) {
+        return eval(instream, ctx, new MapVariableResolverFactory(vars), null);
+    }
+
+    public static Object eval(InputStream instream, Object ctx, Map vars, TemplateRegistry registry) {
+        return execute(compileTemplate(TemplateTools.readStream(instream)), ctx, new MapVariableResolverFactory(vars), registry);
+    }
+
+    public static Object eval(InputStream instream, Object ctx, VariableResolverFactory vars, TemplateRegistry registry) {
+        return execute(compileTemplate(TemplateTools.readStream(instream)), ctx, vars, registry);
+    }
+
+    public static void eval(InputStream instream, Object ctx, VariableResolverFactory vars, TemplateRegistry register,
+            OutputStream stream) {
+        execute(compileTemplate(TemplateTools.readStream(instream)), ctx, vars, register, stream);
+    }
+
+    public static Object eval(String template, Map vars) {
+        return execute(compileTemplate(template), null, new MapVariableResolverFactory(vars));
+    }
+
+    public static void eval(String template, Map vars, OutputStream stream) {
+        execute(compileTemplate(template), null, new MapVariableResolverFactory(vars), null, stream);
+    }
+
+    public static Object eval(String template, Object ctx) {
+        return execute(compileTemplate(template), ctx);
+    }
+
+    public static Object eval(String template, Object ctx, Map vars) {
+        return execute(compileTemplate(template), ctx, new MapVariableResolverFactory(vars));
+    }
+
+    public static void eval(String template, Object ctx, Map vars, OutputStream stream) {
+        execute(compileTemplate(template), ctx, new MapVariableResolverFactory(vars), null, stream);
+    }
+
+    public static Object eval(String template, Object ctx, VariableResolverFactory vars) {
+        return execute(compileTemplate(template), ctx, vars);
+    }
+
+    public static void eval(String template, Object ctx, VariableResolverFactory vars, TemplateOutputStream stream) {
+        execute(compileTemplate(template), ctx, vars, null, stream);
+    }
+
+    public static void eval(String template, Object ctx, VariableResolverFactory vars, OutputStream stream) {
+        execute(compileTemplate(template), ctx, vars, null, stream);
+    }
+
+    public static Object eval(String template, Map vars, TemplateRegistry registry) {
+        return execute(compileTemplate(template), null, new MapVariableResolverFactory(vars), registry);
+    }
+
+    public static void eval(String template, Map vars, TemplateRegistry registry, TemplateOutputStream stream) {
+        execute(compileTemplate(template), null, new MapVariableResolverFactory(vars), registry, stream);
+    }
+
+    public static void eval(String template, Map vars, TemplateRegistry registry, OutputStream stream) {
+        execute(compileTemplate(template), null, new MapVariableResolverFactory(vars), registry, stream);
+    }
+
+    public static Object eval(String template, Object ctx, Map vars, TemplateRegistry registry) {
+        return execute(compileTemplate(template), ctx, new MapVariableResolverFactory(vars), registry);
+    }
+
+    public static void eval(String template, Object ctx, Map vars, TemplateRegistry registry, OutputStream stream) {
+        execute(compileTemplate(template), ctx, new MapVariableResolverFactory(vars), registry, stream);
+    }
+
+    public static Object eval(String template, Object ctx, VariableResolverFactory vars, TemplateRegistry registry) {
+        return execute(compileTemplate(template), ctx, vars, registry);
+    }
+
+    public static void eval(String template, Object ctx, VariableResolverFactory vars, TemplateRegistry registry, OutputStream stream) {
+        execute(compileTemplate(template), ctx, vars, registry, stream);
+    }
+
+    public static void eval(String template, Object ctx, VariableResolverFactory vars, TemplateRegistry registry,
+            TemplateOutputStream stream) {
+        execute(compileTemplate(template), ctx, vars, registry, stream);
+    }
+
+    public static Object execute(CompiledTemplate compiled) {
+        return execute(compiled.getRoot(), compiled.getTemplate(), new StringAppender(), null, new ImmutableDefaultFactory(), null);
+    }
+
+    public static void execute(CompiledTemplate compiled, OutputStream stream) {
+        execute(compiled.getRoot(), compiled.getTemplate(), new StandardOutputStream(stream), null, new ImmutableDefaultFactory(), null);
+    }
+
+    public static Object execute(CompiledTemplate compiled, Object context) {
+        return execute(compiled.getRoot(), compiled.getTemplate(), new StringAppender(), context, new ImmutableDefaultFactory(), null);
+    }
+
+    public static void execute(CompiledTemplate compiled, Object context, OutputStream stream) {
+        execute(compiled.getRoot(), compiled.getTemplate(), new StandardOutputStream(stream), context, new ImmutableDefaultFactory(), null);
+    }
+
+    public static Object execute(CompiledTemplate compiled, Map vars) {
+        return execute(compiled.getRoot(), compiled.getTemplate(), new StringBuilder(), null, new MapVariableResolverFactory(vars), null);
+    }
+
+    public static void execute(CompiledTemplate compiled, Map vars, OutputStream stream) {
+        execute(compiled.getRoot(), compiled.getTemplate(), new StandardOutputStream(stream), null, new MapVariableResolverFactory(vars),
+                null);
+    }
+
+    public static Object execute(CompiledTemplate compiled, Object context, Map vars) {
+        return execute(compiled.getRoot(), compiled.getTemplate(), new StringBuilder(), context, new MapVariableResolverFactory(vars),
+                null);
+    }
+
+    public static void execute(CompiledTemplate compiled, Object context, Map vars, OutputStream stream) {
+        execute(compiled.getRoot(), compiled.getTemplate(), new StandardOutputStream(stream), context, new MapVariableResolverFactory(vars),
+                null);
+    }
+
+    public static Object execute(CompiledTemplate compiled, Object context, TemplateRegistry registry) {
+        return execute(compiled.getRoot(), compiled.getTemplate(), new StringBuilder(), context, null, registry);
+    }
+
+    public static void execute(CompiledTemplate compiled, Object context, TemplateRegistry registry, OutputStream stream) {
+        execute(compiled.getRoot(), compiled.getTemplate(), new StandardOutputStream(stream), context, null, registry);
+    }
+
+    public static Object execute(CompiledTemplate compiled, Object context, Map vars, TemplateRegistry registry) {
+        return execute(compiled.getRoot(), compiled.getTemplate(), new StringBuilder(), context, new MapVariableResolverFactory(vars),
+                registry);
+    }
+
+    public static void execute(CompiledTemplate compiled, Object context, Map vars, TemplateRegistry registry, OutputStream stream) {
+        execute(compiled.getRoot(), compiled.getTemplate(), new StandardOutputStream(stream), context, new MapVariableResolverFactory(vars),
+                registry);
+    }
+
+    public static Object execute(CompiledTemplate compiled, Object context, VariableResolverFactory factory) {
+        return execute(compiled.getRoot(), compiled.getTemplate(), new StringBuilder(), context, factory, null);
+    }
+
+    public static Object execute(CompiledTemplate compiled, Object context, VariableResolverFactory factory, TemplateRegistry registry) {
+        return execute(compiled.getRoot(), compiled.getTemplate(), new StringBuilder(), context, factory, registry);
+    }
+
+    public static Object execute(CompiledTemplate compiled, Object context, VariableResolverFactory factory, String baseDir) {
+        return execute(compiled.getRoot(), compiled.getTemplate(), new StringBuilder(), context, factory, null, baseDir);
+    }
+
+    public static Object execute(CompiledTemplate compiled, Object context, VariableResolverFactory factory, TemplateRegistry registry,
+            String baseDir) {
+        return execute(compiled.getRoot(), compiled.getTemplate(), new StringBuilder(), context, factory, registry, baseDir);
+    }
+
+    public static void execute(CompiledTemplate compiled, Object context, VariableResolverFactory factory, OutputStream stream) {
+        execute(compiled.getRoot(), compiled.getTemplate(), new StandardOutputStream(stream), context, factory, null);
+    }
+
+    public static void execute(CompiledTemplate compiled, Object context, VariableResolverFactory factory, OutputStream stream,
+            String baseDir) {
+        execute(compiled.getRoot(), compiled.getTemplate(), new StandardOutputStream(stream), context, factory, null, baseDir);
+    }
+
+    public static Object execute(CompiledTemplate compiled, Object context, VariableResolverFactory factory, TemplateRegistry registry,
+            OutputStream stream) {
+        return execute(compiled.getRoot(), compiled.getTemplate(), new StandardOutputStream(stream), context, factory, registry);
+    }
+
+    public static Object execute(CompiledTemplate compiled, Object context, VariableResolverFactory factory, TemplateRegistry registry,
+            TemplateOutputStream stream) {
+        return execute(compiled.getRoot(), compiled.getTemplate(), stream, context, factory, registry);
+    }
+
+    public static Object execute(CompiledTemplate compiled, Object context, VariableResolverFactory factory, TemplateRegistry registry,
+            TemplateOutputStream stream, String basedir) {
+        return execute(compiled.getRoot(), compiled.getTemplate(), stream, context, factory, registry, basedir);
+    }
+
+    public static Object execute(Node root, char[] template, StringAppender appender, Object context, VariableResolverFactory factory,
+            TemplateRegistry registry) {
+
+        return new TemplateRuntime(template, registry, root, ".").execute(appender, context, factory);
+    }
+
+    public static Object execute(Node root, char[] template, StringBuilder appender, Object context, VariableResolverFactory factory,
+            TemplateRegistry registry) {
+
+        return new TemplateRuntime(template, registry, root, ".").execute(appender, context, factory);
+    }
+
+    public static Object execute(Node root, char[] template, StringBuilder appender, Object context, VariableResolverFactory factory,
+            TemplateRegistry registry, String baseDir) {
+
+        return new TemplateRuntime(template, registry, root, baseDir).execute(appender, context, factory);
+    }
+
+    public static Object execute(Node root, char[] template, TemplateOutputStream appender, Object context, VariableResolverFactory factory,
+            TemplateRegistry registry) {
+
+        return new TemplateRuntime(template, registry, root, ".").execute(appender, context, factory);
+    }
+
+    public static Object execute(Node root, char[] template, TemplateOutputStream appender, Object context, VariableResolverFactory factory,
+            TemplateRegistry registry, String baseDir) {
+
+        return new TemplateRuntime(template, registry, root, baseDir).execute(appender, context, factory);
+    }
+
+    public Object execute(StringBuilder appender, Object context, VariableResolverFactory factory) {
+        return execute(new StringBuilderStream(appender), context, factory);
+    }
+
+    public Object execute(StringAppender appender, Object context, VariableResolverFactory factory) {
+        return execute(new StringAppenderStream(appender), context, factory);
+    }
+
+    public Object execute(TemplateOutputStream stream, Object context, VariableResolverFactory factory) {
+        return rootNode.eval(this, stream, context, factory);
+    }
+
+    public Node getRootNode() {
+        return rootNode;
+    }
+
+    public void setRootNode(Node rootNode) {
+        this.rootNode = rootNode;
+    }
+
+    public char[] getTemplate() {
+        return template;
+    }
+
+    public void setTemplate(char[] template) {
+        this.template = template;
+    }
+
+    public TemplateRegistry getNamedTemplateRegistry() {
+        return namedTemplateRegistry;
+    }
+
+    public void setNamedTemplateRegistry(TemplateRegistry namedTemplateRegistry) {
+        this.namedTemplateRegistry = namedTemplateRegistry;
+    }
+
+    public ExecutionStack getRelPath() {
+        if (relPath == null) {
+            relPath = new ExecutionStack();
+            relPath.push(baseDir);
+        }
+        return relPath;
+    }
+}

--- a/core/src/main/java/org/mvel2/templates/TemplateRuntimeError.java
+++ b/core/src/main/java/org/mvel2/templates/TemplateRuntimeError.java
@@ -1,0 +1,38 @@
+/**
+ * MVEL 2.0
+ * Copyright (C) 2007 The Codehaus
+ * Mike Brock, Dhanji Prasanna, John Graham, Mark Proctor
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mvel2.templates;
+
+public class TemplateRuntimeError extends RuntimeException {
+
+    public TemplateRuntimeError() {
+        super(); //To change body of overridden methods use File | Settings | File Templates.
+    }
+
+    public TemplateRuntimeError(String s) {
+        super(s); //To change body of overridden methods use File | Settings | File Templates.
+    }
+
+    public TemplateRuntimeError(String s, Throwable throwable) {
+        super(s, throwable); //To change body of overridden methods use File | Settings | File Templates.
+    }
+
+    public TemplateRuntimeError(Throwable throwable) {
+        super(throwable); //To change body of overridden methods use File | Settings | File Templates.
+    }
+}

--- a/core/src/main/java/org/mvel2/templates/TemplateSyntaxError.java
+++ b/core/src/main/java/org/mvel2/templates/TemplateSyntaxError.java
@@ -1,0 +1,38 @@
+/**
+ * MVEL 2.0
+ * Copyright (C) 2007 The Codehaus
+ * Mike Brock, Dhanji Prasanna, John Graham, Mark Proctor
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mvel2.templates;
+
+public class TemplateSyntaxError extends RuntimeException {
+
+    public TemplateSyntaxError() {
+        super(); //To change body of overridden methods use File | Settings | File Templates.
+    }
+
+    public TemplateSyntaxError(String s) {
+        super(s); //To change body of overridden methods use File | Settings | File Templates.
+    }
+
+    public TemplateSyntaxError(String s, Throwable throwable) {
+        super(s, throwable); //To change body of overridden methods use File | Settings | File Templates.
+    }
+
+    public TemplateSyntaxError(Throwable throwable) {
+        super(throwable); //To change body of overridden methods use File | Settings | File Templates.
+    }
+}

--- a/core/src/main/java/org/mvel2/templates/res/CodeNode.java
+++ b/core/src/main/java/org/mvel2/templates/res/CodeNode.java
@@ -1,0 +1,64 @@
+/**
+ * MVEL 2.0
+ * Copyright (C) 2007 The Codehaus
+ * Mike Brock, Dhanji Prasanna, John Graham, Mark Proctor
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mvel2.templates.res;
+
+import org.mvel2.MVEL;
+import org.mvel2.integration.VariableResolverFactory;
+import org.mvel2.templates.TemplateRuntime;
+import org.mvel2.templates.util.TemplateOutputStream;
+
+public class CodeNode extends Node {
+
+    private int start;
+    private int offset;
+    public CodeNode() {
+    }
+
+    public CodeNode(int begin, String name, char[] template, int start, int end) {
+        this.begin = begin;
+        this.name = name;
+        this.contents = template;
+        this.start = start;
+        this.offset = end - start - 1;
+
+        //  this.contents = subset(template, this.cStart = start, (this.end = this.cEnd = end) - start - 1);
+    }
+
+    public CodeNode(int begin, String name, char[] template, int start, int end, Node next) {
+        this.name = name;
+        this.begin = begin;
+        //     this.contents = subset(template, this.cStart = start, (this.end = this.cEnd = end) - start - 1);
+        this.next = next;
+        this.start = start;
+        this.offset = end - start - 1;
+    }
+
+    public Object eval(TemplateRuntime runtime, TemplateOutputStream appender, Object ctx, VariableResolverFactory factory) {
+        MVEL.eval(contents, start, offset, ctx, factory);
+        return next != null ? next.eval(runtime, appender, ctx, factory) : null;
+    }
+
+    public boolean demarcate(Node terminatingNode, char[] template) {
+        return false;
+    }
+
+    public String toString() {
+        return "CodeNode:" + name + "{" + (contents == null ? "" : new String(contents)) + "} (start=" + begin + ";end=" + end + ")";
+    }
+}

--- a/core/src/main/java/org/mvel2/templates/res/CommentNode.java
+++ b/core/src/main/java/org/mvel2/templates/res/CommentNode.java
@@ -1,0 +1,49 @@
+/**
+ * MVEL 2.0
+ * Copyright (C) 2007 The Codehaus
+ * Mike Brock, Dhanji Prasanna, John Graham, Mark Proctor
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mvel2.templates.res;
+
+import org.mvel2.integration.VariableResolverFactory;
+import org.mvel2.templates.TemplateRuntime;
+import org.mvel2.templates.util.TemplateOutputStream;
+
+public class CommentNode extends Node {
+
+    public CommentNode() {
+    }
+
+    public CommentNode(int begin, String name, char[] template, int start, int end) {
+        this.name = name;
+        this.end = this.cEnd = end;
+    }
+
+    public CommentNode(int begin, String name, char[] template, int start, int end, Node next) {
+        this.begin = begin;
+        this.end = this.cEnd = end;
+        this.next = next;
+    }
+
+    public Object eval(TemplateRuntime runtime, TemplateOutputStream appender, Object ctx, VariableResolverFactory factory) {
+        if (next != null) return next.eval(runtime, appender, ctx, factory);
+        else return null;
+    }
+
+    public boolean demarcate(Node terminatingNode, char[] template) {
+        return false;
+    }
+}

--- a/core/src/main/java/org/mvel2/templates/res/CompiledCodeNode.java
+++ b/core/src/main/java/org/mvel2/templates/res/CompiledCodeNode.java
@@ -1,0 +1,62 @@
+/**
+ * MVEL 2.0
+ * Copyright (C) 2007 The Codehaus
+ * Mike Brock, Dhanji Prasanna, John Graham, Mark Proctor
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mvel2.templates.res;
+
+import java.io.Serializable;
+
+import org.mvel2.MVEL;
+import org.mvel2.ParserContext;
+import org.mvel2.integration.VariableResolverFactory;
+import org.mvel2.templates.TemplateRuntime;
+import org.mvel2.templates.util.TemplateOutputStream;
+
+public class CompiledCodeNode extends Node {
+
+    private Serializable ce;
+
+    public CompiledCodeNode() {
+    }
+
+    public CompiledCodeNode(int begin, String name, char[] template, int start, int end, ParserContext context) {
+        this.begin = begin;
+        this.name = name;
+        this.contents = template;
+        this.cStart = start;
+        this.cEnd = end - 1;
+        this.end = end;
+        ce = MVEL.compileExpression(template, cStart, cEnd - cStart, context);
+
+        //        ce = MVEL.compileExpression(
+        //                this.contents = subset(template, this.cStart = start, (this.end = this.cEnd = end) - start - 1),
+        //                   context);
+    }
+
+    public Object eval(TemplateRuntime runtime, TemplateOutputStream appender, Object ctx, VariableResolverFactory factory) {
+        MVEL.executeExpression(ce, ctx, factory);
+        return next != null ? next.eval(runtime, appender, ctx, factory) : null;
+    }
+
+    public boolean demarcate(Node terminatingNode, char[] template) {
+        return false;
+    }
+
+    public String toString() {
+        return "CodeNode:" + name + "{" + (contents == null ? "" : new String(contents)) + "} (start=" + begin + ";end=" + end + ")";
+    }
+}

--- a/core/src/main/java/org/mvel2/templates/res/CompiledDeclareNode.java
+++ b/core/src/main/java/org/mvel2/templates/res/CompiledDeclareNode.java
@@ -1,0 +1,69 @@
+/**
+ * MVEL 2.0
+ * Copyright (C) 2007 The Codehaus
+ * Mike Brock, Dhanji Prasanna, John Graham, Mark Proctor
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mvel2.templates.res;
+
+import java.io.Serializable;
+
+import org.mvel2.MVEL;
+import org.mvel2.ParserContext;
+import org.mvel2.integration.VariableResolverFactory;
+import org.mvel2.templates.CompiledTemplate;
+import org.mvel2.templates.SimpleTemplateRegistry;
+import org.mvel2.templates.TemplateRuntime;
+import org.mvel2.templates.util.TemplateOutputStream;
+
+public class CompiledDeclareNode extends Node {
+
+    private Node nestedNode;
+    private Serializable ce;
+
+    public CompiledDeclareNode(int begin, String name, char[] template, int start, int end, ParserContext context) {
+        this.begin = begin;
+        this.name = name;
+        this.contents = template;
+        this.cStart = start;
+        this.cEnd = end - 1;
+        this.end = end;
+        ce = MVEL.compileExpression(template, cStart, cEnd - cStart, context);
+        //  ce = MVEL.compileExpression(this.contents = subset(template, this.cStart = start, (this.end = this.cEnd = end) - start - 1), context);
+    }
+
+    public Object eval(TemplateRuntime runtime, TemplateOutputStream appender, Object ctx, VariableResolverFactory factory) {
+        if (runtime.getNamedTemplateRegistry() == null) {
+            runtime.setNamedTemplateRegistry(new SimpleTemplateRegistry());
+        }
+
+        runtime.getNamedTemplateRegistry().addNamedTemplate(MVEL.executeExpression(ce, ctx, factory, String.class),
+                new CompiledTemplate(runtime.getTemplate(), nestedNode));
+
+        return next != null ? next.eval(runtime, appender, ctx, factory) : null;
+    }
+
+    public boolean demarcate(Node terminatingNode, char[] template) {
+        Node n = nestedNode = next;
+
+        while (n.getNext() != null)
+            n = n.next;
+
+        n.next = new EndNode();
+
+        next = terminus;
+        return false;
+    }
+}

--- a/core/src/main/java/org/mvel2/templates/res/CompiledEvalNode.java
+++ b/core/src/main/java/org/mvel2/templates/res/CompiledEvalNode.java
@@ -1,0 +1,57 @@
+/**
+ * MVEL 2.0
+ * Copyright (C) 2007 The Codehaus
+ * Mike Brock, Dhanji Prasanna, John Graham, Mark Proctor
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mvel2.templates.res;
+
+import static java.lang.String.valueOf;
+
+import java.io.Serializable;
+
+import org.mvel2.MVEL;
+import org.mvel2.ParserContext;
+import org.mvel2.integration.VariableResolverFactory;
+import org.mvel2.templates.TemplateRuntime;
+import org.mvel2.templates.util.TemplateOutputStream;
+
+public class CompiledEvalNode extends Node {
+
+    private Serializable ce;
+
+    public CompiledEvalNode(int begin, String name, char[] template, int start, int end, ParserContext context) {
+        this.begin = begin;
+        this.name = name;
+        this.contents = template;
+        this.cStart = start;
+        this.cEnd = end - 1;
+        this.end = end;
+        ce = MVEL.compileExpression(template, cStart, cEnd - cStart, context);
+    }
+
+    public Object eval(TemplateRuntime runtime, TemplateOutputStream appender, Object ctx, VariableResolverFactory factory) {
+        appender.append(String.valueOf(TemplateRuntime.eval(valueOf(MVEL.executeExpression(ce, ctx, factory)), ctx, factory)));
+        return next != null ? next.eval(runtime, appender, ctx, factory) : null;
+    }
+
+    public boolean demarcate(Node terminatingNode, char[] template) {
+        return false;
+    }
+
+    public String toString() {
+        return "EvalNode:" + name + "{" + (contents == null ? "" : new String(contents)) + "} (start=" + begin + ";end=" + end + ")";
+    }
+}

--- a/core/src/main/java/org/mvel2/templates/res/CompiledExpressionNode.java
+++ b/core/src/main/java/org/mvel2/templates/res/CompiledExpressionNode.java
@@ -1,0 +1,53 @@
+/**
+ * MVEL 2.0
+ * Copyright (C) 2007 The Codehaus
+ * Mike Brock, Dhanji Prasanna, John Graham, Mark Proctor
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mvel2.templates.res;
+
+import static java.lang.String.valueOf;
+
+import java.io.Serializable;
+
+import org.mvel2.MVEL;
+import org.mvel2.ParserContext;
+import org.mvel2.integration.VariableResolverFactory;
+import org.mvel2.templates.TemplateRuntime;
+import org.mvel2.templates.util.TemplateOutputStream;
+
+public class CompiledExpressionNode extends ExpressionNode {
+
+    private Serializable ce;
+
+    public CompiledExpressionNode(int begin, String name, char[] template, int start, int end, ParserContext context) {
+        this.begin = begin;
+        this.name = name;
+        this.contents = template;
+        this.cStart = start;
+        this.cEnd = end - 1;
+        this.end = end;
+        ce = MVEL.compileExpression(template, cStart, cEnd - cStart, context);
+    }
+
+    public Object eval(TemplateRuntime runtime, TemplateOutputStream appender, Object ctx, VariableResolverFactory factory) {
+        appender.append(valueOf(MVEL.executeExpression(ce, ctx, factory)));
+        return next != null ? next.eval(runtime, appender, ctx, factory) : null;
+    }
+
+    public String toString() {
+        return "ExpressionNode:" + name + "{" + (contents == null ? "" : new String(contents)) + "} (start=" + begin + ";end=" + end + ")";
+    }
+}

--- a/core/src/main/java/org/mvel2/templates/res/CompiledForEachNode.java
+++ b/core/src/main/java/org/mvel2/templates/res/CompiledForEachNode.java
@@ -1,0 +1,184 @@
+/**
+ * MVEL 2.0
+ * Copyright (C) 2007 The Codehaus
+ * Mike Brock, Dhanji Prasanna, John Graham, Mark Proctor
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mvel2.templates.res;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
+
+import org.mvel2.CompileException;
+import org.mvel2.MVEL;
+import org.mvel2.ParserContext;
+import org.mvel2.integration.VariableResolverFactory;
+import org.mvel2.integration.impl.MapVariableResolverFactory;
+import org.mvel2.templates.TemplateRuntime;
+import org.mvel2.templates.TemplateRuntimeError;
+import org.mvel2.templates.util.ArrayIterator;
+import org.mvel2.templates.util.CountIterator;
+import org.mvel2.templates.util.TemplateOutputStream;
+import org.mvel2.util.ParseTools;
+
+public class CompiledForEachNode extends Node {
+
+    public Node nestedNode;
+    private Serializable[] ce;
+
+    private String[] item;
+
+    private char[] sepExpr;
+    private Serializable cSepExpr;
+
+    private ParserContext context;
+
+    public CompiledForEachNode(int begin, String name, char[] template, int start, int end, ParserContext context) {
+        super(begin, name, template, start, end);
+        this.context = context;
+        configure();
+    }
+
+    public Node getNestedNode() {
+        return nestedNode;
+    }
+
+    public void setNestedNode(Node nestedNode) {
+        this.nestedNode = nestedNode;
+    }
+
+    public boolean demarcate(Node terminatingnode, char[] template) {
+        nestedNode = next;
+        next = terminus;
+
+        sepExpr = terminatingnode.getContents();
+        if (sepExpr.length == 0) {
+            sepExpr = null;
+        } else {
+            cSepExpr = MVEL.compileExpression(sepExpr, context);
+        }
+
+        return false;
+    }
+
+    public Object eval(TemplateRuntime runtime, TemplateOutputStream appender, Object ctx, VariableResolverFactory factory) {
+        Iterator[] iters = new Iterator[item.length];
+
+        Object o;
+        for (int i = 0; i < iters.length; i++) {
+            if ((o = MVEL.executeExpression(ce[i], ctx, factory)) instanceof Iterable) {
+                iters[i] = ((Iterable) o).iterator();
+            } else if (o instanceof Object[]) {
+                iters[i] = new ArrayIterator((Object[]) o);
+            } else if (o instanceof Integer) {
+                iters[i] = new CountIterator((Integer) o);
+            } else {
+                throw new TemplateRuntimeError("cannot iterate object type: " + o.getClass().getName());
+            }
+        }
+
+        Map<String, Object> locals = new HashMap<String, Object>();
+        MapVariableResolverFactory localFactory = new MapVariableResolverFactory(locals, factory);
+
+        int iterate = iters.length;
+
+        while (true) {
+            for (int i = 0; i < iters.length; i++) {
+                if (!iters[i].hasNext()) {
+                    iterate--;
+                    locals.put(item[i], "");
+                } else {
+                    locals.put(item[i], iters[i].next());
+                }
+            }
+            if (iterate != 0) {
+                nestedNode.eval(runtime, appender, ctx, localFactory);
+
+                if (sepExpr != null) {
+                    for (Iterator it : iters) {
+                        if (it.hasNext()) {
+                            appender.append(String.valueOf(MVEL.executeExpression(cSepExpr, ctx, factory)));
+                            break;
+                        }
+                    }
+                }
+            } else break;
+        }
+
+        return next != null ? next.eval(runtime, appender, ctx, factory) : null;
+    }
+
+    private void configure() {
+        ArrayList<String> items = new ArrayList<String>();
+        ArrayList<String> expr = new ArrayList<String>();
+
+        int start = cStart;
+        for (int i = start; i < cEnd; i++) {
+            switch (contents[i]) {
+                case '(':
+                case '[':
+                case '{':
+                case '"':
+                case '\'':
+                    i = ParseTools.balancedCapture(contents, i, contents[i]);
+                    break;
+                //                    if (expr.size() < items.size()) {
+                //                        start = i;
+                //                        i = ParseTools.balancedCapture(contents, i, contents[i]);
+                //                        expr.add(ParseTools.createStringTrimmed(contents, start, i - start + 1));
+                //                        start = i + 1;
+                //                    }
+                //                    else {
+                //                        throw new CompileException("unexpected character '" + contents[i] + "' in foreach tag", contents,cStart + 1);
+                //                    }
+                //                    break;
+
+                case ':':
+                    items.add(ParseTools.createStringTrimmed(contents, start, i - start));
+                    start = i + 1;
+                    break;
+                case ',':
+                    if (expr.size() != (items.size() - 1)) {
+                        throw new CompileException("unexpected character ',' in foreach tag", contents, cStart + i);
+                    }
+                    expr.add(ParseTools.createStringTrimmed(contents, start, i - start));
+                    start = i + 1;
+                    break;
+            }
+        }
+
+        if (start < cEnd) {
+            if (expr.size() != (items.size() - 1)) {
+                throw new CompileException("expected character ':' in foreach tag", contents, cEnd);
+            }
+            expr.add(ParseTools.createStringTrimmed(contents, start, cEnd - start));
+        }
+
+        item = new String[items.size()];
+        int i = 0;
+        for (String s : items)
+            item[i++] = s;
+
+        String[] expression;
+        ce = new Serializable[(expression = new String[expr.size()]).length];
+        i = 0;
+        for (String s : expr) {
+            ce[i] = MVEL.compileExpression(expression[i++] = s, context);
+        }
+    }
+}

--- a/core/src/main/java/org/mvel2/templates/res/CompiledIfNode.java
+++ b/core/src/main/java/org/mvel2/templates/res/CompiledIfNode.java
@@ -1,0 +1,49 @@
+/**
+ * MVEL 2.0
+ * Copyright (C) 2007 The Codehaus
+ * Mike Brock, Dhanji Prasanna, John Graham, Mark Proctor
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mvel2.templates.res;
+
+import java.io.Serializable;
+
+import org.mvel2.MVEL;
+import org.mvel2.ParserContext;
+import org.mvel2.integration.VariableResolverFactory;
+import org.mvel2.templates.TemplateRuntime;
+import org.mvel2.templates.util.TemplateOutputStream;
+import org.mvel2.util.ParseTools;
+
+public class CompiledIfNode extends IfNode {
+
+    private Serializable ce;
+
+    public CompiledIfNode(int begin, String name, char[] template, int start, int end, ParserContext context) {
+        super(begin, name, template, start, end);
+        while (cEnd > cStart && ParseTools.isWhitespace(template[cEnd]))
+            cEnd--;
+        if (cStart != cEnd) {
+            ce = MVEL.compileExpression(template, cStart, cEnd - start, context);
+        }
+    }
+
+    public Object eval(TemplateRuntime runtime, TemplateOutputStream appender, Object ctx, VariableResolverFactory factory) {
+        if (ce == null || MVEL.executeExpression(ce, ctx, factory, Boolean.class)) {
+            return trueNode.eval(runtime, appender, ctx, factory);
+        }
+        return next != null ? next.eval(runtime, appender, ctx, factory) : null;
+    }
+}

--- a/core/src/main/java/org/mvel2/templates/res/CompiledIncludeNode.java
+++ b/core/src/main/java/org/mvel2/templates/res/CompiledIncludeNode.java
@@ -1,0 +1,168 @@
+/**
+ * MVEL 2.0
+ * Copyright (C) 2007 The Codehaus
+ * Mike Brock, Dhanji Prasanna, John Graham, Mark Proctor
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mvel2.templates.res;
+
+import static org.mvel2.templates.util.TemplateTools.captureToEOS;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.Serializable;
+
+import org.mvel2.MVEL;
+import org.mvel2.ParserContext;
+import org.mvel2.integration.VariableResolverFactory;
+import org.mvel2.templates.CompiledTemplate;
+import org.mvel2.templates.TemplateCompiler;
+import org.mvel2.templates.TemplateError;
+import org.mvel2.templates.TemplateRuntime;
+import org.mvel2.templates.util.TemplateOutputStream;
+
+public class CompiledIncludeNode extends Node {
+
+    private Serializable cIncludeExpression;
+    private Serializable cPreExpression;
+    private long fileDateStamp;
+    private CompiledTemplate cFileCache;
+
+    private ParserContext context;
+
+    public CompiledIncludeNode(int begin, String name, char[] template, int start, int end, ParserContext context) {
+        this.begin = begin;
+        this.name = name;
+        this.contents = template;
+        this.cStart = start;
+        this.cEnd = end - 1;
+        this.end = end;
+        this.context = context;
+
+        int mark = captureToEOS(contents, cStart);
+        cIncludeExpression = MVEL.compileExpression(contents, cStart, mark - cStart, context);
+        if (mark != contents.length) {
+            cPreExpression = MVEL.compileExpression(contents, ++mark, cEnd - mark, context);
+        }
+    }
+
+    public static String readInFile(TemplateRuntime runtime, File file) {
+        FileInputStream instream = null;
+        BufferedReader in = null;
+        final StringBuilder appender = new StringBuilder();
+
+        try {
+            instream = openInputStream(file);
+            runtime.getRelPath().push(file.getParent());
+
+            in = new BufferedReader(new InputStreamReader(instream, "UTF-8"));
+
+            String currentLine;
+
+            while ((currentLine = in.readLine()) != null) {
+                appender.append(currentLine);
+            }
+
+            runtime.getRelPath().pop();
+            return appender.toString();
+        } catch (FileNotFoundException e) {
+            throw new TemplateError("cannot include template '" + file.getPath() + "': file not found.");
+        } catch (IOException e) {
+            throw new TemplateError("unknown I/O exception while including '" + file.getPath() + "' (stacktrace nested)", e);
+        } finally {
+            if (in != null) {
+                try {
+                    in.close();
+                } catch (IOException e) {
+                    throw new TemplateError("cannot close the reader on template file '" + file.getPath() + "'.");
+                }
+            }
+            if (instream != null) {
+                try {
+                    instream.close();
+                } catch (IOException e) {
+                    throw new TemplateError("cannot close the stream on template file '" + file.getPath() + "'.");
+                }
+            }
+        }
+    }
+
+    /**
+     * Opens a {@link FileInputStream} for the specified file, else providing a
+     * detail error message than simply calling <code>new FileInputStream(file)</code>.
+     *
+     * <p>
+     * An exception is thrown if
+     * <ul>
+     * <li>the file parameter is null,
+     * <li>the file does not exist,
+     * <li>the file object exists but is a directory,
+     * <li>the file exists but cannot be read.
+     * </ul>
+     *
+     * @param file the file to open for input, can be {@code null}
+     * @return a new {@link FileInputStream} for the specified file
+     * @throws FileNotFoundException if the file is null or does not exist
+     * @throws IOException           if the file object is a directory or cannot be read
+     */
+    private static FileInputStream openInputStream(final File file) throws IOException {
+        if (file == null) {
+            throw new FileNotFoundException("file parameter is null");
+        } else if (file.exists()) {
+            if (file.isDirectory()) {
+                throw new IOException("File '" + file + "' exists but is a directory");
+            }
+            if (file.canRead() == false) {
+                throw new IOException("File '" + file + "' cannot be read");
+            }
+        } else {
+            throw new FileNotFoundException("File '" + file + "' does not exist");
+        }
+        return new FileInputStream(file);
+    }
+
+    public Object eval(TemplateRuntime runtime, TemplateOutputStream appender, Object ctx, VariableResolverFactory factory) {
+        String file = MVEL.executeExpression(cIncludeExpression, ctx, factory, String.class);
+
+        if (this.cPreExpression != null) {
+            MVEL.executeExpression(cPreExpression, ctx, factory);
+        }
+
+        if (next != null) {
+            return next.eval(runtime,
+                    appender.append(String.valueOf(TemplateRuntime.eval(readFile(runtime, file, ctx, factory), ctx, factory))), ctx,
+                    factory);
+        } else {
+            return appender.append(String.valueOf(MVEL.eval(readFile(runtime, file, ctx, factory), ctx, factory)));
+        }
+    }
+
+    private String readFile(TemplateRuntime runtime, String fileName, Object ctx, VariableResolverFactory factory) {
+        File file = new File(String.valueOf(runtime.getRelPath().peek()) + "/" + fileName);
+        if (fileDateStamp == 0 || fileDateStamp != file.lastModified()) {
+            fileDateStamp = file.lastModified();
+            cFileCache = TemplateCompiler.compileTemplate(readInFile(runtime, file), context);
+        }
+        return String.valueOf(TemplateRuntime.execute(cFileCache, ctx, factory));
+    }
+
+    public boolean demarcate(Node terminatingNode, char[] template) {
+        return false;
+    }
+}

--- a/core/src/main/java/org/mvel2/templates/res/CompiledNamedIncludeNode.java
+++ b/core/src/main/java/org/mvel2/templates/res/CompiledNamedIncludeNode.java
@@ -1,0 +1,85 @@
+/**
+ * MVEL 2.0
+ * Copyright (C) 2007 The Codehaus
+ * Mike Brock, Dhanji Prasanna, John Graham, Mark Proctor
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mvel2.templates.res;
+
+import static org.mvel2.templates.util.TemplateTools.captureToEOS;
+
+import java.io.Serializable;
+
+import org.mvel2.MVEL;
+import org.mvel2.ParserContext;
+import org.mvel2.integration.VariableResolverFactory;
+import org.mvel2.integration.impl.StackDelimiterResolverFactory;
+import org.mvel2.templates.CompiledTemplate;
+import org.mvel2.templates.TemplateError;
+import org.mvel2.templates.TemplateRuntime;
+import org.mvel2.templates.util.TemplateOutputStream;
+
+public class CompiledNamedIncludeNode extends Node {
+
+    private Serializable cIncludeExpression;
+    private Serializable cPreExpression;
+
+    public CompiledNamedIncludeNode(int begin, String name, char[] template, int start, int end, ParserContext context) {
+        this.begin = begin;
+        this.name = name;
+
+        this.contents = template;
+        this.cStart = start;
+        this.cEnd = end - 1;
+        this.end = end;
+
+        int mark = captureToEOS(contents, cStart);
+        this.cIncludeExpression = MVEL.compileExpression(contents, cStart, mark - cStart, context);
+
+        if (mark != contents.length) {
+            this.cPreExpression = MVEL.compileExpression(contents, ++mark, cEnd - mark, context);
+        }
+    }
+
+    public Object eval(TemplateRuntime runtime, TemplateOutputStream appender, Object ctx, VariableResolverFactory factory) {
+        factory = new StackDelimiterResolverFactory(factory);
+        if (cPreExpression != null) {
+            MVEL.executeExpression(cPreExpression, ctx, factory);
+        }
+
+        if (next != null) {
+            String namedTemplate = MVEL.executeExpression(cIncludeExpression, ctx, factory, String.class);
+            CompiledTemplate ct = runtime.getNamedTemplateRegistry().getNamedTemplate(namedTemplate);
+
+            if (ct == null) throw new TemplateError("named template does not exist: " + namedTemplate);
+
+            return next.eval(runtime,
+                    appender.append(String.valueOf(TemplateRuntime.execute(ct, ctx, factory, runtime.getNamedTemplateRegistry()))), ctx,
+                    factory);
+
+            //            return next.eval(runtime,
+            //                    appender.append(String.valueOf(TemplateRuntime.execute(runtime.getNamedTemplateRegistry().getNamedTemplate(MVEL.executeExpression(cIncludeExpression, ctx, factory, String.class)), ctx, factory))), ctx, factory);
+        } else {
+            return appender.append(String.valueOf(TemplateRuntime.execute(
+                    runtime.getNamedTemplateRegistry()
+                            .getNamedTemplate(MVEL.executeExpression(cIncludeExpression, ctx, factory, String.class)),
+                    ctx, factory, runtime.getNamedTemplateRegistry())));
+        }
+    }
+
+    public boolean demarcate(Node terminatingNode, char[] template) {
+        return false;
+    }
+}

--- a/core/src/main/java/org/mvel2/templates/res/CompiledTerminalExpressionNode.java
+++ b/core/src/main/java/org/mvel2/templates/res/CompiledTerminalExpressionNode.java
@@ -1,0 +1,46 @@
+/**
+ * MVEL 2.0
+ * Copyright (C) 2007 The Codehaus
+ * Mike Brock, Dhanji Prasanna, John Graham, Mark Proctor
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mvel2.templates.res;
+
+import java.io.Serializable;
+
+import org.mvel2.MVEL;
+import org.mvel2.ParserContext;
+import org.mvel2.integration.VariableResolverFactory;
+import org.mvel2.templates.TemplateRuntime;
+import org.mvel2.templates.util.TemplateOutputStream;
+
+public class CompiledTerminalExpressionNode extends TerminalExpressionNode {
+
+    private Serializable ce;
+
+    public CompiledTerminalExpressionNode(Node node, ParserContext context) {
+        this.begin = node.begin;
+        this.name = node.name;
+        ce = MVEL.compileExpression(node.contents, node.cStart, node.cEnd - node.cStart, context);
+    }
+
+    public Object eval(TemplateRuntime runtime, TemplateOutputStream appender, Object ctx, VariableResolverFactory factory) {
+        return MVEL.executeExpression(ce, ctx, factory);
+    }
+
+    public boolean demarcate(Node terminatingNode, char[] template) {
+        return false;
+    }
+}

--- a/core/src/main/java/org/mvel2/templates/res/DeclareNode.java
+++ b/core/src/main/java/org/mvel2/templates/res/DeclareNode.java
@@ -1,0 +1,64 @@
+/**
+ * MVEL 2.0
+ * Copyright (C) 2007 The Codehaus
+ * Mike Brock, Dhanji Prasanna, John Graham, Mark Proctor
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mvel2.templates.res;
+
+import org.mvel2.MVEL;
+import org.mvel2.integration.VariableResolverFactory;
+import org.mvel2.templates.CompiledTemplate;
+import org.mvel2.templates.SimpleTemplateRegistry;
+import org.mvel2.templates.TemplateRuntime;
+import org.mvel2.templates.util.TemplateOutputStream;
+
+public class DeclareNode extends Node {
+
+    private Node nestedNode;
+
+    public DeclareNode(int begin, String name, char[] template, int start, int end) {
+        this.begin = begin;
+        this.name = name;
+        this.contents = template;
+        this.cStart = start;
+        this.cEnd = end - 1;
+        this.end = end;
+        //    this.contents = subset(template, this.cStart = start, (this.end = this.cEnd = end) - start - 1);
+    }
+
+    public Object eval(TemplateRuntime runtime, TemplateOutputStream appender, Object ctx, VariableResolverFactory factory) {
+        if (runtime.getNamedTemplateRegistry() == null) {
+            runtime.setNamedTemplateRegistry(new SimpleTemplateRegistry());
+        }
+
+        runtime.getNamedTemplateRegistry().addNamedTemplate(MVEL.eval(contents, cStart, cEnd - cStart, ctx, factory, String.class),
+                new CompiledTemplate(runtime.getTemplate(), nestedNode));
+
+        return next != null ? next.eval(runtime, appender, ctx, factory) : null;
+    }
+
+    public boolean demarcate(Node terminatingNode, char[] template) {
+        Node n = nestedNode = next;
+
+        while (n.getNext() != null)
+            n = n.next;
+
+        n.next = new EndNode();
+
+        next = terminus;
+        return false;
+    }
+}

--- a/core/src/main/java/org/mvel2/templates/res/EndNode.java
+++ b/core/src/main/java/org/mvel2/templates/res/EndNode.java
@@ -1,0 +1,38 @@
+/**
+ * MVEL 2.0
+ * Copyright (C) 2007 The Codehaus
+ * Mike Brock, Dhanji Prasanna, John Graham, Mark Proctor
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mvel2.templates.res;
+
+import org.mvel2.integration.VariableResolverFactory;
+import org.mvel2.templates.TemplateRuntime;
+import org.mvel2.templates.util.TemplateOutputStream;
+
+public class EndNode extends Node {
+
+    public Object eval(TemplateRuntime runtie, TemplateOutputStream appender, Object ctx, VariableResolverFactory factory) {
+        return appender.toString();
+    }
+
+    public String toString() {
+        return "EndNode";
+    }
+
+    public boolean demarcate(Node terminatingNode, char[] template) {
+        return false;
+    }
+}

--- a/core/src/main/java/org/mvel2/templates/res/EvalNode.java
+++ b/core/src/main/java/org/mvel2/templates/res/EvalNode.java
@@ -1,0 +1,68 @@
+/**
+ * MVEL 2.0
+ * Copyright (C) 2007 The Codehaus
+ * Mike Brock, Dhanji Prasanna, John Graham, Mark Proctor
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mvel2.templates.res;
+
+import static java.lang.String.valueOf;
+
+import org.mvel2.MVEL;
+import org.mvel2.integration.VariableResolverFactory;
+import org.mvel2.templates.TemplateRuntime;
+import org.mvel2.templates.util.TemplateOutputStream;
+
+public class EvalNode extends Node {
+
+    public EvalNode() {
+    }
+
+    public EvalNode(int begin, String name, char[] template, int start, int end) {
+        this.begin = begin;
+        this.name = name;
+        this.contents = template;
+        this.cStart = start;
+        this.cEnd = end - 1;
+        this.end = end;
+        //   this.contents = subset(template, this.cStart = start, (this.end = this.cEnd = end) - start - 1);
+    }
+
+    public EvalNode(int begin, String name, char[] template, int start, int end, Node next) {
+        this.name = name;
+        this.begin = begin;
+        this.contents = template;
+        this.cStart = start;
+        this.cEnd = end - 1;
+        this.end = end;
+        //   this.contents = subset(template, this.cStart = start, (this.end = this.cEnd = end) - start - 1);
+        this.next = next;
+    }
+
+    public Object eval(TemplateRuntime runtime, TemplateOutputStream appender, Object ctx, VariableResolverFactory factory) {
+        appender.append(
+                String.valueOf(TemplateRuntime.eval(valueOf(MVEL.eval(contents, cStart, cEnd - cStart, ctx, factory)), ctx, factory)));
+        return next != null ? next.eval(runtime, appender, ctx, factory) : null;
+    }
+
+    public boolean demarcate(Node terminatingNode, char[] template) {
+        return false;
+    }
+
+    public String toString() {
+        return "EvalNode:" + name + "{" + (contents == null ? "" : new String(contents, cStart, cEnd - cStart)) + "} (start=" + begin
+                + ";end=" + end + ")";
+    }
+}

--- a/core/src/main/java/org/mvel2/templates/res/ExpressionNode.java
+++ b/core/src/main/java/org/mvel2/templates/res/ExpressionNode.java
@@ -1,0 +1,67 @@
+/**
+ * MVEL 2.0
+ * Copyright (C) 2007 The Codehaus
+ * Mike Brock, Dhanji Prasanna, John Graham, Mark Proctor
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mvel2.templates.res;
+
+import static java.lang.String.valueOf;
+
+import org.mvel2.MVEL;
+import org.mvel2.integration.VariableResolverFactory;
+import org.mvel2.templates.TemplateRuntime;
+import org.mvel2.templates.util.TemplateOutputStream;
+
+public class ExpressionNode extends Node {
+
+    public ExpressionNode() {
+    }
+
+    public ExpressionNode(int begin, String name, char[] template, int start, int end) {
+        this.begin = begin;
+        this.name = name;
+        this.contents = template;
+        this.cStart = start;
+        this.cEnd = end - 1;
+        this.end = end;
+        //    this.contents = subset(template, this.cStart = start, (this.end = this.cEnd = end) - start - 1);
+    }
+
+    public ExpressionNode(int begin, String name, char[] template, int start, int end, Node next) {
+        this.name = name;
+        this.begin = begin;
+        this.contents = template;
+        this.cStart = start;
+        this.cEnd = end - 1;
+        this.end = end;
+        //   this.contents = subset(template, this.cStart = start, (this.end = this.cEnd = end) - start - 1);
+        this.next = next;
+    }
+
+    public Object eval(TemplateRuntime runtime, TemplateOutputStream appender, Object ctx, VariableResolverFactory factory) {
+        appender.append(valueOf(MVEL.eval(contents, cStart, cEnd - cStart, ctx, factory)));
+        return next != null ? next.eval(runtime, appender, ctx, factory) : null;
+    }
+
+    public boolean demarcate(Node terminatingNode, char[] template) {
+        return false;
+    }
+
+    public String toString() {
+        return "ExpressionNode:" + name + "{" + (contents == null ? "" : new String(contents, cStart, cEnd - cStart)) + "} (start=" + begin
+                + ";end=" + end + ")";
+    }
+}

--- a/core/src/main/java/org/mvel2/templates/res/ForEachNode.java
+++ b/core/src/main/java/org/mvel2/templates/res/ForEachNode.java
@@ -1,0 +1,159 @@
+/**
+ * MVEL 2.0
+ * Copyright (C) 2007 The Codehaus
+ * Mike Brock, Dhanji Prasanna, John Graham, Mark Proctor
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mvel2.templates.res;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
+
+import org.mvel2.CompileException;
+import org.mvel2.MVEL;
+import org.mvel2.integration.VariableResolverFactory;
+import org.mvel2.integration.impl.MapVariableResolverFactory;
+import org.mvel2.templates.TemplateRuntime;
+import org.mvel2.templates.TemplateRuntimeError;
+import org.mvel2.templates.util.ArrayIterator;
+import org.mvel2.templates.util.TemplateOutputStream;
+import org.mvel2.util.ParseTools;
+
+public class ForEachNode extends Node {
+
+    public Node nestedNode;
+
+    private String[] item;
+    private String[] expression;
+
+    private char[] sepExpr;
+
+    public ForEachNode(int begin, String name, char[] template, int start, int end) {
+        super(begin, name, template, start, end);
+        configure();
+    }
+
+    public Node getNestedNode() {
+        return nestedNode;
+    }
+
+    public void setNestedNode(Node nestedNode) {
+        this.nestedNode = nestedNode;
+    }
+
+    public boolean demarcate(Node terminatingnode, char[] template) {
+        nestedNode = next;
+        next = terminus;
+
+        sepExpr = terminatingnode.getContents();
+        if (sepExpr.length == 0) sepExpr = null;
+
+        return false;
+    }
+
+    public Object eval(TemplateRuntime runtime, TemplateOutputStream appender, Object ctx, VariableResolverFactory factory) {
+        Iterator[] iters = new Iterator[item.length];
+
+        Object o;
+        for (int i = 0; i < iters.length; i++) {
+            if ((o = MVEL.eval(expression[i], ctx, factory)) instanceof Iterable) {
+                iters[i] = ((Iterable) o).iterator();
+            } else if (o instanceof Object[]) {
+                iters[i] = new ArrayIterator((Object[]) o);
+            } else {
+                throw new TemplateRuntimeError("cannot iterate object type: " + o.getClass().getName());
+            }
+        }
+
+        Map<String, Object> locals = new HashMap<String, Object>();
+        MapVariableResolverFactory localFactory = new MapVariableResolverFactory(locals, factory);
+
+        int iterate = iters.length;
+
+        while (true) {
+            for (int i = 0; i < iters.length; i++) {
+                if (!iters[i].hasNext()) {
+                    iterate--;
+                    locals.put(item[i], "");
+                } else {
+                    locals.put(item[i], iters[i].next());
+                }
+            }
+            if (iterate != 0) {
+                nestedNode.eval(runtime, appender, ctx, localFactory);
+
+                if (sepExpr != null) {
+                    for (Iterator it : iters) {
+                        if (it.hasNext()) {
+                            appender.append(String.valueOf(MVEL.eval(sepExpr, ctx, factory)));
+                            break;
+                        }
+                    }
+                }
+            } else break;
+        }
+
+        return next != null ? next.eval(runtime, appender, ctx, factory) : null;
+    }
+
+    private void configure() {
+        ArrayList<String> items = new ArrayList<String>();
+        ArrayList<String> expr = new ArrayList<String>();
+
+        int start = cStart;
+        for (int i = start; i < cEnd; i++) {
+            switch (contents[i]) {
+                case '(':
+                case '[':
+                case '{':
+                case '"':
+                case '\'':
+                    i = ParseTools.balancedCapture(contents, i, contents[i]);
+                    break;
+
+                case ':':
+                    items.add(ParseTools.createStringTrimmed(contents, start, i - start));
+                    start = i + 1;
+                    break;
+                case ',':
+                    if (expr.size() != (items.size() - 1)) {
+                        throw new CompileException("unexpected character ',' in foreach tag", contents, cStart + i);
+                    }
+                    expr.add(ParseTools.createStringTrimmed(contents, start, i - start));
+                    start = i + 1;
+                    break;
+            }
+        }
+
+        if (start < cEnd) {
+            if (expr.size() != (items.size() - 1)) {
+                throw new CompileException("expected character ':' in foreach tag", contents, cEnd);
+            }
+            expr.add(ParseTools.createStringTrimmed(contents, start, cEnd - start));
+        }
+
+        item = new String[items.size()];
+        int i = 0;
+        for (String s : items)
+            item[i++] = s;
+
+        expression = new String[expr.size()];
+        i = 0;
+        for (String s : expr)
+            expression[i++] = s;
+    }
+}

--- a/core/src/main/java/org/mvel2/templates/res/IfNode.java
+++ b/core/src/main/java/org/mvel2/templates/res/IfNode.java
@@ -1,0 +1,66 @@
+/**
+ * MVEL 2.0
+ * Copyright (C) 2007 The Codehaus
+ * Mike Brock, Dhanji Prasanna, John Graham, Mark Proctor
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mvel2.templates.res;
+
+import org.mvel2.MVEL;
+import org.mvel2.integration.VariableResolverFactory;
+import org.mvel2.templates.TemplateRuntime;
+import org.mvel2.templates.util.TemplateOutputStream;
+import org.mvel2.util.ParseTools;
+
+public class IfNode extends Node {
+
+    protected Node trueNode;
+    protected Node elseNode;
+
+    public IfNode(int begin, String name, char[] template, int start, int end) {
+        super(begin, name, template, start, end);
+        while (cEnd > cStart && ParseTools.isWhitespace(template[cEnd]))
+            cEnd--;
+    }
+
+    public Node getTrueNode() {
+        return trueNode;
+    }
+
+    public void setTrueNode(ExpressionNode trueNode) {
+        this.trueNode = trueNode;
+    }
+
+    public Node getElseNode() {
+        return elseNode;
+    }
+
+    public void setElseNode(ExpressionNode elseNode) {
+        this.elseNode = elseNode;
+    }
+
+    public boolean demarcate(Node terminatingNode, char[] template) {
+        trueNode = next;
+        next = terminus;
+        return true;
+    }
+
+    public Object eval(TemplateRuntime runtime, TemplateOutputStream appender, Object ctx, VariableResolverFactory factory) {
+        if (cEnd == cStart || MVEL.eval(contents, cStart, cEnd - cStart, ctx, factory, Boolean.class)) {
+            return trueNode.eval(runtime, appender, ctx, factory);
+        }
+        return next != null ? next.eval(runtime, appender, ctx, factory) : null;
+    }
+}

--- a/core/src/main/java/org/mvel2/templates/res/IncludeNode.java
+++ b/core/src/main/java/org/mvel2/templates/res/IncludeNode.java
@@ -1,0 +1,117 @@
+/**
+ * MVEL 2.0
+ * Copyright (C) 2007 The Codehaus
+ * Mike Brock, Dhanji Prasanna, John Graham, Mark Proctor
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mvel2.templates.res;
+
+import static org.mvel2.templates.util.TemplateTools.captureToEOS;
+
+import java.io.BufferedInputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+
+import org.mvel2.MVEL;
+import org.mvel2.integration.VariableResolverFactory;
+import org.mvel2.templates.TemplateError;
+import org.mvel2.templates.TemplateRuntime;
+import org.mvel2.templates.util.TemplateOutputStream;
+
+public class IncludeNode extends Node {
+    //    private char[] includeExpression;
+    //    private char[] preExpression;
+
+    int includeStart;
+    int includeOffset;
+
+    int preStart;
+    int preOffset;
+
+    public IncludeNode(int begin, String name, char[] template, int start, int end) {
+        this.begin = begin;
+        this.name = name;
+        this.contents = template;
+        this.cStart = start;
+        this.cEnd = end - 1;
+        this.end = end;
+        //this.contents = subset(template, this.cStart = start, (this.end = this.cEnd = end) - start - 1);
+
+        int mark = captureToEOS(contents, 0);
+        includeStart = cStart;
+        includeOffset = mark - cStart;
+        preStart = ++mark;
+        preOffset = cEnd - mark;
+
+        //this.includeExpression = subset(contents, 0, mark = captureToEOS(contents, 0));
+        //        if (mark != contents.length) this.preExpression = subset(contents, ++mark, contents.length - mark);
+    }
+
+    public static String readInFile(TemplateRuntime runtime, String fileName) {
+        File file = new File(String.valueOf(runtime.getRelPath().peek()) + "/" + fileName);
+
+        try {
+            FileInputStream instream = new FileInputStream(file);
+            BufferedInputStream bufstream = new BufferedInputStream(instream);
+
+            runtime.getRelPath().push(file.getParent());
+
+            byte[] buf = new byte[10];
+            int read;
+            int i;
+
+            StringBuilder appender = new StringBuilder();
+
+            while ((read = bufstream.read(buf)) != -1) {
+                for (i = 0; i < read; i++) {
+                    appender.append((char) buf[i]);
+                }
+            }
+
+            bufstream.close();
+            instream.close();
+
+            runtime.getRelPath().pop();
+
+            return appender.toString();
+
+        } catch (FileNotFoundException e) {
+            throw new TemplateError("cannot include template '" + fileName + "': file not found.");
+        } catch (IOException e) {
+            throw new TemplateError("unknown I/O exception while including '" + fileName + "' (stacktrace nested)", e);
+        }
+    }
+
+    public Object eval(TemplateRuntime runtime, TemplateOutputStream appender, Object ctx, VariableResolverFactory factory) {
+        String file = MVEL.eval(contents, includeStart, includeOffset, ctx, factory, String.class);
+
+        if (preOffset != 0) {
+            MVEL.eval(contents, preStart, preOffset, ctx, factory);
+        }
+
+        if (next != null) {
+            return next.eval(runtime, appender.append(String.valueOf(TemplateRuntime.eval(readInFile(runtime, file), ctx, factory))), ctx,
+                    factory);
+        } else {
+            return appender.append(String.valueOf(MVEL.eval(readInFile(runtime, file), ctx, factory)));
+        }
+    }
+
+    public boolean demarcate(Node terminatingNode, char[] template) {
+        return false;
+    }
+}

--- a/core/src/main/java/org/mvel2/templates/res/NamedIncludeNode.java
+++ b/core/src/main/java/org/mvel2/templates/res/NamedIncludeNode.java
@@ -1,0 +1,81 @@
+/**
+ * MVEL 2.0
+ * Copyright (C) 2007 The Codehaus
+ * Mike Brock, Dhanji Prasanna, John Graham, Mark Proctor
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mvel2.templates.res;
+
+import static org.mvel2.templates.util.TemplateTools.captureToEOS;
+
+import org.mvel2.MVEL;
+import org.mvel2.integration.VariableResolverFactory;
+import org.mvel2.templates.TemplateRuntime;
+import org.mvel2.templates.util.TemplateOutputStream;
+
+public class NamedIncludeNode extends Node {
+    //  private char[] includeExpression;
+    //  private char[] preExpression;
+
+    int includeStart;
+    int includeOffset;
+
+    int preStart;
+    int preOffset;
+
+    public NamedIncludeNode(int begin, String name, char[] template, int start, int end) {
+        this.begin = begin;
+        this.name = name;
+        this.contents = template;
+        this.cStart = start;
+        this.cEnd = end - 1;
+        this.end = end;
+        //    this.contents = subset(template, this.cStart = start, (this.end = this.cEnd = end) - start - 1);
+
+        int mark = captureToEOS(contents, 0);
+        includeStart = cStart;
+        includeOffset = mark - cStart;
+        preStart = ++mark;
+        preOffset = cEnd - mark;
+
+        //        int mark;
+        //        this.includeExpression = subset(contents, 0, mark = captureToEOS(contents, 0));
+        //        if (mark != contents.length) this.preExpression = subset(contents, ++mark, contents.length - mark);
+    }
+
+    public Object eval(TemplateRuntime runtime, TemplateOutputStream appender, Object ctx, VariableResolverFactory factory) {
+        if (preOffset != 0) {
+            MVEL.eval(contents, preStart, preOffset, ctx, factory);
+        }
+
+        if (next != null) {
+            return next
+                    .eval(runtime,
+                            appender.append(
+                                    String.valueOf(TemplateRuntime.execute(
+                                            runtime.getNamedTemplateRegistry().getNamedTemplate(
+                                                    MVEL.eval(contents, includeStart, includeOffset, ctx, factory, String.class)),
+                                            ctx, factory))),
+                            ctx, factory);
+        } else {
+            return appender.append(String.valueOf(TemplateRuntime.execute(runtime.getNamedTemplateRegistry()
+                    .getNamedTemplate(MVEL.eval(contents, includeStart, includeOffset, ctx, factory, String.class)), ctx, factory)));
+        }
+    }
+
+    public boolean demarcate(Node terminatingNode, char[] template) {
+        return false;
+    }
+}

--- a/core/src/main/java/org/mvel2/templates/res/Node.java
+++ b/core/src/main/java/org/mvel2/templates/res/Node.java
@@ -1,0 +1,143 @@
+/**
+ * MVEL 2.0
+ * Copyright (C) 2007 The Codehaus
+ * Mike Brock, Dhanji Prasanna, John Graham, Mark Proctor
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mvel2.templates.res;
+
+import static org.mvel2.util.ParseTools.subset;
+
+import java.io.Serializable;
+
+import org.mvel2.integration.VariableResolverFactory;
+import org.mvel2.templates.TemplateRuntime;
+import org.mvel2.templates.util.TemplateOutputStream;
+
+public abstract class Node implements Serializable {
+
+    public Node next;
+    protected String name;
+    protected char[] contents;
+    protected int begin;
+    protected int cStart;
+    protected int cEnd;
+    protected int end;
+    protected Node terminus;
+
+    public Node() {
+    }
+
+    public Node(int begin, String name, char[] template, int start, int end) {
+        this.begin = begin;
+        this.cStart = start;
+        this.cEnd = end - 1;
+        this.end = end;
+        this.name = name;
+        this.contents = template;
+        //    this.contents = subset(template, this.cStart = start, (this.end = this.cEnd = end) - start - 1);
+    }
+
+    public Node(int begin, String name, char[] template, int start, int end, Node next) {
+        this.name = name;
+        this.begin = begin;
+        this.cStart = start;
+        this.cEnd = end - 1;
+        this.end = end;
+        this.contents = template;
+        //  this.contents = subset(template, this.cStart = start, (this.end = this.cEnd = end) - start - 1);
+        this.next = next;
+    }
+
+    public abstract Object eval(TemplateRuntime runtime, TemplateOutputStream appender, Object ctx, VariableResolverFactory factory);
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public char[] getContents() {
+        return contents;
+    }
+
+    public void setContents(char[] contents) {
+        this.contents = contents;
+    }
+
+    public int getBegin() {
+        return begin;
+    }
+
+    public void setBegin(int begin) {
+        this.begin = begin;
+    }
+
+    public int getEnd() {
+        return end;
+    }
+
+    public void setEnd(int end) {
+        this.end = end;
+    }
+
+    public int getCStart() {
+        return cStart;
+    }
+
+    public void setCStart(int cStart) {
+        this.cStart = cStart;
+    }
+
+    public int getCEnd() {
+        return cEnd;
+    }
+
+    public void setCEnd(int cEnd) {
+        this.cEnd = cEnd;
+    }
+
+    public boolean isOpenNode() {
+        return false;
+    }
+
+    public abstract boolean demarcate(Node terminatingNode, char[] template);
+
+    public Node getNext() {
+        return next;
+    }
+
+    public Node setNext(Node next) {
+        return this.next = next;
+    }
+
+    public Node getTerminus() {
+        return terminus;
+    }
+
+    public void setTerminus(Node terminus) {
+        this.terminus = terminus;
+    }
+
+    public void calculateContents(char[] template) {
+        this.contents = subset(template, cStart, end - cStart);
+    }
+
+    public int getLength() {
+        return this.end - this.begin;
+    }
+}

--- a/core/src/main/java/org/mvel2/templates/res/Opcodes.java
+++ b/core/src/main/java/org/mvel2/templates/res/Opcodes.java
@@ -1,0 +1,37 @@
+/**
+ * MVEL 2.0
+ * Copyright (C) 2007 The Codehaus
+ * Mike Brock, Dhanji Prasanna, John Graham, Mark Proctor
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mvel2.templates.res;
+
+public interface Opcodes {
+
+    public static int IF = 1;
+    public static int ELSE = 2;
+    public static int FOREACH = 3;
+    public static int END = 10;
+
+    public static int INCLUDE_FILE = 50;
+    public static int INCLUDE_NAMED = 51;
+    public static int COMMENT = 52;
+    public static int CODE = 53;
+    public static int EVAL = 55;
+
+    public static int DECLARE = 54;
+
+    public static int STOP = 70;
+}

--- a/core/src/main/java/org/mvel2/templates/res/TerminalExpressionNode.java
+++ b/core/src/main/java/org/mvel2/templates/res/TerminalExpressionNode.java
@@ -1,0 +1,46 @@
+/**
+ * MVEL 2.0
+ * Copyright (C) 2007 The Codehaus
+ * Mike Brock, Dhanji Prasanna, John Graham, Mark Proctor
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mvel2.templates.res;
+
+import org.mvel2.MVEL;
+import org.mvel2.integration.VariableResolverFactory;
+import org.mvel2.templates.TemplateRuntime;
+import org.mvel2.templates.util.TemplateOutputStream;
+
+public class TerminalExpressionNode extends Node {
+
+    public TerminalExpressionNode() {
+    }
+
+    public TerminalExpressionNode(Node node) {
+        this.begin = node.begin;
+        this.name = node.name;
+        this.contents = node.contents;
+        this.cStart = node.cStart;
+        this.cEnd = node.cEnd;
+    }
+
+    public Object eval(TemplateRuntime runtime, TemplateOutputStream appender, Object ctx, VariableResolverFactory factory) {
+        return MVEL.eval(contents, cStart, cEnd - cStart, ctx, factory);
+    }
+
+    public boolean demarcate(Node terminatingNode, char[] template) {
+        return false;
+    }
+}

--- a/core/src/main/java/org/mvel2/templates/res/TerminalNode.java
+++ b/core/src/main/java/org/mvel2/templates/res/TerminalNode.java
@@ -1,0 +1,42 @@
+/**
+ * MVEL 2.0
+ * Copyright (C) 2007 The Codehaus
+ * Mike Brock, Dhanji Prasanna, John Graham, Mark Proctor
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mvel2.templates.res;
+
+import org.mvel2.integration.VariableResolverFactory;
+import org.mvel2.templates.TemplateRuntime;
+import org.mvel2.templates.util.TemplateOutputStream;
+
+public class TerminalNode extends Node {
+
+    public TerminalNode() {
+    }
+
+    public TerminalNode(int begin, int end) {
+        this.begin = begin;
+        this.end = end;
+    }
+
+    public Object eval(TemplateRuntime runtime, TemplateOutputStream appender, Object ctx, VariableResolverFactory factory) {
+        return next != null ? next.eval(runtime, appender, ctx, factory) : null;
+    }
+
+    public boolean demarcate(Node terminatingNode, char[] template) {
+        return false;
+    }
+}

--- a/core/src/main/java/org/mvel2/templates/res/TextNode.java
+++ b/core/src/main/java/org/mvel2/templates/res/TextNode.java
@@ -1,0 +1,56 @@
+/**
+ * MVEL 2.0
+ * Copyright (C) 2007 The Codehaus
+ * Mike Brock, Dhanji Prasanna, John Graham, Mark Proctor
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mvel2.templates.res;
+
+import org.mvel2.integration.VariableResolverFactory;
+import org.mvel2.templates.TemplateRuntime;
+import org.mvel2.templates.util.TemplateOutputStream;
+
+public class TextNode extends Node {
+
+    public TextNode(int begin, int end) {
+        this.begin = begin;
+        this.end = end;
+    }
+
+    public TextNode(int begin, int end, ExpressionNode next) {
+        this.begin = begin;
+        this.end = end;
+        this.next = next;
+    }
+
+    public Object eval(TemplateRuntime runtime, TemplateOutputStream appender, Object ctx, VariableResolverFactory factory) {
+        int len = end - begin;
+        if (len != 0) {
+            appender.append(new String(runtime.getTemplate(), begin, len));
+        }
+        return next != null ? next.eval(runtime, appender, ctx, factory) : null;
+    }
+
+    public String toString() {
+        return "TextNode(" + begin + "," + end + ")";
+    }
+
+    public boolean demarcate(Node terminatingNode, char[] template) {
+        return false;
+    }
+
+    public void calculateContents(char[] template) {
+    }
+}

--- a/core/src/main/java/org/mvel2/templates/util/ArrayIterator.java
+++ b/core/src/main/java/org/mvel2/templates/util/ArrayIterator.java
@@ -1,0 +1,42 @@
+/**
+ * MVEL 2.0
+ * Copyright (C) 2007 The Codehaus
+ * Mike Brock, Dhanji Prasanna, John Graham, Mark Proctor
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mvel2.templates.util;
+
+import java.util.Iterator;
+
+public class ArrayIterator implements Iterator {
+
+    private Object[] array;
+    private int cursor = 0;
+
+    public ArrayIterator(Object[] array) {
+        this.array = array;
+    }
+
+    public boolean hasNext() {
+        return cursor != array.length;
+    }
+
+    public Object next() {
+        return array[cursor++];
+    }
+
+    public void remove() {
+    }
+}

--- a/core/src/main/java/org/mvel2/templates/util/CountIterator.java
+++ b/core/src/main/java/org/mvel2/templates/util/CountIterator.java
@@ -1,0 +1,29 @@
+package org.mvel2.templates.util;
+
+import java.util.Iterator;
+
+/**
+ * User: christopherbrock
+ * Date: 10-Aug-2010
+ * Time: 6:42:20 PM
+ */
+public class CountIterator implements Iterator {
+
+    int cursor;
+    int countTo;
+
+    public CountIterator(int countTo) {
+        this.countTo = countTo;
+    }
+
+    public boolean hasNext() {
+        return cursor < countTo;
+    }
+
+    public Object next() {
+        return cursor++;
+    }
+
+    public void remove() {
+    }
+}

--- a/core/src/main/java/org/mvel2/templates/util/TemplateOutputStream.java
+++ b/core/src/main/java/org/mvel2/templates/util/TemplateOutputStream.java
@@ -1,0 +1,8 @@
+package org.mvel2.templates.util;
+
+public interface TemplateOutputStream {
+
+    public TemplateOutputStream append(CharSequence c);
+
+    public TemplateOutputStream append(char[] c);
+}

--- a/core/src/main/java/org/mvel2/templates/util/TemplateTools.java
+++ b/core/src/main/java/org/mvel2/templates/util/TemplateTools.java
@@ -1,0 +1,122 @@
+/**
+ * MVEL 2.0
+ * Copyright (C) 2007 The Codehaus
+ * Mike Brock, Dhanji Prasanna, John Graham, Mark Proctor
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mvel2.templates.util;
+
+import static java.nio.ByteBuffer.allocateDirect;
+import static org.mvel2.util.ParseTools.balancedCapture;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.ByteBuffer;
+import java.nio.channels.FileChannel;
+
+import org.mvel2.templates.TemplateError;
+import org.mvel2.templates.res.Node;
+import org.mvel2.templates.res.TerminalNode;
+
+public class TemplateTools {
+
+    public static Node getLastNode(Node node) {
+        Node n = node;
+        while (true) {
+            if (n.getNext() instanceof TerminalNode) return n;
+            n = n.getNext();
+        }
+    }
+
+    public static int captureToEOS(char[] expression, int cursor) {
+        int length = expression.length;
+        while (cursor != length) {
+            switch (expression[cursor]) {
+                case '(':
+                case '[':
+                case '{':
+                    cursor = balancedCapture(expression, cursor, expression[cursor]);
+                    break;
+
+                case ';':
+                case '}':
+                    return cursor;
+
+            }
+            cursor++;
+        }
+
+        return cursor;
+    }
+
+    public static String readInFile(String file) {
+        return readInFile(new File(file));
+    }
+
+    public static String readInFile(File file) {
+        try {
+            FileChannel fc = new FileInputStream(file).getChannel();
+            ByteBuffer buf = allocateDirect(10);
+            StringBuilder appender = new StringBuilder();
+            int read;
+
+            while (true) {
+                buf.rewind();
+                if ((read = fc.read(buf)) != -1) {
+                    buf.rewind();
+                    for (; read != 0; read--) {
+                        appender.append((char) buf.get());
+                    }
+                } else {
+                    break;
+                }
+            }
+
+            fc.close();
+
+            return appender.toString();
+        } catch (FileNotFoundException e) {
+            throw new TemplateError("cannot include template '" + file.getName() + "': file not found.");
+        } catch (IOException e) {
+            throw new TemplateError("unknown I/O exception while including '" + file.getName() + "' (stacktrace nested)", e);
+        }
+    }
+
+    public static String readStream(InputStream instream) {
+        try {
+            byte[] buf = new byte[10];
+            StringBuilder appender = new StringBuilder();
+            int read;
+            while ((read = instream.read(buf)) != -1) {
+                for (int i = 0; i < read; i++) {
+                    appender.append((char) buf[i]);
+                }
+            }
+
+            return appender.toString();
+        } catch (NullPointerException e) {
+            if (instream == null) {
+                throw new TemplateError("null input stream", e);
+            } else {
+                throw e;
+            }
+        } catch (IOException e) {
+            throw new TemplateError("unknown I/O exception while including (stacktrace nested)", e);
+        }
+    }
+}

--- a/core/src/main/java/org/mvel2/templates/util/io/StandardOutputStream.java
+++ b/core/src/main/java/org/mvel2/templates/util/io/StandardOutputStream.java
@@ -1,0 +1,44 @@
+package org.mvel2.templates.util.io;
+
+import java.io.IOException;
+import java.io.OutputStream;
+
+import org.mvel2.templates.util.TemplateOutputStream;
+
+public class StandardOutputStream implements TemplateOutputStream {
+
+    private OutputStream outputStream;
+
+    public StandardOutputStream(OutputStream outputStream) {
+        this.outputStream = outputStream;
+    }
+
+    public TemplateOutputStream append(CharSequence c) {
+        try {
+            for (int i = 0; i < c.length(); i++) {
+                outputStream.write(c.charAt(i));
+            }
+
+            return this;
+        } catch (IOException e) {
+            throw new RuntimeException("failed to write to stream", e);
+        }
+    }
+
+    public TemplateOutputStream append(char[] c) {
+        try {
+
+            for (char i : c) {
+                outputStream.write(i);
+            }
+            return this;
+        } catch (IOException e) {
+            throw new RuntimeException("failed to write to stream", e);
+        }
+    }
+
+    @Override
+    public String toString() {
+        return null;
+    }
+}

--- a/core/src/main/java/org/mvel2/templates/util/io/StringAppenderStream.java
+++ b/core/src/main/java/org/mvel2/templates/util/io/StringAppenderStream.java
@@ -1,0 +1,28 @@
+package org.mvel2.templates.util.io;
+
+import org.mvel2.templates.util.TemplateOutputStream;
+import org.mvel2.util.StringAppender;
+
+public class StringAppenderStream implements TemplateOutputStream {
+
+    private StringAppender appender;
+
+    public StringAppenderStream(StringAppender appender) {
+        this.appender = appender;
+    }
+
+    public TemplateOutputStream append(CharSequence c) {
+        appender.append(c);
+        return this;
+    }
+
+    public TemplateOutputStream append(char[] c) {
+        appender.append(c);
+        return this;
+    }
+
+    @Override
+    public String toString() {
+        return appender.toString();
+    }
+}

--- a/core/src/main/java/org/mvel2/templates/util/io/StringBuilderStream.java
+++ b/core/src/main/java/org/mvel2/templates/util/io/StringBuilderStream.java
@@ -1,0 +1,27 @@
+package org.mvel2.templates.util.io;
+
+import org.mvel2.templates.util.TemplateOutputStream;
+
+public class StringBuilderStream implements TemplateOutputStream {
+
+    private StringBuilder appender;
+
+    public StringBuilderStream(StringBuilder appender) {
+        this.appender = appender;
+    }
+
+    public TemplateOutputStream append(CharSequence c) {
+        appender.append(c);
+        return this;
+    }
+
+    public TemplateOutputStream append(char[] c) {
+        appender.append(c);
+        return this;
+    }
+
+    @Override
+    public String toString() {
+        return appender.toString();
+    }
+}

--- a/core/src/main/java/org/mvel2/util/ASTBinaryTree.java
+++ b/core/src/main/java/org/mvel2/util/ASTBinaryTree.java
@@ -1,0 +1,130 @@
+package org.mvel2.util;
+
+import static org.mvel2.Operator.ADD;
+import static org.mvel2.Operator.AND;
+import static org.mvel2.Operator.CONTAINS;
+import static org.mvel2.Operator.DIV;
+import static org.mvel2.Operator.EQUAL;
+import static org.mvel2.Operator.GETHAN;
+import static org.mvel2.Operator.GTHAN;
+import static org.mvel2.Operator.INSTANCEOF;
+import static org.mvel2.Operator.LETHAN;
+import static org.mvel2.Operator.LTHAN;
+import static org.mvel2.Operator.MULT;
+import static org.mvel2.Operator.NEQUAL;
+import static org.mvel2.Operator.OR;
+import static org.mvel2.Operator.PTABLE;
+import static org.mvel2.Operator.REGEX;
+import static org.mvel2.Operator.SIMILARITY;
+import static org.mvel2.Operator.SOUNDEX;
+import static org.mvel2.Operator.SUB;
+import static org.mvel2.Operator.TERNARY;
+import static org.mvel2.Operator.TERNARY_ELSE;
+
+import org.mvel2.ast.ASTNode;
+import org.mvel2.ast.EndOfStatement;
+import org.mvel2.ast.OperatorNode;
+
+public class ASTBinaryTree {
+
+    private ASTNode root;
+    private ASTBinaryTree left;
+    private ASTBinaryTree right;
+
+    public ASTBinaryTree(ASTNode node) {
+        this.root = node;
+    }
+
+    public static ASTBinaryTree buildTree(ASTIterator input) {
+        ASTIterator iter = new ASTLinkedList(input.firstNode());
+        ASTBinaryTree tree = new ASTBinaryTree(iter.nextNode());
+        while (iter.hasMoreNodes()) {
+            ASTNode node = iter.nextNode();
+            if (node instanceof EndOfStatement) {
+                if (iter.hasMoreNodes()) tree = new ASTBinaryTree(iter.nextNode());
+            } else {
+                tree = tree.append(node);
+            }
+        }
+        return tree;
+    }
+
+    public ASTBinaryTree append(ASTNode node) {
+        if (comparePrecedence(root, node) >= 0) {
+            ASTBinaryTree tree = new ASTBinaryTree(node);
+            tree.left = this;
+            return tree;
+        } else {
+            if (left == null) throw new RuntimeException("Missing left node");
+            if (right == null) {
+                right = new ASTBinaryTree(node);
+            } else {
+                right = right.append(node);
+            }
+            return this;
+        }
+    }
+
+    public Class<?> getReturnType(boolean strongTyping) {
+        if (!(root instanceof OperatorNode)) return root.getEgressType();
+        if (left == null || right == null) throw new RuntimeException("Malformed expression");
+        Class<?> leftType = left.getReturnType(strongTyping);
+        Class<?> rightType = right.getReturnType(strongTyping);
+        switch (((OperatorNode) root).getOperator()) {
+            case CONTAINS:
+            case SOUNDEX:
+            case INSTANCEOF:
+            case SIMILARITY:
+            case REGEX:
+                return Boolean.class;
+            case ADD:
+                if (leftType.equals(String.class) || rightType.equals(String.class)) return String.class;
+            case SUB:
+            case MULT:
+            case DIV:
+                if (strongTyping && !CompatibilityStrategy.areEqualityCompatible(leftType, rightType))
+                    throw new RuntimeException("Associative operation requires compatible types. Found " + leftType + " and " + rightType);
+                return Double.class;
+            case TERNARY_ELSE:
+                if (strongTyping && !CompatibilityStrategy.areEqualityCompatible(leftType, rightType))
+                    throw new RuntimeException("Associative operation requires compatible types. Found " + leftType + " and " + rightType);
+                return leftType;
+            case EQUAL:
+            case NEQUAL:
+                if (strongTyping && !CompatibilityStrategy.areEqualityCompatible(leftType, rightType))
+                    throw new RuntimeException("Comparison operation requires compatible types. Found " + leftType + " and " + rightType);
+                return Boolean.class;
+            case LTHAN:
+            case LETHAN:
+            case GTHAN:
+            case GETHAN:
+                if (strongTyping && !CompatibilityStrategy.areComparisonCompatible(leftType, rightType))
+                    throw new RuntimeException("Comparison operation requires compatible types. Found " + leftType + " and " + rightType);
+                return Boolean.class;
+            case AND:
+            case OR:
+                if (strongTyping) {
+                    if (leftType != Boolean.class && leftType != Boolean.TYPE)
+                        throw new RuntimeException("Left side of logical operation is not of type boolean. Found " + leftType);
+                    if (rightType != Boolean.class && rightType != Boolean.TYPE)
+                        throw new RuntimeException("Right side of logical operation is not of type boolean. Found " + rightType);
+                }
+                return Boolean.class;
+            case TERNARY:
+                if (strongTyping && leftType != Boolean.class && leftType != Boolean.TYPE)
+                    throw new RuntimeException("Condition of ternary operator is not of type boolean. Found " + leftType);
+                return rightType;
+        }
+        // TODO: should throw new RuntimeException("Unknown operator");
+        // it doesn't because I am afraid I am not covering all the OperatorNode types
+        return root.getEgressType();
+    }
+
+    private int comparePrecedence(ASTNode node1, ASTNode node2) {
+        if (!(node1 instanceof OperatorNode) && !(node2 instanceof OperatorNode)) return 0;
+        if (node1 instanceof OperatorNode && node2 instanceof OperatorNode) {
+            return PTABLE[((OperatorNode) node1).getOperator()] - PTABLE[((OperatorNode) node2).getOperator()];
+        }
+        return node1 instanceof OperatorNode ? -1 : 1;
+    }
+}

--- a/core/src/main/java/org/mvel2/util/ASTIterator.java
+++ b/core/src/main/java/org/mvel2/util/ASTIterator.java
@@ -1,0 +1,67 @@
+/**
+ * MVEL 2.0
+ * Copyright (C) 2007 The Codehaus
+ * Mike Brock, Dhanji Prasanna, John Graham, Mark Proctor
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.mvel2.util;
+
+import java.io.Serializable;
+
+import org.mvel2.ast.ASTNode;
+
+/**
+ * The ASTIterator interface defines the functionality required by the enginer, for compiletime and runtime
+ * operations.  Unlike other script implementations, MVEL does not use a completely normalized AST tree for
+ * it's execution.  Instead, nodes are organized into a linear order and delivered via this iterator interface,
+ * much like bytecode instructions.
+ */
+public interface ASTIterator extends Serializable {
+
+    public void reset();
+
+    public ASTNode nextNode();
+
+    public void skipNode();
+
+    public ASTNode peekNext();
+
+    public ASTNode peekNode();
+
+    public ASTNode peekLast();
+
+    //  public boolean peekNextTokenFlags(int flags);
+    public void back();
+
+    public ASTNode nodesBack(int offset);
+
+    public ASTNode nodesAhead(int offset);
+
+    public boolean hasMoreNodes();
+
+    public String showNodeChain();
+
+    public ASTNode firstNode();
+
+    public int size();
+
+    public int index();
+
+    public void finish();
+
+    public void addTokenNode(ASTNode node);
+
+    public void addTokenNode(ASTNode node1, ASTNode node2);
+
+}

--- a/core/src/main/java/org/mvel2/util/ASTLinkedList.java
+++ b/core/src/main/java/org/mvel2/util/ASTLinkedList.java
@@ -1,0 +1,183 @@
+/**
+ * MVEL 2.0
+ * Copyright (C) 2007 The Codehaus
+ * Mike Brock, Dhanji Prasanna, John Graham, Mark Proctor
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mvel2.util;
+
+import org.mvel2.ast.ASTNode;
+
+public class ASTLinkedList implements ASTIterator {
+
+    private ASTNode firstASTNode;
+    private ASTNode current;
+    private ASTNode last;
+    private int size;
+
+    public ASTLinkedList() {
+    }
+
+    public ASTLinkedList(ASTIterator iter) {
+        this.current = this.firstASTNode = iter.firstNode();
+    }
+
+    public ASTLinkedList(ASTNode firstASTNode) {
+        this.current = this.firstASTNode = firstASTNode;
+    }
+
+    public ASTLinkedList(ASTNode firstASTNode, int size) {
+        this.current = this.firstASTNode = firstASTNode;
+        this.size = size;
+    }
+
+    public void addTokenNode(ASTNode astNode) {
+        size++;
+
+        if (this.firstASTNode == null) {
+            this.firstASTNode = this.current = astNode;
+        } else {
+            this.last = this.current = (this.current.nextASTNode = astNode);
+        }
+    }
+
+    public void addTokenNode(ASTNode astNode, ASTNode token2) {
+        size += 2;
+
+        if (this.firstASTNode == null) {
+            this.last = this.current = ((this.firstASTNode = astNode).nextASTNode = token2);
+        } else {
+            this.last = this.current = (this.current.nextASTNode = astNode).nextASTNode = token2;
+        }
+    }
+
+    public ASTNode firstNode() {
+        return firstASTNode;
+    }
+
+    public boolean isSingleNode() {
+        return size == 1 || (size == 2 && firstASTNode.fields == -1);
+    }
+
+    public ASTNode firstNonSymbol() {
+        if (firstASTNode.fields == -1) {
+            return firstASTNode.nextASTNode;
+        } else {
+            return firstASTNode;
+        }
+    }
+
+    public void reset() {
+        this.current = firstASTNode;
+    }
+
+    public boolean hasMoreNodes() {
+        return this.current != null;
+    }
+
+    public ASTNode nextNode() {
+        if (current == null) return null;
+        try {
+            return current;
+        } finally {
+            last = current;
+            current = current.nextASTNode;
+        }
+    }
+
+    public void skipNode() {
+        if (current != null) current = current.nextASTNode;
+    }
+
+    public ASTNode peekNext() {
+        if (current != null && current.nextASTNode != null) return current.nextASTNode;
+        else return null;
+    }
+
+    public ASTNode peekNode() {
+        if (current == null) return null;
+        return current;
+    }
+
+    public void removeToken() {
+        if (current != null) {
+            current = current.nextASTNode;
+        }
+    }
+
+    public ASTNode peekLast() {
+        return last;
+    }
+
+    public ASTNode nodesBack(int offset) {
+        throw new RuntimeException("unimplemented");
+    }
+
+    public ASTNode nodesAhead(int offset) {
+        if (current == null) return null;
+        ASTNode cursor = null;
+        for (int i = 0; i < offset; i++) {
+            if ((cursor = current.nextASTNode) == null) return null;
+        }
+        return cursor;
+    }
+
+    public void back() {
+        current = last;
+    }
+
+    public String showNodeChain() {
+        throw new RuntimeException("unimplemented");
+    }
+
+    public int size() {
+        return size;
+    }
+
+    public int index() {
+        return -1;
+    }
+
+    public void setCurrentNode(ASTNode node) {
+        this.current = node;
+    }
+
+    public void finish() {
+        reset();
+
+        ASTNode last = null;
+        ASTNode curr;
+
+        while (hasMoreNodes()) {
+            if ((curr = nextNode()).isDiscard()) {
+                if (last == null) {
+                    last = firstASTNode = nextNode();
+                } else {
+                    last.nextASTNode = nextNode();
+                }
+                continue;
+            }
+
+            if (!hasMoreNodes()) break;
+
+            last = curr;
+        }
+
+        this.last = last;
+
+        reset();
+    }
+
+}

--- a/core/src/main/java/org/mvel2/util/ArrayTools.java
+++ b/core/src/main/java/org/mvel2/util/ArrayTools.java
@@ -1,0 +1,36 @@
+/**
+ * MVEL 2.0
+ * Copyright (C) 2007 The Codehaus
+ * Mike Brock, Dhanji Prasanna, John Graham, Mark Proctor
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.mvel2.util;
+
+public class ArrayTools {
+
+    public static int findFirst(char c, int start, int offset, char[] array) {
+        int end = start + offset;
+        for (int i = start; i < end; i++) {
+            if (array[i] == c) return i;
+        }
+        return -1;
+    }
+
+    public static int findLast(char c, int start, int offset, char[] array) {
+        for (int i = start + offset - 1; i >= 0; i--) {
+            if (array[i] == c) return i;
+        }
+        return -1;
+    }
+}

--- a/core/src/main/java/org/mvel2/util/CallableProxy.java
+++ b/core/src/main/java/org/mvel2/util/CallableProxy.java
@@ -1,0 +1,8 @@
+package org.mvel2.util;
+
+import org.mvel2.integration.VariableResolverFactory;
+
+public interface CallableProxy {
+
+    public Object call(Object ctx, Object thisCtx, VariableResolverFactory factory, Object[] parameters);
+}

--- a/core/src/main/java/org/mvel2/util/CollectionParser.java
+++ b/core/src/main/java/org/mvel2/util/CollectionParser.java
@@ -1,0 +1,257 @@
+/**
+ * MVEL 2.0
+ * Copyright (C) 2007 The Codehaus
+ * Mike Brock, Dhanji Prasanna, John Graham, Mark Proctor
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mvel2.util;
+
+import static org.mvel2.util.ParseTools.balancedCapture;
+import static org.mvel2.util.ParseTools.createStringTrimmed;
+import static org.mvel2.util.ParseTools.getBaseComponentType;
+import static org.mvel2.util.ParseTools.isIdentifierPart;
+import static org.mvel2.util.ParseTools.isWhitespace;
+import static org.mvel2.util.ParseTools.skipWhitespace;
+import static org.mvel2.util.ParseTools.subCompileExpression;
+import static org.mvel2.util.ReflectionUtil.isAssignableFrom;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.mvel2.CompileException;
+import org.mvel2.DataConversion;
+import org.mvel2.ParserContext;
+import org.mvel2.compiler.ExecutableStatement;
+
+/**
+ * This is the inline collection sub-parser.  It produces a skeleton model of the collection which is in turn translated
+ * into a sequenced AST to produce the collection efficiently at runtime, and passed off to one of the JIT's if
+ * configured.
+ *
+ * @author Christopher Brock
+ */
+public class CollectionParser {
+
+    public static final int LIST = 0;
+    public static final int ARRAY = 1;
+    public static final int MAP = 2;
+    private static final Object[] EMPTY_ARRAY = new Object[0];
+    private char[] property;
+    private int cursor;
+    private int start;
+    private int end;
+    private int type;
+    private Class colType;
+    private ParserContext pCtx;
+
+    public CollectionParser() {
+    }
+
+    public CollectionParser(int type) {
+        this.type = type;
+    }
+
+    public Object parseCollection(char[] property, int start, int offset, boolean subcompile, ParserContext pCtx) {
+        this.property = property;
+        this.pCtx = pCtx;
+        this.end = start + offset;
+
+        while (start < end && isWhitespace(property[start])) {
+            start++;
+        }
+        this.start = this.cursor = start;
+
+        return parseCollection(subcompile);
+    }
+
+    public Object parseCollection(char[] property, int start, int offset, boolean subcompile, Class colType, ParserContext pCtx) {
+        if (colType != null) this.colType = getBaseComponentType(colType);
+        this.property = property;
+
+        this.end = start + offset;
+
+        while (start < end && isWhitespace(property[start])) {
+            start++;
+        }
+
+        this.start = this.cursor = start;
+
+        this.pCtx = pCtx;
+
+        return parseCollection(subcompile);
+    }
+
+    private Object parseCollection(boolean subcompile) {
+        if (end - start == 0) {
+            if (type == LIST) return new ArrayList();
+            else return EMPTY_ARRAY;
+        }
+
+        Map<Object, Object> map = null;
+        List<Object> list = null;
+
+        int st = start;
+
+        if (type != -1) {
+            switch (type) {
+                case ARRAY:
+                case LIST:
+                    list = new ArrayList<Object>();
+                    break;
+                case MAP:
+                    map = new HashMap<Object, Object>();
+                    break;
+            }
+        }
+
+        Object curr = null;
+        int newType = -1;
+
+        for (; cursor < end; cursor++) {
+            switch (property[cursor]) {
+                case '{':
+                    if (newType == -1) {
+                        newType = ARRAY;
+                    }
+
+                case '[':
+                    if (cursor > start && isIdentifierPart(property[cursor - 1])) continue;
+
+                    if (newType == -1) {
+                        newType = LIST;
+                    }
+
+                    /**
+                     * Sub-parse nested collections.
+                     */
+                    Object o = new CollectionParser(newType).parseCollection(property, (st = cursor) + 1,
+                            (cursor = balancedCapture(property, st, end, property[st])) - st - 1, subcompile, colType, pCtx);
+
+                    if (type == MAP) {
+                        map.put(curr, o);
+                    } else {
+                        list.add(curr = o);
+                    }
+
+                    cursor = skipWhitespace(property, ++cursor);
+
+                    if ((st = cursor) < end && property[cursor] == ',') {
+                        st = cursor + 1;
+                    } else if (cursor < end) {
+                        if (ParseTools.opLookup(property[cursor]) == -1) {
+                            throw new CompileException("unterminated collection element", property, cursor);
+                        }
+                    }
+
+                    continue;
+
+                case '(':
+                    cursor = balancedCapture(property, cursor, end, '(');
+
+                    break;
+
+                case '\"':
+                case '\'':
+                    cursor = balancedCapture(property, cursor, end, property[cursor]);
+
+                    break;
+
+                case ',':
+                    if (type != MAP) {
+                        list.add(new String(property, st, cursor - st).trim());
+                    } else {
+                        map.put(curr, createStringTrimmed(property, st, cursor - st));
+                    }
+
+                    if (subcompile) {
+                        subCompile(st, cursor - st);
+                    }
+
+                    st = cursor + 1;
+
+                    break;
+
+                case ':':
+                    if (type != MAP) {
+                        map = new HashMap<Object, Object>();
+                        type = MAP;
+                    }
+                    curr = createStringTrimmed(property, st, cursor - st);
+
+                    if (subcompile) {
+                        subCompile(st, cursor - st);
+                    }
+
+                    st = cursor + 1;
+                    break;
+
+                case '.':
+                    cursor++;
+                    cursor = skipWhitespace(property, cursor);
+                    if (cursor != end && property[cursor] == '{') {
+                        cursor = balancedCapture(property, cursor, '{');
+                    }
+                    break;
+            }
+        }
+
+        if (st < end && isWhitespace(property[st])) {
+            st = skipWhitespace(property, st);
+        }
+
+        if (st < end) {
+            if (cursor < (end - 1)) cursor++;
+
+            if (type == MAP) {
+                map.put(curr, createStringTrimmed(property, st, cursor - st));
+            } else {
+                if (cursor < end) cursor++;
+                list.add(createStringTrimmed(property, st, cursor - st));
+            }
+
+            if (subcompile) subCompile(st, cursor - st);
+        }
+
+        switch (type) {
+            case MAP:
+                return map;
+            case ARRAY:
+                return list.toArray();
+            default:
+                return list;
+        }
+    }
+
+    private void subCompile(int start, int offset) {
+        if (colType == null) {
+            subCompileExpression(property, start, offset, pCtx);
+        } else {
+            Class r = ((ExecutableStatement) subCompileExpression(property, start, offset, pCtx)).getKnownEgressType();
+            if (r != null && !isAssignableFrom(colType, r) && (isStrongType() || !DataConversion.canConvert(r, colType))) {
+                throw new CompileException("expected type: " + colType.getName() + "; but found: " + r.getName(), property, cursor);
+            }
+        }
+    }
+
+    private boolean isStrongType() {
+        return pCtx != null && pCtx.isStrongTyping();
+    }
+
+    public int getCursor() {
+        return cursor;
+    }
+}

--- a/core/src/main/java/org/mvel2/util/CompatibilityStrategy.java
+++ b/core/src/main/java/org/mvel2/util/CompatibilityStrategy.java
@@ -1,0 +1,60 @@
+package org.mvel2.util;
+
+public class CompatibilityStrategy {
+
+    public static CompatibilityEvaluator compatibilityEvaluator = new DefaultCompatibilityEvaluator();
+
+    private CompatibilityStrategy() {
+    }
+
+    public static boolean areEqualityCompatible(Class<?> c1, Class<?> c2) {
+        return compatibilityEvaluator.areEqualityCompatible(c1, c2);
+    }
+
+    public static boolean areComparisonCompatible(Class<?> c1, Class<?> c2) {
+        return compatibilityEvaluator.areComparisonCompatible(c1, c2);
+    }
+
+    public static void setCompatibilityEvaluator(CompatibilityEvaluator compatibilityEvaluator) {
+        CompatibilityStrategy.compatibilityEvaluator = compatibilityEvaluator;
+    }
+
+    public interface CompatibilityEvaluator {
+
+        boolean areEqualityCompatible(Class<?> c1, Class<?> c2);
+
+        boolean areComparisonCompatible(Class<?> c1, Class<?> c2);
+    }
+
+    public static class DefaultCompatibilityEvaluator implements CompatibilityEvaluator {
+
+        public boolean areEqualityCompatible(Class<?> c1, Class<?> c2) {
+            if (c1 == NullType.class || c2 == NullType.class) return true;
+            if (c1.isAssignableFrom(c2) || c2.isAssignableFrom(c1)) return true;
+            if (isBoxedNumber(c1, false) && isBoxedNumber(c2, true)) return true;
+            if (c1.isPrimitive()) return c2.isPrimitive() || arePrimitiveCompatible(c1, c2, true);
+            if (c2.isPrimitive()) return arePrimitiveCompatible(c2, c1, false);
+            return false;
+        }
+
+        public boolean areComparisonCompatible(Class<?> c1, Class<?> c2) {
+            return areEqualityCompatible(c1, c2);
+        }
+
+        private boolean arePrimitiveCompatible(Class<?> primitive, Class<?> boxed, boolean leftFirst) {
+            if (primitive == Boolean.TYPE) return boxed == Boolean.class;
+            if (primitive == Integer.TYPE) return isBoxedNumber(boxed, leftFirst);
+            if (primitive == Long.TYPE) return isBoxedNumber(boxed, leftFirst);
+            if (primitive == Double.TYPE) return isBoxedNumber(boxed, leftFirst);
+            if (primitive == Float.TYPE) return isBoxedNumber(boxed, leftFirst);
+            if (primitive == Character.TYPE) return boxed == Character.class;
+            if (primitive == Byte.TYPE) return boxed == Byte.class;
+            if (primitive == Short.TYPE) return boxed == Short.class;
+            return false;
+        }
+
+        private boolean isBoxedNumber(Class<?> c, boolean allowString) {
+            return Number.class.isAssignableFrom(c) || (allowString && c == String.class);
+        }
+    }
+}

--- a/core/src/main/java/org/mvel2/util/CompilerTools.java
+++ b/core/src/main/java/org/mvel2/util/CompilerTools.java
@@ -1,0 +1,459 @@
+/**
+ * MVEL 2.0
+ * Copyright (C) 2007 The Codehaus
+ * Mike Brock, Dhanji Prasanna, John Graham, Mark Proctor
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mvel2.util;
+
+import static org.mvel2.Operator.PTABLE;
+import static org.mvel2.Operator.TERNARY;
+import static org.mvel2.util.ASTBinaryTree.buildTree;
+import static org.mvel2.util.ParseTools.__resolveType;
+import static org.mvel2.util.ParseTools.boxPrimitive;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import org.mvel2.CompileException;
+import org.mvel2.Operator;
+import org.mvel2.ParserContext;
+import org.mvel2.ast.ASTNode;
+import org.mvel2.ast.And;
+import org.mvel2.ast.BinaryOperation;
+import org.mvel2.ast.BooleanNode;
+import org.mvel2.ast.Contains;
+import org.mvel2.ast.Convertable;
+import org.mvel2.ast.DeclTypedVarNode;
+import org.mvel2.ast.Function;
+import org.mvel2.ast.Instance;
+import org.mvel2.ast.IntAdd;
+import org.mvel2.ast.IntDiv;
+import org.mvel2.ast.IntMult;
+import org.mvel2.ast.IntOptimized;
+import org.mvel2.ast.IntSub;
+import org.mvel2.ast.LiteralNode;
+import org.mvel2.ast.Or;
+import org.mvel2.ast.RegExMatchNode;
+import org.mvel2.ast.Soundslike;
+import org.mvel2.ast.Strsim;
+import org.mvel2.compiler.Accessor;
+import org.mvel2.compiler.BlankLiteral;
+import org.mvel2.compiler.CompiledExpression;
+import org.mvel2.compiler.ExecutableAccessor;
+import org.mvel2.compiler.ExecutableLiteral;
+import org.mvel2.integration.VariableResolverFactory;
+import org.mvel2.integration.impl.ClassImportResolverFactory;
+
+public class CompilerTools {
+
+    /**
+     * Finalize the payload, by reducing any stack-based-operations to dedicated nodes where possible.
+     *
+     * @param astLinkedList          - AST to be optimized.
+     * @param secondPassOptimization - perform a second pass optimization to optimize boolean expressions.
+     * @param pCtx                    - The parser context
+     * @return optimized AST
+     */
+    public static ASTLinkedList finalizePayload(ASTLinkedList astLinkedList, boolean secondPassOptimization, ParserContext pCtx) {
+        ASTLinkedList optimizedAst = new ASTLinkedList();
+        ASTNode tk, tkOp, tkOp2;
+
+        /**
+         * Re-process the AST and optimize it.
+         */
+        while (astLinkedList.hasMoreNodes()) {
+            if ((tk = astLinkedList.nextNode()).getFields() == -1) {
+                optimizedAst.addTokenNode(tk);
+            } else if (astLinkedList.hasMoreNodes()) {
+                if ((tkOp = astLinkedList.nextNode()).getFields() == -1) {
+                    optimizedAst.addTokenNode(tk, tkOp);
+                } else if (tkOp.isOperator() && tkOp.getOperator() < 21) {
+                    int op = tkOp.getOperator();
+                    int op2;
+
+                    if (op == -1) {
+                        throw new CompileException("illegal use of operator: " + tkOp.getName(), tkOp.getExpr(), tk.getStart());
+                    }
+
+                    ASTNode tk2 = astLinkedList.nextNode();
+                    BinaryOperation bo;
+
+                    if (tk.getEgressType() == Integer.class && tk2.getEgressType() == Integer.class) {
+                        bo = boOptimize(op, tk, tk2, pCtx);
+                    } else {
+                        /**
+                         * Let's see if we can simply the expression more.
+                         */
+                        bo = null;
+
+                        boolean inv = tkOp.isOperator(Operator.SUB);
+                        boolean reduc = tk.isLiteral() && isReductionOpportunity(tkOp, tk2);
+                        boolean p_inv = false;
+
+                        while (reduc) {
+                            ASTNode oper = astLinkedList.nextNode();
+                            ASTNode rightNode = astLinkedList.nextNode();
+
+                            if (rightNode == null) break;
+
+                            Object val = new BinaryOperation(oper.getOperator(),
+                                    inv ? new LiteralNode(signNumber(tk2.getLiteralValue()), pCtx) : tk2, rightNode, pCtx)
+                                            .getReducedValueAccelerated(null, null, null);
+
+                            if (!astLinkedList.hasMoreNodes() && BlankLiteral.INSTANCE.equals(val)) {
+                                optimizedAst.addTokenNode(tk);
+                                continue;
+                            }
+
+                            reduc = astLinkedList.hasMoreNodes() && (reducacbleOperator(astLinkedList.peekNode().getOperator()))
+                                    && astLinkedList.peekNext().isLiteral();
+
+                            if (inv) p_inv = true;
+                            inv = false;
+
+                            if (!reduc) {
+                                bo = new BinaryOperation(tkOp.getOperator(), tk, new LiteralNode(p_inv ? signNumber(val) : val, pCtx),
+                                        pCtx);
+                            } else {
+                                tk2 = new LiteralNode(val, pCtx);
+                            }
+                        }
+
+                        if (bo == null) bo = new BinaryOperation(op, tk, tk2, pCtx);
+                    }
+
+                    tkOp2 = null;
+
+                    /**
+                     * If we have a chain of math/comparitive operators then we fill them into the tree
+                     * right here.
+                     */
+                    while (astLinkedList.hasMoreNodes() && (tkOp2 = astLinkedList.nextNode()).isOperator() && tkOp2.getFields() != -1
+                            && (op2 = tkOp2.getOperator()) != -1 && op2 < 21) {
+
+                        if (PTABLE[op2] > PTABLE[op]) {
+                            //       bo.setRightMost(new BinaryOperation(op2, bo.getRightMost(), astLinkedList.nextNode(), pCtx));
+                            bo.setRightMost(boOptimize(op2, bo.getRightMost(), astLinkedList.nextNode(), pCtx));
+                        } else if (bo.getOperation() != op2 && PTABLE[op] == PTABLE[op2]) {
+                            if (PTABLE[bo.getOperation()] == PTABLE[op2]) {
+                                //     bo = new BinaryOperation(op2, bo, astLinkedList.nextNode(), pCtx);
+                                bo = boOptimize(op2, bo, astLinkedList.nextNode(), pCtx);
+                            } else {
+                                tk2 = astLinkedList.nextNode();
+
+                                if (isIntOptimizationviolation(bo, tk2)) {
+                                    bo = new BinaryOperation(bo.getOperation(), bo.getLeft(), bo.getRight(), pCtx);
+                                }
+
+                                bo.setRight(new BinaryOperation(op2, bo.getRight(), tk2, pCtx));
+                            }
+                        } else if (PTABLE[bo.getOperation()] >= PTABLE[op2]) {
+                            bo = new BinaryOperation(op2, bo, astLinkedList.nextNode(), pCtx);
+                        } else {
+                            tk2 = astLinkedList.nextNode();
+
+                            if (isIntOptimizationviolation(bo, tk2)) {
+                                bo = new BinaryOperation(bo.getOperation(), bo.getLeft(), bo.getRight(), pCtx);
+                            }
+
+                            bo.setRight(new BinaryOperation(op2, bo.getRight(), tk2, pCtx));
+                        }
+
+                        op = op2;
+                        tkOp = tkOp2;
+                    }
+
+                    if (tkOp2 != null && tkOp2 != tkOp) {
+                        optimizeOperator(tkOp2.getOperator(), bo, tkOp2, astLinkedList, optimizedAst, pCtx);
+                    } else {
+                        optimizedAst.addTokenNode(bo);
+                    }
+                } else if (tkOp.isOperator()) {
+                    optimizeOperator(tkOp.getOperator(), tk, tkOp, astLinkedList, optimizedAst, pCtx);
+                } else if (!tkOp.isAssignment() && !tkOp.isOperator() && tk.getLiteralValue() instanceof Class) {
+                    optimizedAst.addTokenNode(new DeclTypedVarNode(tkOp.getName(), tkOp.getExpr(), tkOp.getStart(), tk.getOffset(),
+                            (Class) tk.getLiteralValue(), 0, pCtx));
+                } else if (tkOp.isAssignment() && tk.getLiteralValue() instanceof Class) {
+                    tk.discard();
+                    optimizedAst.addTokenNode(tkOp);
+                } else if (astLinkedList.hasMoreNodes() && tkOp.getLiteralValue() instanceof Class
+                        && astLinkedList.peekNode().isAssignment()) {
+                    tkOp.discard();
+                    optimizedAst.addTokenNode(tk, astLinkedList.nextNode());
+                } else {
+                    astLinkedList.back();
+                    optimizedAst.addTokenNode(tk);
+                }
+            } else {
+                optimizedAst.addTokenNode(tk);
+            }
+        }
+
+        if (secondPassOptimization) {
+            /**
+             * Perform a second pass optimization for boolean conditions.
+             */
+            (astLinkedList = optimizedAst).reset();
+            optimizedAst = new ASTLinkedList();
+
+            while (astLinkedList.hasMoreNodes()) {
+                if ((tk = astLinkedList.nextNode()).getFields() == -1) {
+                    optimizedAst.addTokenNode(tk);
+                } else if (astLinkedList.hasMoreNodes()) {
+                    if ((tkOp = astLinkedList.nextNode()).getFields() == -1) {
+                        optimizedAst.addTokenNode(tk, tkOp);
+                    } else if (tkOp.isOperator() && (tkOp.getOperator() == Operator.AND || tkOp.getOperator() == Operator.OR)) {
+
+                        tkOp2 = null;
+                        BooleanNode bool;
+
+                        if (tkOp.getOperator() == Operator.AND) {
+                            bool = new And(tk, astLinkedList.nextNode(), pCtx.isStrongTyping(), pCtx);
+                        } else {
+                            bool = new Or(tk, astLinkedList.nextNode(), pCtx.isStrongTyping(), pCtx);
+                        }
+
+                        while (astLinkedList.hasMoreNodes() && (tkOp2 = astLinkedList.nextNode()).isOperator()
+                                && (tkOp2.isOperator(Operator.AND) || tkOp2.isOperator(Operator.OR))) {
+
+                            if ((tkOp = tkOp2).getOperator() == Operator.AND) {
+                                bool.setRightMost(new And(bool.getRightMost(), astLinkedList.nextNode(), pCtx.isStrongTyping(), pCtx));
+                            } else {
+                                bool = new Or(bool, astLinkedList.nextNode(), pCtx.isStrongTyping(), pCtx);
+                            }
+
+                        }
+
+                        optimizedAst.addTokenNode(bool);
+
+                        if (tkOp2 != null && tkOp2 != tkOp) {
+                            optimizedAst.addTokenNode(tkOp2);
+                        }
+                    } else {
+                        optimizedAst.addTokenNode(tk, tkOp);
+                    }
+                } else {
+                    optimizedAst.addTokenNode(tk);
+                }
+            }
+        }
+
+        return optimizedAst;
+    }
+
+    private static BinaryOperation boOptimize(int op, ASTNode tk, ASTNode tk2, ParserContext pCtx) {
+        if (tk.getEgressType() == Integer.class && tk2.getEgressType() == Integer.class) {
+            switch (op) {
+                case Operator.ADD:
+                    return new IntAdd(tk, tk2, pCtx);
+
+                case Operator.SUB:
+                    return new IntSub(tk, tk2, pCtx);
+
+                case Operator.MULT:
+                    return new IntMult(tk, tk2, pCtx);
+
+                case Operator.DIV:
+                    return new IntDiv(tk, tk2, pCtx);
+
+                default:
+                    return new BinaryOperation(op, tk, tk2, pCtx);
+            }
+        } else {
+            return new BinaryOperation(op, tk, tk2, pCtx);
+        }
+    }
+
+    private static boolean isReductionOpportunity(ASTNode oper, ASTNode node) {
+        ASTNode n = node;
+        return (n != null && n.isLiteral() && (n = n.nextASTNode) != null && reducacbleOperator(n.getOperator())
+                && PTABLE[oper.getOperator()] <= PTABLE[n.getOperator()] && (n = n.nextASTNode) != null && n.isLiteral()
+                && n.getLiteralValue() instanceof Number);
+    }
+
+    private static boolean reducacbleOperator(int oper) {
+        switch (oper) {
+            case Operator.ADD:
+            case Operator.SUB:
+                return true;
+
+        }
+        return false;
+    }
+
+    private static void optimizeOperator(int operator, ASTNode tk, ASTNode tkOp, ASTLinkedList astLinkedList, ASTLinkedList optimizedAst,
+            ParserContext pCtx) {
+        switch (operator) {
+            case Operator.REGEX:
+                optimizedAst.addTokenNode(new RegExMatchNode(tk, astLinkedList.nextNode(), pCtx));
+                break;
+            case Operator.CONTAINS:
+                optimizedAst.addTokenNode(new Contains(tk, astLinkedList.nextNode(), pCtx));
+                break;
+            case Operator.INSTANCEOF:
+                optimizedAst.addTokenNode(new Instance(tk, astLinkedList.nextNode(), pCtx));
+                break;
+            case Operator.CONVERTABLE_TO:
+                optimizedAst.addTokenNode((new Convertable(tk, astLinkedList.nextNode(), pCtx)));
+                break;
+            case Operator.SIMILARITY:
+                optimizedAst.addTokenNode(new Strsim(tk, astLinkedList.nextNode(), pCtx));
+                break;
+            case Operator.SOUNDEX:
+                optimizedAst.addTokenNode(new Soundslike(tk, astLinkedList.nextNode(), pCtx));
+                break;
+
+            case TERNARY:
+                if (pCtx.isStrongTyping() && tk.getEgressType() != Boolean.class && tk.getEgressType() != Boolean.TYPE)
+                    throw new RuntimeException("Condition of ternary operator is not of type boolean. Found " + tk.getEgressType());
+
+            default:
+                optimizedAst.addTokenNode(tk, tkOp);
+        }
+    }
+
+    private static boolean isIntOptimizationviolation(BooleanNode bn, ASTNode bn2) {
+        return (bn instanceof IntOptimized && bn2.getEgressType() != Integer.class);
+    }
+
+    public static Class getReturnType(ASTIterator input, boolean strongTyping) {
+        ASTNode begin = input.firstNode();
+        if (begin == null) return Object.class;
+        if (input.size() == 1) return begin.getEgressType();
+        return buildTree(input).getReturnType(strongTyping);
+    }
+
+    /**
+     * Returns an ordered Map of all functions declared within an compiled script.
+     *
+     * @param compile
+     * @return - ordered Map
+     */
+    public static Map<String, Function> extractAllDeclaredFunctions(CompiledExpression compile) {
+        Map<String, Function> allFunctions = new LinkedHashMap<String, Function>();
+        ASTIterator instructions = new ASTLinkedList(compile.getFirstNode());
+
+        ASTNode n;
+        while (instructions.hasMoreNodes()) {
+            if ((n = instructions.nextNode()) instanceof Function) {
+                allFunctions.put(n.getName(), (Function) n);
+            }
+        }
+
+        return allFunctions;
+    }
+
+    public static void expectType(ParserContext pCtx, Accessor expression, Class type, boolean compileMode) {
+        Class retType = expression.getKnownEgressType();
+        if (compileMode) {
+            if ((retType == null || !boxPrimitive(type).isAssignableFrom(boxPrimitive(retType)))
+                    && (!Object.class.equals(retType) || pCtx.isStrictTypeEnforcement())) {
+                throw new CompileException("was expecting type: " + type.getName() + "; but found type: "
+                        + (retType != null ? retType.getName() : "<Unknown>"), new char[0], 0);
+            }
+        } else if (retType == null || !Object.class.equals(retType) && !boxPrimitive(type).isAssignableFrom(boxPrimitive(retType))) {
+            throw new CompileException(
+                    "was expecting type: " + type.getName() + "; but found type: " + (retType != null ? retType.getName() : "<Unknown>"),
+                    new char[0], 0);
+        }
+    }
+
+    public static void expectType(ParserContext pCtx, ASTNode node, Class type, boolean compileMode) {
+        Class retType = boxPrimitive(node.getEgressType());
+        if (compileMode) {
+            if ((retType == null || !boxPrimitive(type).isAssignableFrom(retType))
+                    && (!Object.class.equals(retType) && pCtx.isStrictTypeEnforcement())) {
+                throw new CompileException("was expecting type: " + type.getName() + "; but found type: "
+                        + (retType != null ? retType.getName() : "<Unknown>"), new char[0], 0);
+            }
+        } else if (retType == null || !Object.class.equals(retType) && !boxPrimitive(type).isAssignableFrom(retType)) {
+            throw new CompileException(
+                    "was expecting type: " + type.getName() + "; but found type: " + (retType != null ? retType.getName() : "<Unknown>"),
+                    new char[0], 0);
+        }
+    }
+
+    public static Class getReturnTypeFromOp(int operation, Class left, Class right) {
+        switch (operation) {
+            case Operator.LETHAN:
+            case Operator.LTHAN:
+            case Operator.GETHAN:
+            case Operator.GTHAN:
+            case Operator.EQUAL:
+            case Operator.NEQUAL:
+            case Operator.AND:
+            case Operator.OR:
+            case Operator.CONTAINS:
+            case Operator.CONVERTABLE_TO:
+                return Boolean.class;
+
+            case Operator.ADD:
+                if (left == String.class) return String.class;
+            case Operator.SUB:
+            case Operator.MULT:
+            case Operator.POWER:
+            case Operator.MOD:
+            case Operator.DIV:
+                if (left == Object.class || right == Object.class) return Object.class;
+                else return __resolveType(boxPrimitive(left)) < __resolveType(boxPrimitive(right)) ? right : left;
+
+            case Operator.BW_AND:
+            case Operator.BW_OR:
+            case Operator.BW_XOR:
+            case Operator.BW_SHIFT_RIGHT:
+            case Operator.BW_SHIFT_LEFT:
+            case Operator.BW_USHIFT_LEFT:
+            case Operator.BW_USHIFT_RIGHT:
+            case Operator.BW_NOT:
+                return Integer.class;
+
+            case Operator.STR_APPEND:
+                return String.class;
+        }
+        return null;
+    }
+
+    public static Accessor extractAccessor(ASTNode n) {
+        if (n instanceof LiteralNode) return new ExecutableLiteral(n.getLiteralValue());
+        else return new ExecutableAccessor(n, n.getEgressType());
+    }
+
+    public static Map<String, Object> getInjectedImports(VariableResolverFactory factory) {
+        if (factory == null) return null;
+        do {
+            if (factory instanceof ClassImportResolverFactory) {
+                return ((ClassImportResolverFactory) factory).getImportedClasses();
+            }
+        } while ((factory = factory.getNextFactory()) != null);
+
+        return null;
+    }
+
+    public static Number signNumber(Object number) {
+        if (number instanceof Integer) {
+            return -((Integer) number);
+        } else if (number instanceof Double) {
+            return -((Double) number);
+        } else if (number instanceof Float) {
+            return -((Float) number);
+        } else if (number instanceof Short) {
+            return -((Short) number);
+        } else {
+            throw new CompileException("expected a numeric type but found: " + number.getClass().getName(), new char[0], 0);
+        }
+    }
+
+}

--- a/core/src/main/java/org/mvel2/util/ErrorUtil.java
+++ b/core/src/main/java/org/mvel2/util/ErrorUtil.java
@@ -1,0 +1,45 @@
+package org.mvel2.util;
+
+import org.mvel2.CompileException;
+import org.mvel2.ErrorDetail;
+
+/**
+ * @author Mike Brock .
+ */
+public class ErrorUtil {
+
+    public static CompileException rewriteIfNeeded(CompileException caught, char[] outer, int outerCursor) {
+        if (outer != caught.getExpr()) {
+            if (caught.getExpr().length <= caught.getCursor()) {
+                caught.setCursor(caught.getExpr().length - 1);
+            }
+
+            try {
+                String innerExpr = new String(caught.getExpr()).substring(caught.getCursor());
+                caught.setExpr(outer);
+
+                String outerStr = new String(outer);
+
+                int newCursor = outerStr.substring(outerStr.indexOf(new String(caught.getExpr()))).indexOf(innerExpr);
+
+                caught.setCursor(newCursor);
+            } catch (Throwable t) {
+                t.printStackTrace();
+            }
+        }
+        return caught;
+    }
+
+    public static ErrorDetail rewriteIfNeeded(ErrorDetail detail, char[] outer, int outerCursor) {
+        if (outer != detail.getExpr()) {
+            String innerExpr = new String(detail.getExpr()).substring(detail.getCursor());
+            detail.setExpr(outer);
+
+            int newCursor = outerCursor;
+            newCursor += new String(outer).substring(outerCursor).indexOf(innerExpr);
+
+            detail.setCursor(newCursor);
+        }
+        return detail;
+    }
+}

--- a/core/src/main/java/org/mvel2/util/ExecutionStack.java
+++ b/core/src/main/java/org/mvel2/util/ExecutionStack.java
@@ -1,0 +1,231 @@
+/**
+ * MVEL 2.0
+ * Copyright (C) 2007 The Codehaus
+ * Mike Brock, Dhanji Prasanna, John Graham, Mark Proctor
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mvel2.util;
+
+import static java.lang.String.valueOf;
+import static org.mvel2.math.MathProcessor.doOperations;
+
+import org.mvel2.ScriptRuntimeException;
+
+public class ExecutionStack {
+
+    private StackElement element;
+    private int size = 0;
+
+    public boolean isEmpty() {
+        return size == 0;
+    }
+
+    public void add(Object o) {
+        size++;
+        StackElement el = element;
+        if (el != null) {
+            while (el.next != null) {
+                el = el.next;
+            }
+            el.next = new StackElement(null, o);
+        } else {
+            element = new StackElement(null, o);
+        }
+    }
+
+    public void push(Object o) {
+        size++;
+        element = new StackElement(element, o);
+        assert size == deepCount();
+
+    }
+
+    public void push(Object obj1, Object obj2) {
+        size += 2;
+        element = new StackElement(new StackElement(element, obj1), obj2);
+        assert size == deepCount();
+
+    }
+
+    public void push(Object obj1, Object obj2, Object obj3) {
+        size += 3;
+        element = new StackElement(new StackElement(new StackElement(element, obj1), obj2), obj3);
+        assert size == deepCount();
+
+    }
+
+    public Object peek() {
+        if (size == 0) return null;
+        else return element.value;
+    }
+
+    public void dup() {
+        size++;
+        element = new StackElement(element, element.value);
+        assert size == deepCount();
+
+    }
+
+    public Boolean peekBoolean() {
+        if (size == 0) return null;
+        if (element.value instanceof Boolean) return (Boolean) element.value;
+        throw new ScriptRuntimeException(
+                "expected Boolean; but found: " + (element.value == null ? "null" : element.value.getClass().getName()));
+    }
+
+    public void copy2(ExecutionStack es) {
+        element = new StackElement(new StackElement(element, es.element.value), es.element.next.value);
+        es.element = es.element.next.next;
+        size += 2;
+        es.size -= 2;
+    }
+
+    public void copyx2(ExecutionStack es) {
+        element = new StackElement(new StackElement(element, es.element.next.value), es.element.value);
+        es.element = es.element.next.next;
+        size += 2;
+        es.size -= 2;
+    }
+
+    public Object peek2() {
+        return element.next.value;
+    }
+
+    public Object pop() {
+        if (size == 0) {
+            return null;
+        }
+        try {
+            size--;
+            return element.value;
+        } finally {
+            element = element.next;
+            assert size == deepCount();
+        }
+    }
+
+    public Boolean popBoolean() {
+        if (size-- == 0) {
+            return null;
+        }
+        try {
+            if (element.value instanceof Boolean) return (Boolean) element.value;
+            throw new ScriptRuntimeException(
+                    "expected Boolean; but found: " + (element.value == null ? "null" : element.value.getClass().getName()));
+        } finally {
+            element = element.next;
+            assert size == deepCount();
+
+        }
+    }
+
+    public Object pop2() {
+        try {
+            size -= 2;
+            return element.value;
+        } finally {
+            element = element.next.next;
+            assert size == deepCount();
+        }
+    }
+
+    public void discard() {
+        if (size != 0) {
+            size--;
+            element = element.next;
+        }
+    }
+
+    public int size() {
+        return size;
+    }
+
+    public boolean isReduceable() {
+        return size > 1;
+    }
+
+    public void clear() {
+        size = 0;
+        element = null;
+    }
+
+    public void xswap_op() {
+        element = new StackElement(element.next.next.next,
+                doOperations(element.next.next.value, (Integer) element.next.value, element.value));
+        size -= 2;
+        assert size == deepCount();
+    }
+
+    public void op() {
+        element = new StackElement(element.next.next.next,
+                doOperations(element.next.next.value, (Integer) element.value, element.next.value));
+        size -= 2;
+        assert size == deepCount();
+    }
+
+    public void op(int operator) {
+        element = new StackElement(element.next.next, doOperations(element.next.value, operator, element.value));
+        size--;
+        assert size == deepCount();
+    }
+
+    public void xswap() {
+        StackElement e = element.next;
+        StackElement relink = e.next;
+        e.next = element;
+        (element = e).next.next = relink;
+    }
+
+    public void xswap2() {
+        StackElement node2 = element.next;
+        StackElement node3 = node2.next;
+
+        (node2.next = element).next = node3.next;
+        element = node3;
+        element.next = node2;
+    }
+
+    public int deepCount() {
+        int count = 0;
+
+        if (element == null) {
+            return 0;
+        } else {
+            count++;
+        }
+
+        StackElement element = this.element;
+        while ((element = element.next) != null) {
+            count++;
+        }
+        return count;
+    }
+
+    public String toString() {
+        StackElement el = element;
+
+        if (element == null) return "<EMPTY>";
+
+        StringBuilder appender = new StringBuilder().append("[");
+        do {
+            appender.append(valueOf(el.value));
+            if (el.next != null) appender.append(", ");
+        } while ((el = el.next) != null);
+
+        appender.append("]");
+
+        return appender.toString();
+    }
+}

--- a/core/src/main/java/org/mvel2/util/FastList.java
+++ b/core/src/main/java/org/mvel2/util/FastList.java
@@ -1,0 +1,308 @@
+/**
+ * MVEL 2.0
+ * Copyright (C) 2007 The Codehaus
+ * Mike Brock, Dhanji Prasanna, John Graham, Mark Proctor
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mvel2.util;
+
+import java.io.Externalizable;
+import java.io.IOException;
+import java.io.ObjectInput;
+import java.io.ObjectOutput;
+import java.util.AbstractList;
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.List;
+import java.util.ListIterator;
+
+import org.mvel2.ImmutableElementException;
+
+public class FastList<E> extends AbstractList<E> implements Externalizable {
+
+    private E[] elements;
+    private int size = 0;
+    private boolean updated = false;
+
+    public FastList(int size) {
+        elements = (E[]) new Object[size == 0 ? 1 : size];
+    }
+
+    public FastList(E[] elements) {
+        this.size = (this.elements = elements).length;
+    }
+
+    public FastList() {
+        this(10);
+    }
+
+    public void writeExternal(ObjectOutput out) throws IOException {
+        out.writeInt(size);
+        for (int i = 0; i < size; i++) {
+            out.writeObject(elements[i]);
+        }
+    }
+
+    public void readExternal(ObjectInput in) throws IOException, ClassNotFoundException {
+        elements = (E[]) new Object[size = in.readInt()];
+        for (int i = 0; i < size; i++) {
+            elements[i] = (E) in.readObject();
+        }
+    }
+
+    public E get(int index) {
+        return (E) elements[index];
+    }
+
+    public int size() {
+        return size;
+    }
+
+    public boolean add(E o) {
+        if (size == elements.length) {
+            increaseSize(elements.length * 2);
+        }
+
+        elements[size++] = o;
+        return true;
+    }
+
+    public E set(int i, E o) {
+        if (!updated) copyArray();
+        E old = elements[i];
+        elements[i] = o;
+        return old;
+    }
+
+    public void add(int i, E o) {
+        if (size == elements.length) {
+            increaseSize(elements.length * 2);
+        }
+
+        for (int c = size; c != i; c--) {
+            elements[c] = elements[c - 1];
+        }
+        elements[i] = o;
+        size++;
+    }
+
+    public E remove(int i) {
+        E old = elements[i];
+        for (int c = i + 1; c < size; c++) {
+            elements[c - 1] = elements[c];
+            elements[c] = null;
+        }
+        size--;
+        return old;
+    }
+
+    public int indexOf(Object o) {
+        if (o == null) return -1;
+        for (int i = 0; i < elements.length; i++) {
+            if (o.equals(elements[i])) return i;
+        }
+        return -1;
+    }
+
+    public int lastIndexOf(Object o) {
+        if (o == null) return -1;
+        for (int i = elements.length - 1; i != -1; i--) {
+            if (o.equals(elements[i])) return i;
+        }
+        return -1;
+    }
+
+    public void clear() {
+        elements = (E[]) new Object[1];
+        size = 0;
+    }
+
+    public boolean addAll(int i, Collection<? extends E> collection) {
+        int offset = collection.size();
+        ensureCapacity(offset + size);
+
+        if (i != 0) {
+            // copy forward all elements that the insertion is occuring before
+            for (int c = i; c != (i + offset); c++) {
+                elements[c + offset + 1] = elements[c];
+            }
+        }
+
+        int c = size == 0 ? -1 : 0;
+        for (E o : collection) {
+            elements[offset + c++] = o;
+        }
+
+        size += offset;
+
+        return true;
+    }
+
+    public Iterator iterator() {
+        final int size = this.size;
+        return new Iterator() {
+
+            private int cursor = 0;
+
+            public boolean hasNext() {
+                return cursor < size;
+            }
+
+            public Object next() {
+                return elements[cursor++];
+            }
+
+            public void remove() {
+                throw new ImmutableElementException("cannot change elements in immutable list");
+            }
+        };
+
+    }
+
+    public ListIterator<E> listIterator() {
+        return new ListIterator<E>() {
+
+            private int i = -1;
+
+            public boolean hasNext() {
+                return i < size - 1;
+            }
+
+            public E next() {
+                return elements[++i];
+            }
+
+            public boolean hasPrevious() {
+                return i > 0;
+            }
+
+            public E previous() {
+                return elements[--i];
+            }
+
+            public int nextIndex() {
+                return i++;
+            }
+
+            public int previousIndex() {
+                return i--;
+            }
+
+            public void remove() {
+                throw new UnsupportedOperationException();
+            }
+
+            public void set(E o) {
+                elements[i] = o;
+            }
+
+            public void add(Object o) {
+                throw new UnsupportedOperationException();
+            }
+        };
+    }
+
+    public ListIterator listIterator(int i) {
+        return super.listIterator(i);
+    }
+
+    public List subList(int i, int i1) {
+        return super.subList(i, i1);
+    }
+
+    public boolean equals(Object o) {
+        if (o == this) return true;
+        if (!(o instanceof List)) return false;
+
+        ListIterator e1 = listIterator();
+        ListIterator e2 = ((List) o).listIterator();
+        while (e1.hasNext() && e2.hasNext()) {
+            Object o1 = e1.next();
+            Object o2 = e2.next();
+            if (!(o1 == null ? o2 == null : o1.equals(o2))) return false;
+        }
+        return !(e1.hasNext() || e2.hasNext());
+    }
+
+    public int hashCode() {
+        return super.hashCode();
+    }
+
+    protected void removeRange(int i, int i1) {
+        throw new RuntimeException("not implemented");
+    }
+
+    public boolean isEmpty() {
+        return size == 0;
+    }
+
+    public boolean contains(Object o) {
+        return indexOf(o) != -1;
+    }
+
+    public Object[] toArray() {
+        return toArray(new Object[size]);
+    }
+
+    public Object[] toArray(Object[] objects) {
+        if (objects.length < size) objects = new Object[size];
+        for (int i = 0; i < size; i++) {
+            objects[i] = elements[i];
+        }
+        return objects;
+    }
+
+    public boolean remove(Object o) {
+        throw new RuntimeException("not implemented");
+    }
+
+    public boolean containsAll(Collection collection) {
+        throw new RuntimeException("not implemented");
+    }
+
+    public boolean addAll(Collection collection) {
+        return addAll(size, collection);
+    }
+
+    public boolean removeAll(Collection collection) {
+        throw new RuntimeException("not implemented");
+    }
+
+    public boolean retainAll(Collection collection) {
+        throw new RuntimeException("not implemented");
+    }
+
+    private void ensureCapacity(int additional) {
+        if ((size + additional) > elements.length) increaseSize((size + additional) * 2);
+    }
+
+    private void copyArray() {
+        increaseSize(elements.length);
+    }
+
+    private void increaseSize(int newSize) {
+        E[] newElements = (E[]) new Object[newSize];
+        for (int i = 0; i < elements.length; i++)
+            newElements[i] = elements[i];
+
+        elements = newElements;
+
+        updated = true;
+    }
+
+    public String toString() {
+        return super.toString();
+    }
+}

--- a/core/src/main/java/org/mvel2/util/FunctionParser.java
+++ b/core/src/main/java/org/mvel2/util/FunctionParser.java
@@ -1,0 +1,119 @@
+package org.mvel2.util;
+
+import static org.mvel2.util.ParseTools.balancedCaptureWithLineAccounting;
+
+import org.mvel2.CompileException;
+import org.mvel2.ParserContext;
+import org.mvel2.ast.EndOfStatement;
+import org.mvel2.ast.Function;
+
+public class FunctionParser {
+
+    private String name;
+
+    private int cursor;
+    private int length;
+
+    private int fields;
+    private char[] expr;
+    private ParserContext pCtx;
+
+    private ExecutionStack splitAccumulator;
+
+    public FunctionParser(String functionName, int cursor, int endOffset, char[] expr, int fields, ParserContext pCtx,
+            ExecutionStack splitAccumulator) {
+
+        this.name = functionName;
+        this.cursor = cursor;
+        this.length = endOffset;
+
+        this.expr = expr;
+        this.fields = fields;
+        this.pCtx = pCtx;
+        this.splitAccumulator = splitAccumulator;
+    }
+
+    public Function parse() {
+        int start = cursor;
+
+        int startCond = 0;
+        int endCond = 0;
+
+        int blockStart;
+        int blockEnd;
+
+        int end = cursor + length;
+
+        cursor = ParseTools.captureToNextTokenJunction(expr, cursor, end, pCtx);
+
+        if (expr[cursor = ParseTools.nextNonBlank(expr, cursor)] == '(') {
+            /**
+             * If we discover an opening bracket after the function name, we check to see
+             * if this function accepts parameters.
+             */
+            endCond = cursor = balancedCaptureWithLineAccounting(expr, startCond = cursor, end, '(', pCtx);
+            startCond++;
+            cursor++;
+
+            cursor = ParseTools.skipWhitespace(expr, cursor);
+
+            if (cursor >= end) {
+                throw new CompileException("incomplete statement", expr, cursor);
+            } else if (expr[cursor] == '{') {
+                blockEnd = cursor = balancedCaptureWithLineAccounting(expr, blockStart = cursor, end, '{', pCtx);
+            } else {
+                blockStart = cursor - 1;
+                cursor = ParseTools.captureToEOS(expr, cursor, end, pCtx);
+                blockEnd = cursor;
+            }
+        } else {
+            /**
+             * This function has not parameters.
+             */
+            if (expr[cursor] == '{') {
+                /**
+                 * This function is bracketed.  We capture the entire range in the brackets.
+                 */
+                blockEnd = cursor = balancedCaptureWithLineAccounting(expr, blockStart = cursor, end, '{', pCtx);
+            } else {
+                /**
+                 * This is a single statement function declaration.  We only capture the statement.
+                 */
+                blockStart = cursor - 1;
+                cursor = ParseTools.captureToEOS(expr, cursor, end, pCtx);
+                blockEnd = cursor;
+            }
+        }
+
+        /**
+         * Trim any whitespace from the captured block range.
+         */
+        blockStart = ParseTools.trimRight(expr, blockStart + 1);
+        blockEnd = ParseTools.trimLeft(expr, start, blockEnd);
+
+        cursor++;
+
+        /**
+         * Check if the function is manually terminated.
+         */
+        if (splitAccumulator != null && ParseTools.isStatementNotManuallyTerminated(expr, cursor)) {
+            /**
+             * Add an EndOfStatement to the split accumulator in the parser.
+             */
+            splitAccumulator.add(new EndOfStatement(pCtx));
+        }
+
+        /**
+         * Produce the funciton node.
+         */
+        return new Function(name, expr, startCond, endCond - startCond, blockStart, blockEnd - blockStart, fields, pCtx);
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public int getCursor() {
+        return cursor;
+    }
+}

--- a/core/src/main/java/org/mvel2/util/InternalNumber.java
+++ b/core/src/main/java/org/mvel2/util/InternalNumber.java
@@ -1,0 +1,90 @@
+/**
+ * MVEL 2.0
+ * Copyright (C) 2007 The Codehaus
+ * Mike Brock, Dhanji Prasanna, John Graham, Mark Proctor
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mvel2.util;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.math.MathContext;
+
+public class InternalNumber extends BigDecimal {
+
+    public InternalNumber(char[] chars, int i, int i1) {
+        super(chars, i, i1);
+    }
+
+    public InternalNumber(char[] chars, int i, int i1, MathContext mathContext) {
+        super(chars, i, i1, mathContext);
+    }
+
+    public InternalNumber(char[] chars) {
+        super(chars);
+    }
+
+    public InternalNumber(char[] chars, MathContext mathContext) {
+        super(chars, mathContext);
+    }
+
+    public InternalNumber(String s) {
+        super(s);
+    }
+
+    public InternalNumber(String s, MathContext mathContext) {
+        super(s, mathContext);
+    }
+
+    public InternalNumber(double v) {
+        super(v);
+    }
+
+    public InternalNumber(double v, MathContext mathContext) {
+        super(v, mathContext);
+    }
+
+    public InternalNumber(BigInteger bigInteger) {
+        super(bigInteger);
+    }
+
+    public InternalNumber(BigInteger bigInteger, MathContext mathContext) {
+        super(bigInteger, mathContext);
+    }
+
+    public InternalNumber(BigInteger bigInteger, int i) {
+        super(bigInteger, i);
+    }
+
+    public InternalNumber(BigInteger bigInteger, int i, MathContext mathContext) {
+        super(bigInteger, i, mathContext);
+    }
+
+    public InternalNumber(int i) {
+        super(i);
+    }
+
+    public InternalNumber(int i, MathContext mathContext) {
+        super(i, mathContext);
+    }
+
+    public InternalNumber(long l) {
+        super(l);
+    }
+
+    public InternalNumber(long l, MathContext mathContext) {
+        super(l, mathContext);
+    }
+}

--- a/core/src/main/java/org/mvel2/util/JITClassLoader.java
+++ b/core/src/main/java/org/mvel2/util/JITClassLoader.java
@@ -1,0 +1,30 @@
+/**
+ * MVEL 2.0
+ * Copyright (C) 2007 The Codehaus
+ * Mike Brock, Dhanji Prasanna, John Graham, Mark Proctor
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mvel2.util;
+
+public class JITClassLoader extends ClassLoader implements MVELClassLoader {
+
+    public JITClassLoader(ClassLoader classLoader) {
+        super(classLoader);
+    }
+
+    public Class<?> defineClassX(String className, byte[] b, int off, int len) {
+        return super.defineClass(className, b, off, len);
+    }
+}

--- a/core/src/main/java/org/mvel2/util/LineMapper.java
+++ b/core/src/main/java/org/mvel2/util/LineMapper.java
@@ -1,0 +1,99 @@
+package org.mvel2.util;
+
+import java.util.ArrayList;
+import java.util.Set;
+import java.util.TreeSet;
+
+/**
+ * @author Mike Brock <cbrock@redhat.com>
+ */
+public class LineMapper {
+
+    private char[] expr;
+
+    private ArrayList<Node> lineMapping;
+    private Set<Integer> lines;
+
+    public LineMapper(char[] expr) {
+        this.expr = expr;
+    }
+
+    public LineLookup map() {
+        lineMapping = new ArrayList<Node>();
+        lines = new TreeSet<Integer>();
+
+        int cursor = 0;
+        int start = 0;
+        int line = 1;
+
+        for (; cursor < expr.length; cursor++) {
+            switch (expr[cursor]) {
+                case '\n':
+                    lines.add(line);
+                    lineMapping.add(new Node(start, cursor, line++));
+                    start = cursor + 1;
+                    break;
+            }
+        }
+
+        if (cursor > start) {
+            lines.add(line);
+            lineMapping.add(new Node(start, cursor, line));
+        }
+
+        return new LineLookup() {
+
+            public int getLineFromCursor(int cursor) {
+                for (Node n : lineMapping) {
+                    if (n.isInRange(cursor)) {
+                        return n.getLine();
+                    }
+                }
+                return -1;
+            }
+
+            public boolean hasLine(int line) {
+                return lines.contains(line);
+            }
+        };
+    }
+
+    public static interface LineLookup {
+
+        public int getLineFromCursor(int cursor);
+
+        public boolean hasLine(int line);
+    }
+
+    private static class Node implements Comparable<Node> {
+
+        private int cursorStart;
+        private int cursorEnd;
+
+        private int line;
+
+        private Node(int cursorStart, int cursorEnd, int line) {
+            this.cursorStart = cursorStart;
+            this.cursorEnd = cursorEnd;
+            this.line = line;
+        }
+
+        public int getLine() {
+            return line;
+        }
+
+        public boolean isInRange(int cursor) {
+            return cursor >= cursorStart && cursor <= cursorEnd;
+        }
+
+        public int compareTo(Node node) {
+            if (node.cursorStart >= cursorEnd) {
+                return 1;
+            } else if (node.cursorEnd < cursorStart) {
+                return -1;
+            } else {
+                return 0;
+            }
+        }
+    }
+}

--- a/core/src/main/java/org/mvel2/util/MVELClassLoader.java
+++ b/core/src/main/java/org/mvel2/util/MVELClassLoader.java
@@ -1,0 +1,25 @@
+/**
+ * MVEL 2.0
+ * Copyright (C) 2007 The Codehaus
+ * Mike Brock, Dhanji Prasanna, John Graham, Mark Proctor
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mvel2.util;
+
+public interface MVELClassLoader {
+
+    public Class defineClassX(String className, byte[] b, int start, int end);
+
+}

--- a/core/src/main/java/org/mvel2/util/Make.java
+++ b/core/src/main/java/org/mvel2/util/Make.java
@@ -1,0 +1,163 @@
+package org.mvel2.util;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+
+public class Make {
+
+    public static class Map<K, V> {
+
+        private java.util.Map<K, V> mapInstance;
+
+        private Map(java.util.Map<K, V> mapInstance) {
+            this.mapInstance = mapInstance;
+        }
+
+        public static <K, V> Map<K, V> $() {
+            return start();
+        }
+
+        public static <K, V> Map<K, V> start() {
+            return new Map(new HashMap());
+        }
+
+        public static <K, V> Map<K, V> start(Class<? extends java.util.Map> mapImpl) {
+            try {
+                return new Map(mapImpl.newInstance());
+            } catch (Throwable t) {
+                throw new RuntimeException("error creating instance", t);
+            }
+        }
+
+        public Map<K, V> _(K key, V value) {
+            mapInstance.put(key, value);
+            return this;
+        }
+
+        public java.util.Map<K, V> _() {
+            return finish();
+        }
+
+        public java.util.Map<K, V> finish() {
+            return mapInstance;
+        }
+    }
+
+    public static class String {
+
+        private StringBuilder stringAppender;
+
+        String(StringBuilder stringAppender) {
+            this.stringAppender = stringAppender;
+        }
+
+        public static String $() {
+            return start();
+        }
+
+        public static String start() {
+            return new String(new StringBuilder());
+        }
+
+        public java.lang.String _() {
+            return finish();
+        }
+
+        public java.lang.String finish() {
+            return stringAppender.toString();
+        }
+
+        public String _(char c) {
+            stringAppender.append(c);
+            return this;
+        }
+
+        public String _(CharSequence cs) {
+            stringAppender.append(cs);
+            return this;
+        }
+
+        public String _(String s) {
+            stringAppender.append(s);
+            return this;
+        }
+    }
+
+    public static class List<V> {
+
+        private java.util.List<V> listInstance;
+
+        List(java.util.List<V> listInstance) {
+            this.listInstance = listInstance;
+        }
+
+        public static <V> List<V> $() {
+            return start();
+        }
+
+        public static <V> List<V> start() {
+            return new List(new ArrayList());
+        }
+
+        public static <V> List<V> start(Class<? extends java.util.List> listImpl) {
+            try {
+                return new List(listImpl.newInstance());
+            } catch (Throwable t) {
+                throw new RuntimeException("error creating instance", t);
+            }
+        }
+
+        public List<V> _(V value) {
+            listInstance.add(value);
+            return this;
+        }
+
+        public java.util.List<V> _() {
+            return finish();
+        }
+
+        public java.util.List<V> finish() {
+            return listInstance;
+        }
+    }
+
+    public static class Set<V> {
+
+        private java.util.Set<V> listInstance;
+
+        Set(java.util.Set<V> listInstance) {
+            this.listInstance = listInstance;
+        }
+
+        public static <V> Set<V> $() {
+            return start();
+        }
+
+        public static <V> Set<V> start() {
+            return new Set(new HashSet());
+        }
+
+        public static <V> Set<V> start(Class<? extends java.util.Set> listImpl) {
+            try {
+                return new Set(listImpl.newInstance());
+            } catch (Throwable t) {
+                throw new RuntimeException("error creating instance", t);
+            }
+        }
+
+        public Set<V> _(V value) {
+            listInstance.add(value);
+            return this;
+        }
+
+        public java.util.Set<V> _() {
+            return finish();
+        }
+
+        public java.util.Set<V> finish() {
+            return listInstance;
+        }
+    }
+
+}

--- a/core/src/main/java/org/mvel2/util/MethodStub.java
+++ b/core/src/main/java/org/mvel2/util/MethodStub.java
@@ -1,0 +1,72 @@
+/**
+ * MVEL 2.0
+ * Copyright (C) 2007 The Codehaus
+ * Mike Brock, Dhanji Prasanna, John Graham, Mark Proctor
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mvel2.util;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+
+import org.mvel2.integration.VariableResolverFactory;
+
+public class MethodStub implements StaticStub {
+
+    private Class classReference;
+    private String name;
+
+    private transient Method method;
+
+    public MethodStub(Method method) {
+        this.classReference = method.getDeclaringClass();
+        this.name = method.getName();
+    }
+
+    public MethodStub(Class classReference, String methodName) {
+        this.classReference = classReference;
+        this.name = methodName;
+    }
+
+    public Class getClassReference() {
+        return classReference;
+    }
+
+    public void setClassReference(Class classReference) {
+        this.classReference = classReference;
+    }
+
+    public String getMethodName() {
+        return name;
+    }
+
+    public void setMethodName(String methodName) {
+        this.name = methodName;
+    }
+
+    public Method getMethod() {
+        if (method == null) {
+            for (Method method : classReference.getMethods()) {
+                if (name.equals(method.getName())) return this.method = method;
+            }
+        }
+        return method;
+    }
+
+    public Object call(Object ctx, Object thisCtx, VariableResolverFactory factory, Object[] parameters)
+            throws IllegalAccessException, InvocationTargetException {
+        return method.invoke(ctx, parameters);
+    }
+}

--- a/core/src/main/java/org/mvel2/util/NullType.java
+++ b/core/src/main/java/org/mvel2/util/NullType.java
@@ -1,0 +1,7 @@
+package org.mvel2.util;
+
+/**
+ * @author Mike Brock .
+ */
+public class NullType {
+}

--- a/core/src/main/java/org/mvel2/util/ParseTools.java
+++ b/core/src/main/java/org/mvel2/util/ParseTools.java
@@ -1,0 +1,2084 @@
+/**
+ * MVEL 2.0
+ * Copyright (C) 2007 The Codehaus
+ * Mike Brock, Dhanji Prasanna, John Graham, Mark Proctor
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mvel2.util;
+
+import static java.lang.Class.forName;
+import static java.lang.Double.parseDouble;
+import static java.lang.String.valueOf;
+import static java.lang.System.arraycopy;
+import static java.lang.Thread.currentThread;
+import static java.nio.ByteBuffer.allocateDirect;
+import static org.mvel2.DataConversion.canConvert;
+import static org.mvel2.DataTypes.DOUBLE;
+import static org.mvel2.DataTypes.INTEGER;
+import static org.mvel2.DataTypes.LONG;
+import static org.mvel2.MVEL.getDebuggingOutputFileName;
+import static org.mvel2.compiler.AbstractParser.LITERALS;
+import static org.mvel2.integration.ResolverTools.appendFactory;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.Serializable;
+import java.lang.ref.WeakReference;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.math.MathContext;
+import java.nio.ByteBuffer;
+import java.nio.channels.ReadableByteChannel;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.WeakHashMap;
+
+import org.mvel2.CompileException;
+import org.mvel2.DataTypes;
+import org.mvel2.MVEL;
+import org.mvel2.Operator;
+import org.mvel2.OptimizationFailure;
+import org.mvel2.ParserContext;
+import org.mvel2.ast.ASTNode;
+import org.mvel2.compiler.AbstractParser;
+import org.mvel2.compiler.BlankLiteral;
+import org.mvel2.compiler.CompiledExpression;
+import org.mvel2.compiler.ExecutableAccessor;
+import org.mvel2.compiler.ExecutableAccessorSafe;
+import org.mvel2.compiler.ExecutableLiteral;
+import org.mvel2.compiler.ExpressionCompiler;
+import org.mvel2.integration.VariableResolverFactory;
+import org.mvel2.integration.impl.ClassImportResolverFactory;
+import org.mvel2.math.MathProcessor;
+
+@SuppressWarnings({ "ManualArrayCopy" })
+public class ParseTools {
+
+    public static final Object[] EMPTY_OBJ_ARR = new Object[0];
+    public static final Class[] EMPTY_CLS_ARR = new Class[0];
+    private static final Map<Constructor, WeakReference<Class[]>> CONSTRUCTOR_PARMS_CACHE = Collections
+            .synchronizedMap(new WeakHashMap<Constructor, WeakReference<Class[]>>(10));
+    private static final Map<ClassLoader, Map<String, WeakReference<Class>>> CLASS_RESOLVER_CACHE = Collections
+            .synchronizedMap(new WeakHashMap<ClassLoader, Map<String, WeakReference<Class>>>(1, 1.0f));
+    private static final Map<Class, WeakReference<Constructor[]>> CLASS_CONSTRUCTOR_CACHE = Collections
+            .synchronizedMap(new WeakHashMap<Class, WeakReference<Constructor[]>>(10));
+    private static final HashMap<Class, Integer> typeResolveMap = new HashMap<Class, Integer>();
+    private static final Map<Class, Integer> typeCodes = new HashMap<Class, Integer>(30, 0.5f);
+
+    static {
+        Map<Class, Integer> t = typeResolveMap;
+        t.put(BigDecimal.class, DataTypes.BIG_DECIMAL);
+        t.put(BigInteger.class, DataTypes.BIG_INTEGER);
+        t.put(String.class, DataTypes.STRING);
+
+        t.put(int.class, INTEGER);
+        t.put(Integer.class, DataTypes.W_INTEGER);
+
+        t.put(short.class, DataTypes.SHORT);
+        t.put(Short.class, DataTypes.W_SHORT);
+
+        t.put(float.class, DataTypes.FLOAT);
+        t.put(Float.class, DataTypes.W_FLOAT);
+
+        t.put(double.class, DOUBLE);
+        t.put(Double.class, DataTypes.W_DOUBLE);
+
+        t.put(long.class, LONG);
+        t.put(Long.class, DataTypes.W_LONG);
+
+        t.put(boolean.class, DataTypes.BOOLEAN);
+        t.put(Boolean.class, DataTypes.W_BOOLEAN);
+
+        t.put(byte.class, DataTypes.BYTE);
+        t.put(Byte.class, DataTypes.W_BYTE);
+
+        t.put(char.class, DataTypes.CHAR);
+        t.put(Character.class, DataTypes.W_CHAR);
+
+        t.put(BlankLiteral.class, DataTypes.EMPTY);
+    }
+
+    static {
+        typeCodes.put(Integer.class, DataTypes.W_INTEGER);
+        typeCodes.put(Double.class, DataTypes.W_DOUBLE);
+        typeCodes.put(Boolean.class, DataTypes.W_BOOLEAN);
+        typeCodes.put(String.class, DataTypes.STRING);
+        typeCodes.put(Long.class, DataTypes.W_LONG);
+        typeCodes.put(Short.class, DataTypes.W_SHORT);
+        typeCodes.put(Float.class, DataTypes.W_FLOAT);
+        typeCodes.put(Byte.class, DataTypes.W_BYTE);
+        typeCodes.put(Character.class, DataTypes.W_CHAR);
+
+        typeCodes.put(BigDecimal.class, DataTypes.BIG_DECIMAL);
+        typeCodes.put(BigInteger.class, DataTypes.BIG_INTEGER);
+
+        typeCodes.put(int.class, DataTypes.INTEGER);
+        typeCodes.put(double.class, DataTypes.DOUBLE);
+        typeCodes.put(boolean.class, DataTypes.BOOLEAN);
+        typeCodes.put(long.class, DataTypes.LONG);
+        typeCodes.put(short.class, DataTypes.SHORT);
+        typeCodes.put(float.class, DataTypes.FLOAT);
+        typeCodes.put(byte.class, DataTypes.BYTE);
+        typeCodes.put(char.class, DataTypes.CHAR);
+
+        typeCodes.put(BlankLiteral.class, DataTypes.EMPTY);
+    }
+
+    public static List<char[]> parseMethodOrConstructor(char[] parm) {
+        int start = -1;
+        for (int i = 0; i < parm.length; i++) {
+            if (parm[i] == '(') {
+                start = ++i;
+                break;
+            }
+        }
+        if (start != -1) {
+            return parseParameterList(parm, --start + 1, balancedCapture(parm, start, '(') - start - 1);
+        }
+
+        return Collections.emptyList();
+    }
+
+    public static String[] parseParameterDefList(char[] parm, int offset, int length) {
+        List<String> list = new LinkedList<String>();
+
+        if (length == -1) length = parm.length;
+
+        int start = offset;
+        int i = offset;
+        int end = i + length;
+        String s;
+
+        for (; i < end; i++) {
+            switch (parm[i]) {
+                case '(':
+                case '[':
+                case '{':
+                    i = balancedCapture(parm, i, parm[i]);
+                    continue;
+
+                case '\'':
+                    i = captureStringLiteral('\'', parm, i, parm.length);
+                    continue;
+
+                case '"':
+                    i = captureStringLiteral('"', parm, i, parm.length);
+                    continue;
+
+                case ',':
+                    if (i > start) {
+                        while (isWhitespace(parm[start]))
+                            start++;
+
+                        checkNameSafety(s = new String(parm, start, i - start));
+
+                        list.add(s);
+                    }
+
+                    while (isWhitespace(parm[i]))
+                        i++;
+
+                    start = i + 1;
+                    continue;
+
+                default:
+                    if (!isWhitespace(parm[i]) && !isIdentifierPart(parm[i])) {
+                        throw new CompileException("expected parameter", parm, start);
+                    }
+            }
+        }
+
+        if (start < (length + offset) && i > start) {
+            if ((s = createStringTrimmed(parm, start, i - start)).length() > 0) {
+                checkNameSafety(s);
+                list.add(s);
+            }
+        } else if (list.size() == 0) {
+            if ((s = createStringTrimmed(parm, start, length)).length() > 0) {
+                checkNameSafety(s);
+                list.add(s);
+            }
+        }
+
+        return list.toArray(new String[list.size()]);
+    }
+
+    public static List<char[]> parseParameterList(char[] parm, int offset, int length) {
+        List<char[]> list = new ArrayList<char[]>();
+
+        if (length == -1) length = parm.length;
+
+        int start = offset;
+        int i = offset;
+        int end = i + length;
+
+        for (; i < end; i++) {
+            switch (parm[i]) {
+                case '(':
+                case '[':
+                case '{':
+                    i = balancedCapture(parm, i, parm[i]);
+                    continue;
+
+                case '\'':
+                    i = captureStringLiteral('\'', parm, i, parm.length);
+                    continue;
+
+                case '"':
+                    i = captureStringLiteral('"', parm, i, parm.length);
+                    continue;
+
+                case ',':
+                    if (i > start) {
+                        while (isWhitespace(parm[start]))
+                            start++;
+
+                        list.add(subsetTrimmed(parm, start, i - start));
+                    }
+
+                    while (isWhitespace(parm[i]))
+                        i++;
+
+                    start = i + 1;
+            }
+        }
+
+        if (start < (length + offset) && i > start) {
+            char[] s = subsetTrimmed(parm, start, i - start);
+            if (s.length > 0) list.add(s);
+        } else if (list.size() == 0) {
+            char[] s = subsetTrimmed(parm, start, length);
+            if (s.length > 0) list.add(s);
+        }
+
+        return list;
+    }
+
+    public static Method getBestCandidate(Object[] arguments, String method, Class decl, Method[] methods, boolean requireExact) {
+        Class[] targetParms = new Class[arguments.length];
+        for (int i = 0; i != arguments.length; i++) {
+            targetParms[i] = arguments[i] != null ? arguments[i].getClass() : null;
+        }
+        return getBestCandidate(targetParms, method, decl, methods, requireExact);
+    }
+
+    public static Method getBestCandidate(Class[] arguments, String method, Class decl, Method[] methods, boolean requireExact) {
+        return getBestCandidate(arguments, method, decl, methods, requireExact, false);
+    }
+
+    public static Method getBestCandidate(Class[] arguments, String method, Class decl, Method[] methods, boolean requireExact,
+            boolean classTarget) {
+
+        if (methods.length == 0) {
+            return null;
+        }
+
+        Class<?>[] parmTypes;
+        Method bestCandidate = null;
+        int bestScore = -1;
+        boolean retry = false;
+
+        do {
+            for (Method meth : methods) {
+                if (classTarget && !Modifier.isStatic(meth.getModifiers())) continue;
+
+                if (method.equals(meth.getName())) {
+                    parmTypes = meth.getParameterTypes();
+                    if (parmTypes.length == 0 && arguments.length == 0) {
+                        if (bestCandidate == null || isMoreSpecialized(meth, bestCandidate)) {
+                            bestCandidate = meth;
+                        }
+                        continue;
+                    }
+
+                    boolean isVarArgs = meth.isVarArgs();
+                    if (isArgsNumberNotCompatible(arguments, parmTypes, isVarArgs)) {
+                        continue;
+                    }
+
+                    int score = getMethodScore(arguments, requireExact, parmTypes, isVarArgs);
+                    if (score != 0) {
+                        if (score > bestScore) {
+                            bestCandidate = meth;
+                            bestScore = score;
+                        } else if (score == bestScore) {
+                            if (isMoreSpecialized(meth, bestCandidate) && !isVarArgs) {
+                                bestCandidate = meth;
+                            }
+                        }
+                    }
+                }
+            }
+
+            if (bestCandidate != null) {
+                break;
+            }
+
+            if (!retry && decl.isInterface()) {
+                Method[] objMethods = Object.class.getMethods();
+                Method[] nMethods = new Method[methods.length + objMethods.length];
+                for (int i = 0; i < methods.length; i++) {
+                    nMethods[i] = methods[i];
+                }
+
+                for (int i = 0; i < objMethods.length; i++) {
+                    nMethods[i + methods.length] = objMethods[i];
+                }
+                methods = nMethods;
+
+                retry = true;
+            } else {
+                break;
+            }
+        } while (true);
+
+        return bestCandidate;
+    }
+
+    private static boolean isArgsNumberNotCompatible(Class[] arguments, Class<?>[] parmTypes, boolean isVarArgs) {
+        return (isVarArgs && parmTypes.length - 1 > arguments.length) || (!isVarArgs && parmTypes.length != arguments.length);
+    }
+
+    private static boolean isMoreSpecialized(Method newCandidate, Method oldCandidate) {
+        return oldCandidate.getReturnType().isAssignableFrom(newCandidate.getReturnType())
+                && oldCandidate.getDeclaringClass().isAssignableFrom(newCandidate.getDeclaringClass());
+    }
+
+    private static int getMethodScore(Class[] arguments, boolean requireExact, Class<?>[] parmTypes, boolean varArgs) {
+        int score = 0;
+        for (int i = 0; i != arguments.length; i++) {
+            Class<?> actualParamType;
+            if (varArgs && i >= parmTypes.length - 1) actualParamType = parmTypes[parmTypes.length - 1].getComponentType();
+            else actualParamType = parmTypes[i];
+
+            if (arguments[i] == null) {
+                if (!actualParamType.isPrimitive()) {
+                    score += 7;
+                } else {
+                    score = 0;
+                    break;
+                }
+            } else if (actualParamType == arguments[i]) {
+                score += 8;
+            } else if (actualParamType.isPrimitive() && boxPrimitive(actualParamType) == arguments[i]) {
+                score += 7;
+            } else if (arguments[i].isPrimitive() && unboxPrimitive(arguments[i]) == actualParamType) {
+                score += 7;
+            } else if (actualParamType.isAssignableFrom(arguments[i])) {
+                score += 6;
+            } else if (isPrimitiveSubtype(arguments[i], actualParamType)) {
+                score += 5;
+            } else if (isNumericallyCoercible(arguments[i], actualParamType)) {
+                score += 4;
+            } else if (boxPrimitive(actualParamType).isAssignableFrom(boxPrimitive(arguments[i])) && Object.class != arguments[i]) {
+                score += 3 + scoreInterface(actualParamType, arguments[i]);
+            } else if (!requireExact && canConvert(actualParamType, arguments[i])) {
+                if (actualParamType.isArray() && arguments[i].isArray()) score += 1;
+                else if (actualParamType == char.class && arguments[i] == String.class) score += 1;
+
+                score += 1;
+            } else if (actualParamType == Object.class || arguments[i] == NullType.class) {
+                score += 1;
+            } else {
+                score = 0;
+                break;
+            }
+        }
+        if (score == 0 && varArgs && parmTypes.length - 1 == arguments.length) {
+            score += 3;
+        }
+        return score;
+    }
+
+    public static int scoreInterface(Class<?> parm, Class<?> arg) {
+        if (parm.isInterface()) {
+            Class[] iface = arg.getInterfaces();
+            if (iface != null) {
+                for (Class c : iface) {
+                    if (c == parm) return 1;
+                    else if (parm.isAssignableFrom(c)) return scoreInterface(parm, arg.getSuperclass());
+                }
+            }
+        }
+        return 0;
+    }
+
+    public static Method getExactMatch(String name, Class[] args, Class returnType, Class cls) {
+        outer: for (Method meth : cls.getMethods()) {
+            if (name.equals(meth.getName()) && returnType == meth.getReturnType()) {
+                Class[] parameterTypes = meth.getParameterTypes();
+                if (parameterTypes.length != args.length) continue;
+
+                for (int i = 0; i < parameterTypes.length; i++) {
+                    if (parameterTypes[i] != args[i]) continue outer;
+                }
+                return meth;
+            }
+        }
+        return null;
+    }
+
+    public static Method getWidenedTarget(Method method) {
+        return getWidenedTarget(method.getDeclaringClass(), method);
+    }
+
+    public static Method getWidenedTarget(Class cls, Method method) {
+        if (Modifier.isStatic(method.getModifiers())) {
+            return method;
+        }
+
+        Method m = method, best = method;
+        Class[] args = method.getParameterTypes();
+        String name = method.getName();
+        Class rt = m.getReturnType();
+
+        Class currentCls = cls;
+        while (currentCls != null) {
+            for (Class iface : currentCls.getInterfaces()) {
+                if ((m = getExactMatch(name, args, rt, iface)) != null) {
+                    best = m;
+                }
+            }
+            currentCls = currentCls.getSuperclass();
+        }
+
+        if (best != method) return best;
+
+        for (currentCls = cls; currentCls != null; currentCls = currentCls.getSuperclass()) {
+            if ((m = getExactMatch(name, args, rt, currentCls)) != null) {
+                best = m;
+            }
+        }
+        return best;
+    }
+
+    private static Class[] getConstructors(Constructor cns) {
+        WeakReference<Class[]> ref = CONSTRUCTOR_PARMS_CACHE.get(cns);
+        Class[] parms;
+        if (ref != null && (parms = ref.get()) != null) {
+            return parms;
+        } else {
+            CONSTRUCTOR_PARMS_CACHE.put(cns, new WeakReference<Class[]>(parms = cns.getParameterTypes()));
+            return parms;
+        }
+    }
+
+    public static Constructor getBestConstructorCandidate(Object[] args, Class cls, boolean requireExact) {
+        Class[] arguments = new Class[args.length];
+
+        for (int i = 0; i != args.length; i++) {
+            if (args[i] != null) {
+                arguments[i] = args[i].getClass();
+            }
+        }
+
+        return getBestConstructorCandidate(arguments, cls, requireExact);
+    }
+
+    public static Constructor getBestConstructorCandidate(Class[] arguments, Class cls, boolean requireExact) {
+        Class[] parmTypes;
+        Constructor bestCandidate = null;
+        int bestScore = 0;
+
+        for (Constructor construct : getConstructors(cls)) {
+            boolean isVarArgs = construct.isVarArgs();
+            parmTypes = getConstructors(construct);
+            if (isArgsNumberNotCompatible(arguments, parmTypes, isVarArgs)) {
+                continue;
+            } else if (arguments.length == 0 && parmTypes.length == 0) {
+                return construct;
+            }
+
+            int score = getMethodScore(arguments, requireExact, parmTypes, isVarArgs);
+            if (score != 0 && score > bestScore) {
+                bestCandidate = construct;
+                bestScore = score;
+            }
+        }
+
+        return bestCandidate;
+    }
+
+    public static Class createClass(String className, ParserContext pCtx) throws ClassNotFoundException {
+        ClassLoader classLoader = pCtx != null ? pCtx.getClassLoader() : currentThread().getContextClassLoader();
+
+        Map<String, WeakReference<Class>> cache = CLASS_RESOLVER_CACHE.get(classLoader);
+
+        if (cache == null) {
+            CLASS_RESOLVER_CACHE.put(classLoader, cache = Collections.synchronizedMap(new WeakHashMap<String, WeakReference<Class>>(10)));
+        }
+
+        WeakReference<Class> ref;
+        Class cls;
+
+        if ((ref = cache.get(className)) != null && (cls = ref.get()) != null) {
+            return cls;
+        } else {
+            try {
+                cls = Class.forName(className, true, classLoader);
+            } catch (ClassNotFoundException e) {
+                /**
+                 * Now try the system classloader.
+                 */
+                if (classLoader != Thread.currentThread().getContextClassLoader()) {
+                    cls = forName(className, true, Thread.currentThread().getContextClassLoader());
+                } else {
+                    throw e;
+                }
+            }
+
+            cache.put(className, new WeakReference<Class>(cls));
+            return cls;
+        }
+    }
+
+    public static Constructor[] getConstructors(Class cls) {
+        WeakReference<Constructor[]> ref = CLASS_CONSTRUCTOR_CACHE.get(cls);
+        Constructor[] cns;
+
+        if (ref != null && (cns = ref.get()) != null) {
+            return cns;
+        } else {
+            CLASS_CONSTRUCTOR_CACHE.put(cls, new WeakReference<Constructor[]>(cns = cls.getConstructors()));
+            return cns;
+        }
+    }
+
+    public static String[] captureContructorAndResidual(char[] cs, int start, int offset) {
+        int depth = 0;
+        int end = start + offset;
+        boolean inQuotes = false;
+        for (int i = start; i < end; i++) {
+            switch (cs[i]) {
+                case '"':
+                    inQuotes = !inQuotes;
+                    break;
+                case '(':
+                    depth++;
+                    break;
+                case ')':
+                    if (!inQuotes) {
+                        if (1 == depth--) {
+                            return new String[] { createStringTrimmed(cs, start, ++i - start), createStringTrimmed(cs, i, end - i) };
+                        }
+                    }
+            }
+        }
+        return new String[] { new String(cs, start, offset) };
+    }
+
+    public static Class<?> boxPrimitive(Class cls) {
+        if (cls == int.class || cls == Integer.class) {
+            return Integer.class;
+        } else if (cls == int[].class || cls == Integer[].class) {
+            return Integer[].class;
+        } else if (cls == char.class || cls == Character.class) {
+            return Character.class;
+        } else if (cls == char[].class || cls == Character[].class) {
+            return Character[].class;
+        } else if (cls == long.class || cls == Long.class) {
+            return Long.class;
+        } else if (cls == long[].class || cls == Long[].class) {
+            return Long[].class;
+        } else if (cls == short.class || cls == Short.class) {
+            return Short.class;
+        } else if (cls == short[].class || cls == Short[].class) {
+            return Short[].class;
+        } else if (cls == double.class || cls == Double.class) {
+            return Double.class;
+        } else if (cls == double[].class || cls == Double[].class) {
+            return Double[].class;
+        } else if (cls == float.class || cls == Float.class) {
+            return Float.class;
+        } else if (cls == float[].class || cls == Float[].class) {
+            return Float[].class;
+        } else if (cls == boolean.class || cls == Boolean.class) {
+            return Boolean.class;
+        } else if (cls == boolean[].class || cls == Boolean[].class) {
+            return Boolean[].class;
+        } else if (cls == byte.class || cls == Byte.class) {
+            return Byte.class;
+        } else if (cls == byte[].class || cls == Byte[].class) {
+            return Byte[].class;
+        }
+
+        return cls;
+    }
+
+    public static Class unboxPrimitive(Class cls) {
+        if (cls == Integer.class || cls == int.class) {
+            return int.class;
+        } else if (cls == Integer[].class || cls == int[].class) {
+            return int[].class;
+        } else if (cls == Long.class || cls == long.class) {
+            return long.class;
+        } else if (cls == Long[].class || cls == long[].class) {
+            return long[].class;
+        } else if (cls == Character.class || cls == char.class) {
+            return char.class;
+        } else if (cls == Character[].class || cls == char[].class) {
+            return char[].class;
+        } else if (cls == Short.class || cls == short.class) {
+            return short.class;
+        } else if (cls == Short[].class || cls == short[].class) {
+            return short[].class;
+        } else if (cls == Double.class || cls == double.class) {
+            return double.class;
+        } else if (cls == Double[].class || cls == double[].class) {
+            return double[].class;
+        } else if (cls == Float.class || cls == float.class) {
+            return float.class;
+        } else if (cls == Float[].class || cls == float[].class) {
+            return float[].class;
+        } else if (cls == Boolean.class || cls == boolean.class) {
+            return boolean.class;
+        } else if (cls == Boolean[].class || cls == boolean[].class) {
+            return boolean[].class;
+        } else if (cls == Byte.class || cls == byte.class) {
+            return byte.class;
+        } else if (cls == Byte[].class || cls == byte[].class) {
+            return byte[].class;
+        }
+
+        return cls;
+    }
+
+    public static boolean containsCheck(Object compareTo, Object compareTest) {
+        if (compareTo == null) return false;
+        else if (compareTo instanceof String) return ((String) compareTo).contains(valueOf(compareTest));
+        else if (compareTo instanceof Collection) return ((Collection) compareTo).contains(compareTest);
+        else if (compareTo instanceof Map) return ((Map) compareTo).containsKey(compareTest);
+        else if (compareTo.getClass().isArray()) {
+            if (compareTo.getClass().getComponentType().isPrimitive()) return containsCheckOnPrimitveArray(compareTo, compareTest);
+            for (Object o : ((Object[]) compareTo)) {
+                if (compareTest == null && o == null) return true;
+                if ((Boolean) MathProcessor.doOperations(o, Operator.EQUAL, compareTest)) return true;
+            }
+        }
+        return false;
+    }
+
+    private static boolean containsCheckOnPrimitveArray(Object primitiveArray, Object compareTest) {
+        Class<?> primitiveType = primitiveArray.getClass().getComponentType();
+        if (primitiveType == boolean.class)
+            return compareTest instanceof Boolean && containsCheckOnBooleanArray((boolean[]) primitiveArray, (Boolean) compareTest);
+        if (primitiveType == int.class)
+            return compareTest instanceof Integer && containsCheckOnIntArray((int[]) primitiveArray, (Integer) compareTest);
+        if (primitiveType == long.class)
+            return compareTest instanceof Long && containsCheckOnLongArray((long[]) primitiveArray, (Long) compareTest);
+        if (primitiveType == double.class)
+            return compareTest instanceof Double && containsCheckOnDoubleArray((double[]) primitiveArray, (Double) compareTest);
+        if (primitiveType == float.class)
+            return compareTest instanceof Float && containsCheckOnFloatArray((float[]) primitiveArray, (Float) compareTest);
+        if (primitiveType == char.class)
+            return compareTest instanceof Character && containsCheckOnCharArray((char[]) primitiveArray, (Character) compareTest);
+        if (primitiveType == short.class)
+            return compareTest instanceof Short && containsCheckOnShortArray((short[]) primitiveArray, (Short) compareTest);
+        if (primitiveType == byte.class)
+            return compareTest instanceof Byte && containsCheckOnByteArray((byte[]) primitiveArray, (Byte) compareTest);
+        return false;
+    }
+
+    private static boolean containsCheckOnBooleanArray(boolean[] array, Boolean compareTest) {
+        boolean test = compareTest;
+        for (boolean b : array)
+            if (b == test) return true;
+        return false;
+    }
+
+    private static boolean containsCheckOnIntArray(int[] array, Integer compareTest) {
+        int test = compareTest;
+        for (int i : array)
+            if (i == test) return true;
+        return false;
+    }
+
+    private static boolean containsCheckOnLongArray(long[] array, Long compareTest) {
+        long test = compareTest;
+        for (long l : array)
+            if (l == test) return true;
+        return false;
+    }
+
+    private static boolean containsCheckOnDoubleArray(double[] array, Double compareTest) {
+        double test = compareTest;
+        for (double d : array)
+            if (d == test) return true;
+        return false;
+    }
+
+    private static boolean containsCheckOnFloatArray(float[] array, Float compareTest) {
+        float test = compareTest;
+        for (float f : array)
+            if (f == test) return true;
+        return false;
+    }
+
+    private static boolean containsCheckOnCharArray(char[] array, Character compareTest) {
+        char test = compareTest;
+        for (char c : array)
+            if (c == test) return true;
+        return false;
+    }
+
+    private static boolean containsCheckOnShortArray(short[] array, Short compareTest) {
+        short test = compareTest;
+        for (short s : array)
+            if (s == test) return true;
+        return false;
+    }
+
+    private static boolean containsCheckOnByteArray(byte[] array, Byte compareTest) {
+        byte test = compareTest;
+        for (byte b : array)
+            if (b == test) return true;
+        return false;
+    }
+
+    /**
+     * Replace escape sequences and return trim required.
+     *
+     * @param escapeStr -
+     * @param pos       -
+     * @return -
+     */
+    public static int handleEscapeSequence(char[] escapeStr, int pos) {
+        escapeStr[pos - 1] = 0;
+
+        switch (escapeStr[pos]) {
+            case '\\':
+                escapeStr[pos] = '\\';
+                return 1;
+            case 'b':
+                escapeStr[pos] = '\b';
+                return 1;
+            case 'f':
+                escapeStr[pos] = '\f';
+                return 1;
+            case 't':
+                escapeStr[pos] = '\t';
+                return 1;
+            case 'r':
+                escapeStr[pos] = '\r';
+                return 1;
+            case 'n':
+                escapeStr[pos] = '\n';
+                return 1;
+            case '\'':
+                escapeStr[pos] = '\'';
+                return 1;
+            case '"':
+                escapeStr[pos] = '\"';
+                return 1;
+            case 'u':
+                //unicode
+                int s = pos;
+                if (s + 4 > escapeStr.length) throw new CompileException("illegal unicode escape sequence", escapeStr, pos);
+                else {
+                    while (++pos - s != 5) {
+                        if ((escapeStr[pos] > ('0' - 1) && escapeStr[pos] < ('9' + 1))
+                                || (escapeStr[pos] > ('A' - 1) && escapeStr[pos] < ('F' + 1))) {} else {
+                            throw new CompileException("illegal unicode escape sequence", escapeStr, pos);
+                        }
+                    }
+
+                    escapeStr[s - 1] = (char) Integer.decode("0x" + new String(escapeStr, s + 1, 4)).intValue();
+                    escapeStr[s] = 0;
+                    escapeStr[s + 1] = 0;
+                    escapeStr[s + 2] = 0;
+                    escapeStr[s + 3] = 0;
+                    escapeStr[s + 4] = 0;
+
+                    return 5;
+                }
+
+            default:
+                //octal
+                s = pos;
+                while (escapeStr[pos] >= '0' && escapeStr[pos] < '8') {
+                    if (pos != s && escapeStr[s] > '3') {
+                        escapeStr[s - 1] = (char) Integer.decode("0" + new String(escapeStr, s, pos - s + 1)).intValue();
+                        escapeStr[s] = 0;
+                        escapeStr[s + 1] = 0;
+                        return 2;
+                    } else if ((pos - s) == 2) {
+                        escapeStr[s - 1] = (char) Integer.decode("0" + new String(escapeStr, s, pos - s + 1)).intValue();
+                        escapeStr[s] = 0;
+                        escapeStr[s + 1] = 0;
+                        escapeStr[s + 2] = 0;
+                        return 3;
+                    }
+
+                    if (pos + 1 == escapeStr.length || (escapeStr[pos] < '0' || escapeStr[pos] > '7')) {
+                        escapeStr[s - 1] = (char) Integer.decode("0" + new String(escapeStr, s, pos - s + 1)).intValue();
+                        escapeStr[s] = 0;
+                        return 1;
+                    }
+
+                    pos++;
+                }
+                throw new CompileException("illegal escape sequence: " + escapeStr[pos], escapeStr, pos);
+        }
+    }
+
+    public static char[] createShortFormOperativeAssignment(String name, char[] statement, int start, int offset, int operation) {
+        if (operation == -1) {
+            return statement;
+        }
+
+        char[] stmt;
+        char op = 0;
+        switch (operation) {
+            case Operator.ADD:
+                op = '+';
+                break;
+            case Operator.STR_APPEND:
+                op = '#';
+                break;
+            case Operator.SUB:
+                op = '-';
+                break;
+            case Operator.MULT:
+                op = '*';
+                break;
+            case Operator.MOD:
+                op = '%';
+                break;
+            case Operator.DIV:
+                op = '/';
+                break;
+            case Operator.BW_AND:
+                op = '&';
+                break;
+            case Operator.BW_OR:
+                op = '|';
+                break;
+            case Operator.BW_SHIFT_LEFT:
+                op = '\u00AB';
+                break;
+            case Operator.BW_SHIFT_RIGHT:
+                op = '\u00BB';
+                break;
+            case Operator.BW_USHIFT_RIGHT:
+                op = '\u00AC';
+                break;
+        }
+
+        arraycopy(name.toCharArray(), 0, (stmt = new char[name.length() + offset + 1]), 0, name.length());
+        stmt[name.length()] = op;
+        arraycopy(statement, start, stmt, name.length() + 1, offset);
+
+        return stmt;
+    }
+
+    public static ClassImportResolverFactory findClassImportResolverFactory(VariableResolverFactory factory, ParserContext pCtx) {
+        if (factory == null) {
+            throw new OptimizationFailure("unable to import classes.  no variable resolver factory available.");
+        }
+
+        for (VariableResolverFactory v = factory; v != null; v = v.getNextFactory()) {
+            if (v instanceof ClassImportResolverFactory) {
+                return (ClassImportResolverFactory) v;
+            }
+        }
+
+        return appendFactory(factory, new ClassImportResolverFactory(null, null, false));
+    }
+
+    public static Class findClass(VariableResolverFactory factory, String name, ParserContext pCtx) throws ClassNotFoundException {
+        try {
+            if (LITERALS.containsKey(name)) {
+                return (Class) LITERALS.get(name);
+            } else if (factory != null && factory.isResolveable(name)) {
+                return (Class) factory.getVariableResolver(name).getValue();
+            } else if (pCtx != null && pCtx.hasImport(name)) {
+                return pCtx.getImport(name);
+            } else {
+                return createClass(name, pCtx);
+            }
+        } catch (ClassNotFoundException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new RuntimeException("class not found: " + name, e);
+        }
+    }
+
+    public static char[] subsetTrimmed(char[] array, int start, int length) {
+        if (length <= 0) {
+            return new char[0];
+        }
+
+        int end = start + length;
+        while (end > 0 && isWhitespace(array[end - 1])) {
+            end--;
+        }
+
+        while (isWhitespace(array[start]) && start < end) {
+            start++;
+        }
+
+        length = end - start;
+
+        if (length == 0) {
+            return new char[0];
+        }
+
+        return subset(array, start, length);
+    }
+
+    public static char[] subset(char[] array, int start, int length) {
+
+        char[] newArray = new char[length];
+
+        for (int i = 0; i < newArray.length; i++) {
+            newArray[i] = array[i + start];
+        }
+
+        return newArray;
+    }
+
+    public static char[] subset(char[] array, int start) {
+        char[] newArray = new char[array.length - start];
+
+        for (int i = 0; i < newArray.length; i++) {
+            newArray[i] = array[i + start];
+        }
+
+        return newArray;
+    }
+
+    public static int resolveType(Object o) {
+        if (o == null) return DataTypes.OBJECT;
+        else return __resolveType(o.getClass());
+    }
+
+    public static int __resolveType(Class cls) {
+        Integer code = typeCodes.get(cls);
+        if (code == null) {
+            if (cls != null && Collection.class.isAssignableFrom(cls)) {
+                return DataTypes.COLLECTION;
+            } else {
+                return DataTypes.OBJECT;
+            }
+        }
+        return code;
+    }
+
+    private static boolean isPrimitiveSubtype(Class argument, Class<?> actualParamType) {
+        if (!actualParamType.isPrimitive()) {
+            return false;
+        }
+        Class<?> primitiveArgument = unboxPrimitive(argument);
+        if (!primitiveArgument.isPrimitive()) {
+            return false;
+        }
+        return (actualParamType == double.class && primitiveArgument == float.class)
+                || (actualParamType == float.class && primitiveArgument == long.class)
+                || (actualParamType == long.class && primitiveArgument == int.class)
+                || (actualParamType == int.class && primitiveArgument == char.class)
+                || (actualParamType == int.class && primitiveArgument == short.class)
+                || (actualParamType == short.class && primitiveArgument == byte.class);
+    }
+
+    public static boolean isNumericallyCoercible(Class target, Class parm) {
+        Class boxedTarget = target.isPrimitive() ? boxPrimitive(target) : target;
+
+        if (boxedTarget != null && Number.class.isAssignableFrom(target)) {
+            if ((boxedTarget = parm.isPrimitive() ? boxPrimitive(parm) : parm) != null) {
+                return Number.class.isAssignableFrom(boxedTarget);
+            }
+        }
+        return false;
+    }
+
+    public static Object narrowType(final BigDecimal result, int returnTarget) {
+        if (returnTarget == DataTypes.W_DOUBLE || result.scale() > 0) {
+            return result.doubleValue();
+        } else if (returnTarget == DataTypes.W_LONG || result.longValue() > Integer.MAX_VALUE) {
+            return result.longValue();
+        } else {
+            return result.intValue();
+        }
+    }
+
+    public static Method determineActualTargetMethod(Method method) {
+        return determineActualTargetMethod(method.getDeclaringClass(), method);
+    }
+
+    private static Method determineActualTargetMethod(Class clazz, Method method) {
+        String name = method.getName();
+
+        /**
+         * Follow our way up the class heirarchy until we find the physical target method.
+         */
+        for (Class cls : clazz.getInterfaces()) {
+            for (Method meth : cls.getMethods()) {
+                if (meth.getParameterTypes().length == 0 && name.equals(meth.getName())) {
+                    return meth;
+                }
+            }
+        }
+
+        return clazz.getSuperclass() != null ? determineActualTargetMethod(clazz.getSuperclass(), method) : null;
+    }
+
+    public static int captureToNextTokenJunction(char[] expr, int cursor, int end, ParserContext pCtx) {
+        while (cursor != expr.length) {
+            switch (expr[cursor]) {
+                case '{':
+                case '(':
+                    return cursor;
+                case '[':
+                    cursor = balancedCaptureWithLineAccounting(expr, cursor, end, '[', pCtx) + 1;
+                    continue;
+                default:
+                    if (isWhitespace(expr[cursor])) {
+                        return cursor;
+                    }
+                    cursor++;
+            }
+        }
+        return cursor;
+    }
+
+    public static int nextNonBlank(char[] expr, int cursor) {
+        if ((cursor + 1) >= expr.length) {
+            throw new CompileException("unexpected end of statement", expr, cursor);
+        }
+        int i = cursor;
+        while (i != expr.length && isWhitespace(expr[i]))
+            i++;
+        return i;
+    }
+
+    public static int skipWhitespace(char[] expr, int cursor) {
+        Skip: while (cursor != expr.length) {
+            switch (expr[cursor]) {
+                case '\n':
+                case '\r':
+                    cursor++;
+                    continue;
+                case '/':
+                    if (cursor + 1 != expr.length) {
+                        switch (expr[cursor + 1]) {
+                            case '/':
+                                expr[cursor++] = ' ';
+                                while (cursor != expr.length && expr[cursor] != '\n')
+                                    expr[cursor++] = ' ';
+                                if (cursor != expr.length) expr[cursor++] = ' ';
+                                continue;
+
+                            case '*':
+                                int len = expr.length - 1;
+                                expr[cursor++] = ' ';
+                                while (cursor != len && !(expr[cursor] == '*' && expr[cursor + 1] == '/')) {
+                                    expr[cursor++] = ' ';
+                                }
+                                if (cursor != len) expr[cursor++] = expr[cursor++] = ' ';
+                                continue;
+
+                            default:
+                                break Skip;
+
+                        }
+                    }
+                default:
+                    if (!isWhitespace(expr[cursor])) break Skip;
+
+            }
+            cursor++;
+        }
+
+        return cursor;
+    }
+
+    public static boolean isStatementNotManuallyTerminated(char[] expr, int cursor) {
+        if (cursor >= expr.length) return false;
+        int c = cursor;
+        while (c != expr.length && isWhitespace(expr[c]))
+            c++;
+        return !(c != expr.length && expr[c] == ';');
+    }
+
+    public static int captureToEOS(char[] expr, int cursor, int end, ParserContext pCtx) {
+        while (cursor != expr.length) {
+            switch (expr[cursor]) {
+                case '(':
+                case '[':
+                case '{':
+                    if ((cursor = balancedCaptureWithLineAccounting(expr, cursor, end, expr[cursor], pCtx)) >= expr.length) return cursor;
+                    break;
+
+                case '"':
+                case '\'':
+                    cursor = captureStringLiteral(expr[cursor], expr, cursor, expr.length);
+                    break;
+
+                case ',':
+                case ';':
+                case '}':
+                    return cursor;
+            }
+            cursor++;
+        }
+        return cursor;
+    }
+
+    /**
+     * From the specified cursor position, trim out any whitespace between the current position and the end of the
+     * last non-whitespace character.
+     *
+     * @param expr  -
+     * @param start -
+     * @param pos   - current position
+     * @return new position.
+     */
+    public static int trimLeft(char[] expr, int start, int pos) {
+        if (pos > expr.length) pos = expr.length;
+        while (pos != 0 && pos >= start && isWhitespace(expr[pos - 1]))
+            pos--;
+        return pos;
+    }
+
+    /**
+     * From the specified cursor position, trim out any whitespace between the current position and beginning of the
+     * first non-whitespace character.
+     *
+     * @param expr -
+     * @param pos  -
+     * @return -
+     */
+    public static int trimRight(char[] expr, int pos) {
+        while (pos != expr.length && isWhitespace(expr[pos]))
+            pos++;
+        return pos;
+    }
+
+    public static char[] subArray(char[] expr, final int start, final int end) {
+        if (start >= end) return new char[0];
+
+        char[] newA = new char[end - start];
+        for (int i = 0; i != newA.length; i++) {
+            newA[i] = expr[i + start];
+        }
+
+        return newA;
+    }
+
+    /**
+     * This is an important aspect of the core parser tools.  This method is used throughout the core parser
+     * and sub-lexical parsers to capture a balanced capture between opening and terminating tokens such as:
+     * <em>( [ { ' " </em>
+     * <br>
+     * <br>
+     * For example: ((foo + bar + (bar - foo)) * 20;<br>
+     * <br>
+     * <p/>
+     * If a balanced capture is performed from position 2, we get "(foo + bar + (bar - foo))" back.<br>
+     * If a balanced capture is performed from position 15, we get "(bar - foo)" back.<br>
+     * Etc.
+     *
+     * @param chars -
+     * @param start -
+     * @param type  -
+     * @return -
+     */
+    public static int balancedCapture(char[] chars, int start, char type) {
+        return balancedCapture(chars, start, chars.length, type);
+    }
+
+    public static int balancedCapture(char[] chars, int start, int end, char type) {
+        int depth = 1;
+        char term = type;
+        switch (type) {
+            case '[':
+                term = ']';
+                break;
+            case '{':
+                term = '}';
+                break;
+            case '(':
+                term = ')';
+                break;
+        }
+
+        if (type == term) {
+            for (start++; start < end; start++) {
+                if (chars[start] == type) {
+                    return start;
+                }
+            }
+        } else {
+            for (start++; start < end; start++) {
+                if (start < end && chars[start] == '/') {
+                    if (start + 1 == end) return start;
+                    if (chars[start + 1] == '/') {
+                        start++;
+                        while (start < end && chars[start] != '\n')
+                            start++;
+                    } else if (chars[start + 1] == '*') {
+                        start += 2;
+                        SkipComment: while (start < end) {
+                            switch (chars[start]) {
+                                case '*':
+                                    if (start + 1 < end && chars[start + 1] == '/') {
+                                        break SkipComment;
+                                    }
+                                case '\r':
+                                case '\n':
+
+                                    break;
+                            }
+                            start++;
+                        }
+                    }
+                }
+                if (start == end) return start;
+                if (chars[start] == '\'' || chars[start] == '"') {
+                    start = captureStringLiteral(chars[start], chars, start, end);
+                } else if (chars[start] == type) {
+                    depth++;
+                } else if (chars[start] == term && --depth == 0) {
+                    return start;
+                }
+            }
+        }
+
+        switch (type) {
+            case '[':
+                throw new CompileException("unbalanced braces [ ... ]", chars, start);
+            case '{':
+                throw new CompileException("unbalanced braces { ... }", chars, start);
+            case '(':
+                throw new CompileException("unbalanced braces ( ... )", chars, start);
+            default:
+                throw new CompileException("unterminated string literal", chars, start);
+        }
+    }
+
+    public static int balancedCaptureWithLineAccounting(char[] chars, int start, int end, char type, ParserContext pCtx) {
+        int depth = 1;
+        int st = start;
+        char term = type;
+        switch (type) {
+            case '[':
+                term = ']';
+                break;
+            case '{':
+                term = '}';
+                break;
+            case '(':
+                term = ')';
+                break;
+        }
+
+        if (type == term) {
+            for (start++; start != end; start++) {
+                if (chars[start] == type) {
+                    return start;
+                }
+            }
+        } else {
+            int lines = 0;
+            for (start++; start < end; start++) {
+                if (isWhitespace(chars[start])) {
+                    switch (chars[start]) {
+                        case '\r':
+                            continue;
+                        case '\n':
+                            if (pCtx != null) pCtx.setLineOffset((short) start);
+                            lines++;
+                    }
+                } else if (start < end && chars[start] == '/') {
+                    if (start + 1 == end) return start;
+                    if (chars[start + 1] == '/') {
+                        start++;
+                        while (start < end && chars[start] != '\n')
+                            start++;
+                    } else if (chars[start + 1] == '*') {
+                        start += 2;
+                        Skiploop: while (start != end) {
+                            switch (chars[start]) {
+                                case '*':
+                                    if (start + 1 < end && chars[start + 1] == '/') {
+                                        break Skiploop;
+                                    }
+                                case '\r':
+                                case '\n':
+                                    if (pCtx != null) pCtx.setLineOffset((short) start);
+                                    lines++;
+                                    break;
+                            }
+                            start++;
+                        }
+                    }
+                }
+                if (start == end) return start;
+                if (chars[start] == '\'' || chars[start] == '"') {
+                    start = captureStringLiteral(chars[start], chars, start, end);
+                } else if (chars[start] == type) {
+                    depth++;
+                } else if (chars[start] == term && --depth == 0) {
+                    if (pCtx != null) pCtx.incrementLineCount(lines);
+                    return start;
+                }
+            }
+        }
+
+        switch (type) {
+            case '[':
+                throw new CompileException("unbalanced braces [ ... ]", chars, st);
+            case '{':
+                throw new CompileException("unbalanced braces { ... }", chars, st);
+            case '(':
+                throw new CompileException("unbalanced braces ( ... )", chars, st);
+            default:
+                throw new CompileException("unterminated string literal", chars, st);
+        }
+    }
+
+    public static String handleStringEscapes(char[] input) {
+        int escapes = 0;
+        for (int i = 0; i < input.length; i++) {
+            if (input[i] == '\\') {
+                escapes += handleEscapeSequence(input, ++i);
+            }
+        }
+
+        if (escapes == 0) return new String(input);
+
+        char[] processedEscapeString = new char[input.length - escapes];
+        int cursor = 0;
+        for (char aName : input) {
+            if (aName != 0) {
+                processedEscapeString[cursor++] = aName;
+            }
+        }
+
+        return new String(processedEscapeString);
+    }
+
+    public static int captureStringLiteral(final char type, final char[] expr, int cursor, int end) {
+        while (++cursor < end && expr[cursor] != type) {
+            if (expr[cursor] == '\\') cursor++;
+        }
+
+        if (cursor >= end || expr[cursor] != type) {
+            throw new CompileException("unterminated string literal", expr, cursor);
+        }
+
+        return cursor;
+    }
+
+    public static void parseWithExpressions(String nestParm, char[] block, int start, int offset, Object ctx,
+            VariableResolverFactory factory) {
+        /**
+         *
+         * MAINTENANCE NOTE: A COMPILING VERSION OF THIS CODE IS DUPLICATED IN: WithNode
+         *
+         */
+        int _st = start;
+        int _end = -1;
+
+        int end = start + offset;
+
+        int oper = -1;
+        String parm = "";
+
+        for (int i = start; i < end; i++) {
+            switch (block[i]) {
+                case '{':
+                case '[':
+                case '(':
+                case '\'':
+                case '"':
+                    i = balancedCapture(block, i, end, block[i]);
+                    continue;
+
+                case '/':
+                    if (i < end && block[i + 1] == '/') {
+                        while (i < end && block[i] != '\n')
+                            block[i++] = ' ';
+                        if (parm == null) _st = i;
+                    } else if (i < end && block[i + 1] == '*') {
+                        int len = end - 1;
+                        while (i < len && !(block[i] == '*' && block[i + 1] == '/')) {
+                            block[i++] = ' ';
+                        }
+                        block[i++] = ' ';
+                        block[i++] = ' ';
+
+                        if (parm == null) _st = i;
+                    } else if (i < end && block[i + 1] == '=') {
+                        oper = Operator.DIV;
+                    }
+                    continue;
+
+                case '%':
+                case '*':
+                case '-':
+                case '+':
+                    if (i + 1 < end && block[i + 1] == '=') {
+                        oper = opLookup(block[i]);
+                    }
+                    continue;
+
+                case '=':
+                    parm = new String(block, _st, i - _st - (oper != -1 ? 1 : 0)).trim();
+                    _st = i + 1;
+                    continue;
+
+                case ',':
+                    if (_end == -1) _end = i;
+
+                    if (parm == null) {
+                        try {
+                            if (nestParm == null) {
+                                MVEL.eval(new String(block, _st, _end - _st), ctx, factory);
+                            } else {
+                                MVEL.eval(new StringBuilder(nestParm).append('.').append(block, _st, _end - _st).toString(), ctx, factory);
+                            }
+                        } catch (CompileException e) {
+                            e.setCursor(_st + (e.getCursor() - (e.getExpr().length - offset)));
+                            e.setExpr(block);
+                            throw e;
+                        }
+
+                        oper = -1;
+                        _st = ++i;
+                    } else {
+                        try {
+                            if (oper != -1) {
+                                if (nestParm == null) {
+                                    throw new CompileException("operative assignment not possible here", block, start);
+                                }
+
+                                String rewrittenExpr = new String(
+                                        createShortFormOperativeAssignment(nestParm + "." + parm, block, _st, _end - _st, oper));
+
+                                MVEL.setProperty(ctx, parm, MVEL.eval(rewrittenExpr, ctx, factory));
+                            } else {
+                                MVEL.setProperty(ctx, parm, MVEL.eval(block, _st, _end - _st, ctx, factory));
+                            }
+                        } catch (CompileException e) {
+                            e.setCursor(_st + (e.getCursor() - (e.getExpr().length - offset)));
+                            e.setExpr(block);
+                            throw e;
+                        }
+
+                        parm = null;
+                        oper = -1;
+                        _st = ++i;
+                    }
+
+                    _end = -1;
+                    break;
+            }
+        }
+
+        if (_st != (_end = end)) {
+            try {
+                if (parm == null || "".equals(parm)) {
+                    if (nestParm == null) {
+                        MVEL.eval(new String(block, _st, _end - _st), ctx, factory);
+                    } else {
+                        MVEL.eval(new StringAppender(nestParm).append('.').append(block, _st, _end - _st).toString(), ctx, factory);
+                    }
+                } else {
+                    if (oper != -1) {
+                        if (nestParm == null) {
+                            throw new CompileException("operative assignment not possible here", block, start);
+                        }
+
+                        MVEL.setProperty(ctx, parm,
+                                MVEL.eval(
+                                        new String(createShortFormOperativeAssignment(nestParm + "." + parm, block, _st, _end - _st, oper)),
+                                        ctx, factory));
+                    } else {
+                        MVEL.setProperty(ctx, parm, MVEL.eval(block, _st, end - _st, ctx, factory));
+                    }
+                }
+            } catch (CompileException e) {
+                e.setCursor(_st + (e.getCursor() - (e.getExpr().length - offset)));
+                e.setExpr(block);
+                throw e;
+            }
+        }
+    }
+
+    public static Object handleNumericConversion(final char[] val, int start, int offset) {
+        if (offset != 1 && val[start] == '0' && val[start + 1] != '.') {
+            if (!isDigit(val[start + offset - 1])) {
+                switch (val[start + offset - 1]) {
+                    case 'L':
+                    case 'l':
+                        return Long.decode(new String(val, start, offset - 1));
+                    case 'I':
+                        return new BigInteger(new String(val, start, offset - 1));
+                    case 'B':
+                        return new BigDecimal(new String(val, start, offset - 1));
+                }
+            }
+
+            return Integer.decode(new String(val, start, offset));
+        } else if (!isDigit(val[start + offset - 1])) {
+            switch (val[start + offset - 1]) {
+                case 'l':
+                case 'L':
+                    return Long.parseLong(new String(val, start, offset - 1));
+                case '.':
+                case 'd':
+                case 'D':
+                    return parseDouble(new String(val, start, offset - 1));
+                case 'f':
+                case 'F':
+                    return Float.parseFloat(new String(val, start, offset - 1));
+                case 'I':
+                    return new BigInteger(new String(val, start, offset - 1));
+                case 'B':
+                    return new BigDecimal(new String(val, start, offset - 1));
+            }
+            throw new CompileException("unrecognized numeric literal", val, start);
+        } else {
+            switch (numericTest(val, start, offset)) {
+                case DataTypes.FLOAT:
+                    return Float.parseFloat(new String(val, start, offset));
+                case INTEGER:
+                    return Integer.parseInt(new String(val, start, offset));
+                case LONG:
+                    return Long.parseLong(new String(val, start, offset));
+                case DOUBLE:
+                    return parseDouble(new String(val, start, offset));
+                case DataTypes.BIG_DECIMAL:
+                    return new BigDecimal(val, MathContext.DECIMAL128);
+                default:
+                    return new String(val, start, offset);
+            }
+        }
+    }
+
+    public static boolean isNumeric(Object val) {
+        if (val == null) return false;
+
+        Class clz;
+        if (val instanceof Class) {
+            clz = (Class) val;
+        } else {
+            clz = val.getClass();
+        }
+
+        return clz == int.class || clz == long.class || clz == short.class || clz == double.class || clz == float.class
+                || Number.class.isAssignableFrom(clz);
+    }
+
+    public static int numericTest(final char[] val, int start, int offset) {
+        boolean fp = false;
+
+        char c;
+        int i = start;
+
+        if (offset > 1) {
+            if (val[start] == '-') i++;
+            else if (val[start] == '~') {
+                i++;
+                if (val[start + 1] == '-') i++;
+            }
+        }
+
+        int end = start + offset;
+        for (; i < end; i++) {
+            if (!isDigit(c = val[i])) {
+                switch (c) {
+                    case '.':
+                        fp = true;
+                        break;
+                    case 'e':
+                    case 'E':
+                        fp = true;
+                        if (i++ < end && val[i] == '-') i++;
+                        break;
+
+                    default:
+                        return -1;
+                }
+            }
+        }
+
+        if (offset != 0) {
+            if (fp) {
+                return DOUBLE;
+            } else if (offset > 9) {
+                return LONG;
+            } else {
+                return INTEGER;
+            }
+        }
+        return -1;
+    }
+
+    public static boolean isNumber(Object val) {
+        if (val == null) return false;
+        if (val instanceof String) return isNumber((String) val);
+        if (val instanceof char[]) return isNumber(new String((char[]) val));
+        return val instanceof Integer || val instanceof BigDecimal || val instanceof BigInteger || val instanceof Float
+                || val instanceof Double || val instanceof Long || val instanceof Short || val instanceof Character;
+    }
+
+    public static boolean isNumber(final String val) {
+        int len = val.length();
+        char c;
+        boolean f = true;
+        int i = 0;
+        if (len > 1) {
+            if (val.charAt(0) == '-') i++;
+            else if (val.charAt(0) == '~') {
+                i++;
+                if (val.charAt(1) == '-') i++;
+            }
+        }
+        for (; i < len; i++) {
+            if (!isDigit(c = val.charAt(i))) {
+                if (c == '.' && f) {
+                    f = false;
+                } else {
+                    return false;
+                }
+            }
+        }
+
+        return len > 0;
+    }
+
+    public static boolean isNumber(char[] val, int start, int offset) {
+        char c;
+        boolean f = true;
+        int i = start;
+        int end = start + offset;
+        if (offset > 1) {
+            switch (val[start]) {
+                case '-':
+                    if (val[start + 1] == '-') i++;
+                case '~':
+                    i++;
+            }
+        }
+        for (; i < end; i++) {
+            if (!isDigit(c = val[i])) {
+                if (f && c == '.') {
+                    f = false;
+                } else if (offset != 1 && i == start + offset - 1) {
+                    switch (c) {
+                        case 'l':
+                        case 'L':
+                        case 'f':
+                        case 'F':
+                        case 'd':
+                        case 'D':
+                        case 'I':
+                        case 'B':
+                            return true;
+                        case '.':
+                            throw new CompileException("invalid number literal: " + new String(val), val, start);
+                    }
+                    return false;
+                } else if (i == start + 1 && c == 'x' && val[start] == '0') {
+                    for (i++; i < end; i++) {
+                        if (!isDigit(c = val[i])) {
+                            if ((c < 'A' || c > 'F') && (c < 'a' || c > 'f')) {
+                                if (i == offset - 1) {
+                                    switch (c) {
+                                        case 'l':
+                                        case 'L':
+                                        case 'I':
+                                        case 'B':
+                                            return true;
+                                    }
+                                }
+
+                                return false;
+                            }
+                        }
+                    }
+                    return offset - 2 > 0;
+
+                } else if (i != start && (i + 1) < end && (c == 'E' || c == 'e')) {
+                    if (val[++i] == '-' || val[i] == '+') i++;
+                } else {
+                    if (i != start) throw new CompileException("invalid number literal: " + new String(val, start, offset), val, start);
+                    return false;
+                }
+            }
+        }
+
+        return end > start;
+    }
+
+    public static int find(char[] c, int start, int offset, char find) {
+        int length = start + offset;
+        for (int i = start; i < length; i++)
+            if (c[i] == find) return i;
+        return -1;
+    }
+
+    public static int findLast(char[] c, int start, int offset, char find) {
+        for (int i = start + offset; i >= start; i--)
+            if (c[i] == find) return i;
+        return -1;
+    }
+
+    public static String createStringTrimmed(char[] s) {
+        int start = 0, end = s.length;
+        while (start != end && s[start] < '\u0020' + 1)
+            start++;
+        while (end != start && s[end - 1] < '\u0020' + 1)
+            end--;
+        return new String(s, start, end - start);
+    }
+
+    public static String createStringTrimmed(char[] s, int start, int length) {
+        if ((length = start + length) > s.length) return new String(s);
+        while (start != length && s[start] < '\u0020' + 1) {
+            start++;
+        }
+        while (length != start && s[length - 1] < '\u0020' + 1) {
+            length--;
+        }
+        return new String(s, start, length - start);
+    }
+
+    public static boolean endsWith(char[] c, int start, int offset, char[] test) {
+        if (test.length > c.length) return false;
+
+        int tD = test.length - 1;
+        int cD = start + offset - 1;
+
+        while (tD >= 0) {
+            if (c[cD--] != test[tD--]) return false;
+        }
+
+        return true;
+    }
+
+    public static boolean isIdentifierPart(final int c) {
+        return ((c > 96 && c < 123) || (c > 64 && c < 91) || (c > 47 && c < 58) || (c == '_') || (c == '$')
+                || Character.isJavaIdentifierPart(c));
+    }
+
+    public static boolean isDigit(final int c) {
+        return c > ('0' - 1) && c < ('9' + 1);
+    }
+
+    public static float similarity(String s1, String s2) {
+        if (s1 == null || s2 == null) return s1 == null && s2 == null ? 1f : 0f;
+
+        char[] c1 = s1.toCharArray();
+        char[] c2 = s2.toCharArray();
+
+        char[] comp;
+        char[] against;
+
+        float same = 0;
+        float baselength;
+
+        int cur1 = 0;
+
+        if (c1.length > c2.length) {
+            baselength = c1.length;
+            comp = c1;
+            against = c2;
+        } else {
+            baselength = c2.length;
+            comp = c2;
+            against = c1;
+        }
+
+        while (cur1 < comp.length && cur1 < against.length) {
+            if (comp[cur1] == against[cur1]) {
+                same++;
+            }
+
+            cur1++;
+        }
+
+        return same / baselength;
+    }
+
+    public static int findAbsoluteLast(char[] array) {
+        int depth = 0;
+        for (int i = array.length - 1; i >= 0; i--) {
+            if (array[i] == ']') {
+                depth++;
+            }
+            if (array[i] == '[') {
+                depth--;
+            }
+
+            if (depth == 0 && array[i] == '.' || array[i] == '[') return i;
+        }
+        return -1;
+    }
+
+    public static Class getBaseComponentType(Class cls) {
+        while (cls.isArray()) {
+            cls = cls.getComponentType();
+        }
+        return cls;
+    }
+
+    public static Class getSubComponentType(Class cls) {
+        if (cls.isArray()) {
+            cls = cls.getComponentType();
+        }
+        return cls;
+    }
+
+    public static boolean isJunct(char c) {
+        switch (c) {
+            case '[':
+            case '(':
+                return true;
+            default:
+                return isWhitespace(c);
+        }
+    }
+
+    public static int opLookup(char c) {
+        switch (c) {
+            case '|':
+                return Operator.BW_OR;
+            case '&':
+                return Operator.BW_AND;
+            case '^':
+                return Operator.BW_XOR;
+            case '*':
+                return Operator.MULT;
+            case '/':
+                return Operator.DIV;
+            case '+':
+                return Operator.ADD;
+            case '%':
+                return Operator.MOD;
+            case '\u00AB':
+                return Operator.BW_SHIFT_LEFT;
+            case '\u00BB':
+                return Operator.BW_SHIFT_RIGHT;
+            case '\u00AC':
+                return Operator.BW_USHIFT_RIGHT;
+        }
+        return -1;
+    }
+
+    /**
+     * Check if the specified string is a reserved word in the parser.
+     *
+     * @param name -
+     * @return -
+     */
+    public static boolean isReservedWord(String name) {
+        return LITERALS.containsKey(name) || AbstractParser.OPERATORS.containsKey(name);
+    }
+
+    /**
+     * Check if the specfied string represents a valid name of label.
+     *
+     * @param name -
+     * @return -
+     */
+    public static boolean isNotValidNameorLabel(String name) {
+        for (char c : name.toCharArray()) {
+            if (c == '.') return true;
+            else if (!isIdentifierPart(c)) return true;
+        }
+        return false;
+    }
+
+    public static boolean isPropertyOnly(char[] array, int start, int end) {
+        for (int i = start; i < end; i++) {
+            if (!isIdentifierPart(array[i])) return false;
+        }
+        return true;
+    }
+
+    public static boolean isArrayType(char[] array, int start, int end) {
+        return end > start + 2 && isPropertyOnly(array, start, end - 2) && array[end - 2] == '[' && array[end - 1] == ']';
+    }
+
+    public static void checkNameSafety(String name) {
+        if (isReservedWord(name)) {
+            throw new RuntimeException("illegal use of reserved word: " + name);
+        } else if (isDigit(name.charAt(0))) {
+            throw new RuntimeException("not an identifier: " + name);
+        }
+    }
+
+    public static FileWriter getDebugFileWriter() throws IOException {
+        return new FileWriter(new File(getDebuggingOutputFileName()), true);
+    }
+
+    public static boolean isPrimitiveWrapper(Class clazz) {
+        return clazz == Integer.class || clazz == Boolean.class || clazz == Long.class || clazz == Double.class || clazz == Float.class
+                || clazz == Character.class || clazz == Short.class || clazz == Byte.class;
+    }
+
+    public static Serializable subCompileExpression(char[] expression) {
+        return _optimizeTree(new ExpressionCompiler(expression)._compile());
+    }
+
+    public static Serializable subCompileExpression(char[] expression, ParserContext ctx) {
+        ExpressionCompiler c = new ExpressionCompiler(expression, ctx);
+        return _optimizeTree(c._compile());
+    }
+
+    public static Serializable subCompileExpression(char[] expression, int start, int offset, ParserContext ctx) {
+        ExpressionCompiler c = new ExpressionCompiler(expression, start, offset, ctx);
+        return _optimizeTree(c._compile());
+    }
+
+    public static Serializable subCompileExpression(String expression, ParserContext ctx) {
+        ExpressionCompiler c = new ExpressionCompiler(expression, ctx);
+        return _optimizeTree(c._compile());
+    }
+
+    public static Serializable optimizeTree(final CompiledExpression compiled) {
+        /**
+         * If there is only one token, and it's an identifier, we can optimize this as an accessor expression.
+         */
+        if (!compiled.isImportInjectionRequired() && compiled.getParserConfiguration().isAllowBootstrapBypass()
+                && compiled.isSingleNode()) {
+
+            return _optimizeTree(compiled);
+        }
+
+        return compiled;
+    }
+
+    private static Serializable _optimizeTree(final CompiledExpression compiled) {
+        /**
+         * If there is only one token, and it's an identifier, we can optimize this as an accessor expression.
+         */
+        if (compiled.isSingleNode()) {
+            ASTNode tk = compiled.getFirstNode();
+
+            if (tk.isLiteral() && !tk.isThisVal()) {
+                return new ExecutableLiteral(tk.getLiteralValue());
+            }
+            return tk.canSerializeAccessor() ? new ExecutableAccessorSafe(tk, compiled.getKnownEgressType()) : new ExecutableAccessor(tk,
+                    compiled.getKnownEgressType());
+        }
+
+        return compiled;
+    }
+
+    public static boolean isWhitespace(char c) {
+        return c < '\u0020' + 1;
+    }
+
+    public static String repeatChar(char c, int times) {
+        char[] n = new char[times];
+        for (int i = 0; i < times; i++) {
+            n[i] = c;
+        }
+        return new String(n);
+    }
+
+    public static char[] loadFromFile(File file) throws IOException {
+        return loadFromFile(file, null);
+    }
+
+    public static char[] loadFromFile(File file, String encoding) throws IOException {
+        if (!file.exists()) throw new RuntimeException("cannot find file: " + file.getName());
+
+        FileInputStream inStream = null;
+        ReadableByteChannel fc = null;
+        try {
+            fc = (inStream = new FileInputStream(file)).getChannel();
+            ByteBuffer buf = allocateDirect(10);
+
+            StringAppender sb = new StringAppender((int) file.length(), encoding);
+
+            int read = 0;
+            while (read >= 0) {
+                buf.rewind();
+                read = fc.read(buf);
+                buf.rewind();
+
+                for (; read > 0; read--) {
+                    sb.append(buf.get());
+                }
+            }
+
+            //noinspection unchecked
+            return sb.toChars();
+        } catch (FileNotFoundException e) {
+            // this can't be thrown, we check for this explicitly.
+        } finally {
+            if (inStream != null) inStream.close();
+            if (fc != null) fc.close();
+        }
+
+        return null;
+    }
+
+    public static char[] readIn(InputStream inStream, String encoding) throws IOException {
+        try {
+            byte[] buf = new byte[10];
+
+            StringAppender sb = new StringAppender(10, encoding);
+
+            int bytesRead;
+            while ((bytesRead = inStream.read(buf)) > 0) {
+                for (int i = 0; i < bytesRead; i++) {
+                    sb.append(buf[i]);
+                }
+            }
+
+            //noinspection unchecked
+            return sb.toChars();
+        } finally {
+            if (inStream != null) inStream.close();
+        }
+    }
+
+    public static Class forNameWithInner(String className, ClassLoader classLoader) throws ClassNotFoundException {
+        try {
+            return classLoader.loadClass(className);
+        } catch (ClassNotFoundException cnfe) {
+            return findInnerClass(className, classLoader, cnfe);
+        }
+    }
+
+    public static Class findInnerClass(String className, ClassLoader classLoader, ClassNotFoundException cnfe)
+            throws ClassNotFoundException {
+        for (int lastDotPos = className.lastIndexOf('.'); lastDotPos > 0; lastDotPos = className.lastIndexOf('.')) {
+            className = className.substring(0, lastDotPos) + "$" + className.substring(lastDotPos + 1);
+            try {
+                return classLoader.loadClass(className);
+            } catch (ClassNotFoundException e) { /* ignore */ }
+        }
+        throw cnfe;
+    }
+}

--- a/core/src/main/java/org/mvel2/util/PropertyTools.java
+++ b/core/src/main/java/org/mvel2/util/PropertyTools.java
@@ -1,0 +1,214 @@
+/**
+ * MVEL 2.0
+ * Copyright (C) 2007 The Codehaus
+ * Mike Brock, Dhanji Prasanna, John Graham, Mark Proctor
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mvel2.util;
+
+import static java.lang.String.valueOf;
+import static java.lang.reflect.Modifier.PUBLIC;
+import static java.lang.reflect.Modifier.STATIC;
+import static java.lang.reflect.Modifier.isPublic;
+import static org.mvel2.DataConversion.canConvert;
+import static org.mvel2.util.ParseTools.boxPrimitive;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Member;
+import java.lang.reflect.Method;
+import java.util.Collection;
+import java.util.Map;
+
+import org.mvel2.ParserContext;
+import org.mvel2.compiler.PropertyVerifier;
+
+public class PropertyTools {
+
+    public static boolean isEmpty(Object o) {
+        if (o != null) {
+            if (o instanceof Object[]) {
+                return ((Object[]) o).length == 0 || (((Object[]) o).length == 1 && isEmpty(((Object[]) o)[0]));
+            } else {
+                return ("".equals(valueOf(o))) || "null".equals(valueOf(o)) || (o instanceof Collection && ((Collection) o).size() == 0)
+                        || (o instanceof Map && ((Map) o).size() == 0);
+            }
+        }
+        return true;
+    }
+
+    public static Method getSetter(Class clazz, String property) {
+        property = ReflectionUtil.getSetter(property);
+
+        for (Method meth : clazz.getMethods()) {
+            if ((meth.getModifiers() & PUBLIC) != 0 && meth.getParameterTypes().length == 1 && property.equals(meth.getName())) {
+                return meth;
+            }
+        }
+
+        return null;
+    }
+
+    public static Method getSetter(Class clazz, String property, Class type) {
+        String simple = "set" + property;
+        property = ReflectionUtil.getSetter(property);
+
+        for (Method meth : clazz.getMethods()) {
+            if ((meth.getModifiers() & PUBLIC) != 0 && meth.getParameterTypes().length == 1
+                    && (property.equals(meth.getName()) || simple.equals(meth.getName()))
+                    && (type == null || canConvert(meth.getParameterTypes()[0], type))) {
+                return meth;
+            }
+        }
+
+        return null;
+    }
+
+    public static boolean hasGetter(Field field) {
+        Method meth = getGetter(field.getDeclaringClass(), field.getName());
+        return meth != null && field.getType().isAssignableFrom(meth.getReturnType());
+    }
+
+    public static boolean hasSetter(Field field) {
+        Method meth = getSetter(field.getDeclaringClass(), field.getName());
+        return meth != null && meth.getParameterTypes().length == 1 && field.getType().isAssignableFrom(meth.getParameterTypes()[0]);
+    }
+
+    public static Method getGetter(Class clazz, String property) {
+        String simple = "get" + property;
+        String simpleIsGet = "is" + property;
+        String isGet = ReflectionUtil.getIsGetter(property);
+        String getter = ReflectionUtil.getGetter(property);
+
+        Method candidate = null;
+
+        if (Collection.class.isAssignableFrom(clazz) && "isEmpty".equals(isGet)) {
+            try {
+                return Collection.class.getMethod("isEmpty");
+            } catch (NoSuchMethodException ignore) {}
+        }
+
+        for (Method meth : clazz.getMethods()) {
+            if ((meth.getModifiers() & PUBLIC) != 0 && (meth.getModifiers() & STATIC) == 0 && meth.getParameterTypes().length == 0
+                    && (getter.equals(meth.getName()) || property.equals(meth.getName())
+                            || ((isGet.equals(meth.getName()) || simpleIsGet.equals(meth.getName()))
+                                    && meth.getReturnType() == boolean.class)
+                            || simple.equals(meth.getName()))) {
+                if (candidate == null || candidate.getReturnType().isAssignableFrom(meth.getReturnType())) {
+                    candidate = meth;
+                }
+            }
+        }
+        return candidate;
+    }
+
+    public static Class getReturnType(Class clazz, String property, ParserContext ctx) {
+        return new PropertyVerifier(property, ctx, clazz).analyze();
+    }
+
+    public static Member getFieldOrAccessor(Class clazz, String property) {
+        Field[] fields = clazz.getFields();
+        for (Field f : fields) {
+            f.setAccessible(true);
+            if (property.equals(f.getName())) {
+                return f;
+            }
+        }
+        fields = clazz.getDeclaredFields();
+        for (Field f : fields) {
+            f.setAccessible(true);
+            if (property.equals(f.getName())) {
+                return f;
+            }
+        }
+        return getGetter(clazz, property);
+    }
+
+    public static Member getFieldOrWriteAccessor(Class clazz, String property) {
+        Field field;
+        try {
+            if ((field = clazz.getField(property)) != null && isPublic(field.getModifiers())) {
+                return field;
+            }
+        } catch (NullPointerException e) {
+            return null;
+        } catch (NoSuchFieldException e) {
+            // do nothing.
+        }
+
+        return getSetter(clazz, property);
+    }
+
+    public static Member getFieldOrWriteAccessor(Class clazz, String property, Class type) {
+        for (Field f : clazz.getFields()) {
+            if (property.equals(f.getName()) && (type == null || canConvert(f.getType(), type))) {
+                return f;
+            }
+        }
+
+        return getSetter(clazz, property, type);
+    }
+
+    public static boolean contains(Object toCompare, Object testValue) {
+        if (toCompare == null) return false;
+        else if (toCompare instanceof String) return ((String) toCompare).contains(valueOf(testValue));
+        //    return ((String) toCompare).indexOf(valueOf(testValue)) > -1;
+        else if (toCompare instanceof Collection) return ((Collection) toCompare).contains(testValue);
+        else if (toCompare instanceof Map) return ((Map) toCompare).containsKey(testValue);
+        else if (toCompare.getClass().isArray()) {
+            for (Object o : ((Object[]) toCompare)) {
+                if (testValue == null && o == null) return true;
+                else if (o != null && o.equals(testValue)) return true;
+            }
+        }
+        return false;
+    }
+
+    public static Object getPrimitiveInitialValue(Class type) {
+        if (type == int.class) {
+            return 0;
+        } else if (type == boolean.class) {
+            return false;
+        } else if (type == char.class) {
+            return (char) 0;
+        } else if (type == double.class) {
+            return 0d;
+        } else if (type == long.class) {
+            return 0l;
+        } else if (type == float.class) {
+            return 0f;
+        } else if (type == short.class) {
+            return (short) 0;
+        } else if (type == byte.class) {
+            return (byte) 0;
+        } else {
+            return 0;
+        }
+    }
+
+    public static boolean isAssignable(Class to, Class from) {
+        return (to.isPrimitive() ? boxPrimitive(to) : to).isAssignableFrom(from.isPrimitive() ? boxPrimitive(from) : from);
+    }
+
+    /**
+     * Get the JVM version
+     * @return first <code>mvel.java.version</code>, then <code>java.version</code>
+     * @see System.getProperty("mvel.java.version");
+     * @see System.getProperty("java.version");
+     */
+    public static String getJavaVersion() {
+        return System.getProperty("mvel.java.version") != null ? System.getProperty("mvel.java.version") : System
+                .getProperty("java.version");
+    }
+}

--- a/core/src/main/java/org/mvel2/util/ProtoParser.java
+++ b/core/src/main/java/org/mvel2/util/ProtoParser.java
@@ -1,0 +1,301 @@
+package org.mvel2.util;
+
+import static org.mvel2.util.ParseTools.balancedCaptureWithLineAccounting;
+import static org.mvel2.util.ParseTools.isIdentifierPart;
+import static org.mvel2.util.ParseTools.subCompileExpression;
+
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.LinkedList;
+import java.util.Queue;
+import java.util.Set;
+
+import org.mvel2.CompileException;
+import org.mvel2.ParserContext;
+import org.mvel2.ast.ASTNode;
+import org.mvel2.ast.EndOfStatement;
+import org.mvel2.ast.Proto;
+import org.mvel2.compiler.ExecutableStatement;
+
+public class ProtoParser {
+
+    private static ThreadLocal<Queue<DeferredTypeResolve>> deferred = new ThreadLocal<Queue<DeferredTypeResolve>>();
+    String tk1 = null;
+    String tk2 = null;
+    private char[] expr;
+    private ParserContext pCtx;
+    private int endOffset;
+    private int cursor;
+    private String protoName;
+    private Class type;
+    private String name;
+    private String deferredName;
+    private boolean interpreted = false;
+    private ExecutionStack splitAccumulator;
+
+    public ProtoParser(char[] expr, int offset, int offsetEnd, String protoName, ParserContext pCtx, int fields,
+            ExecutionStack splitAccumulator) {
+        this.expr = expr;
+
+        this.cursor = offset;
+        this.endOffset = offsetEnd;
+
+        this.protoName = protoName;
+        this.pCtx = pCtx;
+
+        this.interpreted = (ASTNode.COMPILE_IMMEDIATE & fields) == 0;
+
+        this.splitAccumulator = splitAccumulator;
+    }
+
+    public static void notifyForLateResolution(final Proto proto) {
+        if (deferred.get() != null) {
+            Queue<DeferredTypeResolve> recv = deferred.get();
+            Set<DeferredTypeResolve> remove = new HashSet<DeferredTypeResolve>();
+            for (DeferredTypeResolve r : recv) {
+                if (r.isWaitingFor(proto)) {
+                    remove.add(r);
+                }
+            }
+
+            for (DeferredTypeResolve r : remove) {
+                recv.remove(r);
+            }
+        }
+    }
+
+    /**
+     * This is such a horrible hack, but it's more performant than any other horrible hack I can think of
+     * right now.
+     *
+     * @param expr
+     * @param cursor
+     * @param pCtx
+     */
+    public static void checkForPossibleUnresolvedViolations(char[] expr, int cursor, ParserContext pCtx) {
+        if (isUnresolvedWaiting()) {
+            LinkedHashMap<String, Object> imports = (LinkedHashMap<String, Object>) pCtx.getParserConfiguration().getImports();
+
+            Object o = imports.values().toArray()[imports.size() - 1];
+
+            if (o instanceof Proto) {
+                Proto proto = (Proto) o;
+
+                int last = proto.getCursorEnd();
+                cursor--;
+
+                /**
+                 * We walk backwards to ensure that the last valid statement was a proto declaration.
+                 */
+
+                while (cursor > last && ParseTools.isWhitespace(expr[cursor]))
+                    cursor--;
+                while (cursor > last && ParseTools.isIdentifierPart(expr[cursor]))
+                    cursor--;
+                while (cursor > last && (ParseTools.isWhitespace(expr[cursor]) || expr[cursor] == ';'))
+                    cursor--;
+
+                if (cursor != last) {
+                    throw new CompileException(
+                            "unresolved reference (possible illegal forward-reference?): " + ProtoParser.getNextUnresolvedWaiting(), expr,
+                            proto.getCursorStart());
+                }
+            }
+        }
+    }
+
+    public static boolean isUnresolvedWaiting() {
+        return deferred.get() != null && !deferred.get().isEmpty();
+    }
+
+    public static String getNextUnresolvedWaiting() {
+        if (deferred.get() != null && !deferred.get().isEmpty()) {
+            return deferred.get().poll().getName();
+        }
+        return null;
+    }
+
+    public Proto parse() {
+        Proto proto = new Proto(protoName, pCtx);
+
+        Mainloop: while (cursor < endOffset) {
+            cursor = ParseTools.skipWhitespace(expr, cursor);
+
+            int start = cursor;
+
+            if (tk2 == null) {
+                while (cursor < endOffset && isIdentifierPart(expr[cursor]))
+                    cursor++;
+
+                if (cursor > start) {
+                    tk1 = new String(expr, start, cursor - start);
+
+                    if ("def".equals(tk1) || "function".equals(tk1)) {
+                        cursor++;
+                        cursor = ParseTools.skipWhitespace(expr, cursor);
+                        start = cursor;
+                        while (cursor < endOffset && isIdentifierPart(expr[cursor]))
+                            cursor++;
+
+                        if (start == cursor) {
+                            throw new CompileException("attempt to declare an anonymous function as a prototype member", expr, start);
+                        }
+
+                        FunctionParser parser = new FunctionParser(new String(expr, start, cursor - start), cursor, endOffset, expr, 0,
+                                pCtx, null);
+
+                        proto.declareReceiver(parser.getName(), parser.parse());
+                        cursor = parser.getCursor() + 1;
+
+                        tk1 = null;
+                        continue;
+                    }
+                }
+
+                cursor = ParseTools.skipWhitespace(expr, cursor);
+            }
+
+            if (cursor > endOffset) {
+                throw new CompileException("unexpected end of statement in proto declaration: " + protoName, expr, start);
+            }
+
+            switch (expr[cursor]) {
+                case ';':
+                    cursor++;
+                    calculateDecl();
+
+                    if (interpreted && type == DeferredTypeResolve.class) {
+                        /**
+                         * If this type could not be immediately resolved, it may be a look-ahead case, so
+                         * we defer resolution of the type until later and place it in the wait queue.
+                         */
+                        enqueueReceiverForLateResolution(deferredName, proto.declareReceiver(name, Proto.ReceiverType.DEFERRED, null),
+                                null);
+                    } else {
+                        proto.declareReceiver(name, type, null);
+                    }
+                    break;
+
+                case '=':
+                    cursor++;
+                    cursor = ParseTools.skipWhitespace(expr, cursor);
+                    start = cursor;
+
+                    Loop: while (cursor < endOffset) {
+                        switch (expr[cursor]) {
+                            case '{':
+                            case '[':
+                            case '(':
+                            case '\'':
+                            case '"':
+                                cursor = balancedCaptureWithLineAccounting(expr, cursor, endOffset, expr[cursor], pCtx);
+                                break;
+
+                            case ';':
+                                break Loop;
+                        }
+                        cursor++;
+                    }
+
+                    calculateDecl();
+
+                    String initString = new String(expr, start, cursor++ - start);
+
+                    if (interpreted && type == DeferredTypeResolve.class) {
+                        enqueueReceiverForLateResolution(deferredName, proto.declareReceiver(name, Proto.ReceiverType.DEFERRED, null),
+                                initString);
+                    } else {
+                        proto.declareReceiver(name, type, (ExecutableStatement) subCompileExpression(initString, pCtx));
+                    }
+                    break;
+
+                default:
+                    start = cursor;
+                    while (cursor < endOffset && isIdentifierPart(expr[cursor]))
+                        cursor++;
+                    if (cursor > start) {
+                        tk2 = new String(expr, start, cursor - start);
+                    }
+            }
+        }
+
+        cursor++;
+
+        /**
+         * Check if the function is manually terminated.
+         */
+        if (splitAccumulator != null && ParseTools.isStatementNotManuallyTerminated(expr, cursor)) {
+            /**
+             * Add an EndOfStatement to the split accumulator in the parser.
+             */
+            splitAccumulator.add(new EndOfStatement(pCtx));
+        }
+
+        return proto;
+    }
+
+    private void calculateDecl() {
+        if (tk2 != null) {
+            try {
+                if (pCtx.hasProtoImport(tk1)) {
+                    type = Proto.class;
+
+                } else {
+                    type = ParseTools.findClass(null, tk1, pCtx);
+                }
+                name = tk2;
+
+            } catch (ClassNotFoundException e) {
+                if (interpreted) {
+                    type = DeferredTypeResolve.class;
+                    deferredName = tk1;
+                    name = tk2;
+                } else {
+                    throw new CompileException("could not resolve class: " + tk1, expr, cursor, e);
+                }
+            }
+        } else {
+            type = Object.class;
+            name = tk1;
+        }
+
+        tk1 = null;
+        tk2 = null;
+    }
+
+    private void enqueueReceiverForLateResolution(final String name, final Proto.Receiver receiver, final String initializer) {
+        Queue<DeferredTypeResolve> recv = deferred.get();
+        if (recv == null) {
+            deferred.set(recv = new LinkedList<DeferredTypeResolve>());
+        }
+
+        recv.add(new DeferredTypeResolve() {
+
+            public boolean isWaitingFor(Proto proto) {
+                if (name.equals(proto.getName())) {
+                    receiver.setType(Proto.ReceiverType.PROPERTY);
+                    receiver.setInitValue((ExecutableStatement) subCompileExpression(initializer, pCtx));
+                    return true;
+                }
+                return false;
+            }
+
+            public String getName() {
+                return name;
+            }
+        });
+    }
+
+    public int getCursor() {
+        return cursor;
+    }
+
+    private interface DeferredTypeResolve {
+
+        public boolean isWaitingFor(Proto proto);
+
+        public String getName();
+
+    }
+
+}

--- a/core/src/main/java/org/mvel2/util/ReflectionUtil.java
+++ b/core/src/main/java/org/mvel2/util/ReflectionUtil.java
@@ -1,0 +1,170 @@
+/**
+ * MVEL 2.0
+ * Copyright (C) 2007 The Codehaus
+ * Mike Brock, Dhanji Prasanna, John Graham, Mark Proctor
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mvel2.util;
+
+import static java.lang.Character.toLowerCase;
+import static java.lang.Character.toUpperCase;
+import static java.lang.System.arraycopy;
+
+/**
+ * Utilities for working with reflection.
+ */
+public class ReflectionUtil {
+
+    /**
+     * This new method 'slightly' outperforms the old method, it was
+     * essentially a perfect example of me wasting my time and a
+     * premature optimization.  But what the hell...
+     *
+     * @param s -
+     * @return String
+     */
+    public static String getSetter(String s) {
+        char[] chars = new char[s.length() + 3];
+
+        chars[0] = 's';
+        chars[1] = 'e';
+        chars[2] = 't';
+
+        chars[3] = toUpperCase(s.charAt(0));
+
+        for (int i = s.length() - 1; i != 0; i--) {
+            chars[i + 3] = s.charAt(i);
+        }
+
+        return new String(chars);
+    }
+
+    public static String getGetter(String s) {
+        char[] c = s.toCharArray();
+        char[] chars = new char[c.length + 3];
+
+        chars[0] = 'g';
+        chars[1] = 'e';
+        chars[2] = 't';
+
+        chars[3] = toUpperCase(c[0]);
+
+        arraycopy(c, 1, chars, 4, c.length - 1);
+
+        return new String(chars);
+    }
+
+    public static String getIsGetter(String s) {
+        char[] c = s.toCharArray();
+        char[] chars = new char[c.length + 2];
+
+        chars[0] = 'i';
+        chars[1] = 's';
+
+        chars[2] = toUpperCase(c[0]);
+
+        arraycopy(c, 1, chars, 3, c.length - 1);
+
+        return new String(chars);
+    }
+
+    public static String getPropertyFromAccessor(String s) {
+        char[] c = s.toCharArray();
+        char[] chars;
+
+        if (c.length > 3 && c[1] == 'e' && c[2] == 't') {
+            chars = new char[c.length - 3];
+
+            if (c[0] == 'g' || c[0] == 's') {
+                chars[0] = toLowerCase(c[3]);
+
+                for (int i = 1; i < chars.length; i++) {
+                    chars[i] = c[i + 3];
+                }
+
+                return new String(chars);
+            } else {
+                return s;
+            }
+        } else if (c.length > 2 && c[0] == 'i' && c[1] == 's') {
+            chars = new char[c.length - 2];
+
+            chars[0] = toLowerCase(c[2]);
+
+            for (int i = 1; i < chars.length; i++) {
+                chars[i] = c[i + 2];
+            }
+
+            return new String(chars);
+        }
+        return s;
+    }
+
+    public static Class<?> toNonPrimitiveType(Class<?> c) {
+        if (!c.isPrimitive()) return c;
+        if (c == int.class) return Integer.class;
+        if (c == long.class) return Long.class;
+        if (c == double.class) return Double.class;
+        if (c == float.class) return Float.class;
+        if (c == short.class) return Short.class;
+        if (c == byte.class) return Byte.class;
+        if (c == char.class) return Character.class;
+        return Boolean.class;
+    }
+
+    public static Class<?> toNonPrimitiveArray(Class<?> c) {
+        if (!c.isArray() || !c.getComponentType().isPrimitive()) return c;
+        if (c == int[].class) return Integer[].class;
+        if (c == long[].class) return Long[].class;
+        if (c == double[].class) return Double[].class;
+        if (c == float[].class) return Float[].class;
+        if (c == short[].class) return Short[].class;
+        if (c == byte[].class) return Byte[].class;
+        if (c == char[].class) return Character[].class;
+        return Boolean[].class;
+    }
+
+    public static Class<?> toPrimitiveArrayType(Class<?> c) {
+        if (!c.isPrimitive()) throw new RuntimeException(c + " is not a primitive type");
+        if (c == int.class) return int[].class;
+        if (c == long.class) return long[].class;
+        if (c == double.class) return double[].class;
+        if (c == float.class) return float[].class;
+        if (c == short.class) return short[].class;
+        if (c == byte.class) return byte[].class;
+        if (c == char.class) return char[].class;
+        return boolean[].class;
+    }
+
+    public static boolean isAssignableFrom(Class<?> from, Class<?> to) {
+        return from.isAssignableFrom(to) || areBoxingCompatible(from, to);
+    }
+
+    private static boolean areBoxingCompatible(Class<?> c1, Class<?> c2) {
+        return c1.isPrimitive() ? isPrimitiveOf(c2, c1) : (c2.isPrimitive() && isPrimitiveOf(c1, c2));
+    }
+
+    private static boolean isPrimitiveOf(Class<?> boxed, Class<?> primitive) {
+        if (primitive == int.class) return boxed == Integer.class;
+        if (primitive == long.class) return boxed == Long.class;
+        if (primitive == double.class) return boxed == Double.class;
+        if (primitive == float.class) return boxed == Float.class;
+        if (primitive == short.class) return boxed == Short.class;
+        if (primitive == byte.class) return boxed == Byte.class;
+        if (primitive == char.class) return boxed == Character.class;
+        if (primitive == boolean.class) return boxed == Boolean.class;
+        return false;
+    }
+}

--- a/core/src/main/java/org/mvel2/util/SharedVariableSpaceModel.java
+++ b/core/src/main/java/org/mvel2/util/SharedVariableSpaceModel.java
@@ -1,0 +1,37 @@
+package org.mvel2.util;
+
+import org.mvel2.integration.VariableResolver;
+import org.mvel2.integration.VariableResolverFactory;
+import org.mvel2.integration.impl.IndexVariableResolver;
+import org.mvel2.integration.impl.IndexedVariableResolverFactory;
+import org.mvel2.integration.impl.SimpleValueResolver;
+
+/**
+ * @author Mike Brock .
+ */
+public class SharedVariableSpaceModel extends VariableSpaceModel {
+
+    private VariableResolver[] cachedGlobalResolvers;
+
+    public SharedVariableSpaceModel(String[] allVars, Object[] vals) {
+        this.allVars = allVars;
+
+        cachedGlobalResolvers = new VariableResolver[vals.length];
+        for (int i = 0; i < vals.length; i++) {
+            cachedGlobalResolvers[i] = new IndexVariableResolver(i, vals);
+        }
+    }
+
+    public VariableResolverFactory createFactory() {
+        VariableResolver[] resolvers = new VariableResolver[allVars.length];
+        for (int i = 0; i < resolvers.length; i++) {
+            if (i >= cachedGlobalResolvers.length) {
+                resolvers[i] = new SimpleValueResolver(null);
+            } else {
+                resolvers[i] = cachedGlobalResolvers[i];
+            }
+        }
+
+        return new IndexedVariableResolverFactory(allVars, resolvers);
+    }
+}

--- a/core/src/main/java/org/mvel2/util/SimpleIndexHashMapWrapper.java
+++ b/core/src/main/java/org/mvel2/util/SimpleIndexHashMapWrapper.java
@@ -1,0 +1,188 @@
+package org.mvel2.util;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * As most use-cases of the VariableResolverFactory's rely on Maps, this is meant to implement a simple wrapper
+ * which records index positions for use by the optimizing facilities.
+ * <p/>
+ * This wrapper also ensures that the Map is only additive.  You cannot remove an element once it's been added.
+ * While this may seem like an odd limitation, it is consistent with the language semantics. (ie. it's not possible
+ * to delete a variable at runtime once it's been declared).
+ *
+ * @author Mike Brock
+ */
+public class SimpleIndexHashMapWrapper<K, V> implements Map<K, V> {
+
+    private final Map<K, ValueContainer<K, V>> wrappedMap;
+    private final ArrayList<ValueContainer<K, V>> indexBasedLookup;
+    private int indexCounter;
+
+    public SimpleIndexHashMapWrapper() {
+        this.wrappedMap = new HashMap<K, ValueContainer<K, V>>();
+        this.indexBasedLookup = new ArrayList<ValueContainer<K, V>>();
+    }
+
+    public SimpleIndexHashMapWrapper(SimpleIndexHashMapWrapper<K, V> wrapper, boolean allocateOnly) {
+        this.indexBasedLookup = new ArrayList<ValueContainer<K, V>>(wrapper.indexBasedLookup.size());
+        this.wrappedMap = new HashMap<K, ValueContainer<K, V>>();
+
+        ValueContainer<K, V> vc;
+        int index = 0;
+        if (allocateOnly) {
+            for (ValueContainer<K, V> key : wrapper.indexBasedLookup) {
+                vc = new ValueContainer<K, V>(index++, key.getKey(), null);
+                indexBasedLookup.add(vc);
+                wrappedMap.put(key.getKey(), vc);
+            }
+        } else {
+            for (ValueContainer<K, V> key : wrapper.indexBasedLookup) {
+                vc = new ValueContainer<K, V>(index++, key.getKey(), key.getValue());
+                indexBasedLookup.add(vc);
+                wrappedMap.put(key.getKey(), vc);
+            }
+        }
+    }
+
+    public SimpleIndexHashMapWrapper(K[] keys) {
+        this.wrappedMap = new HashMap<K, ValueContainer<K, V>>(keys.length * 2);
+        this.indexBasedLookup = new ArrayList<ValueContainer<K, V>>(keys.length);
+
+        initWithKeys(keys);
+    }
+
+    public SimpleIndexHashMapWrapper(K[] keys, int initialCapacity, float load) {
+        this.wrappedMap = new HashMap<K, ValueContainer<K, V>>(initialCapacity * 2, load);
+        this.indexBasedLookup = new ArrayList<ValueContainer<K, V>>(initialCapacity);
+
+        initWithKeys(keys);
+    }
+
+    public void initWithKeys(K[] keys) {
+        int index = 0;
+        ValueContainer<K, V> vc;
+        for (K key : keys) {
+            vc = new ValueContainer<K, V>(index++, key, null);
+            wrappedMap.put(key, vc);
+            indexBasedLookup.add(vc);
+        }
+    }
+
+    public void addKey(K key) {
+        ValueContainer<K, V> vc = new ValueContainer<K, V>(indexCounter++, key, null);
+        this.indexBasedLookup.add(vc);
+        this.wrappedMap.put(key, vc);
+    }
+
+    public void addKey(K key, V value) {
+        ValueContainer<K, V> vc = new ValueContainer<K, V>(indexCounter++, key, value);
+        this.indexBasedLookup.add(vc);
+        this.wrappedMap.put(key, vc);
+    }
+
+    public int size() {
+        return wrappedMap.size();
+    }
+
+    public boolean isEmpty() {
+        return wrappedMap.isEmpty();
+    }
+
+    public boolean containsKey(Object key) {
+        return wrappedMap.containsKey(key);
+    }
+
+    public boolean containsValue(Object value) {
+        return wrappedMap.containsValue(value);
+    }
+
+    public V get(Object key) {
+        return wrappedMap.get(key).getValue();
+    }
+
+    public V getByIndex(int index) {
+        return indexBasedLookup.get(index).getValue();
+    }
+
+    public K getKeyAtIndex(int index) {
+        return indexBasedLookup.get(index).getKey();
+    }
+
+    public int indexOf(K key) {
+        return wrappedMap.get(key).getIndex();
+    }
+
+    public V put(K key, V value) {
+        ValueContainer<K, V> vc = wrappedMap.get(key);
+        if (vc == null) throw new RuntimeException("cannot add a new entry.  you must allocate a new key with addKey() first.");
+
+        indexBasedLookup.add(vc);
+        return wrappedMap.put(key, vc).getValue();
+    }
+
+    public void putAtIndex(int index, V value) {
+        ValueContainer<K, V> vc = indexBasedLookup.get(index);
+        vc.setValue(value);
+    }
+
+    public V remove(Object key) {
+        throw new UnsupportedOperationException("cannot remove keys");
+    }
+
+    public void putAll(Map<? extends K, ? extends V> m) {
+        //   wrappedMap.put
+    }
+
+    public void clear() {
+        throw new UnsupportedOperationException("cannot clear map");
+    }
+
+    public Set<K> keySet() {
+        return wrappedMap.keySet();
+    }
+
+    public Collection<V> values() {
+        throw new UnsupportedOperationException();
+    }
+
+    public Set<Entry<K, V>> entrySet() {
+        throw new UnsupportedOperationException();
+    }
+
+    private class ValueContainer<K, V> {
+
+        private int index;
+        private K key;
+        private V value;
+
+        public ValueContainer(int index, K key, V value) {
+            this.index = index;
+            this.key = key;
+            this.value = value;
+        }
+
+        public int getIndex() {
+            return index;
+        }
+
+        public K getKey() {
+            return key;
+        }
+
+        void setKey(K key) {
+            this.key = key;
+        }
+
+        public V getValue() {
+            return value;
+        }
+
+        void setValue(V value) {
+            this.value = value;
+        }
+    }
+}

--- a/core/src/main/java/org/mvel2/util/SimpleVariableSpaceModel.java
+++ b/core/src/main/java/org/mvel2/util/SimpleVariableSpaceModel.java
@@ -1,0 +1,30 @@
+package org.mvel2.util;
+
+import org.mvel2.integration.VariableResolver;
+import org.mvel2.integration.VariableResolverFactory;
+import org.mvel2.integration.impl.IndexVariableResolver;
+import org.mvel2.integration.impl.IndexedVariableResolverFactory;
+import org.mvel2.integration.impl.SimpleValueResolver;
+
+/**
+ * @author Mike Brock .
+ */
+public class SimpleVariableSpaceModel extends VariableSpaceModel {
+
+    public SimpleVariableSpaceModel(String[] varNames) {
+        this.allVars = varNames;
+    }
+
+    public VariableResolverFactory createFactory(Object[] vals) {
+        VariableResolver[] resolvers = new VariableResolver[allVars.length];
+        for (int i = 0; i < resolvers.length; i++) {
+            if (i >= vals.length) {
+                resolvers[i] = new SimpleValueResolver(null);
+            } else {
+                resolvers[i] = new IndexVariableResolver(i, vals);
+            }
+        }
+
+        return new IndexedVariableResolverFactory(allVars, resolvers);
+    }
+}

--- a/core/src/main/java/org/mvel2/util/Soundex.java
+++ b/core/src/main/java/org/mvel2/util/Soundex.java
@@ -1,0 +1,70 @@
+/**
+ * MVEL 2.0
+ * Copyright (C) 2007 The Codehaus
+ * Mike Brock, Dhanji Prasanna, John Graham, Mark Proctor
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mvel2.util;
+
+/**
+ * An implementation of Knuth's soundex algorithm.  Used by the <tt>soundslike</tt> operator.
+ */
+public class Soundex {
+
+    /* Implements the mapping
+    * from: AEHIOUWYBFPVCGJKQSXZDTLMNR
+    * to:   00000000111122222222334556
+    */
+    public static final char[] MAP = {
+            //A   B    C    D    E    F    G    H    I    J    K    L    M
+            '0', '1', '2', '3', '0', '1', '2', '0', '0', '2', '2', '4', '5',
+            //N  O   P   W   R   S   T   U   V   W   X   Y   Z
+            '5', '0', '1', '2', '6', '2', '3', '0', '1', '0', '2', '0', '2' };
+
+    /**
+     * Convert the given String to its Soundex code.
+     *
+     * @param s input string
+     * @return null If the given string can't be mapped to Soundex.
+     */
+    public static String soundex(String s) {
+        char[] ca = s.toUpperCase().toCharArray();
+
+        StringBuilder res = new StringBuilder();
+        char c, prev = '?';
+
+        // Main loop: find up to 4 chars that map.
+        for (int i = 0; i < ca.length && res.length() < 4 && (c = ca[i]) != ','; i++) {
+
+            // Check to see if the given character is alphabetic.
+            // Text is already converted to uppercase. Algorithm
+            // only handles ASCII letters, do NOT use Character.isLetter()!
+            // Also, skip double letters.
+            if (c >= 'A' && c <= 'Z' && c != prev) {
+                prev = c;
+
+                char m = MAP[c - 'A'];
+                if (m != '0') res.append(m);
+            }
+        }
+
+        if (res.length() == 0) return null;
+
+        for (int i = res.length(); i < 4; i++)
+            res.append('0');
+
+        return res.toString();
+    }
+}

--- a/core/src/main/java/org/mvel2/util/Stack.java
+++ b/core/src/main/java/org/mvel2/util/Stack.java
@@ -1,0 +1,52 @@
+/**
+ * MVEL 2.0
+ * Copyright (C) 2007 The Codehaus
+ * Mike Brock, Dhanji Prasanna, John Graham, Mark Proctor
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mvel2.util;
+
+import java.io.Serializable;
+
+public interface Stack extends Serializable {
+
+    public boolean isEmpty();
+
+    public Object peek();
+
+    public Object peek2();
+
+    public void add(Object obj);
+
+    public void push(Object obj);
+
+    public Object pushAndPeek(Object obj);
+
+    public void push(Object obj1, Object obj2);
+
+    public void push(Object obj1, Object obj2, Object obj3);
+
+    public Object pop();
+
+    public Object pop2();
+
+    public void discard();
+
+    public void clear();
+
+    public int size();
+
+    public void showStack();
+}

--- a/core/src/main/java/org/mvel2/util/StackElement.java
+++ b/core/src/main/java/org/mvel2/util/StackElement.java
@@ -1,0 +1,31 @@
+/**
+ * MVEL 2.0
+ * Copyright (C) 2007 The Codehaus
+ * Mike Brock, Dhanji Prasanna, John Graham, Mark Proctor
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mvel2.util;
+
+import java.io.Serializable;
+
+public class StackElement implements Serializable {
+
+    public StackElement next;
+    public Object value;
+    public StackElement(StackElement next, Object value) {
+        this.next = next;
+        this.value = value;
+    }
+}

--- a/core/src/main/java/org/mvel2/util/StaticFieldStub.java
+++ b/core/src/main/java/org/mvel2/util/StaticFieldStub.java
@@ -1,0 +1,33 @@
+package org.mvel2.util;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+
+import org.mvel2.integration.VariableResolverFactory;
+
+/**
+ * @author Mike Brock <cbrock@redhat.com>
+ */
+public class StaticFieldStub implements StaticStub {
+
+    private final Field field;
+    private final Object cachedValue;
+
+    public StaticFieldStub(Field field) {
+        this.field = field;
+
+        if (!field.isAccessible() || (field.getModifiers() & Modifier.STATIC) == 0) {
+            throw new RuntimeException("not an accessible static field: " + field.getDeclaringClass().getName() + "." + field.getName());
+        }
+
+        try {
+            cachedValue = field.get(null);
+        } catch (IllegalAccessException e) {
+            throw new RuntimeException("error accessing static field", e);
+        }
+    }
+
+    public Object call(Object ctx, Object thisCtx, VariableResolverFactory factory, Object[] parameters) {
+        return cachedValue;
+    }
+}

--- a/core/src/main/java/org/mvel2/util/StaticStub.java
+++ b/core/src/main/java/org/mvel2/util/StaticStub.java
@@ -1,0 +1,15 @@
+package org.mvel2.util;
+
+import java.io.Serializable;
+import java.lang.reflect.InvocationTargetException;
+
+import org.mvel2.integration.VariableResolverFactory;
+
+/**
+ * @author Mike Brock <cbrock@redhat.com>
+ */
+public interface StaticStub extends Serializable {
+
+    public Object call(Object ctx, Object thisCtx, VariableResolverFactory factory, Object[] parameters)
+            throws IllegalAccessException, InvocationTargetException;
+}

--- a/core/src/main/java/org/mvel2/util/StringAppender.java
+++ b/core/src/main/java/org/mvel2/util/StringAppender.java
@@ -1,0 +1,220 @@
+/**
+ * MVEL 2.0
+ * Copyright (C) 2007 The Codehaus
+ * Mike Brock, Dhanji Prasanna, John Graham, Mark Proctor
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mvel2.util;
+
+import static java.lang.System.arraycopy;
+
+import java.io.UnsupportedEncodingException;
+
+/**
+ *
+ * @author Mike Brock
+ */
+public class StringAppender implements CharSequence {
+
+    private static final int DEFAULT_SIZE = 15;
+
+    private char[] str;
+    private int capacity;
+    private int size = 0;
+    private byte[] btr;
+    private String encoding;
+
+    public StringAppender() {
+        str = new char[capacity = DEFAULT_SIZE];
+    }
+
+    public StringAppender(final int capacity) {
+        str = new char[this.capacity = capacity];
+    }
+
+    public StringAppender(final int capacity, final String encoding) {
+        str = new char[this.capacity = capacity];
+        this.encoding = encoding;
+    }
+
+    public StringAppender(final char c) {
+        (str = new char[this.capacity = DEFAULT_SIZE])[0] = c;
+    }
+
+    public StringAppender(final char[] s) {
+        capacity = size = (str = s).length;
+    }
+
+    public StringAppender(final CharSequence s) {
+        str = new char[this.capacity = size = s.length()];
+        for (int i = 0; i < str.length; i++)
+            str[i] = s.charAt(i);
+
+    }
+
+    public StringAppender(final String s) {
+        capacity = size = (str = s.toCharArray()).length;
+    }
+
+    public StringAppender append(final char[] chars) {
+        if (chars.length > (capacity - size)) grow(chars.length);
+        for (int i = 0; i < chars.length; size++) {
+            str[size] = chars[i++];
+        }
+        return this;
+    }
+
+    public StringAppender append(final byte[] chars) {
+        if (chars.length > (capacity - size)) grow(chars.length);
+        for (int i = 0; i < chars.length; size++) {
+            str[size] = (char) chars[i++];
+        }
+        return this;
+    }
+
+    public StringAppender append(final char[] chars, final int start, final int length) {
+        if (length > (capacity - size)) grow(length);
+        int x = start + length;
+        for (int i = start; i < x; i++) {
+            str[size++] = chars[i];
+        }
+        return this;
+    }
+
+    public StringAppender append(final byte[] chars, final int start, final int length) {
+        if (length > (capacity - size)) grow(length);
+        int x = start + length;
+        for (int i = start; i < x; i++) {
+            str[size++] = (char) chars[i];
+        }
+        return this;
+    }
+
+    public StringAppender append(final Object o) {
+        return append(String.valueOf(o));
+    }
+
+    public StringAppender append(final CharSequence s) {
+        if (s.length() > (capacity - size)) grow(s.length());
+        for (int i = 0; i < s.length(); size++) {
+            str[size] = s.charAt(i++);
+        }
+        return this;
+    }
+
+    public StringAppender append(final String s) {
+        if (s == null) return this;
+
+        final int len = s.length();
+        if (len > (capacity - size)) {
+            grow(len);
+        }
+
+        s.getChars(0, len, str, size);
+        size += len;
+
+        return this;
+    }
+
+    public StringAppender append(final char c) {
+        if (size >= capacity) grow(size);
+        str[size++] = c;
+        return this;
+    }
+
+    public StringAppender append(final byte b) {
+        if (btr == null) btr = new byte[capacity = DEFAULT_SIZE];
+        if (size >= capacity) growByte(size * 2);
+        btr[size++] = b;
+        return this;
+    }
+
+    public int length() {
+        return size;
+    }
+
+    private void grow(final int s) {
+        if (capacity == 0) capacity = DEFAULT_SIZE;
+        final char[] newArray = new char[capacity += s * 2];
+        arraycopy(str, 0, newArray, 0, size);
+        str = newArray;
+    }
+
+    private void growByte(final int s) {
+        final byte[] newByteArray = new byte[capacity += s];
+        arraycopy(btr, 0, newByteArray, 0, size);
+        btr = newByteArray;
+    }
+
+    public char[] getChars(final int start, final int count) {
+        char[] chars = new char[count];
+        arraycopy(str, start, chars, 0, count);
+        return chars;
+    }
+
+    public char[] toChars() {
+        if (btr != null) {
+            if (encoding == null) encoding = System.getProperty("file.encoding");
+            String s;
+            try {
+                s = new String(btr, encoding);
+            } catch (UnsupportedEncodingException e) {
+                s = new String(btr);
+            }
+            return s.toCharArray();
+        }
+        final char[] chars = new char[size];
+        arraycopy(str, 0, chars, 0, size);
+        return chars;
+    }
+
+    public String toString() {
+        if (btr != null) {
+            if (encoding == null) encoding = System.getProperty("file.encoding");
+            String s;
+            try {
+                s = new String(btr, 0, size, encoding);
+            } catch (UnsupportedEncodingException e) {
+                s = new String(btr, 0, size);
+            }
+            return s;
+        }
+        if (size == capacity) return new String(str);
+        else return new String(str, 0, size);
+    }
+
+    public void getChars(int start, int count, char[] target, int offset) {
+        int delta = offset;
+        for (int i = start; i < count; i++) {
+            target[delta++] = str[i];
+        }
+    }
+
+    public void reset() {
+        size = 0;
+    }
+
+    public char charAt(int index) {
+        return str[index];
+    }
+
+    public CharSequence substring(int start, int end) {
+        return new String(str, start, (end - start));
+    }
+
+    public CharSequence subSequence(int start, int end) {
+        return substring(start, end);
+    }
+}

--- a/core/src/main/java/org/mvel2/util/ThisLiteral.java
+++ b/core/src/main/java/org/mvel2/util/ThisLiteral.java
@@ -1,0 +1,22 @@
+/**
+ * MVEL 2.0
+ * Copyright (C) 2007 The Codehaus
+ * Mike Brock, Dhanji Prasanna, John Graham, Mark Proctor
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mvel2.util;
+
+public class ThisLiteral {
+}

--- a/core/src/main/java/org/mvel2/util/Varargs.java
+++ b/core/src/main/java/org/mvel2/util/Varargs.java
@@ -1,0 +1,30 @@
+package org.mvel2.util;
+
+import java.lang.reflect.Array;
+
+public class Varargs {
+
+    public static Object[] normalizeArgsForVarArgs(Class<?>[] parameterTypes, Object[] args, boolean isVarArgs) {
+        if (!isVarArgs) return args;
+        Object lastArgument = args.length > 0 ? args[args.length - 1] : Array
+                .newInstance(parameterTypes[parameterTypes.length - 1].getComponentType(), 0);
+        if (parameterTypes.length == args.length && (lastArgument == null || lastArgument.getClass().isArray())) return args;
+
+        int varargLength = args.length - parameterTypes.length + 1;
+        Object vararg = Array.newInstance(parameterTypes[parameterTypes.length - 1].getComponentType(), varargLength);
+        for (int i = 0; i < varargLength; i++)
+            Array.set(vararg, i, args[parameterTypes.length - 1 + i]);
+
+        Object[] normalizedArgs = new Object[parameterTypes.length];
+        for (int i = 0; i < parameterTypes.length - 1; i++)
+            normalizedArgs[i] = args[i];
+        normalizedArgs[parameterTypes.length - 1] = vararg;
+        return normalizedArgs;
+    }
+
+    public static Class<?> paramTypeVarArgsSafe(Class<?>[] parameterTypes, int i, boolean isVarArgs) {
+        if (!isVarArgs) return parameterTypes[i];
+        if (i < parameterTypes.length - 1) return parameterTypes[i];
+        return parameterTypes[parameterTypes.length - 1].getComponentType();
+    }
+}

--- a/core/src/main/java/org/mvel2/util/VariableSpaceCompiler.java
+++ b/core/src/main/java/org/mvel2/util/VariableSpaceCompiler.java
@@ -1,0 +1,60 @@
+package org.mvel2.util;
+
+import java.util.Set;
+
+import org.mvel2.MVEL;
+import org.mvel2.ParserContext;
+
+/**
+ * @author Mike Brock .
+ */
+public class VariableSpaceCompiler {
+
+    private static final Object[] EMPTY_OBJ = new Object[0];
+
+    public static SharedVariableSpaceModel compileShared(String expr, ParserContext pCtx) {
+        return compileShared(expr, pCtx, EMPTY_OBJ);
+    }
+
+    public static SharedVariableSpaceModel compileShared(String expr, ParserContext pCtx, Object[] vars) {
+        String[] varNames = pCtx.getIndexedVarNames();
+
+        ParserContext analysisContext = ParserContext.create();
+        analysisContext.setIndexAllocation(true);
+
+        MVEL.analysisCompile(expr, analysisContext);
+
+        Set<String> localNames = analysisContext.getVariables().keySet();
+
+        pCtx.addIndexedLocals(localNames);
+
+        String[] locals = localNames.toArray(new String[localNames.size()]);
+        String[] allVars = new String[varNames.length + locals.length];
+
+        System.arraycopy(varNames, 0, allVars, 0, varNames.length);
+        System.arraycopy(locals, 0, allVars, varNames.length, locals.length);
+
+        return new SharedVariableSpaceModel(allVars, vars);
+    }
+
+    public static SimpleVariableSpaceModel compile(String expr, ParserContext pCtx) {
+        String[] varNames = pCtx.getIndexedVarNames();
+
+        ParserContext analysisContext = ParserContext.create();
+        analysisContext.setIndexAllocation(true);
+
+        MVEL.analysisCompile(expr, analysisContext);
+
+        Set<String> localNames = analysisContext.getVariables().keySet();
+
+        pCtx.addIndexedLocals(localNames);
+
+        String[] locals = localNames.toArray(new String[localNames.size()]);
+        String[] allVars = new String[varNames.length + locals.length];
+
+        System.arraycopy(varNames, 0, allVars, 0, varNames.length);
+        System.arraycopy(locals, 0, allVars, varNames.length, locals.length);
+
+        return new SimpleVariableSpaceModel(allVars);
+    }
+}

--- a/core/src/main/java/org/mvel2/util/VariableSpaceModel.java
+++ b/core/src/main/java/org/mvel2/util/VariableSpaceModel.java
@@ -1,0 +1,9 @@
+package org.mvel2.util;
+
+/**
+ * @author Mike Brock .
+ */
+public abstract class VariableSpaceModel {
+
+    protected String[] allVars;
+}

--- a/deploy-xhiniang-as.sh
+++ b/deploy-xhiniang-as.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+scp -r boot/target/arthas-boot-jar-with-dependencies.jar xhinliang.com:/www/https-statics/files/arthas-boot.jar
+scp -r packaging/target/*.zip xhinliang.com:/www/https-statics/files/arthas.zip
+


### PR DESCRIPTION
MVEL 是一个动态执行 Java 代码的工具，类似 OGNL。

与 OGNL 不同的是，MVEL 允许在运行时定义方法。
所以我们可以让 MVEL 帮我们去加载一些对象，比较典型的就是 Spring 中的 Bean。

举个例子，假设我们使用 Spring，而且让一个 com.example.BeanFactory 的类来集中托管 Spring Bean。
那么，我们可以定义一个方法：
```
mvel 'def getBeanByName(name) { com.example.BeanFactory.getBean(name); 
```

然后，我们在执行其他的 MVEL 表达式的时候，MVEL 就可以帮我们动态加载这些 Bean。
```
mvel 'userService.getUser(123L)' // userService 会委托 MVEL 帮我们加载 
```

除此之外，格式化了一些代码。

TODO：
1. 支持自定义 ClassLoader
2. 支持访问私有方法和私有字段（这个是 MVEL 本身的限制，可以通过修改源代码来做到）