### PR TITLE
fix: git-commit-id-plugin with useNativeGit for support git worktree

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -97,6 +97,7 @@
                         </executions>
                         <configuration>
                             <verbose>false</verbose>
+                            <useNativeGit>true</useNativeGit>
                             <dateFormat>yyyy-MM-dd'T'HH:mm:ssZ</dateFormat>
                             <generateGitPropertiesFile>true</generateGitPropertiesFile>
                             <generateGitPropertiesFilename>${project.build.outputDirectory}/arthas-git.properties</generateGitPropertiesFilename>


### PR DESCRIPTION
<useNativeGit>true</useNativeGit>

```
Caused by: pl.project13.maven.git.GitCommitIdExecutionException: Error
    at pl.project13.maven.git.JGitProvider.prepareGitToExtractMoreDetailedRepoInformation (JGitProvider.java:102)
    at pl.project13.maven.git.GitDataProvider.loadGitData (GitDataProvider.java:114)
    at pl.project13.maven.git.GitCommitIdMojo.loadGitDataWithJGit (GitCommitIdMojo.java:588)
    at pl.project13.maven.git.GitCommitIdMojo.loadGitData (GitCommitIdMojo.java:555)
    at pl.project13.maven.git.GitCommitIdMojo.execute (GitCommitIdMojo.java:376)
    at org.apache.maven.plugin.DefaultBuildPluginManager.executeMojo (DefaultBuildPluginManager.java:137)
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:210)
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:156)
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:148)
    at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject (LifecycleModuleBuilder.java:117)
    at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject (LifecycleModuleBuilder.java:81)
    at org.apache.maven.lifecycle.internal.builder.singlethreaded.SingleThreadedBuilder.build (SingleThreadedBuilder.java:56)
    at org.apache.maven.lifecycle.internal.LifecycleStarter.execute (LifecycleStarter.java:128)
    at org.apache.maven.DefaultMaven.doExecute (DefaultMaven.java:305)
    at org.apache.maven.DefaultMaven.doExecute (DefaultMaven.java:192)
    at org.apache.maven.DefaultMaven.execute (DefaultMaven.java:105)
    at org.apache.maven.cli.MavenCli.execute (MavenCli.java:957)
    at org.apache.maven.cli.MavenCli.doMain (MavenCli.java:289)
    at org.apache.maven.cli.MavenCli.main (MavenCli.java:193)
    at sun.reflect.NativeMethodAccessorImpl.invoke0 (Native Method)
    at sun.reflect.NativeMethodAccessorImpl.invoke (NativeMethodAccessorImpl.java:62)
    at sun.reflect.DelegatingMethodAccessorImpl.invoke (DelegatingMethodAccessorImpl.java:43)
    at java.lang.reflect.Method.invoke (Method.java:498)
    at org.codehaus.plexus.classworlds.launcher.Launcher.launchEnhanced (Launcher.java:282)
    at org.codehaus.plexus.classworlds.launcher.Launcher.launch (Launcher.java:225)
    at org.codehaus.plexus.classworlds.launcher.Launcher.mainWithExitCode (Launcher.java:406)
    at org.codehaus.plexus.classworlds.launcher.Launcher.main (Launcher.java:347)
Caused by: pl.project13.maven.git.GitCommitIdExecutionException: Could not get HEAD Ref, are you sure you have some commits in the dotGitDirectory?
    at pl.project13.maven.git.JGitProvider.prepareGitToExtractMoreDetailedRepoInformation (JGitProvider.java:97)
    at pl.project13.maven.git.GitDataProvider.loadGitData (GitDataProvider.java:114)
    at pl.project13.maven.git.GitCommitIdMojo.loadGitDataWithJGit (GitCommitIdMojo.java:588)
    at pl.project13.maven.git.GitCommitIdMojo.loadGitData (GitCommitIdMojo.java:555)
    at pl.project13.maven.git.GitCommitIdMojo.execute (GitCommitIdMojo.java:376)
    at org.apache.maven.plugin.DefaultBuildPluginManager.executeMojo (DefaultBuildPluginManager.java:137)
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:210)

```