### PR TITLE
feat: add search limit(-l) for sc and sm

### DIFF
--- a/core/src/main/java/com/taobao/arthas/core/GlobalOptions.java
+++ b/core/src/main/java/com/taobao/arthas/core/GlobalOptions.java
@@ -133,4 +133,14 @@ public class GlobalOptions {
             description = "This option enables print verbose information, default value false."
     )
     public static volatile boolean verbose = false;
+
+    /*
+     * default search limit size
+     */
+    @Option(level = 1,
+            name = "search-limit",
+            summary = "default search limit size",
+            description = ""
+    )
+    public static volatile int searchLimit = 0;
 }

--- a/core/src/main/java/com/taobao/arthas/core/command/klass100/SearchClassCommand.java
+++ b/core/src/main/java/com/taobao/arthas/core/command/klass100/SearchClassCommand.java
@@ -7,6 +7,7 @@ import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 
+import com.taobao.arthas.core.GlobalOptions;
 import com.taobao.arthas.core.command.Constants;
 import com.taobao.arthas.core.shell.cli.Completion;
 import com.taobao.arthas.core.shell.cli.CompletionUtils;
@@ -44,6 +45,7 @@ public class SearchClassCommand extends AnnotatedCommand {
     private boolean isRegEx = false;
     private String hashCode = null;
     private Integer expand;
+    private int limit = GlobalOptions.searchLimit;
 
     @Argument(argName = "class-pattern", index = 0)
     @Description("Class name pattern, use either '.' or '/' as separator")
@@ -81,12 +83,18 @@ public class SearchClassCommand extends AnnotatedCommand {
         this.hashCode = hashCode;
     }
 
+    @Option(shortName = "l", longName = "limit")
+    @Description("Limit for the result, default is no limit")
+    public void setLimit(int limit) {
+        this.limit = limit;
+    }
+
     @Override
     public void process(CommandProcess process) {
         // TODO: null check
         RowAffect affect = new RowAffect();
         Instrumentation inst = process.session().getInstrumentation();
-        List<Class<?>> matchedClasses = new ArrayList<Class<?>>(SearchUtils.searchClass(inst, classPattern, isRegEx, hashCode));
+        List<Class<?>> matchedClasses = new ArrayList<Class<?>>(SearchUtils.searchClass(inst, classPattern, isRegEx, hashCode, limit));
         Collections.sort(matchedClasses, new Comparator<Class<?>>() {
             @Override
             public int compare(Class<?> c1, Class<?> c2) {

--- a/core/src/main/java/com/taobao/arthas/core/util/SearchUtils.java
+++ b/core/src/main/java/com/taobao/arthas/core/util/SearchUtils.java
@@ -34,7 +34,7 @@ public class SearchUtils {
             if (classNameMatcher.matching(clazz.getName())) {
                 matches.add(clazz);
             }
-            if (matches.size() >= limit) {
+            if (limit > 0 && matches.size() >= limit) {
                 break;
             }
         }
@@ -42,17 +42,25 @@ public class SearchUtils {
     }
 
     public static Set<Class<?>> searchClass(Instrumentation inst, Matcher<String> classNameMatcher) {
-        return searchClass(inst, classNameMatcher, Integer.MAX_VALUE);
+        return searchClass(inst, classNameMatcher, 0);
     }
 
     public static Set<Class<?>> searchClass(Instrumentation inst, String classPattern, boolean isRegEx) {
+        return searchClass(inst, classPattern, isRegEx, 0);
+    }
+
+    public static Set<Class<?>> searchClass(Instrumentation inst, String classPattern, boolean isRegEx, int limit) {
         Matcher<String> classNameMatcher = classNameMatcher(classPattern, isRegEx);
-        return GlobalOptions.isDisableSubClass ? searchClass(inst, classNameMatcher) :
-                searchSubClass(inst, searchClass(inst, classNameMatcher));
+        return GlobalOptions.isDisableSubClass ? searchClass(inst, classNameMatcher, limit) :
+                searchSubClass(inst, searchClass(inst, classNameMatcher, limit));
     }
 
     public static Set<Class<?>> searchClass(Instrumentation inst, String classPattern, boolean isRegEx, String code) {
-        Set<Class<?>> matchedClasses = searchClass(inst, classPattern, isRegEx);
+        return searchClass(inst, classPattern, isRegEx, code, 0);
+    }
+
+    public static Set<Class<?>> searchClass(Instrumentation inst, String classPattern, boolean isRegEx, String code, int limit) {
+        Set<Class<?>> matchedClasses = searchClass(inst, classPattern, isRegEx, limit);
         return filter(matchedClasses, code);
     }
 


### PR DESCRIPTION
增加sc/sm查找时限制返回记录以提升使用体验
现已支持全局设置，但默认还是保持现状：不限制
我认为应该设置一个合适默认值，此问题留给项目所有者决策：）