### PR TITLE
Improve invoke binding

### DIFF
--- a/bytekit/src/main/java/com/taobao/arthas/bytekit/asm/location/InvokeLocationMatcher.java
+++ b/bytekit/src/main/java/com/taobao/arthas/bytekit/asm/location/InvokeLocationMatcher.java
@@ -62,6 +62,8 @@ public class InvokeLocationMatcher implements LocationMatcher {
 
     private boolean atInvokeExcpetionExit = false;
 
+    private boolean stackNeedSave = false;
+
     public InvokeLocationMatcher(String owner, String methodName, String desc, int count, boolean whenComplete,
             List<String> excludes, boolean atInvokeExcpetionExit) {
         super();
@@ -104,7 +106,7 @@ public class InvokeLocationMatcher implements LocationMatcher {
                     if(locationFilter.allow(methodInsnNode, locationType, this.whenComplete)) {
                         matchedCount++;
                         if (count <= 0 || count == matchedCount) {
-                            InvokeLocation invokeLocation = new InvokeLocation(methodInsnNode, count, whenComplete);
+                            InvokeLocation invokeLocation = new InvokeLocation(methodInsnNode, count, whenComplete, stackNeedSave);
                             locations.add(invokeLocation);
                         }
                     }
@@ -199,6 +201,14 @@ public class InvokeLocationMatcher implements LocationMatcher {
 
         return true;
 
+    }
+
+    public boolean isStackNeedSave() {
+        return stackNeedSave;
+    }
+
+    public void setStackNeedSave(boolean stackNeedSave) {
+        this.stackNeedSave = stackNeedSave;
     }
 
     public String getMethodName() {

--- a/bytekit/src/main/java/com/taobao/arthas/bytekit/asm/location/Location.java
+++ b/bytekit/src/main/java/com/taobao/arthas/bytekit/asm/location/Location.java
@@ -213,10 +213,10 @@ public abstract class Location {
          */
         private int count;
 
-        public InvokeLocation(MethodInsnNode insnNode, int count, boolean whenComplete) {
+        public InvokeLocation(MethodInsnNode insnNode, int count, boolean whenComplete, boolean stackNeedSave) {
             super(insnNode, whenComplete);
             this.count = count;
-            this.stackNeedSave = false;
+            this.stackNeedSave = stackNeedSave;
         }
 
         @Override

--- a/bytekit/src/main/java/com/taobao/arthas/bytekit/asm/location/filter/InvokeCheckLocationFilter.java
+++ b/bytekit/src/main/java/com/taobao/arthas/bytekit/asm/location/filter/InvokeCheckLocationFilter.java
@@ -3,6 +3,7 @@ package com.taobao.arthas.bytekit.asm.location.filter;
 import com.alibaba.arthas.deps.org.objectweb.asm.tree.AbstractInsnNode;
 import com.alibaba.arthas.deps.org.objectweb.asm.tree.MethodInsnNode;
 import com.taobao.arthas.bytekit.asm.location.LocationType;
+import com.taobao.arthas.bytekit.utils.AsmOpUtils;
 
 /**
  * 
@@ -46,6 +47,9 @@ public class InvokeCheckLocationFilter implements LocationFilter {
                 insnNode = insnNode.getNext();
                 if (insnNode instanceof MethodInsnNode) {
                     MethodInsnNode methodInsnNode = (MethodInsnNode) insnNode;
+                    if (isIgnoredMethod(methodInsnNode)){
+                        continue;
+                    }
                     return methodInsnNode;
                 }
             }
@@ -54,11 +58,22 @@ public class InvokeCheckLocationFilter implements LocationFilter {
                 insnNode = insnNode.getPrevious();
                 if (insnNode instanceof MethodInsnNode) {
                     MethodInsnNode methodInsnNode = (MethodInsnNode) insnNode;
+                    if (isIgnoredMethod(methodInsnNode)){
+                        continue;
+                    }
                     return methodInsnNode;
                 }
             }
         }
         return null;
+    }
+
+    private boolean isIgnoredMethod(MethodInsnNode methodInsnNode) {
+        //过滤unbox的方法调用，解决invokeBefore判断不准确的问题（保存invoke args时可能进行box转换，额外引入了unbox方法）
+        if (AsmOpUtils.isUnBoxMethod(methodInsnNode)) {
+            return true;
+        }
+        return false;
     }
 
 }

--- a/bytekit/src/main/java/com/taobao/arthas/bytekit/utils/AsmOpUtils.java
+++ b/bytekit/src/main/java/com/taobao/arthas/bytekit/utils/AsmOpUtils.java
@@ -308,7 +308,26 @@ public class AsmOpUtils {
 		}
 	}
 
-    public static boolean needBox(Type type) {
+	public static boolean isUnBoxMethod(String owner, String methodName, String desc) {
+		Method method = new Method(methodName, desc);
+		if (NUMBER_TYPE.getInternalName().equals(owner)) {
+			return (INT_VALUE.equals(method)
+					|| LONG_VALUE.equals(method)
+					|| DOUBLE_VALUE.equals(method)
+					|| FLOAT_VALUE.equals(method));
+		} else if (CHARACTER_TYPE.getInternalName().equals(owner)) {
+			return method.equals(CHAR_VALUE);
+		} else if (BOOLEAN_TYPE.getInternalName().equals(owner)) {
+			return method.equals(BOOLEAN_VALUE);
+		}
+		return false;
+	}
+
+	public static boolean isUnBoxMethod(MethodInsnNode methodInsnNode) {
+		return isUnBoxMethod(methodInsnNode.owner, methodInsnNode.name, methodInsnNode.desc);
+	}
+
+	public static boolean needBox(Type type) {
         switch (type.getSort()) {
         case Type.BYTE:
         case Type.BOOLEAN:

--- a/bytekit/src/main/java/com/taobao/arthas/bytekit/utils/AsmUtils.java
+++ b/bytekit/src/main/java/com/taobao/arthas/bytekit/utils/AsmUtils.java
@@ -283,6 +283,9 @@ public class AsmUtils {
         return methodInsnNode.getOpcode() == Opcodes.INVOKESTATIC;
     }
 
+	public static boolean isConstructor(MethodInsnNode methodInsnNode) {
+		return methodInsnNode.getOpcode() == Opcodes.INVOKESPECIAL && methodInsnNode.name != null && methodInsnNode.name.equals("<init>");
+	}
 
 	public static boolean isConstructor(MethodNode methodNode) {
 		return methodNode.name != null && methodNode.name.equals("<init>");

--- a/bytekit/src/test/java/com/taobao/arthas/bytekit/asm/interceptor/InlineForTest.java
+++ b/bytekit/src/test/java/com/taobao/arthas/bytekit/asm/interceptor/InlineForTest.java
@@ -1,0 +1,96 @@
+package com.taobao.arthas.bytekit.asm.interceptor;
+
+import com.taobao.arthas.bytekit.asm.binding.Binding;
+import com.taobao.arthas.bytekit.asm.interceptor.annotation.AtEnter;
+import com.taobao.arthas.bytekit.asm.interceptor.annotation.ExceptionHandler;
+import com.taobao.arthas.bytekit.utils.Decompiler;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.springframework.boot.test.rule.OutputCapture;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class InlineForTest {
+
+    @Rule
+    public ExpectedException expectedEx = ExpectedException.none();
+
+    @Rule
+    public OutputCapture capture = new OutputCapture();
+
+    public static class Sample {
+
+        long longField;
+        String strField;
+        static int intField;
+
+        public int hello(String str, boolean exception) {
+            if (exception) {
+                throw new RuntimeException("test exception");
+            }
+            return str.length();
+        }
+
+        public long toBeInvoke(int i , long l, String s, long ll) {
+            return l + ll;
+        }
+
+        public void testInvokeArgs() {
+            toBeInvoke(1, 123L, "abc", 100L);
+        }
+
+    }
+
+    public static class TestPrintSuppressHandler {
+
+        @ExceptionHandler(inline = true)
+        public static void onSuppress(@Binding.Throwable Throwable e, @Binding.Class Object clazz) {
+            System.err.println("exception handler: " + clazz);
+            e.printStackTrace();
+        }
+    }
+
+    public static class EnterInterceptor {
+
+        @AtEnter(inline = true
+                , suppress = RuntimeException.class, suppressHandler = TestPrintSuppressHandler.class
+                )
+        public static long onEnter(
+                @Binding.This Object object, @Binding.Class Object clazz,
+               @Binding.Field(name = "longField") long longField,
+               @Binding.Field(name = "longField") Object longFieldObject,
+               @Binding.Field(name = "intField") int intField,
+               @Binding.Field(name = "strField") String strField,
+               @Binding.Field(name = "intField") Object intFielObject,
+               @Binding.MethodName String methodName,
+               @Binding.MethodDesc String methodDesc
+               ) {
+            System.err.println("onEnter, object:" + object);
+            System.err.println("onEnter, methodName:" + methodName);
+            System.err.println("onEnter, methodDesc:" + methodDesc);
+
+            for(int i=0; i < 100;i++) {
+
+            }
+            return 123L;
+        }
+
+    }
+
+
+
+    @Test
+    public void testEnter() throws Exception {
+        TestHelper helper = TestHelper.builder().interceptorClass(EnterInterceptor.class).methodMatcher("hello")
+                .reTransform(true);
+        byte[] bytes = helper.process(Sample.class);
+
+        new Sample().hello("abc", false);
+
+        System.err.println(Decompiler.decompile(bytes));
+
+        assertThat(capture.toString()).contains("onEnter, object:");
+    }
+
+}

--- a/bytekit/src/test/java/com/taobao/arthas/bytekit/asm/interceptor/InlineForeachTest.java
+++ b/bytekit/src/test/java/com/taobao/arthas/bytekit/asm/interceptor/InlineForeachTest.java
@@ -75,6 +75,7 @@ public class InlineForeachTest {
             System.err.println("onEnter, methodName:" + methodName);
             System.err.println("onEnter, methodDesc:" + methodDesc);
 
+            // foreach map entries
             Map<String, Object> map = new HashMap<String, Object>();
             map.put("a", 1);
             map.put("b", 2);
@@ -86,6 +87,7 @@ public class InlineForeachTest {
             }
             System.out.println("map: "+sb.toString());
 
+            // foreach list
             List<Integer> list = Arrays.asList(1, 2, 3, 6, 7, 29);
             int total = 0;
             for (Integer n : list) {

--- a/bytekit/src/test/java/com/taobao/arthas/bytekit/asm/interceptor/InlineForeachTest.java
+++ b/bytekit/src/test/java/com/taobao/arthas/bytekit/asm/interceptor/InlineForeachTest.java
@@ -1,0 +1,115 @@
+package com.taobao.arthas.bytekit.asm.interceptor;
+
+import com.taobao.arthas.bytekit.asm.binding.Binding;
+import com.taobao.arthas.bytekit.asm.interceptor.annotation.AtEnter;
+import com.taobao.arthas.bytekit.asm.interceptor.annotation.ExceptionHandler;
+import com.taobao.arthas.bytekit.utils.Decompiler;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.springframework.boot.test.rule.OutputCapture;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class InlineForeachTest {
+
+    @Rule
+    public ExpectedException expectedEx = ExpectedException.none();
+
+    @Rule
+    public OutputCapture capture = new OutputCapture();
+
+    public static class Sample {
+
+        long longField;
+        String strField;
+        static int intField;
+
+        public int hello(String str, boolean exception) {
+            if (exception) {
+                throw new RuntimeException("test exception");
+            }
+            return str.length();
+        }
+
+        public long toBeInvoke(int i , long l, String s, long ll) {
+            return l + ll;
+        }
+
+        public void testInvokeArgs() {
+            toBeInvoke(1, 123L, "abc", 100L);
+        }
+
+    }
+
+    public static class TestPrintSuppressHandler {
+
+        @ExceptionHandler(inline = true)
+        public static void onSuppress(@Binding.Throwable Throwable e, @Binding.Class Object clazz) {
+            System.err.println("exception handler: " + clazz);
+            e.printStackTrace();
+        }
+    }
+
+    public static class EnterInterceptor {
+
+        @AtEnter(inline = true
+                , suppress = RuntimeException.class, suppressHandler = TestPrintSuppressHandler.class
+                )
+        public static long onEnter(
+                @Binding.This Object object, @Binding.Class Object clazz,
+               @Binding.Field(name = "longField") long longField,
+               @Binding.Field(name = "longField") Object longFieldObject,
+               @Binding.Field(name = "intField") int intField,
+               @Binding.Field(name = "strField") String strField,
+               @Binding.Field(name = "intField") Object intFielObject,
+               @Binding.MethodName String methodName,
+               @Binding.MethodDesc String methodDesc
+               ) {
+            System.err.println("onEnter, object:" + object);
+            System.err.println("onEnter, methodName:" + methodName);
+            System.err.println("onEnter, methodDesc:" + methodDesc);
+
+            Map<String, Object> map = new HashMap<String, Object>();
+            map.put("a", 1);
+            map.put("b", 2);
+            map.put("c", 3);
+
+            StringBuilder sb = new StringBuilder();
+            for (Map.Entry<String, Object> entry : map.entrySet()) {
+                sb.append(entry.getKey()).append("=").append(entry.getValue()).append(", ");
+            }
+            System.out.println("map: "+sb.toString());
+
+            List<Integer> list = Arrays.asList(1, 2, 3, 6, 7, 29);
+            int total = 0;
+            for (Integer n : list) {
+                total += n;
+            }
+            System.out.println("total: "+total);
+            return 123L;
+        }
+
+    }
+
+
+
+    @Test
+    public void testEnter() throws Exception {
+        TestHelper helper = TestHelper.builder().interceptorClass(EnterInterceptor.class).methodMatcher("hello")
+                .reTransform(true);
+        byte[] bytes = helper.process(Sample.class);
+
+        new Sample().hello("abc", false);
+
+        System.err.println(Decompiler.decompile(bytes));
+
+        assertThat(capture.toString()).contains("onEnter, object:");
+    }
+
+}

--- a/bytekit/src/test/java/com/taobao/arthas/bytekit/asm/interceptor/InlineIteratorTest.java
+++ b/bytekit/src/test/java/com/taobao/arthas/bytekit/asm/interceptor/InlineIteratorTest.java
@@ -1,0 +1,103 @@
+package com.taobao.arthas.bytekit.asm.interceptor;
+
+import com.taobao.arthas.bytekit.asm.binding.Binding;
+import com.taobao.arthas.bytekit.asm.interceptor.annotation.AtEnter;
+import com.taobao.arthas.bytekit.asm.interceptor.annotation.ExceptionHandler;
+import com.taobao.arthas.bytekit.utils.Decompiler;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.springframework.boot.test.rule.OutputCapture;
+
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class InlineIteratorTest {
+
+    @Rule
+    public ExpectedException expectedEx = ExpectedException.none();
+
+    @Rule
+    public OutputCapture capture = new OutputCapture();
+
+    public static class Sample {
+
+        long longField;
+        String strField;
+        static int intField;
+
+        public int hello(String str, boolean exception) {
+            if (exception) {
+                throw new RuntimeException("test exception");
+            }
+            return str.length();
+        }
+
+        public long toBeInvoke(int i , long l, String s, long ll) {
+            return l + ll;
+        }
+
+        public void testInvokeArgs() {
+            toBeInvoke(1, 123L, "abc", 100L);
+        }
+
+    }
+
+    public static class TestPrintSuppressHandler {
+
+        @ExceptionHandler(inline = true)
+        public static void onSuppress(@Binding.Throwable Throwable e, @Binding.Class Object clazz) {
+            System.err.println("exception handler: " + clazz);
+            e.printStackTrace();
+        }
+    }
+
+    public static class EnterInterceptor {
+
+        @AtEnter(inline = true
+                , suppress = RuntimeException.class, suppressHandler = TestPrintSuppressHandler.class
+                )
+        public static long onEnter(
+                @Binding.This Object object, @Binding.Class Object clazz,
+               @Binding.Field(name = "longField") long longField,
+               @Binding.Field(name = "longField") Object longFieldObject,
+               @Binding.Field(name = "intField") int intField,
+               @Binding.Field(name = "strField") String strField,
+               @Binding.Field(name = "intField") Object intFielObject,
+               @Binding.MethodName String methodName,
+               @Binding.MethodDesc String methodDesc
+               ) {
+            System.err.println("onEnter, object:" + object);
+            System.err.println("onEnter, methodName:" + methodName);
+            System.err.println("onEnter, methodDesc:" + methodDesc);
+
+            List<Integer> list = Arrays.asList(1, 2, 3, 6, 7, 29);
+            Iterator<Integer> iterator = list.iterator();
+            while (iterator.hasNext()) {
+                System.out.println(iterator.next());
+            }
+
+            return 123L;
+        }
+
+    }
+
+
+
+    @Test
+    public void testEnter() throws Exception {
+        TestHelper helper = TestHelper.builder().interceptorClass(EnterInterceptor.class).methodMatcher("hello")
+                .reTransform(true);
+        byte[] bytes = helper.process(Sample.class);
+
+        new Sample().hello("abc", false);
+
+        System.err.println(Decompiler.decompile(bytes));
+
+        assertThat(capture.toString()).contains("onEnter, object:");
+    }
+
+}

--- a/bytekit/src/test/java/com/taobao/arthas/bytekit/asm/interceptor/InlineNestClassTest.java
+++ b/bytekit/src/test/java/com/taobao/arthas/bytekit/asm/interceptor/InlineNestClassTest.java
@@ -1,0 +1,119 @@
+package com.taobao.arthas.bytekit.asm.interceptor;
+
+import com.taobao.arthas.bytekit.asm.binding.Binding;
+import com.taobao.arthas.bytekit.asm.interceptor.annotation.AtEnter;
+import com.taobao.arthas.bytekit.asm.interceptor.annotation.ExceptionHandler;
+import com.taobao.arthas.bytekit.utils.Decompiler;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.springframework.boot.test.rule.OutputCapture;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class InlineNestClassTest {
+
+    @Rule
+    public ExpectedException expectedEx = ExpectedException.none();
+
+    @Rule
+    public OutputCapture capture = new OutputCapture();
+
+    public static class Sample {
+
+        long longField;
+        String strField;
+        static int intField;
+
+        public int hello(String str, boolean exception) {
+            if (exception) {
+                throw new RuntimeException("test exception");
+            }
+            return str.length();
+        }
+
+        public long toBeInvoke(int i , long l, String s, long ll) {
+            return l + ll;
+        }
+
+        public void testInvokeArgs() {
+            toBeInvoke(1, 123L, "abc", 100L);
+        }
+
+    }
+
+    public static class EnterInterceptor {
+
+        @AtEnter(inline = true
+                , suppress = RuntimeException.class, suppressHandler = TestPrintSuppressHandler.class
+                )
+        public static long onEnter(
+                @Binding.This Object object, @Binding.Class Object clazz,
+               @Binding.Field(name = "longField") long longField,
+               @Binding.Field(name = "longField") Object longFieldObject,
+               @Binding.Field(name = "intField") int intField,
+               @Binding.Field(name = "strField") String strField,
+               @Binding.Field(name = "intField") Object intFielObject,
+               @Binding.MethodName String methodName,
+               @Binding.MethodDesc String methodDesc
+               ) {
+            System.err.println("onEnter, object:" + object);
+            System.err.println("onEnter, methodName:" + methodName);
+            System.err.println("onEnter, methodDesc:" + methodDesc);
+
+            Runnable runnable = new Runnable() {
+                @Override
+                public void run() {
+                    System.err.println("hello from runnable");
+                    UserVO userVO = new UserVO("Tom", 24);
+                    System.out.println("user: "+ userVO.getName());
+                }
+
+                class UserVO {
+                    private String name;
+                    private int age;
+
+                    public UserVO(String name, int age) {
+                        this.name = name;
+                        this.age = age;
+                    }
+
+                    public String getName() {
+                        return name;
+                    }
+
+                    public int getAge() {
+                        return age;
+                    }
+                }
+            };
+            runnable.run();
+
+            return 123L;
+        }
+
+    }
+
+    public static class TestPrintSuppressHandler {
+
+        @ExceptionHandler(inline = true)
+        public static void onSuppress(@Binding.Throwable Throwable e, @Binding.Class Object clazz) {
+            System.err.println("exception handler: " + clazz);
+            e.printStackTrace();
+        }
+    }
+
+    @Test
+    public void testEnter() throws Exception {
+        TestHelper helper = TestHelper.builder().interceptorClass(EnterInterceptor.class).methodMatcher("hello")
+                .reTransform(true);
+        byte[] bytes = helper.process(Sample.class);
+
+        new Sample().hello("abc", false);
+
+        System.err.println(Decompiler.decompile(bytes));
+
+        assertThat(capture.toString()).contains("onEnter, object:");
+    }
+
+}

--- a/bytekit/src/test/java/com/taobao/arthas/bytekit/asm/interceptor/InlineStaticFieldTest.java
+++ b/bytekit/src/test/java/com/taobao/arthas/bytekit/asm/interceptor/InlineStaticFieldTest.java
@@ -1,0 +1,95 @@
+package com.taobao.arthas.bytekit.asm.interceptor;
+
+import com.taobao.arthas.bytekit.asm.binding.Binding;
+import com.taobao.arthas.bytekit.asm.interceptor.annotation.AtEnter;
+import com.taobao.arthas.bytekit.asm.interceptor.annotation.ExceptionHandler;
+import com.taobao.arthas.bytekit.utils.Decompiler;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.springframework.boot.test.rule.OutputCapture;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class InlineStaticFieldTest {
+
+    @Rule
+    public ExpectedException expectedEx = ExpectedException.none();
+
+    @Rule
+    public OutputCapture capture = new OutputCapture();
+
+    public static class Sample {
+
+        long longField;
+        String strField;
+        static int intField;
+
+        public int hello(String str, boolean exception) {
+            if (exception) {
+                throw new RuntimeException("test exception");
+            }
+            return str.length();
+        }
+
+        public long toBeInvoke(int i , long l, String s, long ll) {
+            return l + ll;
+        }
+
+        public void testInvokeArgs() {
+            toBeInvoke(1, 123L, "abc", 100L);
+        }
+
+    }
+
+    public static class EnterInterceptor {
+
+        private static int n;
+
+        @AtEnter(inline = true
+                , suppress = RuntimeException.class, suppressHandler = TestPrintSuppressHandler.class
+                )
+        public static long onEnter(
+                @Binding.This Object object, @Binding.Class Object clazz,
+               @Binding.Field(name = "longField") long longField,
+               @Binding.Field(name = "longField") Object longFieldObject,
+               @Binding.Field(name = "intField") int intField,
+               @Binding.Field(name = "strField") String strField,
+               @Binding.Field(name = "intField") Object intFielObject,
+               @Binding.MethodName String methodName,
+               @Binding.MethodDesc String methodDesc
+               ) {
+            System.err.println("onEnter, object:" + object);
+            System.err.println("onEnter, methodName:" + methodName);
+            System.err.println("onEnter, methodDesc:" + methodDesc);
+
+            n++;
+            System.err.println("access count: "+n);
+            return 123L;
+        }
+
+    }
+
+    public static class TestPrintSuppressHandler {
+
+        @ExceptionHandler(inline = true)
+        public static void onSuppress(@Binding.Throwable Throwable e, @Binding.Class Object clazz) {
+            System.err.println("exception handler: " + clazz);
+            e.printStackTrace();
+        }
+    }
+
+    @Test
+    public void testEnter() throws Exception {
+        TestHelper helper = TestHelper.builder().interceptorClass(EnterInterceptor.class).methodMatcher("hello")
+                .reTransform(true);
+        byte[] bytes = helper.process(Sample.class);
+
+        new Sample().hello("abc", false);
+
+        System.err.println(Decompiler.decompile(bytes));
+
+        assertThat(capture.toString()).contains("onEnter, object:");
+    }
+
+}

--- a/bytekit/src/test/java/com/taobao/arthas/bytekit/asm/interceptor/InlineSwitchTest.java
+++ b/bytekit/src/test/java/com/taobao/arthas/bytekit/asm/interceptor/InlineSwitchTest.java
@@ -1,0 +1,99 @@
+package com.taobao.arthas.bytekit.asm.interceptor;
+
+import com.taobao.arthas.bytekit.asm.binding.Binding;
+import com.taobao.arthas.bytekit.asm.interceptor.annotation.AtEnter;
+import com.taobao.arthas.bytekit.asm.interceptor.annotation.ExceptionHandler;
+import com.taobao.arthas.bytekit.utils.Decompiler;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.springframework.boot.test.rule.OutputCapture;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class InlineSwitchTest {
+
+    @Rule
+    public ExpectedException expectedEx = ExpectedException.none();
+
+    @Rule
+    public OutputCapture capture = new OutputCapture();
+
+    public static class Sample {
+
+        long longField;
+        String strField;
+        static int intField;
+
+        public int hello(String str, boolean exception) {
+            if (exception) {
+                throw new RuntimeException("test exception");
+            }
+            return str.length();
+        }
+
+        public long toBeInvoke(int i , long l, String s, long ll) {
+            return l + ll;
+        }
+
+        public void testInvokeArgs() {
+            toBeInvoke(1, 123L, "abc", 100L);
+        }
+
+    }
+
+    public static class TestPrintSuppressHandler {
+
+        @ExceptionHandler(inline = true)
+        public static void onSuppress(@Binding.Throwable Throwable e, @Binding.Class Object clazz) {
+            System.err.println("exception handler: " + clazz);
+            e.printStackTrace();
+        }
+    }
+
+    public static class EnterInterceptor {
+
+        @AtEnter(inline = true
+                , suppress = RuntimeException.class, suppressHandler = TestPrintSuppressHandler.class
+                )
+        public static long onEnter(
+                @Binding.This Object object, @Binding.Class Object clazz,
+               @Binding.Field(name = "longField") long longField,
+               @Binding.Field(name = "longField") Object longFieldObject,
+               @Binding.Field(name = "intField") int intField,
+               @Binding.Field(name = "strField") String strField,
+               @Binding.Field(name = "intField") Object intFielObject,
+               @Binding.MethodName String methodName,
+               @Binding.MethodDesc String methodDesc
+               ) {
+            System.err.println("onEnter, object:" + object);
+            System.err.println("onEnter, methodName:" + methodName);
+            System.err.println("onEnter, methodDesc:" + methodDesc);
+            switch (intField) {
+                case 0:
+                    System.out.println("switch branch 0");
+                    break;
+                default:
+                    System.out.println("switch branch 1");
+            }
+            return 123L;
+        }
+
+    }
+
+
+
+    @Test
+    public void testEnter() throws Exception {
+        TestHelper helper = TestHelper.builder().interceptorClass(EnterInterceptor.class).methodMatcher("hello")
+                .reTransform(true);
+        byte[] bytes = helper.process(Sample.class);
+
+        new Sample().hello("abc", false);
+
+        System.err.println(Decompiler.decompile(bytes));
+
+        assertThat(capture.toString()).contains("onEnter, object:");
+    }
+
+}

--- a/bytekit/src/test/java/com/taobao/arthas/bytekit/asm/interceptor/InlineThrowTest.java
+++ b/bytekit/src/test/java/com/taobao/arthas/bytekit/asm/interceptor/InlineThrowTest.java
@@ -1,0 +1,98 @@
+package com.taobao.arthas.bytekit.asm.interceptor;
+
+import com.taobao.arthas.bytekit.asm.binding.Binding;
+import com.taobao.arthas.bytekit.asm.interceptor.annotation.AtEnter;
+import com.taobao.arthas.bytekit.asm.interceptor.annotation.ExceptionHandler;
+import com.taobao.arthas.bytekit.utils.Decompiler;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.springframework.boot.test.rule.OutputCapture;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class InlineThrowTest {
+
+    @Rule
+    public ExpectedException expectedEx = ExpectedException.none();
+
+    @Rule
+    public OutputCapture capture = new OutputCapture();
+
+    public static class Sample {
+
+        long longField;
+        String strField;
+        static int intField;
+
+        public int hello(String str, boolean exception) {
+            if (exception) {
+                throw new RuntimeException("test exception");
+            }
+            return str.length();
+        }
+
+        public long toBeInvoke(int i , long l, String s, long ll) {
+            return l + ll;
+        }
+
+        public void testInvokeArgs() {
+            toBeInvoke(1, 123L, "abc", 100L);
+        }
+
+    }
+
+    public static class TestPrintSuppressHandler {
+
+        @ExceptionHandler(inline = true)
+        public static void onSuppress(@Binding.Throwable Throwable e, @Binding.Class Object clazz) {
+            System.err.println("exception handler: " + clazz);
+            e.printStackTrace();
+        }
+    }
+
+    public static class EnterInterceptor {
+
+        @AtEnter(inline = true,
+                suppress = RuntimeException.class,
+                suppressHandler = TestPrintSuppressHandler.class
+                )
+        public static long onEnter(
+                @Binding.This Object object, @Binding.Class Object clazz,
+               @Binding.Field(name = "longField") long longField,
+               @Binding.Field(name = "longField") Object longFieldObject,
+               @Binding.Field(name = "intField") int intField,
+               @Binding.Field(name = "strField") String strField,
+               @Binding.Field(name = "intField") Object intFielObject,
+               @Binding.MethodName String methodName,
+               @Binding.MethodDesc String methodDesc
+               ) {
+            System.err.println("onEnter, object:" + object);
+            System.err.println("onEnter, methodName:" + methodName);
+            System.err.println("onEnter, methodDesc:" + methodDesc);
+
+            int i=0;
+            if (i <= 0){
+                throw new IllegalArgumentException("invalid argument");
+            }
+            return 123L;
+        }
+
+    }
+
+
+
+    @Test
+    public void testEnter() throws Exception {
+        TestHelper helper = TestHelper.builder().interceptorClass(EnterInterceptor.class).methodMatcher("hello")
+                .reTransform(true);
+        byte[] bytes = helper.process(Sample.class);
+
+        new Sample().hello("abc", false);
+
+        System.err.println(Decompiler.decompile(bytes));
+
+        assertThat(capture.toString()).contains("onEnter, object:");
+    }
+
+}

--- a/bytekit/src/test/java/com/taobao/arthas/bytekit/asm/interceptor/TestHelper.java
+++ b/bytekit/src/test/java/com/taobao/arthas/bytekit/asm/interceptor/TestHelper.java
@@ -7,10 +7,10 @@ import com.alibaba.arthas.deps.org.objectweb.asm.tree.ClassNode;
 import com.alibaba.arthas.deps.org.objectweb.asm.tree.MethodNode;
 
 import com.taobao.arthas.bytekit.asm.MethodProcessor;
-import com.taobao.arthas.bytekit.asm.interceptor.InterceptorProcessor;
 import com.taobao.arthas.bytekit.asm.interceptor.parser.DefaultInterceptorClassParser;
 import com.taobao.arthas.bytekit.utils.AgentUtils;
 import com.taobao.arthas.bytekit.utils.AsmUtils;
+import com.taobao.arthas.bytekit.utils.Decompiler;
 import com.taobao.arthas.bytekit.utils.MatchUtils;
 import com.taobao.arthas.bytekit.utils.VerifyUtils;
 
@@ -31,6 +31,8 @@ public class TestHelper {
 
     private boolean asmVerity = true;
 
+    private boolean debug;
+
     public static TestHelper builder() {
         return new TestHelper();
     }
@@ -47,6 +49,11 @@ public class TestHelper {
 
     public TestHelper reTransform(boolean reTransform) {
         this.reTransform = reTransform;
+        return this;
+    }
+
+    public TestHelper debug(boolean debug) {
+        this.debug = debug;
         return this;
     }
 
@@ -70,7 +77,7 @@ public class TestHelper {
         }
 
         for (MethodNode methodNode : matchedMethods) {
-            MethodProcessor methodProcessor = new MethodProcessor(classNode, methodNode);
+            MethodProcessor methodProcessor = new MethodProcessor(classNode, methodNode, true);
             for (InterceptorProcessor interceptor : interceptorProcessors) {
                 interceptor.process(methodProcessor);
             }
@@ -79,6 +86,10 @@ public class TestHelper {
         byte[] bytes = AsmUtils.toBytes(classNode);
         if (asmVerity) {
             VerifyUtils.asmVerify(bytes);
+        }
+
+        if (debug) {
+            System.err.println(Decompiler.toString(classNode));
         }
 
         if (redefine) {


### PR DESCRIPTION
Improve ByteKit invoke binding process:  
1. save invoke stack on demand  
2. restore stack saver of on invoke before, fix invoke constructor arg error  
3. Fix problem: repeatedly inserting invoke before callback when using @Binding.InvokeArgs annotation  
4. improve testcase  

fix Bytekit AtInvokeTest 单元测试失败 #1264 .  
Passed unit tests on jdk1.8.0_151 and jdk 11.0.7, exclude 3 testcase:   
1. com.taobao.arthas.bytekit.asm.interceptor.InlineForTest  
2. com.taobao.arthas.bytekit.asm.interceptor.InlineWhileTest  
3. com.taobao.arthas.bytekit.asm.interceptor.InlineStaticFieldTest  
