### PR TITLE
add delegation implementation for invokeOrigin (issue #1261)

### DIFF
--- a/bytekit/src/main/java/com/taobao/arthas/bytekit/asm/inst/impl/InstrumentImpl.java
+++ b/bytekit/src/main/java/com/taobao/arthas/bytekit/asm/inst/impl/InstrumentImpl.java
@@ -70,7 +70,7 @@ public class InstrumentImpl {
         // 修改apmMethod字节码：替换InstrumentApi.invokeOrigin()语句为renamedMethod invoke语句
         replaceInvokeOrigin(classNode.name, renamedMethodNode, apmMethodNode);
 
-        // 用apmMethod替换originMethod内容
+        // apmMethod名称必须为originMethod名称
         apmMethodNode.name = originMethodName;
         // 将apmMethod插入到renamedMethod前面
         AsmUtils.insertMethodBefore(classNode, renamedMethodNode, apmMethodNode);

--- a/bytekit/src/main/java/com/taobao/arthas/bytekit/utils/AsmUtils.java
+++ b/bytekit/src/main/java/com/taobao/arthas/bytekit/utils/AsmUtils.java
@@ -113,6 +113,16 @@ public class AsmUtils {
 		}
 	}
 
+	public static void insertMethodBefore(ClassNode classNode, MethodNode methodNode, MethodNode newMethodNode) {
+		for (int index = 0; index < classNode.methods.size(); ++index) {
+			MethodNode tmp = classNode.methods.get(index);
+			if (tmp.name.equals(methodNode.name) && tmp.desc.equals(methodNode.desc)) {
+				classNode.methods.add(index, newMethodNode);
+				break;
+			}
+		}
+	}
+
 	public static String toASMCode(byte[] bytecode) throws IOException {
 		return toASMCode(bytecode, true);
 	}

--- a/bytekit/src/main/java/com/taobao/arthas/bytekit/utils/AsmUtils.java
+++ b/bytekit/src/main/java/com/taobao/arthas/bytekit/utils/AsmUtils.java
@@ -113,28 +113,6 @@ public class AsmUtils {
 		}
 	}
 
-	/**
-	 * copy origin method as new method
-	 * @param classNode
-	 * @param originMethodNode
-	 * @param newMethodName
-	 * @return
-	 */
-	public static MethodNode copyAsMethod(MethodNode originMethodNode, int access, String newMethodName) {
-		//replace new method's public/protected to arg `access`
-		access |= originMethodNode.access;
-		access &= ~(Opcodes.ACC_PUBLIC|Opcodes.ACC_PROTECTED);
-
-		//copy method inst and localVariables
-		MethodNode newMethod = new MethodNode(access, newMethodName, originMethodNode.desc, originMethodNode.signature,
-				originMethodNode.exceptions.toArray(new String[0]));
-		originMethodNode.instructions.accept(newMethod);
-		for (LocalVariableNode localVariable : originMethodNode.localVariables) {
-			localVariable.accept(newMethod);
-		}
-		return newMethod;
-	}
-
 	public static String toASMCode(byte[] bytecode) throws IOException {
 		return toASMCode(bytecode, true);
 	}

--- a/bytekit/src/main/java/com/taobao/arthas/bytekit/utils/AsmUtils.java
+++ b/bytekit/src/main/java/com/taobao/arthas/bytekit/utils/AsmUtils.java
@@ -113,6 +113,28 @@ public class AsmUtils {
 		}
 	}
 
+	/**
+	 * copy origin method as new method
+	 * @param classNode
+	 * @param originMethodNode
+	 * @param newMethodName
+	 * @return
+	 */
+	public static MethodNode copyAsMethod(MethodNode originMethodNode, int access, String newMethodName) {
+		//replace new method's public/protected to arg `access`
+		access |= originMethodNode.access;
+		access &= ~(Opcodes.ACC_PUBLIC|Opcodes.ACC_PROTECTED);
+
+		//copy method inst and localVariables
+		MethodNode newMethod = new MethodNode(access, newMethodName, originMethodNode.desc, originMethodNode.signature,
+				originMethodNode.exceptions.toArray(new String[0]));
+		originMethodNode.instructions.accept(newMethod);
+		for (LocalVariableNode localVariable : originMethodNode.localVariables) {
+			localVariable.accept(newMethod);
+		}
+		return newMethod;
+	}
+
 	public static String toASMCode(byte[] bytecode) throws IOException {
 		return toASMCode(bytecode, true);
 	}

--- a/bytekit/src/test/java/com/taobao/arthas/bytekit/asm/inst/DelegateInvokeOriginTest.java
+++ b/bytekit/src/test/java/com/taobao/arthas/bytekit/asm/inst/DelegateInvokeOriginTest.java
@@ -214,6 +214,7 @@ public class DelegateInvokeOriginTest {
             VerifyUtils.invoke(object, methodName, 1);
         } catch (Throwable e) {
             throwable = e.getCause();
+            throwable.printStackTrace();
         }
         Assertions.assertThat(throwable.getMessage().contains("input i is less than 10"));
     }

--- a/bytekit/src/test/java/com/taobao/arthas/bytekit/asm/inst/DelegateInvokeOriginTest.java
+++ b/bytekit/src/test/java/com/taobao/arthas/bytekit/asm/inst/DelegateInvokeOriginTest.java
@@ -185,4 +185,11 @@ public class DelegateInvokeOriginTest {
         Object object = replace(methodName);
         Assertions.assertThat(VerifyUtils.invoke(object, methodName, -1)).isEqualTo(1);
     }
+
+    @Test
+    public void test_nestClass() throws Exception {
+        String methodName = testName.getMethodName().substring("test_".length());
+        Object object = replace(methodName);
+        Assertions.assertThat(VerifyUtils.invoke(object, methodName)).isEqualTo(100);
+    }
 }

--- a/bytekit/src/test/java/com/taobao/arthas/bytekit/asm/inst/DelegateInvokeOriginTest.java
+++ b/bytekit/src/test/java/com/taobao/arthas/bytekit/asm/inst/DelegateInvokeOriginTest.java
@@ -15,6 +15,8 @@ import org.junit.Test;
 import org.junit.rules.TestName;
 
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  *
@@ -192,4 +194,54 @@ public class DelegateInvokeOriginTest {
         Object object = replace(methodName);
         Assertions.assertThat(VerifyUtils.invoke(object, methodName)).isEqualTo(100);
     }
+
+    @Test
+    public void test_finallyCase() throws Exception {
+        String methodName = testName.getMethodName().substring("test_".length());
+        Object object = replace(methodName);
+        List<Integer> inputs = new ArrayList<Integer>();
+        inputs.add(100);
+        Assertions.assertThat(VerifyUtils.invoke(object, methodName, inputs)).isEqualTo(100);
+        Assertions.assertThat(inputs.isEmpty());
+    }
+
+    @Test
+    public void test_throwCase1() throws Exception {
+        final String methodName = testName.getMethodName().substring("test_".length());
+        final Object object = replace(methodName);
+        Throwable throwable = null;
+        try {
+            VerifyUtils.invoke(object, methodName, 1);
+        } catch (Throwable e) {
+            throwable = e.getCause();
+        }
+        Assertions.assertThat(throwable.getMessage().contains("input i is less than 10"));
+    }
+
+    @Test
+    public void test_throwCase2() throws Exception {
+        final String methodName = testName.getMethodName().substring("test_".length());
+        final Object object = replace(methodName);
+        Throwable throwable = null;
+        try {
+            VerifyUtils.invoke(object, methodName, 1);
+        } catch (Throwable e) {
+            throwable = e.getCause();
+        }
+        Assertions.assertThat(throwable.getMessage().contains("input i is less than 10"));
+    }
+
+    @Test
+    public void test_throwCase3() throws Exception {
+        final String methodName = testName.getMethodName().substring("test_".length());
+        final Object object = replace(methodName);
+        Throwable throwable = null;
+        try {
+            VerifyUtils.invoke(object, methodName, 1);
+        } catch (Throwable e) {
+            throwable = e.getCause();
+        }
+        Assertions.assertThat(throwable.getMessage().contains("input i is less than 10"));
+    }
+
 }

--- a/bytekit/src/test/java/com/taobao/arthas/bytekit/asm/inst/DelegateInvokeOriginTest.java
+++ b/bytekit/src/test/java/com/taobao/arthas/bytekit/asm/inst/DelegateInvokeOriginTest.java
@@ -171,4 +171,18 @@ public class DelegateInvokeOriginTest {
         Object object = replace(methodName);
         Assertions.assertThat(VerifyUtils.invoke(object, methodName, 100)).isEqualTo((100 + 1) * 100 / 2);
     }
+
+    @Test
+    public void test_tryCatch1() throws Exception {
+        String methodName = testName.getMethodName().substring("test_".length());
+        Object object = replace(methodName);
+        Assertions.assertThat(VerifyUtils.invoke(object, methodName, -1)).isEqualTo(1);
+    }
+
+    @Test
+    public void test_tryCatch2() throws Exception {
+        String methodName = testName.getMethodName().substring("test_".length());
+        Object object = replace(methodName);
+        Assertions.assertThat(VerifyUtils.invoke(object, methodName, -1)).isEqualTo(1);
+    }
 }

--- a/bytekit/src/test/java/com/taobao/arthas/bytekit/asm/inst/InvokeOriginDemo.java
+++ b/bytekit/src/test/java/com/taobao/arthas/bytekit/asm/inst/InvokeOriginDemo.java
@@ -74,4 +74,23 @@ public class InvokeOriginDemo {
         }
         return i + recursive(i - 1);
     }
+
+    public int tryCatch1(int i) {
+        try {
+            if (i < 1) {
+                throw new IllegalArgumentException("input i is less than 1");
+            }
+        } catch (IllegalArgumentException e) {
+            System.out.println("inner catch: "+e.getMessage());
+            return 1;
+        }
+        return i*10;
+    }
+
+    public int tryCatch2(int i) {
+        if (i < 1) {
+            throw new IllegalArgumentException("input i is less than 1");
+        }
+        return i*10;
+    }
 }

--- a/bytekit/src/test/java/com/taobao/arthas/bytekit/asm/inst/InvokeOriginDemo.java
+++ b/bytekit/src/test/java/com/taobao/arthas/bytekit/asm/inst/InvokeOriginDemo.java
@@ -1,6 +1,7 @@
 package com.taobao.arthas.bytekit.asm.inst;
 
 import java.util.Date;
+import java.util.List;
 import java.util.concurrent.Callable;
 
 /**
@@ -92,7 +93,7 @@ public class InvokeOriginDemo {
         if (i < 1) {
             throw new IllegalArgumentException("input i is less than 1");
         }
-        return i*10;
+        return i;
     }
 
     public int nestClass() throws Exception {
@@ -112,5 +113,36 @@ public class InvokeOriginDemo {
             }
         };
         return (Integer) callable.call();
+    }
+
+    public int finallyCase(List<Integer> inputs) {
+        try {
+            return inputs.get(0);
+        } finally {
+            inputs.clear();
+        }
+    }
+
+    public int throwCase1(int i) {
+        if (i < 1) {
+            throw new IllegalArgumentException("input i is less than 1");
+        } else if (i < 10) {
+            throw new IllegalArgumentException("input i is less than 10");
+        }
+        return i;
+    }
+
+    public int throwCase2(int i) {
+        if (i < 1) {
+            throw new IllegalArgumentException("input i is less than 1");
+        }
+        return i;
+    }
+
+    public int throwCase3(int i) {
+        if (i < 1) {
+            throw new IllegalArgumentException("input i is less than 1");
+        }
+        return i;
     }
 }

--- a/bytekit/src/test/java/com/taobao/arthas/bytekit/asm/inst/InvokeOriginDemo.java
+++ b/bytekit/src/test/java/com/taobao/arthas/bytekit/asm/inst/InvokeOriginDemo.java
@@ -1,6 +1,7 @@
 package com.taobao.arthas.bytekit.asm.inst;
 
 import java.util.Date;
+import java.util.concurrent.Callable;
 
 /**
  * @author hengyunabc 2019-03-13
@@ -92,5 +93,24 @@ public class InvokeOriginDemo {
             throw new IllegalArgumentException("input i is less than 1");
         }
         return i*10;
+    }
+
+    public int nestClass() throws Exception {
+
+        Callable callable = new Callable() {
+            @Override
+            public Object call() throws Exception {
+                return new Result(100).count;
+            }
+
+            class Result {
+                int count;
+
+                public Result(int count) {
+                    this.count = count;
+                }
+            }
+        };
+        return (Integer) callable.call();
     }
 }

--- a/bytekit/src/test/java/com/taobao/arthas/bytekit/asm/inst/InvokeOriginDemo_APM.java
+++ b/bytekit/src/test/java/com/taobao/arthas/bytekit/asm/inst/InvokeOriginDemo_APM.java
@@ -1,5 +1,7 @@
 package com.taobao.arthas.bytekit.asm.inst;
 
+import java.util.Arrays;
+
 /**
  *
  * @author hengyunabc 2019-03-18
@@ -59,9 +61,11 @@ public class InvokeOriginDemo_APM {
     }
 
     public String[] returnStrArrayWithArgs(int i, String s, long l) {
-        System.out.println(i);
+        l -= 100;
+        System.out.println("l = "+l);
         String[] result = InstrumentApi.invokeOrigin();
         result[0] = "fff";
+        System.out.println("result = "+ Arrays.asList(result));
         return result;
     }
 

--- a/bytekit/src/test/java/com/taobao/arthas/bytekit/asm/inst/InvokeOriginDemo_APM.java
+++ b/bytekit/src/test/java/com/taobao/arthas/bytekit/asm/inst/InvokeOriginDemo_APM.java
@@ -1,6 +1,7 @@
 package com.taobao.arthas.bytekit.asm.inst;
 
 import java.util.Arrays;
+import java.util.List;
 
 /**
  *
@@ -107,4 +108,29 @@ public class InvokeOriginDemo_APM {
         int result = InstrumentApi.invokeOrigin();
         return result;
     }
+
+    public int finallyCase(List<Integer> inputs) {
+        return InstrumentApi.invokeOrigin();
+    }
+
+    public int throwCase1(int i) {
+        return InstrumentApi.invokeOrigin();
+    }
+
+    public int throwCase2(int i) {
+        int result = InstrumentApi.invokeOrigin();
+        if (result < 10) {
+            throw new IllegalArgumentException("input i is less than 10");
+        }
+        return result;
+    }
+
+    public int throwCase3(int i) {
+        if (i < 10) {
+            throw new IllegalArgumentException("input i is less than 10");
+        }
+        int result = InstrumentApi.invokeOrigin();
+        return result;
+    }
+
 }

--- a/bytekit/src/test/java/com/taobao/arthas/bytekit/asm/inst/InvokeOriginDemo_APM.java
+++ b/bytekit/src/test/java/com/taobao/arthas/bytekit/asm/inst/InvokeOriginDemo_APM.java
@@ -102,4 +102,9 @@ public class InvokeOriginDemo_APM {
         }
         return result;
     }
+
+    public int nestClass() throws Exception {
+        int result = InstrumentApi.invokeOrigin();
+        return result;
+    }
 }

--- a/bytekit/src/test/java/com/taobao/arthas/bytekit/asm/inst/InvokeOriginDemo_APM.java
+++ b/bytekit/src/test/java/com/taobao/arthas/bytekit/asm/inst/InvokeOriginDemo_APM.java
@@ -86,4 +86,20 @@ public class InvokeOriginDemo_APM {
         System.err.println(result);
         return result;
     }
+
+    public int tryCatch1(int i) {
+        int result = InstrumentApi.invokeOrigin();
+        return result;
+    }
+
+    public int tryCatch2(int i) {
+        int result = -1;
+        try {
+            result = InstrumentApi.invokeOrigin();
+        } catch (Exception e) {
+            System.err.println("outer catch: "+e.getMessage());
+            result = 1;
+        }
+        return result;
+    }
 }

--- a/bytekit/src/test/java/com/taobao/arthas/bytekit/asm/inst/InvokeOriginTest.java
+++ b/bytekit/src/test/java/com/taobao/arthas/bytekit/asm/inst/InvokeOriginTest.java
@@ -216,6 +216,7 @@ public class InvokeOriginTest {
             VerifyUtils.invoke(object, methodName, 1);
         } catch (Throwable e) {
             throwable = e.getCause();
+            throwable.printStackTrace();
         }
         Assertions.assertThat(throwable.getMessage().contains("input i is less than 10"));
     }

--- a/bytekit/src/test/java/com/taobao/arthas/bytekit/asm/inst/InvokeOriginTest.java
+++ b/bytekit/src/test/java/com/taobao/arthas/bytekit/asm/inst/InvokeOriginTest.java
@@ -173,4 +173,18 @@ public class InvokeOriginTest {
         Object object = replace(methodName);
         Assertions.assertThat(VerifyUtils.invoke(object, methodName, 100)).isEqualTo((100 + 1) * 100 / 2);
     }
+
+    @Test
+    public void test_tryCatch1() throws Exception {
+        String methodName = testName.getMethodName().substring("test_".length());
+        Object object = replace(methodName);
+        Assertions.assertThat(VerifyUtils.invoke(object, methodName, -1)).isEqualTo(1);
+    }
+
+    @Test
+    public void test_tryCatch2() throws Exception {
+        String methodName = testName.getMethodName().substring("test_".length());
+        Object object = replace(methodName);
+        Assertions.assertThat(VerifyUtils.invoke(object, methodName, -1)).isEqualTo(1);
+    }
 }

--- a/bytekit/src/test/java/com/taobao/arthas/bytekit/asm/inst/InvokeOriginTest.java
+++ b/bytekit/src/test/java/com/taobao/arthas/bytekit/asm/inst/InvokeOriginTest.java
@@ -187,4 +187,12 @@ public class InvokeOriginTest {
         Object object = replace(methodName);
         Assertions.assertThat(VerifyUtils.invoke(object, methodName, -1)).isEqualTo(1);
     }
+
+    @Test
+    public void test_nestClass() throws Exception {
+        String methodName = testName.getMethodName().substring("test_".length());
+        Object object = replace(methodName);
+        Assertions.assertThat(VerifyUtils.invoke(object, methodName)).isEqualTo(100);
+    }
+
 }

--- a/bytekit/src/test/java/com/taobao/arthas/bytekit/asm/inst/InvokeOriginTest.java
+++ b/bytekit/src/test/java/com/taobao/arthas/bytekit/asm/inst/InvokeOriginTest.java
@@ -1,6 +1,8 @@
 package com.taobao.arthas.bytekit.asm.inst;
 
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
 
 import org.assertj.core.api.Assertions;
 import org.junit.Before;
@@ -195,4 +197,52 @@ public class InvokeOriginTest {
         Assertions.assertThat(VerifyUtils.invoke(object, methodName)).isEqualTo(100);
     }
 
+    @Test
+    public void test_finallyCase() throws Exception {
+        String methodName = testName.getMethodName().substring("test_".length());
+        Object object = replace(methodName);
+        List<Integer> inputs = new ArrayList<Integer>();
+        inputs.add(100);
+        Assertions.assertThat(VerifyUtils.invoke(object, methodName, inputs)).isEqualTo(100);
+        Assertions.assertThat(inputs.isEmpty());
+    }
+
+    @Test
+    public void test_throwCase1() throws Exception {
+        final String methodName = testName.getMethodName().substring("test_".length());
+        final Object object = replace(methodName);
+        Throwable throwable = null;
+        try {
+            VerifyUtils.invoke(object, methodName, 1);
+        } catch (Throwable e) {
+            throwable = e.getCause();
+        }
+        Assertions.assertThat(throwable.getMessage().contains("input i is less than 10"));
+    }
+
+    @Test
+    public void test_throwCase2() throws Exception {
+        final String methodName = testName.getMethodName().substring("test_".length());
+        final Object object = replace(methodName);
+        Throwable throwable = null;
+        try {
+            VerifyUtils.invoke(object, methodName, 1);
+        } catch (Throwable e) {
+            throwable = e.getCause();
+        }
+        Assertions.assertThat(throwable.getMessage().contains("input i is less than 10"));
+    }
+
+    @Test
+    public void test_throwCase3() throws Exception {
+        final String methodName = testName.getMethodName().substring("test_".length());
+        final Object object = replace(methodName);
+        Throwable throwable = null;
+        try {
+            VerifyUtils.invoke(object, methodName, 1);
+        } catch (Throwable e) {
+            throwable = e.getCause();
+        }
+        Assertions.assertThat(throwable.getMessage().contains("input i is less than 10"));
+    }
 }


### PR DESCRIPTION
Add delegation implementation for invokeOrigin, related issue https://github.com/alibaba/arthas/issues/1261 .    
1)  copy and rename origin method, renamed to xxx_origin_hashcode   
2) replace InstrumentApi.invokeOrigin() invoke with renamed method invoke   
3) insert apm method node before renamed method 
 