### PR TITLE
classloader command support the classLoaderClass option

### DIFF
--- a/core/src/main/java/com/taobao/arthas/core/command/klass100/OgnlCommand.java
+++ b/core/src/main/java/com/taobao/arthas/core/command/klass100/OgnlCommand.java
@@ -58,7 +58,7 @@ public class OgnlCommand extends AnnotatedCommand {
     }
 
     @Option(longName = "classLoaderClass")
-    @Description("The class name of the special class's classLoader, default is null")
+    @Description("The class name of the special class's classLoader.")
     public void setClassLoaderClass(String classLoaderClass) {
         this.classLoaderClass = classLoaderClass;
     }
@@ -89,10 +89,10 @@ public class OgnlCommand extends AnnotatedCommand {
                         .setClassLoaderClass(classLoaderClass)
                         .setMatchedClassLoaders(classLoaderVOList);
                 process.appendResult(ognlModel);
-                process.end(-1, "Found more than one classloader of the specified class, please specify classloader by '-c <classloader hash>'");
+                process.end(-1, "Found more than one classloader by class name, please specify classloader with '-c <classloader hash>'");
                 return;
             } else {
-                process.end(-1, "Can not find classloader of class: " + classLoaderClass + ".");
+                process.end(-1, "Can not find classloader by class name: " + classLoaderClass + ".");
                 return;
             }
         } else {

--- a/core/src/main/java/com/taobao/arthas/core/command/klass100/OgnlCommand.java
+++ b/core/src/main/java/com/taobao/arthas/core/command/klass100/OgnlCommand.java
@@ -1,6 +1,7 @@
 package com.taobao.arthas.core.command.klass100;
 
 import java.lang.instrument.Instrumentation;
+import java.util.List;
 
 import com.alibaba.arthas.deps.org.slf4j.Logger;
 import com.alibaba.arthas.deps.org.slf4j.LoggerFactory;
@@ -37,8 +38,8 @@ public class OgnlCommand extends AnnotatedCommand {
     private static final Logger logger = LoggerFactory.getLogger(OgnlCommand.class);
 
     private String express;
-
     private String hashCode;
+    private String classLoaderClass;
     private int expand = 1;
 
     @Argument(argName = "express", index = 0, required = true)
@@ -53,6 +54,12 @@ public class OgnlCommand extends AnnotatedCommand {
         this.hashCode = hashCode;
     }
 
+    @Option(longName = "classLoaderClass")
+    @Description("The class name of the special class's classLoader, default is null")
+    public void setClassLoaderClass(String classLoaderClass) {
+        this.classLoaderClass = classLoaderClass;
+    }
+
     @Option(shortName = "x", longName = "expand")
     @Description("Expand level of object (1 by default).")
     public void setExpand(Integer expand) {
@@ -63,10 +70,18 @@ public class OgnlCommand extends AnnotatedCommand {
     public void process(CommandProcess process) {
         Instrumentation inst = process.session().getInstrumentation();
         ClassLoader classLoader = null;
-        if (hashCode == null) {
-            classLoader = ClassLoader.getSystemClassLoader();
-        } else {
+        if (hashCode != null) {
             classLoader = ClassLoaderUtils.getClassLoader(inst, hashCode);
+        } else if (classLoaderClass != null) {
+            List<ClassLoader> matchedClassLoaders = ClassLoaderUtils.getClassLoaderByClassName(inst, classLoaderClass);
+            if (matchedClassLoaders.size() > 1) {
+                process.end(-1, "Find more than one classloader matching the specified class name : " + classLoaderClass);
+                return;
+            } else if (matchedClassLoaders.size() == 1) {
+                classLoader = matchedClassLoaders.get(0);
+            }
+        } else {
+            classLoader = ClassLoader.getSystemClassLoader();
         }
 
         if (classLoader == null) {

--- a/core/src/main/java/com/taobao/arthas/core/command/model/OgnlModel.java
+++ b/core/src/main/java/com/taobao/arthas/core/command/model/OgnlModel.java
@@ -1,11 +1,17 @@
 package com.taobao.arthas.core.command.model;
 
+import java.util.Collection;
+
 /**
+ * Data model of OgnlCommand
  * @author gongdewei 2020/4/29
  */
 public class OgnlModel extends ResultModel {
     private Object value;
     private int expand = 1;
+
+    private Collection<ClassLoaderVO> matchedClassLoaders;
+    private String classLoaderClass;
 
 
     @Override
@@ -28,6 +34,24 @@ public class OgnlModel extends ResultModel {
 
     public OgnlModel setExpand(int expand) {
         this.expand = expand;
+        return this;
+    }
+
+    public String getClassLoaderClass() {
+        return classLoaderClass;
+    }
+
+    public OgnlModel setClassLoaderClass(String classLoaderClass) {
+        this.classLoaderClass = classLoaderClass;
+        return this;
+    }
+
+    public Collection<ClassLoaderVO> getMatchedClassLoaders() {
+        return matchedClassLoaders;
+    }
+
+    public OgnlModel setMatchedClassLoaders(Collection<ClassLoaderVO> matchedClassLoaders) {
+        this.matchedClassLoaders = matchedClassLoaders;
         return this;
     }
 }

--- a/core/src/main/java/com/taobao/arthas/core/command/view/ClassLoaderView.java
+++ b/core/src/main/java/com/taobao/arthas/core/command/view/ClassLoaderView.java
@@ -11,6 +11,7 @@ import com.taobao.text.Decoration;
 import com.taobao.text.ui.*;
 import com.taobao.text.util.RenderUtil;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 
@@ -57,7 +58,7 @@ public class ClassLoaderView extends ResultView<ClassLoaderModel> {
         return table;
     }
 
-    private void drawClassLoaders(CommandProcess process, List<ClassLoaderVO> classLoaders, Boolean isTree) {
+    public static void drawClassLoaders(CommandProcess process, Collection<ClassLoaderVO> classLoaders, boolean isTree) {
         Element element = isTree ? renderTree(classLoaders) : renderTable(classLoaders);
         process.write(RenderUtil.render(element, process.width()))
                 .write(com.taobao.arthas.core.util.Constants.EMPTY_STRING);
@@ -107,7 +108,7 @@ public class ClassLoaderView extends ResultView<ClassLoaderModel> {
     }
 
     // 统计所有的ClassLoader的信息
-    private static TableElement renderTable(List<ClassLoaderVO> classLoaderInfos) {
+    private static TableElement renderTable(Collection<ClassLoaderVO> classLoaderInfos) {
         TableElement table = new TableElement().leftCellPadding(1).rightCellPadding(1);
         table.add(new RowElement().style(Decoration.bold.bold()).add("name", "loadedCount", "hash", "parent"));
         for (ClassLoaderVO classLoaderVO : classLoaderInfos) {
@@ -117,7 +118,7 @@ public class ClassLoaderView extends ResultView<ClassLoaderModel> {
     }
 
     // 以树状列出ClassLoader的继承结构
-    private static Element renderTree(List<ClassLoaderVO> classLoaderInfos) {
+    private static Element renderTree(Collection<ClassLoaderVO> classLoaderInfos) {
         TreeElement root = new TreeElement();
         for (ClassLoaderVO classLoader : classLoaderInfos) {
             TreeElement child = new TreeElement(classLoader.getName());

--- a/core/src/main/java/com/taobao/arthas/core/command/view/OgnlView.java
+++ b/core/src/main/java/com/taobao/arthas/core/command/view/OgnlView.java
@@ -6,13 +6,21 @@ import com.taobao.arthas.core.util.StringUtils;
 import com.taobao.arthas.core.view.ObjectView;
 
 /**
+ * Term view of OgnlCommand
  * @author gongdewei 2020/4/29
  */
 public class OgnlView extends ResultView<OgnlModel> {
     @Override
-    public void draw(CommandProcess process, OgnlModel result) {
-        int expand = result.getExpand();
-        Object value = result.getValue();
+    public void draw(CommandProcess process, OgnlModel model) {
+        if (model.getMatchedClassLoaders() != null) {
+            process.write("Matched classloaders: \n");
+            ClassLoaderView.drawClassLoaders(process, model.getMatchedClassLoaders(), false);
+            process.write("\n");
+            return;
+        }
+
+        int expand = model.getExpand();
+        Object value = model.getValue();
         String resultStr = StringUtils.objectToString(expand >= 0 ? new ObjectView(value, expand).draw() : value);
         process.write(resultStr).write("\n");
     }

--- a/core/src/main/java/com/taobao/arthas/core/util/ClassLoaderUtils.java
+++ b/core/src/main/java/com/taobao/arthas/core/util/ClassLoaderUtils.java
@@ -1,7 +1,9 @@
 package com.taobao.arthas.core.util;
 
 import java.lang.instrument.Instrumentation;
+import java.util.ArrayList;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 
 /**
@@ -37,6 +39,26 @@ public class ClassLoaderUtils {
             }
         }
         return null;
+    }
+
+    /**
+     * 通过类名查找classloader
+     * @param inst
+     * @param classLoaderClassName
+     * @return
+     */
+    public static List<ClassLoader> getClassLoaderByClassName(Instrumentation inst, String classLoaderClassName) {
+        if (classLoaderClassName == null || classLoaderClassName.isEmpty()) {
+            return null;
+        }
+        Set<ClassLoader> classLoaderSet = getAllClassLoader(inst);
+        List<ClassLoader> matchClassLoaders = new ArrayList<ClassLoader>();
+        for (ClassLoader classLoader : classLoaderSet) {
+            if (classLoader.getClass().getName().equals(classLoaderClassName)) {
+                matchClassLoaders.add(classLoader);
+            }
+        }
+        return matchClassLoaders;
     }
 
     public static String classLoaderHash(ClassLoader classLoader) {

--- a/core/src/main/java/com/taobao/arthas/core/util/ClassUtils.java
+++ b/core/src/main/java/com/taobao/arthas/core/util/ClassUtils.java
@@ -199,6 +199,14 @@ public class ClassUtils {
         return classLoaderVO;
     }
 
+    public static List<ClassLoaderVO> createClassLoaderVOList(Collection<ClassLoader> classLoaders) {
+        List<ClassLoaderVO> classLoaderVOList = new ArrayList<ClassLoaderVO>();
+        for (ClassLoader classLoader : classLoaders) {
+            classLoaderVOList.add(createClassLoaderVO(classLoader));
+        }
+        return classLoaderVOList;
+    }
+
     public static String classLoaderHash(Class<?> clazz) {
         if (clazz == null || clazz.getClassLoader() == null) {
             return "null";

--- a/site/src/site/sphinx/en/ognl.md
+++ b/site/src/site/sphinx/en/ognl.md
@@ -11,6 +11,7 @@ Since 3.0.5.
 |---:|:---|
 |*express*|expression to be executed|
 |`[c:]`| The hashcode of the ClassLoader that executes the expression, default ClassLoader is SystemClassLoader. |
+|`[classLoaderClass:]`| The class name of the ClassLoader that executes the expression. |
 |[x]|Expand level of object (1 by default).|
 
 
@@ -46,6 +47,38 @@ $ ognl '@demo.MathGame@random'
     serialPersistentFields=@ObjectStreamField[][isEmpty=false;size=3],
     unsafe=@Unsafe[sun.misc.Unsafe@28ea5898],
     seedOffset=@Long[24],
+]
+```
+
+
+Specify ClassLoader by hashcode: 
+
+```bash
+$ classloader -t
++-BootstrapClassLoader                                                                                                                                                                          
++-jdk.internal.loader.ClassLoaders$PlatformClassLoader@301ec38b                                                                                                                                 
+  +-com.taobao.arthas.agent.ArthasClassloader@472067c7                                                                                                                                          
+  +-jdk.internal.loader.ClassLoaders$AppClassLoader@4b85612c                                                                                                                                    
+    +-org.springframework.boot.loader.LaunchedURLClassLoader@7f9a81e8 
+
+$ ognl -c 7f9a81e8 @org.springframework.boot.SpringApplication@logger
+@Slf4jLocationAwareLog[
+    FQCN=@String[org.apache.commons.logging.LogAdapter$Slf4jLocationAwareLog],
+    name=@String[org.springframework.boot.SpringApplication],
+    logger=@Logger[Logger[org.springframework.boot.SpringApplication]],
+]
+$ 
+```
+Note that the hashcode changes, you need to check the current ClassLoader information first, and extract the hashcode corresponding to the ClassLoader.
+
+For ClassLoader with only unique instance, it can be specified by class name, which is more convenient to use:
+
+```bash
+$ ognl --classLoaderClass org.springframework.boot.loader.LaunchedURLClassLoader  @org.springframework.boot.SpringApplication@logger
+@Slf4jLocationAwareLog[
+    FQCN=@String[org.apache.commons.logging.LogAdapter$Slf4jLocationAwareLog],
+    name=@String[org.springframework.boot.SpringApplication],
+    logger=@Logger[Logger[org.springframework.boot.SpringApplication]],
 ]
 ```
 

--- a/site/src/site/sphinx/ognl.md
+++ b/site/src/site/sphinx/ognl.md
@@ -11,6 +11,7 @@ ognl
 |---:|:---|
 |*express*|执行的表达式|
 |`[c:]`|执行表达式的 ClassLoader 的 hashcode，默认值是SystemClassLoader|
+|`[classLoaderClass:]`|指定执行表达式的 ClassLoader 的 class name|
 |[x]|结果对象的展开层次，默认值1|
 
 
@@ -49,6 +50,38 @@ $ ognl '@demo.MathGame@random'
     seedOffset=@Long[24],
 ]
 ```
+
+通过hashcode指定ClassLoader：
+
+```bash
+$ classloader -t
++-BootstrapClassLoader                                                                                                                                                                          
++-jdk.internal.loader.ClassLoaders$PlatformClassLoader@301ec38b                                                                                                                                 
+  +-com.taobao.arthas.agent.ArthasClassloader@472067c7                                                                                                                                          
+  +-jdk.internal.loader.ClassLoaders$AppClassLoader@4b85612c                                                                                                                                    
+    +-org.springframework.boot.loader.LaunchedURLClassLoader@7f9a81e8 
+
+$ ognl -c 7f9a81e8 @org.springframework.boot.SpringApplication@logger
+@Slf4jLocationAwareLog[
+    FQCN=@String[org.apache.commons.logging.LogAdapter$Slf4jLocationAwareLog],
+    name=@String[org.springframework.boot.SpringApplication],
+    logger=@Logger[Logger[org.springframework.boot.SpringApplication]],
+]
+$ 
+```
+注意hashcode是变化的，需要先查看当前的ClassLoader信息，提取对应ClassLoader的hashcode。
+
+对于只有唯一实例的ClassLoader可以通过class name指定，使用起来更加方便：
+
+```bash
+$ ognl --classLoaderClass org.springframework.boot.loader.LaunchedURLClassLoader  @org.springframework.boot.SpringApplication@logger
+@Slf4jLocationAwareLog[
+    FQCN=@String[org.apache.commons.logging.LogAdapter$Slf4jLocationAwareLog],
+    name=@String[org.springframework.boot.SpringApplication],
+    logger=@Logger[Logger[org.springframework.boot.SpringApplication]],
+]
+```
+
 
 执行多行表达式，赋值给临时变量，返回一个List：
 


### PR DESCRIPTION
添加通过class name指定classloader的特性，解决katacoda 教程中不能自动指定classloader hash的问题，普通SpringBoot场景可以通过`--classLoaderClass org.springframework.boot.loader.LaunchedURLClassLoader` 来指定classloader。   
也可以方便用户交流及编写通用批处理脚本，大部分场景具有普适性，指定classloader class可以解决通用问题。

```
[arthas@45680]$ ognl --classLoaderClass org.springframework.boot.loader.LaunchedURLClassLoader  @org.springframework.boot.SpringApplication@logger
@Slf4jLocationAwareLog[
    FQCN=@String[org.apache.commons.logging.LogAdapter$Slf4jLocationAwareLog],
    name=@String[org.springframework.boot.SpringApplication],
    logger=@Logger[Logger[org.springframework.boot.SpringApplication]],
]

```