### PR TITLE
WIP: watch命令支持CompletableFuture

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -21,8 +21,8 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>
-                    <source>1.6</source>
-                    <target>1.6</target>
+                    <source>8</source>
+                    <target>8</target>
                     <encoding>UTF-8</encoding>
                     <showDeprecation>true</showDeprecation>
                 </configuration>

--- a/core/src/main/java/com/taobao/arthas/core/command/monitor200/WatchCommand.java
+++ b/core/src/main/java/com/taobao/arthas/core/command/monitor200/WatchCommand.java
@@ -34,6 +34,7 @@ public class WatchCommand extends EnhancerCommand {
     private String express;
     private String conditionExpress;
     private boolean isBefore = false;
+    private boolean isAsync = false;
     private boolean isFinish = false;
     private boolean isException = false;
     private boolean isSuccess = false;
@@ -70,6 +71,12 @@ public class WatchCommand extends EnhancerCommand {
     @Description("Watch before invocation")
     public void setBefore(boolean before) {
         isBefore = before;
+    }
+
+    @Option(shortName = "a", longName = "async", flag = true)
+    @Description("watch async call")
+    public void setAsync(boolean async) {
+        isAsync = async;
     }
 
     @Option(shortName = "f", longName = "finish", flag = true)
@@ -132,6 +139,10 @@ public class WatchCommand extends EnhancerCommand {
 
     public boolean isBefore() {
         return isBefore;
+    }
+
+    public boolean isAsync() {
+        return isAsync;
     }
 
     public boolean isFinish() {


### PR DESCRIPTION
实现了watch命令的-a参数，以支持watch异步方法。

```
[arthas@6906]$ watch Main asyncAction returnObj
Press Q or Ctrl+C to abort.
Affect(class-cnt:1 , method-cnt:1) cost in 57 ms.
ts=2020-04-04 10:37:24; [cost=3.6561ms] result=@CompletableFuture[
    result=null,
    stack=null,
    NIL=@AltResult[java.util.concurrent.CompletableFuture$AltResult@4f8e5cde],
    USE_COMMON_POOL=@Boolean[true],
    ASYNC_POOL=@ForkJoinPool[java.util.concurrent.ForkJoinPool@3b764bce[Running, parallelism = 7, size = 1, active = 1, running = 0, steals = 3, tasks
 = 0, submissions = 0]],
    SYNC=@Integer[0],
    ASYNC=@Integer[1],
    NESTED=@Integer[-1],
    RESULT=@FieldInstanceReadWrite[java.lang.invoke.VarHandleObjects$FieldInstanceReadWrite@484b61fc],
    STACK=@FieldInstanceReadWrite[java.lang.invoke.VarHandleObjects$FieldInstanceReadWrite@45fe3ee3],
    NEXT=@FieldInstanceReadWrite[java.lang.invoke.VarHandleObjects$FieldInstanceReadWrite@4cdf35a9],
]
[arthas@6906]$ watch Main asyncAction returnObj -a
Press Q or Ctrl+C to abort.
Affect(class-cnt:1 , method-cnt:1) cost in 23 ms.
ts=2020-04-04 10:37:34; [cost=4.80702489339E8ms] result=@Integer[4]
ts=2020-04-04 10:37:39; [cost=4.807075062602E8ms] result=@Integer[5]
```

<details><summary>Main.java代码</summary>
<p>

```java
import java.util.concurrent.CompletableFuture;

public class Main {
    private static int cnt = 0;

    private static CompletableFuture<Integer> asyncAction() {
        return CompletableFuture.supplyAsync(() -> {
            try {
                Thread.sleep(5000);
            } catch (InterruptedException e) {
                e.printStackTrace();
            }
            return Main.cnt++;
        });
    }

    public static void main(String[] args) {
        while (true) {
            asyncAction().thenAccept((val) -> {
                System.out.println(val);
            }).join();
        }
    }
}
```

</p>
</details>