### PR TITLE
修复profiler命令仅指定参数 --format jfr 时无法录制成功问题

### DIFF
--- a/core/src/main/java/com/taobao/arthas/core/command/monitor200/ProfilerCommand.java
+++ b/core/src/main/java/com/taobao/arthas/core/command/monitor200/ProfilerCommand.java
@@ -290,6 +290,10 @@ public class ProfilerCommand extends AnnotatedCommand {
                 String result = execute(asyncProfiler, this.actionArg);
                 appendExecuteResult(process, result);
             } else if (ProfilerAction.start.equals(profilerAction)) {
+                //jfr录制，必须在start的时候就指定文件路径
+                if (this.file == null && "jfr".equals(format)) {
+                    this.file = outputFile();
+                }
                 String executeArgs = executeArgs(ProfilerAction.start);
                 String result = execute(asyncProfiler, executeArgs);
                 ProfilerModel profilerModel = createProfilerModel(result);


### PR DESCRIPTION
profiler在jfr录制，必须在start的时候就指定文件路径，否则无法录制成功