### PR TITLE
修复链接问题 fix link issues

### DIFF
--- a/tutorials/katacoda/arthas-advanced-cn/arthas-boot.md
+++ b/tutorials/katacoda/arthas-advanced-cn/arthas-boot.md
@@ -13,4 +13,4 @@ java -jar arthas-boot.jar --target-ip 0.0.0.0`{{execute T2}}
 
 Attach成功之后，会打印Arthas LOGO。输入 `help`{{execute T2}} 可以获取到更多的帮助信息。
 
-![Arthas Boot](/hengyunabc/scenarios/arthas-advanced-cn/assets/arthas-boot.png)
+![Arthas Boot](/arthas/scenarios/arthas-advanced-cn/assets/arthas-boot.png)

--- a/tutorials/katacoda/arthas-advanced-cn/finish.md
+++ b/tutorials/katacoda/arthas-advanced-cn/finish.md
@@ -9,4 +9,4 @@
 
 欢迎关注公众号，获取Arthas项目的信息，源码分析，案例实践。
 
-![Arthas公众号](/hengyunabc/scenarios/arthas-basics-cn/assets/qrcode_gongzhonghao.jpg)
+![Arthas公众号](/arthas/scenarios/arthas-basics-cn/assets/qrcode_gongzhonghao.jpg)

--- a/tutorials/katacoda/arthas-advanced-cn/start-demo.md
+++ b/tutorials/katacoda/arthas-advanced-cn/start-demo.md
@@ -11,4 +11,4 @@ java -jar demo-arthas-spring-boot.jar`{{execute T1}}
 
 启动之后，可以访问80端口： https://[[HOST_SUBDOMAIN]]-80-[[KATACODA_HOST]].environments.katacoda.com
 
-![Demo Web](/hengyunabc/scenarios/arthas-advanced-cn/assets/demo-web.png)
+![Demo Web](/arthas/scenarios/arthas-advanced-cn/assets/demo-web.png)

--- a/tutorials/katacoda/arthas-advanced-cn/web-console.md
+++ b/tutorials/katacoda/arthas-advanced-cn/web-console.md
@@ -14,6 +14,6 @@ http://[[HOST_SUBDOMAIN]]-8563-[[KATACODA_HOST]].environments.katacoda.com/?ip=[
 
 当在本地启动时，可以访问  http://127.0.0.1:8563/ ，通过浏览器来使用Arthas。
 
-![Arthas WebConsole](/hengyunabc/scenarios/arthas-advanced-cn/assets/web-console.png)
+![Arthas WebConsole](/arthas/scenarios/arthas-advanced-cn/assets/web-console.png)
 
 推荐通过“快速入门”来体验： https://alibaba.github.io/arthas/quick-start.html 

--- a/tutorials/katacoda/arthas-advanced-en/arthas-boot.md
+++ b/tutorials/katacoda/arthas-advanced-en/arthas-boot.md
@@ -13,4 +13,4 @@ Select the first process, type `1`{{execute T2}} ，then type `Enter`：
 
 After the Attach is successful, Arthas LOGO is printed. Enter `help`{{execute T2}} for more help.
 
-![Arthas Boot](/hengyunabc/scenarios/arthas-advanced-en/assets/arthas-boot.png)
+![Arthas Boot](/arthas/scenarios/arthas-advanced-en/assets/arthas-boot.png)

--- a/tutorials/katacoda/arthas-advanced-en/start-demo.md
+++ b/tutorials/katacoda/arthas-advanced-en/start-demo.md
@@ -11,4 +11,4 @@ java -jar demo-arthas-spring-boot.jar`{{execute T1}}
 
 After booting, access port 80: https://[[HOST_SUBDOMAIN]]-80-[[KATACODA_HOST]].environments.katacoda.com
 
-![Demo Web](/hengyunabc/scenarios/arthas-advanced-cn/assets/demo-web.png)
+![Demo Web](/arthas/scenarios/arthas-advanced-cn/assets/demo-web.png)

--- a/tutorials/katacoda/arthas-advanced-en/web-console.md
+++ b/tutorials/katacoda/arthas-advanced-en/web-console.md
@@ -14,7 +14,7 @@ http://[[HOST_SUBDOMAIN]]-8563-[[KATACODA_HOST]].environments.katacoda.com/?ip=[
 
 When launching locally, you can access Arthas through a browser by visiting http://127.0.0.1:8563/.
 
-![Arthas WebConsole](/hengyunabc/scenarios/arthas-advanced-en/assets/web-console.png)
+![Arthas WebConsole](/arthas/scenarios/arthas-advanced-en/assets/web-console.png)
 
 
 It is recommended to experience it through "Quick Start": https://alibaba.github.io/arthas/en/quick-start.html

--- a/tutorials/katacoda/arthas-basics-cn/arthas-boot.md
+++ b/tutorials/katacoda/arthas-basics-cn/arthas-boot.md
@@ -13,4 +13,4 @@ java -jar arthas-boot.jar --target-ip 0.0.0.0`{{execute T2}}
 
 Attach成功之后，会打印Arthas LOGO。输入 `help`{{execute T2}} 可以获取到更多的帮助信息。
 
-![Arthas Boot](/hengyunabc/scenarios/arthas-basics-cn/assets/arthas-boot.png)
+![Arthas Boot](/arthas/scenarios/arthas-basics-cn/assets/arthas-boot.png)

--- a/tutorials/katacoda/arthas-basics-cn/finish.md
+++ b/tutorials/katacoda/arthas-basics-cn/finish.md
@@ -7,4 +7,4 @@
 
 欢迎关注公众号，获取Arthas项目的信息，源码分析，案例实践。
 
-![Arthas公众号](/hengyunabc/scenarios/arthas-basics-cn/assets/qrcode_gongzhonghao.jpg)
+![Arthas公众号](/arthas/scenarios/arthas-basics-cn/assets/qrcode_gongzhonghao.jpg)

--- a/tutorials/katacoda/arthas-basics-en/arthas-boot.md
+++ b/tutorials/katacoda/arthas-basics-en/arthas-boot.md
@@ -12,4 +12,4 @@ Select the first process, type `1`{{execute T2}} ，then type `Enter`：
 
 After the Attach is successful, Arthas LOGO is printed. Enter `help`{{execute T2}} for more help.
 
-![Arthas Boot](/hengyunabc/scenarios/arthas-basics-en/assets/arthas-boot.png)
+![Arthas Boot](/arthas/scenarios/arthas-basics-en/assets/arthas-boot.png)


### PR DESCRIPTION
#847 修复迁移过程中链接问题

@hengyunabc 

另外请注意arthas-advanced-cn/start-demo.md和arthas-advanced-en/start-demo.md中第7行的下载链接地址需要另外更改。

这样之后您就可以删除原来的仓库了。

此外我还注意到[这个教程](https://www.katacoda.com/arthas/courses/arthas-cn)是无法访问的，原因是因为arthas-cn-pathway.json命名有误，建议删除arthas-cn-pathway.json和arthas-pathway.json这两个文件。

另外一个更复杂的解决方案：可以将下列文件夹和文件重命名，然后修复链接问题：

arthas-advanced-cn -> arthas-cn-advanced
arthas-advanced-en -> arthas-en-advanced
arthas-basics-cn -> arthas-cn-basics
arthas-basics-en -> arthas-cn-basics
arthas-pathway.json -> arthas-en-pathway

