### PR TITLE
improve grep command for support regexp(-e) and -n/-v/-n/-A/-B/-C and -f

### DIFF
--- a/core/src/main/java/com/taobao/arthas/core/command/BuiltinCommandPack.java
+++ b/core/src/main/java/com/taobao/arthas/core/command/BuiltinCommandPack.java
@@ -2,6 +2,7 @@ package com.taobao.arthas.core.command;
 
 import com.taobao.arthas.core.command.basic1000.CatCommand;
 import com.taobao.arthas.core.command.basic1000.ClsCommand;
+import com.taobao.arthas.core.command.basic1000.GrepCommand;
 import com.taobao.arthas.core.command.basic1000.HelpCommand;
 import com.taobao.arthas.core.command.basic1000.HistoryCommand;
 import com.taobao.arthas.core.command.basic1000.KeymapCommand;
@@ -99,5 +100,6 @@ public class BuiltinCommandPack implements CommandResolver {
         commands.add(Command.create(CatCommand.class));
         commands.add(Command.create(PwdCommand.class));
         commands.add(Command.create(MBeanCommand.class));
+        commands.add(Command.create(GrepCommand.class)); 
     }
 }

--- a/core/src/main/java/com/taobao/arthas/core/command/basic1000/GrepCommand.java
+++ b/core/src/main/java/com/taobao/arthas/core/command/basic1000/GrepCommand.java
@@ -1,0 +1,41 @@
+package com.taobao.arthas.core.command.basic1000;
+
+import com.taobao.arthas.core.command.Constants;
+import com.taobao.arthas.core.shell.command.AnnotatedCommand;
+import com.taobao.arthas.core.shell.command.CommandProcess;
+import com.taobao.middleware.cli.annotations.Description;
+import com.taobao.middleware.cli.annotations.Name;
+import com.taobao.middleware.cli.annotations.Summary;
+
+/**
+ * @see com.taobao.arthas.core.shell.command.internal.GrepHandler
+ */
+@Name("grep")
+@Summary("grep command for pipes (-e -m -n -v -A -B -C -f )\n" )
+@Description(Constants.EXAMPLE +
+        "sysprop | grep java \n" +
+        " sysenv | grep -v JAVA -n\n" +
+        " sysenv | grep -e \"(?i)(JAVA|sun)\" -m 3  -C 2\n" +
+        " sysenv | grep -v JAVA -A2 -B3\n" +
+        " sysenv | grep  -e JAVA -f /tmp/t.log \n" +
+        " thread | grep -m 10 -e  \"TIMED_WAITING|WAITING\"\n\n"
+  +"-e, --regexp              use PATTERN for matching\n"
+  +"-m, --max-count=NUM       stop after NUM selected lines\n"
+  +"-n, --line-number         print line number with output lines\n"
+  +"-v, --invert-match        select non-matching lines\n"
+  +"-A, --after-context=NUM   print NUM lines of trailing context\n"
+  +"-B, --before-context=NUM  print NUM lines of leading context\n"
+  +"-C, --context=NUM         print NUM lines of output context\n"
+  +"-f, --output=File         output result to file, filename endsWith :false for disable append mode\n"
+  + Constants.WIKI + Constants.WIKI_HOME + "grep")
+public class GrepCommand extends AnnotatedCommand {
+    @Override
+    public void process(CommandProcess process) {
+        process.write("The grep command only for pipes ").write("\n");
+        final Description ann = GrepCommand.class.getAnnotation(Description.class);
+        if (ann != null) {
+          process.write(ann.value()).write("\n");
+        }
+        process.end();
+    }
+}

--- a/core/src/main/java/com/taobao/arthas/core/command/basic1000/GrepCommand.java
+++ b/core/src/main/java/com/taobao/arthas/core/command/basic1000/GrepCommand.java
@@ -26,7 +26,7 @@ import com.taobao.middleware.cli.annotations.Summary;
   +"-A, --after-context=NUM   print NUM lines of trailing context\n"
   +"-B, --before-context=NUM  print NUM lines of leading context\n"
   +"-C, --context=NUM         print NUM lines of output context\n"
-  +"-f, --output=File         output result to file, filename endsWith :false for disable append mode\n"
+//  +"-f, --output=File         output result to file, filename endsWith :false for disable append mode\n"
   + Constants.WIKI + Constants.WIKI_HOME + "grep")
 public class GrepCommand extends AnnotatedCommand {
     @Override

--- a/core/src/main/java/com/taobao/arthas/core/shell/command/internal/GrepHandler.java
+++ b/core/src/main/java/com/taobao/arthas/core/shell/command/internal/GrepHandler.java
@@ -1,19 +1,26 @@
 package com.taobao.arthas.core.shell.command.internal;
 
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import com.taobao.arthas.core.shell.cli.CliToken;
 import com.taobao.middleware.cli.Argument;
 import com.taobao.middleware.cli.CLIs;
 import com.taobao.middleware.cli.CommandLine;
 import com.taobao.middleware.cli.Option;
 
-import java.util.List;
-import java.util.regex.Pattern;
-
 /**
  * @author beiwei30 on 12/12/2016.
  */
 public class GrepHandler extends StdoutHandler {
     public static final String NAME = "grep";
+    //强制指定输出文件后缀名是为了防止无意识输错文件名而覆盖现有价值的现有文件
+    private static final String FORCE_OUTPUT_SUFFIX = ".log";
+    //output file name with :false for disable append mode
+    private static final Pattern APPEND_FLAG_PATTERN = Pattern.compile("[:#;](true|false)$");
 
     private String keyword;
     private boolean ignoreCase;
@@ -21,23 +28,27 @@ public class GrepHandler extends StdoutHandler {
     private final boolean invertMatch;
     //-e, --regexp=PATTERN      use PATTERN for matching
     private final Pattern pattern;
-
+    private final String outputFile;
+    private final boolean outputAppend;
+    
     public static StdoutHandler inject(List<CliToken> tokens) {
         List<String> args = StdoutHandler.parseArgs(tokens, NAME);
         CommandLine commandLine = CLIs.create(NAME)
                 .addOption(new Option().setShortName("i").setLongName("ignore-case").setFlag(true))
                 .addOption(new Option().setShortName("v").setLongName("invert-match").setFlag(true))
                 .addOption(new Option().setShortName("e").setLongName("regexp").setFlag(true))
+                .addOption(new Option().setShortName("f").setLongName("output").setSingleValued(true))
                 .addArgument(new Argument().setArgName("keyword").setIndex(0))
                 .parse(args);
         Boolean ignoreCase = commandLine.isFlagEnabled("ignore-case");
         String keyword = commandLine.getArgumentValue(0);
         final boolean invertMatch = commandLine.isFlagEnabled("invert-match");
         final boolean regexpMode = commandLine.isFlagEnabled("regexp");
-        return new GrepHandler(keyword, ignoreCase, invertMatch, regexpMode);
+        final String output = commandLine.getOptionValue("output");
+        return new GrepHandler(keyword, ignoreCase, invertMatch, regexpMode, output);
     }
 
-    private GrepHandler(String keyword, boolean ignoreCase, boolean invertMatch, boolean regexpMode) {
+    private GrepHandler(String keyword, boolean ignoreCase, boolean invertMatch, boolean regexpMode, String output) {
         this.ignoreCase = ignoreCase;
         this.invertMatch = invertMatch;
         if (regexpMode) {
@@ -47,22 +58,53 @@ public class GrepHandler extends StdoutHandler {
            this.pattern = null;
         }
         this.keyword = ignoreCase ?  keyword.toLowerCase() : keyword;
+        if (output != null && output.length() > 0) {
+          final Matcher matcher = APPEND_FLAG_PATTERN.matcher(output);
+          if (matcher.find()) {
+            outputAppend = Boolean.parseBoolean(matcher.group(1)) ;
+            output = matcher.replaceAll("");
+          }else {
+            outputAppend = true;
+          }
+          if(!output.endsWith(FORCE_OUTPUT_SUFFIX)) {
+            output += FORCE_OUTPUT_SUFFIX;
+          }
+        } else {
+          output = null;
+          outputAppend = true;
+        }
+        this.outputFile = output;
     }
 
     @Override
     public String apply(String input) {
         StringBuilder output = new StringBuilder();
         String[] lines = input.split("\n");
-        for (String line : lines) {
-             final boolean match;
+        PrintWriter writer  = null;
+        try {
+          if (outputFile != null) {
+            writer = new PrintWriter(new FileOutputStream(outputFile, outputAppend), true);
+          }
+          for (String line : lines) {
+            final boolean match;
             if (pattern == null) {
               match = (ignoreCase ?  line.toLowerCase() : line).contains(keyword);
             } else {
               match = pattern.matcher(line).find();
             }
             if (invertMatch ? !match : match) {
-                output.append(line).append("\n");
+              output.append(line).append("\n");
+              if (writer != null) {
+                writer.println(line);
+              }
             }
+          }
+        }catch(IOException ex) {
+          throw new IllegalStateException(ex);
+        }finally {
+          if (writer != null) {
+            writer.close();
+          }
         }
         return output.toString();
     }

--- a/core/src/main/java/com/taobao/arthas/core/shell/command/internal/GrepHandler.java
+++ b/core/src/main/java/com/taobao/arthas/core/shell/command/internal/GrepHandler.java
@@ -7,6 +7,7 @@ import com.taobao.middleware.cli.CommandLine;
 import com.taobao.middleware.cli.Option;
 
 import java.util.List;
+import java.util.regex.Pattern;
 
 /**
  * @author beiwei30 on 12/12/2016.
@@ -18,24 +19,34 @@ public class GrepHandler extends StdoutHandler {
     private boolean ignoreCase;
     // -v, --invert-match        select non-matching lines
     private final boolean invertMatch;
+    //-e, --regexp=PATTERN      use PATTERN for matching
+    private final Pattern pattern;
 
     public static StdoutHandler inject(List<CliToken> tokens) {
         List<String> args = StdoutHandler.parseArgs(tokens, NAME);
         CommandLine commandLine = CLIs.create(NAME)
                 .addOption(new Option().setShortName("i").setLongName("ignore-case").setFlag(true))
                 .addOption(new Option().setShortName("v").setLongName("invert-match").setFlag(true))
+                .addOption(new Option().setShortName("e").setLongName("regexp").setFlag(true))
                 .addArgument(new Argument().setArgName("keyword").setIndex(0))
                 .parse(args);
         Boolean ignoreCase = commandLine.isFlagEnabled("ignore-case");
         String keyword = commandLine.getArgumentValue(0);
         final boolean invertMatch = commandLine.isFlagEnabled("invert-match");
-        return new GrepHandler(keyword, ignoreCase, invertMatch);
+        final boolean regexpMode = commandLine.isFlagEnabled("regexp");
+        return new GrepHandler(keyword, ignoreCase, invertMatch, regexpMode);
     }
 
-    private GrepHandler(String keyword, boolean ignoreCase, final boolean invertMatch) {
-        this.keyword = keyword;
+    private GrepHandler(String keyword, boolean ignoreCase, boolean invertMatch, boolean regexpMode) {
         this.ignoreCase = ignoreCase;
         this.invertMatch = invertMatch;
+        if (regexpMode) {
+           final int flags = ignoreCase ?  Pattern.CASE_INSENSITIVE : 0;
+           this.pattern = Pattern.compile(keyword, flags);
+        } else {
+           this.pattern = null;
+        }
+        this.keyword = ignoreCase ?  keyword.toLowerCase() : keyword;
     }
 
     @Override
@@ -43,11 +54,12 @@ public class GrepHandler extends StdoutHandler {
         StringBuilder output = new StringBuilder();
         String[] lines = input.split("\n");
         for (String line : lines) {
-            if (ignoreCase) {
-                line = line.toLowerCase();
-                keyword = keyword.toLowerCase();
+             final boolean match;
+            if (pattern == null) {
+              match = (ignoreCase ?  line.toLowerCase() : line).contains(keyword);
+            } else {
+              match = pattern.matcher(line).find();
             }
-            final boolean match =  line.contains(keyword);
             if (invertMatch ? !match : match) {
                 output.append(line).append("\n");
             }

--- a/core/src/main/java/com/taobao/arthas/core/shell/command/internal/GrepHandler.java
+++ b/core/src/main/java/com/taobao/arthas/core/shell/command/internal/GrepHandler.java
@@ -25,6 +25,13 @@ public class GrepHandler extends StdoutHandler {
     //output file name with :false for disable append mode
     private static final Pattern APPEND_FLAG_PATTERN = Pattern.compile("[:#;](true|false)$");
     private static final Charset UTF8 = Charset.forName("UTF-8");
+    private static final Pattern TRIM_PATTERN;
+    static {
+       //默认删除右边的空白字符是为了解决-n 因空白字符导致显示换行的问题
+       //ie: sysprop | grep -n java
+       final String p = System.getProperty("arthas_grep_trim_pattern", "[ \\f\t\\v]+$");
+       TRIM_PATTERN = "NOP".equals(p) ? null : Pattern.compile(p);
+    }
 
     private String keyword;
     private boolean ignoreCase;
@@ -123,7 +130,7 @@ public class GrepHandler extends StdoutHandler {
         int lastStartPos = 0 ;
         int lastContinueLineNum = -1  ;
         for (int lineNum = 0 ; lineNum < lines.length ;) {
-          String line  = lines[lineNum++];
+          String line  = TRIM_PATTERN.matcher(lines[lineNum++]).replaceAll("");
           final boolean match;
           if (pattern == null) {
             match = (ignoreCase ?  line.toLowerCase() : line).contains(keyword);
@@ -168,7 +175,7 @@ public class GrepHandler extends StdoutHandler {
             }
           }
         }
-        final String str = output.length() > 0 ? output.substring(0, output.length()-1) : "";
+        final String str = output.toString();// output.length() > 0 ? output.substring(0, output.length()-1) : "";
         if (outputFile != null) {
             Writer writer = null;
             try {

--- a/core/src/main/java/com/taobao/arthas/core/shell/command/internal/GrepHandler.java
+++ b/core/src/main/java/com/taobao/arthas/core/shell/command/internal/GrepHandler.java
@@ -16,21 +16,26 @@ public class GrepHandler extends StdoutHandler {
 
     private String keyword;
     private boolean ignoreCase;
+    // -v, --invert-match        select non-matching lines
+    private final boolean invertMatch;
 
     public static StdoutHandler inject(List<CliToken> tokens) {
         List<String> args = StdoutHandler.parseArgs(tokens, NAME);
         CommandLine commandLine = CLIs.create(NAME)
                 .addOption(new Option().setShortName("i").setLongName("ignore-case").setFlag(true))
+                .addOption(new Option().setShortName("v").setLongName("invert-match").setFlag(true))
                 .addArgument(new Argument().setArgName("keyword").setIndex(0))
                 .parse(args);
         Boolean ignoreCase = commandLine.isFlagEnabled("ignore-case");
         String keyword = commandLine.getArgumentValue(0);
-        return new GrepHandler(keyword, ignoreCase);
+        final boolean invertMatch = commandLine.isFlagEnabled("invert-match");
+        return new GrepHandler(keyword, ignoreCase, invertMatch);
     }
 
-    private GrepHandler(String keyword, boolean ignoreCase) {
+    private GrepHandler(String keyword, boolean ignoreCase, final boolean invertMatch) {
         this.keyword = keyword;
         this.ignoreCase = ignoreCase;
+        this.invertMatch = invertMatch;
     }
 
     @Override
@@ -42,8 +47,8 @@ public class GrepHandler extends StdoutHandler {
                 line = line.toLowerCase();
                 keyword = keyword.toLowerCase();
             }
-
-            if (line.contains(keyword)) {
+            final boolean match =  line.contains(keyword);
+            if (invertMatch ? !match : match) {
                 output.append(line).append("\n");
             }
         }

--- a/core/src/test/java/com/taobao/arthas/core/shell/command/interna/GrepHandlerTest.java
+++ b/core/src/test/java/com/taobao/arthas/core/shell/command/interna/GrepHandlerTest.java
@@ -1,9 +1,12 @@
 package com.taobao.arthas.core.shell.command.interna;
 
+import java.io.File;
 import java.lang.reflect.Constructor;
+import java.nio.charset.Charset;
 import org.junit.Assert;
 import org.junit.Test;
 import com.taobao.arthas.core.shell.command.internal.GrepHandler;
+import com.taobao.arthas.core.util.FileUtils;
 
 public class GrepHandlerTest {
 
@@ -109,4 +112,26 @@ public class GrepHandlerTest {
       Assert.assertEquals(expected, ret.substring(0,ret.length()-1));
     }
   }
+  
+  @Test
+  public void test4grep_f() throws Exception {//-f
+    Object[][] samples = new Object[][] {
+      {"java\n1\npython\n2\nc","1:java\n3:python", "java|python" },
+      {"java\n1\npython\njava\nc","1:java\n4:java", "java",false }
+    };
+    String output = File.createTempFile("arthas_test", ".log").getAbsolutePath();
+    final Charset charset = Charset.forName("UTF-8");
+    for(Object[] args : samples) {
+      String word = (String)args[2];
+      boolean regexpMode = args.length >3 ? (Boolean)args[3] : true;
+      GrepHandler handler = Hold.createInst(word,false,false,regexpMode,true,0,0,output+":false");
+      String input = (String)args[0];
+      final String ret = handler.apply(input);
+      final String expected = (String)args[1];
+      Assert.assertEquals(expected, ret.substring(0,ret.length()-1));
+      final String ret2 = FileUtils.readFileToString(new File(output), charset);
+      Assert.assertEquals(expected, ret.substring(0,ret2.length()-1));
+    }
+  }
+  
 }

--- a/core/src/test/java/com/taobao/arthas/core/shell/command/interna/GrepHandlerTest.java
+++ b/core/src/test/java/com/taobao/arthas/core/shell/command/interna/GrepHandlerTest.java
@@ -25,7 +25,7 @@ public class GrepHandlerTest {
          , boolean showLineNumber,  int beforeLines, int afterLines, String output, int maxCount) {
        try {
        final Object[] initargs = new Object[] {   keyword,ignoreCase,invertMatch,regexpMode,showLineNumber
-           ,beforeLines,afterLines,output,maxCount
+           ,beforeLines,afterLines,maxCount
        };
        GrepHandler handler = (GrepHandler)constructor.newInstance(initargs);
        return handler;
@@ -136,25 +136,25 @@ public class GrepHandlerTest {
     }
   }
   
-  @Test
-  public void test4grep_f() throws Exception {//-f
-    Object[][] samples = new Object[][] {
-      {"java\n1\npython\n2\nc","1:java\n3:python", "java|python" },
-      {"java\n1\npython\njava\nc","1:java\n4:java", "java",false }
-    };
-    String output = File.createTempFile("arthas_test", ".log").getAbsolutePath();
-    final Charset charset = Charset.forName("UTF-8");
-    for(Object[] args : samples) {
-      String word = (String)args[2];
-      boolean regexpMode = args.length >3 ? (Boolean)args[3] : true;
-      GrepHandler handler = Hold.createInst(word,false,false,regexpMode,true,0,0,output+":false");
-      String input = (String)args[0];
-      final String ret = handler.apply(input);
-      final String expected = (String)args[1];
-      Assert.assertEquals(expected, ret.substring(0,ret.length()-1));
-      final String ret2 = FileUtils.readFileToString(new File(output), charset);
-      Assert.assertEquals(expected, ret.substring(0,ret2.length()-1));
-    }
-  }
+//  @Test
+//  public void test4grep_f() throws Exception {//-f
+//    Object[][] samples = new Object[][] {
+//      {"java\n1\npython\n2\nc","1:java\n3:python", "java|python" },
+//      {"java\n1\npython\njava\nc","1:java\n4:java", "java",false }
+//    };
+//    String output = File.createTempFile("arthas_test", ".log").getAbsolutePath();
+//    final Charset charset = Charset.forName("UTF-8");
+//    for(Object[] args : samples) {
+//      String word = (String)args[2];
+//      boolean regexpMode = args.length >3 ? (Boolean)args[3] : true;
+//      GrepHandler handler = Hold.createInst(word,false,false,regexpMode,true,0,0,output+":false");
+//      String input = (String)args[0];
+//      final String ret = handler.apply(input);
+//      final String expected = (String)args[1];
+//      Assert.assertEquals(expected, ret.substring(0,ret.length()-1));
+//      final String ret2 = FileUtils.readFileToString(new File(output), charset);
+//      Assert.assertEquals(expected, ret.substring(0,ret2.length()-1));
+//    }
+//  }
   
 }

--- a/core/src/test/java/com/taobao/arthas/core/shell/command/interna/GrepHandlerTest.java
+++ b/core/src/test/java/com/taobao/arthas/core/shell/command/interna/GrepHandlerTest.java
@@ -1,0 +1,112 @@
+package com.taobao.arthas.core.shell.command.interna;
+
+import java.lang.reflect.Constructor;
+import org.junit.Assert;
+import org.junit.Test;
+import com.taobao.arthas.core.shell.command.internal.GrepHandler;
+
+public class GrepHandlerTest {
+
+  private static final class Hold {
+      static final  Constructor<?> constructor;
+      static {
+        constructor = GrepHandler.class.getDeclaredConstructors()[0];
+        constructor.setAccessible(true);
+      }
+    //new GrepHandler(keyword, ignoreCase, invertMatch, regexpMode, showLineNumber, beforeLines, afterLines,output)
+      public static GrepHandler createInst(String keyword, boolean ignoreCase, boolean invertMatch, boolean regexpMode
+         , boolean showLineNumber,  int beforeLines, int afterLines, String output) {
+       try {
+       final Object[] initargs = new Object[] {   keyword,ignoreCase,invertMatch,regexpMode,showLineNumber
+           ,beforeLines,afterLines,output
+       };
+       GrepHandler handler = (GrepHandler)constructor.newInstance(initargs);
+       return handler;
+       }catch(RuntimeException ex) {
+         throw ex;
+       }catch(Exception ex) {
+         throw new IllegalStateException(ex);
+       }
+     }
+  }
+  @Test
+  public void test4grep_ABC() { //-A -B -C
+    Object[][] samples = new Object[][] {
+      {"ABC\n1\n2\n3\n4\nc", "ABC", 0, 4, "ABC\n1\n2\n3\n4"},
+      {"ABC\n1\n2\n3\n4\nABC\n5", "ABC", 2, 1, "ABC\n1\n3\n4\nABC\n5"},
+      {"ABC\n1\n2\n3\n4\na", "ABC", 2, 1, "ABC\n1"},
+      {"ABC\n1\n2\n3\n4\nb", "ABC", 0, 0, "ABC"},
+      {"ABC\n1\n2\n3\n4\nc", "ABC", 0, 5, "ABC\n1\n2\n3\n4\nc"},
+      {"ABC\n1\n2\n3\n4\nc", "ABC", 0, 10, "ABC\n1\n2\n3\n4\nc"},
+      {"ABC\n1\n2\n3\n4\nc", "ABC", 0, 2, "ABC\n1\n2"},
+      {"1\n2\n3\n4\nABC", "ABC", 5, 1, "1\n2\n3\n4\nABC"},
+      {"1\n2\n3\n4\nABC", "ABC", 4, 1, "1\n2\n3\n4\nABC"},
+      {"1\n2\n3\n4\nABC", "ABC", 2, 1, "3\n4\nABC"}
+    };
+    
+    for(Object[] args : samples) {
+      String word = (String)args[1];
+      int beforeLines = (Integer)args[2];
+      int afterLines = (Integer)args[3];
+      GrepHandler handler = Hold.createInst(word,false,false,true,false,beforeLines,afterLines,null);
+      String input = (String)args[0];
+      final String ret = handler.apply(input);
+      final String expected = (String)args[4];
+      Assert.assertEquals(expected, ret);
+    }
+  }
+  @Test
+  public void test4grep_v() {//-v
+    Object[][] samples = new Object[][] {
+      {"ABC\n1\n2\nc", "ABC", 0, 4, "1\n2\nc"},
+      {"ABC\n1\n2\n", "ABC", 0, 0, "1\n2"},
+      {"ABC\n1\n2\nc", "ABC", 0, 1, "1\n2\nc"}
+    };
+    
+    for(Object[] args : samples) {
+      String word = (String)args[1];
+      int beforeLines = (Integer)args[2];
+      int afterLines = (Integer)args[3];
+      GrepHandler handler = Hold.createInst(word,false,true,true,false,beforeLines,afterLines,null);
+      String input = (String)args[0];
+      final String ret = handler.apply(input);
+      final String expected = (String)args[4];
+      Assert.assertEquals(expected, ret);
+    }
+  }
+  
+  @Test
+  public void test4grep_e() {//-e
+    Object[][] samples = new Object[][] {
+      {"java\n1python\n2\nc", "java|python", "java\n1python"},
+      {"java\n1python\n2\nc", "ja|py", "java\n1python"}
+    };
+    
+    for(Object[] args : samples) {
+      String word = (String)args[1];
+      GrepHandler handler = Hold.createInst(word,false,false,true,false,0,0,null);
+      String input = (String)args[0];
+      final String ret = handler.apply(input);
+      final String expected = (String)args[2];
+      Assert.assertEquals(expected, ret);
+    }
+  }
+  
+  @Test
+  public void test4grep_n() {//-n
+    Object[][] samples = new Object[][] {
+      {"java\n1\npython\n2\nc","1:java\n3:python", "java|python" },
+      {"java\n1\npython\njava\nc","1:java\n4:java", "java",false }
+    };
+    
+    for(Object[] args : samples) {
+      String word = (String)args[2];
+      boolean regexpMode = args.length >3 ? (Boolean)args[3] : true;
+      GrepHandler handler = Hold.createInst(word,false,false,regexpMode,true,0,0,null);
+      String input = (String)args[0];
+      final String ret = handler.apply(input);
+      final String expected = (String)args[1];
+      Assert.assertEquals(expected, ret);
+    }
+  }
+}

--- a/core/src/test/java/com/taobao/arthas/core/shell/command/interna/GrepHandlerTest.java
+++ b/core/src/test/java/com/taobao/arthas/core/shell/command/interna/GrepHandlerTest.java
@@ -52,7 +52,7 @@ public class GrepHandlerTest {
       String input = (String)args[0];
       final String ret = handler.apply(input);
       final String expected = (String)args[4];
-      Assert.assertEquals(expected, ret);
+      Assert.assertEquals(expected, ret.substring(0,ret.length()-1));
     }
   }
   @Test
@@ -71,7 +71,7 @@ public class GrepHandlerTest {
       String input = (String)args[0];
       final String ret = handler.apply(input);
       final String expected = (String)args[4];
-      Assert.assertEquals(expected, ret);
+      Assert.assertEquals(expected, ret.substring(0,ret.length()-1));
     }
   }
   
@@ -88,7 +88,7 @@ public class GrepHandlerTest {
       String input = (String)args[0];
       final String ret = handler.apply(input);
       final String expected = (String)args[2];
-      Assert.assertEquals(expected, ret);
+      Assert.assertEquals(expected, ret.substring(0,ret.length()-1));
     }
   }
   
@@ -106,7 +106,7 @@ public class GrepHandlerTest {
       String input = (String)args[0];
       final String ret = handler.apply(input);
       final String expected = (String)args[1];
-      Assert.assertEquals(expected, ret);
+      Assert.assertEquals(expected, ret.substring(0,ret.length()-1));
     }
   }
 }

--- a/core/src/test/java/com/taobao/arthas/core/shell/command/interna/GrepHandlerTest.java
+++ b/core/src/test/java/com/taobao/arthas/core/shell/command/interna/GrepHandlerTest.java
@@ -16,12 +16,16 @@ public class GrepHandlerTest {
         constructor = GrepHandler.class.getDeclaredConstructors()[0];
         constructor.setAccessible(true);
       }
+      public static GrepHandler createInst(String keyword, boolean ignoreCase, boolean invertMatch, boolean regexpMode
+          , boolean showLineNumber,  int beforeLines, int afterLines, String output) {
+          return createInst(keyword, ignoreCase, invertMatch, regexpMode, showLineNumber, beforeLines, afterLines, output, 0);
+      }
     //new GrepHandler(keyword, ignoreCase, invertMatch, regexpMode, showLineNumber, beforeLines, afterLines,output)
       public static GrepHandler createInst(String keyword, boolean ignoreCase, boolean invertMatch, boolean regexpMode
-         , boolean showLineNumber,  int beforeLines, int afterLines, String output) {
+         , boolean showLineNumber,  int beforeLines, int afterLines, String output, int maxCount) {
        try {
        final Object[] initargs = new Object[] {   keyword,ignoreCase,invertMatch,regexpMode,showLineNumber
-           ,beforeLines,afterLines,output
+           ,beforeLines,afterLines,output,maxCount
        };
        GrepHandler handler = (GrepHandler)constructor.newInstance(initargs);
        return handler;
@@ -88,6 +92,25 @@ public class GrepHandlerTest {
     for(Object[] args : samples) {
       String word = (String)args[1];
       GrepHandler handler = Hold.createInst(word,false,false,true,false,0,0,null);
+      String input = (String)args[0];
+      final String ret = handler.apply(input);
+      final String expected = (String)args[2];
+      Assert.assertEquals(expected, ret.substring(0,ret.length()-1));
+    }
+  }
+
+  @Test
+  public void test4grep_m() {//-e
+    Object[][] samples = new Object[][] {
+      {"java\n1python\n2\nc", "java|python", "java", 1},
+      {"java\n1python\n2\nc", "ja|py", "java\n1python",2},
+      {"java\n1python\n2\nc", "ja|py", "java\n1python",3}
+    };
+    
+    for(Object[] args : samples) {
+      String word = (String)args[1];
+      int maxCount = args.length > 3 ? (Integer)args[3] : 0;
+      GrepHandler handler = Hold.createInst(word,false,false,true,false,0,0,null, maxCount);
       String input = (String)args[0];
       final String ret = handler.apply(input);
       final String expected = (String)args[2];


### PR DESCRIPTION
## improve grep command 
* support linux grep: -e/-m/-n/-v/-n/-A/-B/-C

*  save grep result to file: -f --output
 the output filename will end with '.log'
    for disable output append mode we should suffix filename with ':false' , ie: `/tmp/stack01:true` or `/tmp/stack01.log:true`

help grep:
```
 EXAMPLES:
 sysprop | grep java
  sysenv | grep -v JAVA -n
  sysenv | grep -e "(?i)(JAVA|sun)" -m 3  -C 2
  sysenv | grep -v JAVA -A2 -B3
  sysenv | grep  -e JAVA -f /tmp/t.log
  thread | grep -m 10 -e  "TIMED_WAITING|WAITING"

 -e, --regexp              use PATTERN for matching
 -m, --max-count=NUM       stop after NUM selected lines
 -n, --line-number         print line number with output lines
 -v, --invert-match        select non-matching lines
 -A, --after-context=NUM   print NUM lines of trailing context
 -B, --before-context=NUM  print NUM lines of leading context
 -C, --context=NUM         print NUM lines of output context
 -f, --output=File         output result to file, filename endsWith :false for disable append mode
```
