### PR TITLE
fix typo

### DIFF
--- a/site/src/site/sphinx/tt.md
+++ b/site/src/site/sphinx/tt.md
@@ -173,7 +173,7 @@ Time fragment[1004] successfully replayed.
 Affect(row-cnt:1) cost in 14 ms.
 ```
 
-你会发现结果虽然一样，但调用的路径发生了变化，有原来的程序发起变成了 Arthas 自己的内部线程发起的调用了。
+你会发现结果虽然一样，但调用的路径发生了变化，由原来的程序发起变成了 Arthas 自己的内部线程发起的调用了。
 
 - 需要强调的点
 


### PR DESCRIPTION
fix typo [`tt.md`]
`有`原来的程序发起变成了 >> `由`原来的程序发起变成了