### PR TITLE
fix `profiler actions` command does not end

### DIFF
--- a/core/src/main/java/com/taobao/arthas/core/command/monitor200/ProfilerCommand.java
+++ b/core/src/main/java/com/taobao/arthas/core/command/monitor200/ProfilerCommand.java
@@ -276,6 +276,7 @@ public class ProfilerCommand extends AnnotatedCommand {
 
             if (ProfilerAction.actions.equals(profilerAction)) {
                 process.appendResult(new ProfilerModel(actions()));
+                process.end();
                 return;
             }
 


### PR DESCRIPTION
Call `process.end()` before return