### PR TITLE
rename the thread

### DIFF
--- a/core/src/main/java/com/taobao/arthas/core/shell/impl/ShellServerImpl.java
+++ b/core/src/main/java/com/taobao/arthas/core/shell/impl/ShellServerImpl.java
@@ -152,7 +152,7 @@ public class ShellServerImpl extends ShellServer {
             scheduledExecutorService = Executors.newSingleThreadScheduledExecutor(new ThreadFactory() {
                 @Override
                 public Thread newThread(Runnable r) {
-                    final Thread t = new Thread(r, "shell-server");
+                    final Thread t = new Thread(r, "arthas-shell-server");
                     return t;
                 }
             });

--- a/core/src/main/java/com/taobao/arthas/core/shell/impl/ShellServerImpl.java
+++ b/core/src/main/java/com/taobao/arthas/core/shell/impl/ShellServerImpl.java
@@ -31,6 +31,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -148,8 +149,13 @@ public class ShellServerImpl extends ShellServer {
 
     public synchronized void setTimer() {
         if (!closed && reaperInterval > 0) {
-            scheduledExecutorService = Executors.newSingleThreadScheduledExecutor();
-            // TODO rename the thread, currently it is `pool-3-thread-1`, which is ambiguous
+            scheduledExecutorService = Executors.newSingleThreadScheduledExecutor(new ThreadFactory() {
+                @Override
+                public Thread newThread(Runnable r) {
+                    final Thread t = new Thread(r, "shell-server");
+                    return t;
+                }
+            });
             scheduledExecutorService.scheduleAtFixedRate(new Runnable() {
 
                 @Override


### PR DESCRIPTION
After attached and quit from shell, there is a thread with default name in application's JVM.
So, give a specific name to the thread.