### PR TITLE
fix: force compile package-info.java for fix useIncrementalCompilation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -256,6 +256,11 @@
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-compiler-plugin</artifactId>
                     <version>3.8.0</version>
+                    <configuration>
+                        <compilerArgs>
+                           <comiplerArg>-Xpkginfo:always</comiplerArg>
+                        </compilerArgs>
+                    </configuration>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
通过编译参数-Xpkginfo:always来强制编译package-info.java以实现增量构建的目的
据说package-info.java中没有注解的话默认是不会编译
而useIncrementalCompilation发现java源文件没编译会触发重新编译

可通过加-X参数后在maven构建输出中查找“Stale source detected"和”Changes detected“来排查哪些文件导致无法增量构建

```
                <plugin>
                    <groupId>org.apache.maven.plugins</groupId>
                    <artifactId>maven-compiler-plugin</artifactId>
                    <version>3.8.0</version>
                    <configuration>
                        <compilerArgs>
                           <comiplerArg>-Xpkginfo:always</comiplerArg>
                        </compilerArgs>
                    </configuration>
                </plugin>
```