### PR TITLE
修复monitor命令中 监控调用链上的多个method时，RT时间不准的问题

### DIFF
--- a/core/src/main/java/com/taobao/arthas/core/util/ThreadLocalWatch.java
+++ b/core/src/main/java/com/taobao/arthas/core/util/ThreadLocalWatch.java
@@ -1,31 +1,33 @@
 package com.taobao.arthas.core.util;
 
+import java.util.Stack;
+
 /**
- * 简单的调用计时器。TODO 用stack的实现更合理
+ * 简单的调用计时器。
  * Created by vlinux on 16/6/1.
  * @author hengyunabc 2016-10-31
  */
 public class ThreadLocalWatch {
 
-    private final ThreadLocal<Long> timestampRef = new ThreadLocal<Long>() {
+    private final ThreadLocal<Stack<Long>> timestampRef = new ThreadLocal<Stack<Long>>() {
         @Override
-        protected Long initialValue() {
-            return System.nanoTime();
+        protected Stack<Long> initialValue() {
+            return new Stack<Long>();
         }
     };
 
     public long start() {
         final long timestamp = System.nanoTime();
-        timestampRef.set(timestamp);
+        timestampRef.get().push(timestamp);
         return timestamp;
     }
 
     public long cost() {
-        return (System.nanoTime() - timestampRef.get());
+        return (System.nanoTime() - timestampRef.get().pop());
     }
 
     public double costInMillis() {
-        return (System.nanoTime() - timestampRef.get()) / 1000000.0;
+        return (System.nanoTime() - timestampRef.get().pop()) / 1000000.0;
     }
 
     public void clear() {


### PR DESCRIPTION
修复issues #912 方法性能统计误差很大