### PR TITLE
Fix ID doesn't exist in T4

### DIFF
--- a/tutorials/katacoda/case-http-api-cn/session-interaction.md
+++ b/tutorials/katacoda/case-http-api-cn/session-interaction.md
@@ -40,6 +40,8 @@ echo $session_id`{{execute T3}}
 
 `b09f1353-202c-407b-af24-701b744f971e`;
 
+请记下这里的会话ID，在Terminal 4中需要手动输入。
+
 当前消费者ID为：
 
 `consumer_id=$(echo $session_data | sed 's/.*"consumerId":"\([^"]*\)".*/\1/g')
@@ -80,6 +82,8 @@ echo $consumer_id`{{execute T3}}
 
 `8f7f6ad7bc2d4cb5aa57a530927a95cc_2 ` 。
 
+请记下这里的消费者ID，在Terminal 4中需要手动输入。
+
 #### 拉取命令结果
 
 拉取命令结果消息的action为`pull_results`。请使用Http long-polling方式，定时循环拉取结果消息。
@@ -96,6 +100,20 @@ echo $consumer_id`{{execute T3}}
 ' | json_pp`{{execute T3}}
 
 用Bash脚本定时拉取结果消息:
+
+请在Terminal 4中输入Terminal 3中的会话ID，这里的例子如下：
+
+`b09f1353-202c-407b-af24-701b744f971e`
+
+`echo -n "Enter your sessionId in T3:"
+read  session_id`{{execute T4}}
+
+同样，接着输入Terminal 3中的消费者ID，这里的例子如下：
+
+`8f7f6ad7bc2d4cb5aa57a530927a95cc_2 `
+
+`echo -n "Enter your consumerId in T3:"
+read  consumer_id`{{execute T4}}
 
 `while true; do curl -Ss -XPOST http://localhost:8563/api -d '
 {

--- a/tutorials/katacoda/case-http-api-en/session-interaction.md
+++ b/tutorials/katacoda/case-http-api-en/session-interaction.md
@@ -41,12 +41,16 @@ echo $session_id`{{execute T3}}
 
 `b09f1353-202c-407b-af24-701b744f971e`;
 
+Please take a note of your session ID here, it will be entered in Terminal 4 in the following steps.
+
 consumer ID is: 
 
 `consumer_id=$(echo $session_data | sed 's/.*"consumerId":"\([^"]*\)".*/\1/g')
 echo $consumer_id`{{execute T3}}
 
 `5ae4e5fbab8b4e529ac404f260d4e2d1_1`.
+
+Please take a note of your consumer ID here, it will be entered in Terminal 4 in the following steps.
 
 #### Join session
 
@@ -107,6 +111,20 @@ The request parameters require session ID and consumer ID:
 ' | json_pp`{{execute T3}}
 
 Use Bash scripts to regularly pull results messages:
+
+Please enter the sessionID from your Terminal 3 in Terminal 4, an example is here：
+
+`b09f1353-202c-407b-af24-701b744f971e`
+
+`echo -n "Enter your sessionId in T3:"
+read  session_id`{{execute T4}}
+
+Also, Please enter the consumerID, an example is here：
+
+`8f7f6ad7bc2d4cb5aa57a530927a95cc_2`
+
+`echo -n "Enter your consumerId in T3:"
+read  consumer_id`{{execute T4}}
 
 `while true; do curl -Ss -XPOST http://localhost:8563/api -d '
 {


### PR DESCRIPTION
在Terminal 4中执行拉取命令时会因为session_id和consumer_id不存在而报错，所以新增提示用户输入

https://www.katacoda.com/hollowman/scenarios/case-http-api-cn

Signed-off-by: Hollow Man <hollowman@hollowman.ml>