### PR TITLE
Modify Constants.java signiture so that it becomes a class instead of interface

### DIFF
--- a/core/src/main/java/com/taobao/arthas/core/util/Constants.java
+++ b/core/src/main/java/com/taobao/arthas/core/util/Constants.java
@@ -9,49 +9,52 @@ import static com.taobao.arthas.core.util.LogUtil.LOGS_DIR;
 /**
  * @author ralf0131 2016-12-28 16:20.
  */
-public interface Constants {
+public class Constants {
+
+    private Constants() {
+    }
 
     /**
      * Spy的全类名
      */
-    String SPY_CLASSNAME = "java.arthas.Spy";
+    public static final String SPY_CLASSNAME = "java.arthas.Spy";
 
     /**
      * 中断提示
      */
-    String Q_OR_CTRL_C_ABORT_MSG = "Press Q or Ctrl+C to abort.";
+    public static final String Q_OR_CTRL_C_ABORT_MSG = "Press Q or Ctrl+C to abort.";
 
     /**
      * 空字符串
      */
-    String EMPTY_STRING = "";
+    public static final String EMPTY_STRING = "";
 
     /**
      * 命令提示符
      */
-    String DEFAULT_PROMPT = "$ ";
+    public static final String DEFAULT_PROMPT = "$ ";
 
     /**
      * 带颜色命令提示符
      * raw string: "[33m$ [m"
      */
-    String COLOR_PROMPT = Ansi.ansi().fg(Ansi.Color.YELLOW).a(DEFAULT_PROMPT).reset().toString();
+    public static final String COLOR_PROMPT = Ansi.ansi().fg(Ansi.Color.YELLOW).a(DEFAULT_PROMPT).reset().toString();
 
     /**
      * 方法执行耗时
      */
-    String COST_VARIABLE = "cost";
+    public static final String COST_VARIABLE = "cost";
 
-    String CMD_HISTORY_FILE = System.getProperty("user.home") + File.separator + ".arthas" + File.separator + "history";
+    public static final String CMD_HISTORY_FILE = System.getProperty("user.home") + File.separator + ".arthas" + File.separator + "history";
 
     /**
      * 当前进程PID
      */
-    String PID = ApplicationUtils.getPid();
+    public static final String PID = ApplicationUtils.getPid();
 
     /**
      * 缓存目录
      */
-    String CACHE_ROOT = LOGS_DIR + File.separator + "arthas-cache";
+    public static final String CACHE_ROOT = LOGS_DIR + File.separator + "arthas-cache";
 
 }


### PR DESCRIPTION
A small change. Redefine Constants.java as a class rather than an interface. Functionality wise, it doesn't seem to change anything because string defined in an interface is essentially a public static final string anyway. However, it looks like a good Java practice to put these things inside a class rather than an interface. 