### PR TITLE
Throw IllegalAccessException out when set filed failed.

### DIFF
--- a/core/src/main/java/com/taobao/arthas/core/config/Configure.java
+++ b/core/src/main/java/com/taobao/arthas/core/config/Configure.java
@@ -122,18 +122,14 @@ public class Configure {
      * @param toString 序列化字符串
      * @return 反序列化的对象
      */
-    public static Configure toConfigure(String toString) {
+    public static Configure toConfigure(String toString) throws IllegalAccessException {
         final Configure configure = new Configure();
         final Map<String, String> map = codec.toMap(toString);
 
         for (Map.Entry<String, String> entry : map.entrySet()) {
-            try {
-                final Field field = ArthasReflectUtils.getField(Configure.class, entry.getKey());
-                if (null != field && !isStatic(field.getModifiers())) {
-                    ArthasReflectUtils.set(field, ArthasReflectUtils.valueOf(field.getType(), entry.getValue()), configure);
-                }
-            } catch (Throwable t) {
-                //
+            final Field field = ArthasReflectUtils.getField(Configure.class, entry.getKey());
+            if (null != field && !isStatic(field.getModifiers())) {
+                ArthasReflectUtils.set(field, ArthasReflectUtils.valueOf(field.getType(), entry.getValue()), configure);
             }
         }
         return configure;


### PR DESCRIPTION
When I was trying to attach arthas to an Elasticsearch instance and find which permission i should grant to Elasticsearch, nothing printed out but `telnet port is 0, skip bind telnet server.` and `http port is 0, skip bind http server.` in `${user.home}/logs/arthas/arthas.log`.
I added some code to `AgentBootstrap#bind` method to see what `args` and `configure` is, I got `args` is ok and `configure` is empty. It is because method `Configure#toConfigure` catch `IllegalAccessException` throwed by`ArthasReflectUtils#set` method and return empty `Configure` instance.


