### PR TITLE
ignore .pmd for git

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ site/src/site/sphinx/en/_build
 
 dependency-reduced-pom.xml
 pom.xml.versionsBackup
+.pmd


### PR DESCRIPTION
添加原因是eclipse安装了pmd plugin后会自动生成.pmd，为防止git误操作应该忽略此文件