### PR TITLE
Reduce small objects generated by dashboard commands

### DIFF
--- a/core/src/main/java/com/taobao/arthas/core/command/monitor200/DashboardCommand.java
+++ b/core/src/main/java/com/taobao/arthas/core/command/monitor200/DashboardCommand.java
@@ -306,8 +306,8 @@ public class DashboardCommand extends AnnotatedCommand {
                 DashboardModel dashboardModel = new DashboardModel();
 
                 //thread sample
-                Map<String, ThreadVO> threads = ThreadUtil.getThreads();
-                dashboardModel.setThreads(threadSampler.sample(threads.values()));
+                List<ThreadVO> threads = ThreadUtil.getThreads();
+                dashboardModel.setThreads(threadSampler.sample(threads));
 
                 //memory
                 addMemoryInfo(dashboardModel);

--- a/core/src/main/java/com/taobao/arthas/core/command/monitor200/ThreadCommand.java
+++ b/core/src/main/java/com/taobao/arthas/core/command/monitor200/ThreadCommand.java
@@ -129,7 +129,7 @@ public class ThreadCommand extends AnnotatedCommand {
     }
 
     private ExitStatus processAllThreads(CommandProcess process) {
-        Map<String, ThreadVO> threads = ThreadUtil.getThreads();
+        List<ThreadVO> threads = ThreadUtil.getThreads();
 
         // 统计各种线程状态
         Map<State, Integer> stateCountMap = new LinkedHashMap<State, Integer>();
@@ -137,7 +137,7 @@ public class ThreadCommand extends AnnotatedCommand {
             stateCountMap.put(s, 0);
         }
 
-        for (ThreadVO thread : threads.values()) {
+        for (ThreadVO thread : threads) {
             State threadState = thread.getState();
             Integer count = stateCountMap.get(threadState);
             stateCountMap.put(threadState, count + 1);
@@ -149,7 +149,7 @@ public class ThreadCommand extends AnnotatedCommand {
             this.state = this.state.toUpperCase();
             if (states.contains(this.state)) {
                 includeInternalThreads = false;
-                for (ThreadVO thread : threads.values()) {
+                for (ThreadVO thread : threads) {
                     if (thread.getState() != null && state.equals(thread.getState().name())) {
                         resultThreads.add(thread);
                     }
@@ -158,7 +158,7 @@ public class ThreadCommand extends AnnotatedCommand {
                 return ExitStatus.failure(1, "Illegal argument, state should be one of " + states);
             }
         } else {
-            resultThreads = threads.values();
+            resultThreads = threads;
         }
 
         //thread stats
@@ -183,9 +183,9 @@ public class ThreadCommand extends AnnotatedCommand {
 
     private ExitStatus processTopBusyThreads(CommandProcess process) {
         ThreadSampler threadSampler = new ThreadSampler();
-        threadSampler.sample(ThreadUtil.getThreads().values());
+        threadSampler.sample(ThreadUtil.getThreads());
         threadSampler.pause(sampleInterval);
-        List<ThreadVO> threadStats = threadSampler.sample(ThreadUtil.getThreads().values());
+        List<ThreadVO> threadStats = threadSampler.sample(ThreadUtil.getThreads());
 
         int limit = Math.min(threadStats.size(), topNBusy);
         List<ThreadVO> topNThreads = threadStats.subList(0, limit);

--- a/core/src/main/java/com/taobao/arthas/core/command/view/ViewRenderUtil.java
+++ b/core/src/main/java/com/taobao/arthas/core/command/view/ViewRenderUtil.java
@@ -123,6 +123,7 @@ public class ViewRenderUtil {
                 )
         );
 
+        int count = 0;
         for (ThreadVO thread : threads) {
             Color color = colorMapping.get(thread.getState());
             String time = formatTimeMills(thread.getTime());
@@ -151,6 +152,9 @@ public class ViewRenderUtil {
                     new LabelElement(thread.isInterrupted()),
                     daemonLabel
             );
+            if (++count >= height) {
+                break;
+            }
         }
         return RenderUtil.render(table, width, height);
     }

--- a/core/src/main/java/com/taobao/arthas/core/command/view/ViewRenderUtil.java
+++ b/core/src/main/java/com/taobao/arthas/core/command/view/ViewRenderUtil.java
@@ -159,13 +159,33 @@ public class ViewRenderUtil {
         long seconds = timeMills / 1000;
         long mills = timeMills % 1000;
         long min = seconds / 60;
-        //return min + ":" + (seconds % 60);
-        return String.format("%d:%d.%03d", min, seconds, mills);
+        seconds = seconds % 60;
+
+        //return String.format("%d:%d.%03d", min, seconds, mills);
+        String str;
+        if (mills >= 100) {
+            str = min + ":" + seconds + "." + mills;
+        } else if (mills >= 10) {
+            str = min + ":" + seconds + ".0" + mills;
+        } else {
+            str = min + ":" + seconds + ".00" + mills;
+        }
+        return str;
     }
 
     private static String formatTimeMillsToSeconds(long timeMills) {
         long seconds = timeMills / 1000;
         long mills = timeMills % 1000;
-        return String.format("%d.%03d", seconds, mills);
+
+        //return String.format("%d.%03d", seconds, mills);
+        String str;
+        if (mills >= 100) {
+            str = seconds + "." + mills;
+        } else if (mills >= 10) {
+            str = seconds + ".0" + mills;
+        } else {
+            str = seconds + ".00" + mills;
+        }
+        return str;
     }
 }

--- a/core/src/main/java/com/taobao/arthas/core/util/StringUtils.java
+++ b/core/src/main/java/com/taobao/arthas/core/util/StringUtils.java
@@ -449,10 +449,14 @@ public abstract class StringUtils {
 
     public static String replace(String inString, String oldPattern, String newPattern) {
         if(hasLength(inString) && hasLength(oldPattern) && newPattern != null) {
-            StringBuilder sb = new StringBuilder();
             int pos = 0;
             int index = inString.indexOf(oldPattern);
+            if (index < 0) {
+                //no need to replace
+                return inString;
+            }
 
+            StringBuilder sb = new StringBuilder();
             for(int patLen = oldPattern.length(); index >= 0; index = inString.indexOf(oldPattern, pos)) {
                 sb.append(inString.substring(pos, index));
                 sb.append(newPattern);

--- a/core/src/main/java/com/taobao/arthas/core/util/ThreadUtil.java
+++ b/core/src/main/java/com/taobao/arthas/core/util/ThreadUtil.java
@@ -36,29 +36,22 @@ abstract public class ThreadUtil {
     }
 
     /**
-     * 获取所有线程Map，以线程Name-ID为key
-     * 
-     * @return
+     * 获取所有线程
      */
-    public static Map<String, ThreadVO> getThreads() {
+    public static List<ThreadVO> getThreads() {
         ThreadGroup root = getRoot();
         Thread[] threads = new Thread[root.activeCount()];
         while (root.enumerate(threads, true) == threads.length) {
             threads = new Thread[threads.length * 2];
         }
-        SortedMap<String, ThreadVO> map = new TreeMap<String, ThreadVO>(new Comparator<String>() {
-            @Override
-            public int compare(String o1, String o2) {
-                return o1.compareTo(o2);
-            }
-        });
+        List<ThreadVO> list = new ArrayList<ThreadVO>(threads.length);
         for (Thread thread : threads) {
             if (thread != null) {
                 ThreadVO threadVO = createThreadVO(thread);
-                map.put(thread.getName() + "-" + thread.getId(), threadVO);
+                list.add(threadVO);
             }
         }
-        return map;
+        return list;
     }
 
     private static ThreadVO createThreadVO(Thread thread) {


### PR DESCRIPTION

*  Replace String.format() with string concat/builder, reducing lots of Formatter objects
* Improve ThreadUtil.getThreads() 
* Improve text-ui ScreenBuffer and LabelElement (https://github.com/alibaba/text-ui/pull/2)

test command: `dashboard -i 1000 -n 10`
`DashboardView.draw()` profile result statistics:

| Item | Before | After | Reduce | 
| -| -| -| -|
| Object Count | 184303 |67873 | 63% |
| Object Size | 7732976 | 3321216| 57% |
| Object Allocations | 19 K/s | 7.3 K/s | 61% |

**Before:**

![image](https://user-images.githubusercontent.com/5483385/94549279-8b3e8100-0284-11eb-95a2-aeea2ece5b0c.png)
![image](https://user-images.githubusercontent.com/5483385/94549321-9db8ba80-0284-11eb-8485-47b506140e72.png)

**After:**

![image](https://user-images.githubusercontent.com/5483385/94549434-cd67c280-0284-11eb-91ca-3730feb0970c.png)

![image](https://user-images.githubusercontent.com/5483385/94549535-f2f4cc00-0284-11eb-8ca3-656d7e528a3e.png)



