### PR TITLE
命令行提示符增加pid提示

### DIFF
--- a/core/src/main/java/com/taobao/arthas/core/shell/impl/ShellImpl.java
+++ b/core/src/main/java/com/taobao/arthas/core/shell/impl/ShellImpl.java
@@ -46,6 +46,7 @@ public class ShellImpl implements Shell {
     private Term term;
     private String welcome;
     private Job currentForegroundJob;
+    private String prompt;
 
     public ShellImpl(ShellServer server, Term term, InternalCommandManager commandManager,
             Instrumentation instrumentation, int pid, JobControllerImpl jobController) {
@@ -64,6 +65,8 @@ public class ShellImpl implements Shell {
         if (term != null) {
             term.setSession(session);
         }
+
+        this.setPrompt();
     }
 
     public JobController jobController() {
@@ -106,6 +109,14 @@ public class ShellImpl implements Shell {
         this.welcome = welcome;
     }
 
+    private void setPrompt(){
+        StringBuilder stringBuilder = new StringBuilder();
+        stringBuilder.append("[pid:");
+        stringBuilder.append(session.getPid());
+        stringBuilder.append("]$ ");
+        this.prompt = stringBuilder.toString();
+    }
+
     public ShellImpl init() {
         term.interruptHandler(new InterruptHandler(this));
         term.suspendHandler(new SuspendHandler(this));
@@ -142,7 +153,7 @@ public class ShellImpl implements Shell {
     }
 
     public void readline() {
-        term.readline(Constants.DEFAULT_PROMPT, new ShellLineHandler(this),
+        term.readline(prompt, new ShellLineHandler(this),
                 new CommandManagerCompletionHandler(commandManager));
     }
 

--- a/core/src/main/java/com/taobao/arthas/core/shell/impl/ShellImpl.java
+++ b/core/src/main/java/com/taobao/arthas/core/shell/impl/ShellImpl.java
@@ -111,7 +111,7 @@ public class ShellImpl implements Shell {
 
     private void setPrompt(){
         StringBuilder stringBuilder = new StringBuilder();
-        stringBuilder.append("[pid:");
+        stringBuilder.append("[arthas@");
         stringBuilder.append(session.getPid());
         stringBuilder.append("]$ ");
         this.prompt = stringBuilder.toString();


### PR DESCRIPTION
1. 钉钉群里很多人反馈，进入arthas之后，sc无法看到项目中编写的类
2. 最后发现启动时进入了错误的jvm进程
3. 模仿bash，在提示符 $ 前增加pid信息，时刻知道自己在哪个进程里

![](https://github.com/iportman/p/blob/master/arthas/arthas-prompt.jpg?raw=true)