### PR TITLE
double check telnet port and pid before attach agent

### DIFF
--- a/boot/src/main/java/com/taobao/arthas/boot/ProcessUtils.java
+++ b/boot/src/main/java/com/taobao/arthas/boot/ProcessUtils.java
@@ -32,6 +32,24 @@ import com.taobao.arthas.common.PidUtils;
 public class ProcessUtils {
     private static String FOUND_JAVA_HOME = null;
 
+    //status code from com.taobao.arthas.client.TelnetConsole
+    /**
+     * Process success
+     */
+    public static final int STATUS_OK = 0;
+    /**
+     * Generic error
+     */
+    public static final int STATUS_ERROR = 1;
+    /**
+     * Execute commands timeout
+     */
+    public static final int STATUS_EXEC_TIMEOUT = 100;
+    /**
+     * Execute commands error
+     */
+    public static final int STATUS_EXEC_ERROR = 101;
+
     @SuppressWarnings("resource")
     public static long select(boolean v, long telnetPortPid) throws InputMismatchException {
         Map<Long, String> processMap = listProcessByJps(v);
@@ -274,54 +292,49 @@ public class ProcessUtils {
         }
     }
 
-    public static Boolean startArthasClient(String arthasHomeDir, List<String> telnetArgs, OutputStream out) throws Throwable {
+    public static int startArthasClient(String arthasHomeDir, List<String> telnetArgs, OutputStream out) throws Throwable {
         // start java telnet client
         // find arthas-client.jar
         URLClassLoader classLoader = new URLClassLoader(
                 new URL[]{new File(arthasHomeDir, "arthas-client.jar").toURI().toURL()});
         Class<?> telnetConsoleClas = classLoader.loadClass("com.taobao.arthas.client.TelnetConsole");
         Method processMethod = telnetConsoleClas.getMethod("process", String[].class);
-        Method isExecutionOvertimeMethod = telnetConsoleClas.getMethod("isExecutionOvertime");
 
         //redirect System.out/System.err
         PrintStream originSysOut = System.out;
         PrintStream originSysErr = System.err;
         PrintStream newOut = new PrintStream(out);
         PrintStream newErr = new PrintStream(out);
+
+        // call TelnetConsole.process()
+        // fix https://github.com/alibaba/arthas/issues/833
+        ClassLoader tccl = Thread.currentThread().getContextClassLoader();
         try {
             System.setOut(newOut);
             System.setErr(newErr);
-
-            // call TelnetConsole.process()
-            // fix https://github.com/alibaba/arthas/issues/833
-            ClassLoader tccl = Thread.currentThread().getContextClassLoader();
-            try {
-                Thread.currentThread().setContextClassLoader(classLoader);
-                processMethod.invoke(null, new Object[]{telnetArgs.toArray(new String[0])});
-            } catch (Throwable e) {
-                //java.lang.reflect.InvocationTargetException : java.net.ConnectException
-                e = e.getCause();
-                if (e instanceof IOException) {
-                    // ignore connection error
-                } else if (e instanceof InterruptedException) {
-                    // ignore interrupted error
-                } else {
-                    // detection error
-                    throw e;
-                }
-            } finally {
-                Thread.currentThread().setContextClassLoader(tccl);
+            Thread.currentThread().setContextClassLoader(classLoader);
+            return (Integer) processMethod.invoke(null, new Object[]{telnetArgs.toArray(new String[0])});
+        } catch (Throwable e) {
+            //java.lang.reflect.InvocationTargetException : java.net.ConnectException
+            e = e.getCause();
+            if (e instanceof IOException || e instanceof InterruptedException) {
+                // ignore connection error and interrupted error
+                return STATUS_ERROR;
+            } else {
+                // process error
+                AnsiLog.error("process error: {}", e.toString());
+                AnsiLog.error(e);
+                return STATUS_EXEC_ERROR;
             }
+        } finally {
+            Thread.currentThread().setContextClassLoader(tccl);
 
+            //reset System.out/System.err
+            System.setOut(originSysOut);
+            System.setErr(originSysErr);
             //flush output
             newOut.flush();
             newErr.flush();
-
-            //check execution overtime
-            return (Boolean) isExecutionOvertimeMethod.invoke(null);
-        } finally {
-            System.setOut(originSysOut);
-            System.setErr(originSysErr);
         }
     }
 

--- a/boot/src/main/java/com/taobao/arthas/boot/ProcessUtils.java
+++ b/boot/src/main/java/com/taobao/arthas/boot/ProcessUtils.java
@@ -314,7 +314,7 @@ public class ProcessUtils {
                 public void run() {
                     InputStream inputStream = proc.getErrorStream();
                     try {
-                        IOUtils.copy(inputStream, System.err);
+                        IOUtils.copy(inputStream, out);
                     } catch (IOException e) {
                         IOUtils.close(inputStream);
                     }

--- a/boot/src/main/java/com/taobao/arthas/boot/ProcessUtils.java
+++ b/boot/src/main/java/com/taobao/arthas/boot/ProcessUtils.java
@@ -271,7 +271,6 @@ public class ProcessUtils {
     }
 
     public static String startArthasClient(List<String> args) {
-        // find java/java.exe, then try to find tools.jar
         String javaHome = findJavaHome();
 
         // find java/java.exe

--- a/client/src/main/java/com/taobao/arthas/client/IOUtil.java
+++ b/client/src/main/java/com/taobao/arthas/client/IOUtil.java
@@ -53,7 +53,6 @@ public final class IOUtil {
                     }
                 } catch (IOException e) {
                     e.printStackTrace();
-                    System.exit(1);
                 }
             }
         };


### PR DESCRIPTION
#1115 #1118 增加二次检查telnet端口和pid是否匹配，解决部分场景下Arthas注入进程混乱的问题。
主要原因：
1）部分场景存在权限问题导致通过系统命令无法检测到telnet端口已经被使用的情况
2）按照正常流程尝试注入目标进程没有报错（调用注入agent成功，因为端口冲突问题，新的Arthas实例启动失败）
3）as.sh脚本和arthas-boot.jar按照流程连接了原来的另外一个进程的Arthas实例，出现注入混乱问题。
解决办法：
1) 在第二步向目标进程注入agent之前，通过arthas-client.jar 连接目标telnet端口并执行session命令，如果连接成功并获取到结果，则提示用户错误信息，并终止执行。
2) 极端场景出现arthas-client 探测被挂起的问题已经处理，arthas-client添加命令执行超时参数--execution-timeout  2000
已测试指定的telnet port是另外一个arthas进程、某个http服务端口、22端口、remote debug端口4种情况。