### PR TITLE
fix issue 1151 管道符“｜”与前后一条命令之间没有空格，不能正确识别

### DIFF
--- a/core/src/test/java/com/taobao/arthas/core/shell/cli/impl/CliTokenImplTest.java
+++ b/core/src/test/java/com/taobao/arthas/core/shell/cli/impl/CliTokenImplTest.java
@@ -70,6 +70,9 @@ public class CliTokenImplTest {
      * case2:
      * trace -E classA|classB methodA|methodB|grep classA
      * [trace, -E, classA|classB, methodA|methodB|grep, classA] -> [trace, -E, classA|classB, methodA|methodB|grep, classA]
+     * case3:
+     * trace -E classA|classB| methodA|methodB | grep classA
+     * [trace, -E, classA|classB|, methodA|methodB, |, grep, classA] -> [trace, -E, classA|classB，|, methodA|methodB, |, grep, classA]
      */
     @Test
     public void testUnSupportedPipeChar() {
@@ -79,6 +82,10 @@ public class CliTokenImplTest {
 
         expectedTextTokenValue = new String[]{"trace", "-E", "classA|classB", "methodA|methodB|grep", "classA"};
         actualTokens = CliTokenImpl.tokenize("trace -E classA|classB methodA|methodB|grep classA");
+        assertEquals(expectedTextTokenValue, actualTokens);
+
+        expectedTextTokenValue = new String[]{"trace", "-E", "classA|classB", "|", "methodA|methodB", "|", "grep", "classA"};
+        actualTokens = CliTokenImpl.tokenize("trace -E classA|classB| methodA|methodB | grep classA");
         assertEquals(expectedTextTokenValue, actualTokens);
     }
 

--- a/core/src/test/java/com/taobao/arthas/core/shell/cli/impl/CliTokenImplTest.java
+++ b/core/src/test/java/com/taobao/arthas/core/shell/cli/impl/CliTokenImplTest.java
@@ -1,0 +1,103 @@
+package com.taobao.arthas.core.shell.cli.impl;
+
+import com.taobao.arthas.core.shell.cli.CliToken;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.Iterator;
+import java.util.List;
+
+public class CliTokenImplTest {
+
+    /**
+     * supported:
+     * <p>
+     * case1:
+     * thread| grep xxx
+     * [thread|, grep, xxx] -> [thread, |, grep, xxx]
+     * case:2
+     * thread | grep xxx
+     * [thread, |, grep, xxx] -> [thread, |, grep, xxx]
+     * case3:
+     * thread |grep xxx
+     * [thread, |grep] -> [thread, |, grep, xxx]
+     */
+    @Test
+    public void testSupportedPipeCharWithoutRegex() {
+        String[] expectedTextTokenValue = new String[]{"thread", "|", "grep", "xxx"};
+        List<CliToken> actualTokens = CliTokenImpl.tokenize("thread| grep xxx");
+        assertEquals(expectedTextTokenValue, actualTokens);
+
+        actualTokens = CliTokenImpl.tokenize("thread | grep xxx");
+        assertEquals(expectedTextTokenValue, actualTokens);
+
+        actualTokens = CliTokenImpl.tokenize("thread |grep xxx");
+        assertEquals(expectedTextTokenValue, actualTokens);
+    }
+
+    /**
+     * supported:
+     * <p>
+     * case1:
+     * trace -E classA|classB methodA|methodB| grep classA
+     * [trace, -E, classA|classB, methodA|methodB|, grep, classA] -> [trace, -E, classA|classB, methodA|methodB, |, grep, classA]
+     * case2:
+     * trace -E classA|classB methodA|methodB | grep classA
+     * [trace, -E, classA|classB, methodA|methodB, |, grep, classA] -> [trace, -E, classA|classB, methodA|methodB, |, grep, classA]
+     * case3:
+     * trace -E classA|classB methodA|methodB |grep classA
+     * [trace, -E, classA|classB, methodA|methodB, |grep, classA] -> [trace, -E, classA|classB, methodA|methodB, |, grep, classA]
+     */
+    @Test
+    public void testSupportedPipeCharWithRegex() {
+        String[] expectedTextTokenValue = new String[]{"trace", "-E", "classA|classB", "methodA|methodB", "|", "grep", "classA"};
+        List<CliToken> actualTokens = CliTokenImpl.tokenize("trace -E classA|classB methodA|methodB| grep classA");
+        assertEquals(expectedTextTokenValue, actualTokens);
+
+        actualTokens = CliTokenImpl.tokenize("trace -E classA|classB methodA|methodB | grep classA");
+        assertEquals(expectedTextTokenValue, actualTokens);
+
+        actualTokens = CliTokenImpl.tokenize("trace -E classA|classB methodA|methodB |grep classA");
+        assertEquals(expectedTextTokenValue, actualTokens);
+    }
+
+    /**
+     * unsupported:
+     * <p>
+     * case1:
+     * thread|grep xxx
+     * [thread|grep, xxx] -> [thread|grep, xxx]
+     * case2:
+     * trace -E classA|classB methodA|methodB|grep classA
+     * [trace, -E, classA|classB, methodA|methodB|grep, classA] -> [trace, -E, classA|classB, methodA|methodB|grep, classA]
+     */
+    @Test
+    public void testUnSupportedPipeChar() {
+        String[] expectedTextTokenValue = new String[]{"thread|grep", "xxx"};
+        List<CliToken> actualTokens = CliTokenImpl.tokenize("thread|grep xxx");
+        assertEquals(expectedTextTokenValue, actualTokens);
+
+        expectedTextTokenValue = new String[]{"trace", "-E", "classA|classB", "methodA|methodB|grep", "classA"};
+        actualTokens = CliTokenImpl.tokenize("trace -E classA|classB methodA|methodB|grep classA");
+        assertEquals(expectedTextTokenValue, actualTokens);
+    }
+
+    private void assertEquals(String[] expectedTextTokenValue, List<CliToken> actualTokens) {
+        removeBlankToken(actualTokens);
+        for (int i = 0; i < expectedTextTokenValue.length; i++) {
+            Assert.assertEquals(expectedTextTokenValue[i], actualTokens.get(i).value());
+        }
+    }
+
+    private void removeBlankToken(List<CliToken> cliTokens) {
+        CliToken blankToken = new CliTokenImpl(false, " ");
+        Iterator<CliToken> it = cliTokens.iterator();
+        while (it.hasNext()) {
+            CliToken token = it.next();
+            if (blankToken.equals(token)) {
+                it.remove();
+            }
+        }
+    }
+
+}


### PR DESCRIPTION
fix [#1151](https://github.com/alibaba/arthas/issues/1151)

修复后的实际运行结果：
![fix-pipe-symbol](https://user-images.githubusercontent.com/7534743/80965278-d626aa80-8e44-11ea-968f-e10eb0038c73.jpg)
