### PR TITLE
Set default value for the express argument of the watch command

### DIFF
--- a/core/src/main/java/com/taobao/arthas/core/command/monitor200/WatchCommand.java
+++ b/core/src/main/java/com/taobao/arthas/core/command/monitor200/WatchCommand.java
@@ -8,6 +8,7 @@ import com.taobao.arthas.core.shell.cli.Completion;
 import com.taobao.arthas.core.shell.cli.CompletionUtils;
 import com.taobao.arthas.core.shell.command.CommandProcess;
 import com.taobao.arthas.core.util.SearchUtils;
+import com.taobao.arthas.core.util.StringUtils;
 import com.taobao.arthas.core.util.matcher.Matcher;
 import com.taobao.middleware.cli.annotations.Argument;
 import com.taobao.middleware.cli.annotations.Description;
@@ -54,7 +55,7 @@ public class WatchCommand extends EnhancerCommand {
         this.methodPattern = methodPattern;
     }
 
-    @Argument(index = 2, argName = "express")
+    @Argument(index = 2, argName = "express", required = false)
     @Description("the content you want to watch, written by ognl.\n" + Constants.EXPRESS_EXAMPLES)
     public void setExpress(String express) {
         this.express = express;
@@ -123,6 +124,9 @@ public class WatchCommand extends EnhancerCommand {
     }
 
     public String getExpress() {
+        if (express == null) {
+            express ="{params, target, returnObj}";
+        }
         return express;
     }
 

--- a/core/src/main/java/com/taobao/arthas/core/command/monitor200/WatchCommand.java
+++ b/core/src/main/java/com/taobao/arthas/core/command/monitor200/WatchCommand.java
@@ -8,9 +8,9 @@ import com.taobao.arthas.core.shell.cli.Completion;
 import com.taobao.arthas.core.shell.cli.CompletionUtils;
 import com.taobao.arthas.core.shell.command.CommandProcess;
 import com.taobao.arthas.core.util.SearchUtils;
-import com.taobao.arthas.core.util.StringUtils;
 import com.taobao.arthas.core.util.matcher.Matcher;
 import com.taobao.middleware.cli.annotations.Argument;
+import com.taobao.middleware.cli.annotations.DefaultValue;
 import com.taobao.middleware.cli.annotations.Description;
 import com.taobao.middleware.cli.annotations.Name;
 import com.taobao.middleware.cli.annotations.Option;
@@ -56,6 +56,7 @@ public class WatchCommand extends EnhancerCommand {
     }
 
     @Argument(index = 2, argName = "express", required = false)
+    @DefaultValue("{params, target, returnObj}")
     @Description("the content you want to watch, written by ognl.\n" + Constants.EXPRESS_EXAMPLES)
     public void setExpress(String express) {
         this.express = express;
@@ -124,9 +125,6 @@ public class WatchCommand extends EnhancerCommand {
     }
 
     public String getExpress() {
-        if (express == null) {
-            express ="{params, target, returnObj}";
-        }
         return express;
     }
 


### PR DESCRIPTION
其目的为让watch命令和trace/stack默认必选参数一致，方便替换方式切换,
并可减少使用者的健盘输入，方便使用者，以提高生产力:)