### PR TITLE
Optimize the hints at the beginning, when choosing a process

### DIFF
--- a/bin/as.sh
+++ b/bin/as.sh
@@ -645,7 +645,7 @@ parse_arguments()
             return 1
         fi
 
-        echo "Found existing java process, please choose one and hit RETURN."
+        echo "Found existing java process, please choose one and input the serial number of the process, eg : 1. Then hit RETURN."
 
         index=0
         suggest=1

--- a/boot/src/main/java/com/taobao/arthas/boot/ProcessUtils.java
+++ b/boot/src/main/java/com/taobao/arthas/boot/ProcessUtils.java
@@ -45,7 +45,7 @@ public class ProcessUtils {
             return -1;
         }
 
-        AnsiLog.info("Found existing java process, please choose one and hit RETURN.");
+        AnsiLog.info("Found existing java process, please choose one and input the serial number of the process, eg : 1. Then hit RETURN.");
         // print list
         int count = 1;
         for (String process : processMap.values()) {

--- a/site/src/site/sphinx/en/start-arthas.md
+++ b/site/src/site/sphinx/en/start-arthas.md
@@ -9,7 +9,7 @@ Start Arthas
 
 ```bash
 ➜  bin git:(develop) ✗ ./as.sh
-Found existing java process, please choose one and hit RETURN.
+Found existing java process, please choose one and input the serial number of the process, eg : 1. Then hit RETURN.
   [1]: 3088 org.jetbrains.idea.maven.server.RemoteMavenServer
 * [2]: 12872 org.apache.catalina.startup.Bootstrap
   [3]: 2455

--- a/site/src/site/sphinx/start-arthas.md
+++ b/site/src/site/sphinx/start-arthas.md
@@ -9,7 +9,7 @@
 
 ```bash
 ➜  bin git:(develop) ✗ ./as.sh
-Found existing java process, please choose one and hit RETURN.
+Found existing java process, please choose one and input the serial number of the process, eg: 1 . Then hit RETURN.
   [1]: 3088 org.jetbrains.idea.maven.server.RemoteMavenServer
 * [2]: 12872 org.apache.catalina.startup.Bootstrap
   [3]: 2455


### PR DESCRIPTION
I used artas for the first time today. At the beginning, I entered the process ID as prompted, but the result was as follows:
```
[INFO] arthas-boot version: 3.1.7
[INFO] Found existing java process, please choose one and hit RETURN.
* [1]: 54304 org.jboss.Main
54304
Please select an available pid.
```
Later, I found out that entering the serial number in front of the process id can enter the monitoring interface, like this:
```
[INFO] arthas-boot version: 3.1.7
[INFO] Found existing java process, please choose one and hit RETURN.
* [1]: 54304 org.jboss.Main
1
[INFO] arthas home: /home/mwopr/.arthas/lib/3.1.7/arthas
[INFO] Try to attach process 54304
[INFO] Attach process 54304 success.
[INFO] arthas-client connect 127.0.0.1 3658
  ,---.  ,------. ,--------.,--.  ,--.  ,---.   ,---.                           
 /  O  \ |  .--. ''--.  .--'|  '--'  | /  O  \ '   .-'                          
|  .-.  ||  '--'.'   |  |   |  .--.  ||  .-.  |`.  `-.                          
|  | |  ||  |\  \    |  |   |  |  |  ||  | |  |.-'    |                         
`--' `--'`--' '--'   `--'   `--'  `--'`--' `--'`-----'                          
                                                                                

wiki      https://alibaba.github.io/arthas                                      
tutorials https://alibaba.github.io/arthas/arthas-tutorials                     
version   3.1.7                                                                 
pid       54304                                                                 
time      2020-02-13 22:21:18
```
So I modified the hint about the selection process.