### PR TITLE
improve reproducibility of the build

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
         <developerConnection>scm:git:git@github.com:alibaba/arthas.git</developerConnection>
         <url>https://github.com/alibaba/arthas</url>
       <tag>HEAD</tag>
-  </scm>
+    </scm>
 
     <developers>
         <developer>
@@ -102,6 +102,7 @@
                             <generateGitPropertiesFile>true</generateGitPropertiesFile>
                             <generateGitPropertiesFilename>${project.build.outputDirectory}/arthas-git.properties</generateGitPropertiesFilename>
                             <excludeProperties>
+                                <excludeProperty>git.branch</excludeProperty>
                                 <excludeProperty>git.build.host</excludeProperty>
                                 <excludeProperty>git.build.time</excludeProperty>
                                 <excludeProperty>git.build.user.email</excludeProperty>
@@ -111,6 +112,7 @@
                                 <excludeProperty>git.commit.time</excludeProperty>
                                 <excludeProperty>git.local.branch.ahead</excludeProperty>
                                 <excludeProperty>git.local.branch.behind</excludeProperty>
+                                <excludeProperty>git.tags</excludeProperty>
                             </excludeProperties>
                             <injectAllReactorProjects>true</injectAllReactorProjects>
                         </configuration>


### PR DESCRIPTION
as checked in Reproducible Central https://github.com/jvm-repo-rebuild/reproducible-central#com.taobao.arthas:arthas-all, reproducibility of latest releases has improved (with 3.4.4 having been done from a dirty Git workspace...) but after having checked 3.4.5, there are 2 remaining issues:
1. there are 2 remaining non-reproducible Git properties, that this PR removes
2. something during the rebuild changes pom.xml xsd from http to https

Changing xsd to https://maven.apache.org/xsd/maven-4.0.0.xsd in source tree could be a good idea, I don't know if there are any objections