### PR TITLE
Remove init Spy in Enhancer.transform, not necessary any more.

### DIFF
--- a/spy/src/main/java/java/arthas/Spy.java
+++ b/spy/src/main/java/java/arthas/Spy.java
@@ -29,26 +29,6 @@ public class Spy {
     public static volatile Method AGENT_RESET_METHOD;
 
     /**
-     * 用于普通的间谍初始化
-     */
-    public static void init(
-            ClassLoader classLoader,
-            Method onBeforeMethod,
-            Method onReturnMethod,
-            Method onThrowsMethod,
-            Method beforeInvokingMethod,
-            Method afterInvokingMethod,
-            Method throwInvokingMethod) {
-        CLASSLOADER = classLoader;
-        ON_BEFORE_METHOD = onBeforeMethod;
-        ON_RETURN_METHOD = onReturnMethod;
-        ON_THROWS_METHOD = onThrowsMethod;
-        BEFORE_INVOKING_METHOD = beforeInvokingMethod;
-        AFTER_INVOKING_METHOD = afterInvokingMethod;
-        THROW_INVOKING_METHOD = throwInvokingMethod;
-    }
-
-    /**
      * 用于启动线程初始化
      */
     public static void initForAgentLauncher(


### PR DESCRIPTION
Spy class has been init in bootstrap classloader, no longer needed to be init in this Enhancer#transform.
Thus the init method in Spy class is redundant as well.