### PR TITLE
feat: 在版本信息显示中附加构建时源代码commitId前16位

### DIFF
--- a/boot/pom.xml
+++ b/boot/pom.xml
@@ -63,6 +63,7 @@
                                     <Specification-Version>${project.version}</Specification-Version>
                                     <Implementation-Title>${project.name}</Implementation-Title>
                                     <Implementation-Version>${project.version}</Implementation-Version>
+                                    <Implementation-Title>${git.commit.id}</Implementation-Title>
                                 </manifestEntries>
                             </archive>
                         </configuration>

--- a/boot/src/main/java/com/taobao/arthas/boot/Bootstrap.java
+++ b/boot/src/main/java/com/taobao/arthas/boot/Bootstrap.java
@@ -277,6 +277,10 @@ public class Bootstrap {
         if (bootstrapPackage != null) {
             String arthasBootVersion = bootstrapPackage.getImplementationVersion();
             if (arthasBootVersion != null) {
+                final String implementationTitle = bootstrapPackage.getImplementationTitle();
+                if (implementationTitle != null && implementationTitle.length() > 16) {
+                    arthasBootVersion += " # " + implementationTitle.substring(0,16);
+                }
                 AnsiLog.info("arthas-boot version: " + arthasBootVersion);
             }
         }

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -47,6 +47,7 @@
                                         <Created-By>core engine team, middleware group, alibaba inc.</Created-By>
                                         <Implementation-Version>${project.version}</Implementation-Version>
                                         <Implementation-Vendor-Id>com.taobao.arthas</Implementation-Vendor-Id>
+                                        <Implementation-Title>${git.commit.id}</Implementation-Title>
                                         <Specification-Version>${project.version}</Specification-Version>
                                         <Specification-Title>arthas-core</Specification-Title>
                                     </manifestEntries>

--- a/core/src/main/java/com/taobao/arthas/core/util/ArthasBanner.java
+++ b/core/src/main/java/com/taobao/arthas/core/util/ArthasBanner.java
@@ -40,9 +40,14 @@ public class ArthasBanner {
             if (versionInputStream != null) {
                 VERSION = IOUtils.toString(versionInputStream).trim();
             } else {
-                String implementationVersion = ArthasBanner.class.getPackage().getImplementationVersion();
+                final Package p = ArthasBanner.class.getPackage();
+                String implementationVersion = p.getImplementationVersion();
                 if (implementationVersion != null) {
                     VERSION = implementationVersion;
+                    final String implementationTitle = p.getImplementationTitle();
+                    if (implementationTitle != null && implementationTitle.length() > 16) {
+                        VERSION += " # " + implementationTitle.substring(0,16);
+                    }
                 }
             }
 

--- a/pom.xml
+++ b/pom.xml
@@ -103,6 +103,25 @@
                             <excludeProperties>git.build.host</excludeProperties>
                         </configuration>
                     </plugin>
+                    <plugin>
+                        <groupId>org.codehaus.mojo</groupId>
+                        <artifactId>properties-maven-plugin</artifactId>
+                        <version>1.0.0</version>
+                        <executions>
+                          <execution>
+                            <phase>prepare-package</phase>
+                            <goals>
+                              <goal>read-project-properties</goal>
+                            </goals>
+                            <configuration>
+                              <quiet>true</quiet>
+                              <files>
+                                <file>${project.build.outputDirectory}/arthas-git.properties</file>
+                              </files>
+                            </configuration>
+                          </execution>
+                        </executions>
+                    </plugin>
                 </plugins>
             </build>
         </profile>


### PR DESCRIPTION
目的在让使用人员知道当前使用的版本对应用源代码
以便在需要时可以根据commitId快速检出源代码进行回溯

这里借用了Implementation-Title来传递commitId