### PR TITLE
fix: output file of the profiler is saved in the arthas.output.dir di…

### DIFF
--- a/core/src/main/java/com/taobao/arthas/core/command/monitor200/ProfilerCommand.java
+++ b/core/src/main/java/com/taobao/arthas/core/command/monitor200/ProfilerCommand.java
@@ -435,7 +435,8 @@ public class ProfilerCommand extends AnnotatedCommand {
 
     private String outputFile() {
         if (this.file == null) {
-            this.file = new File("arthas-output",
+            String outputPath = System.getProperty("arthas.output.dir", "arthas-output");
+            this.file = new File(outputPath,
                     new SimpleDateFormat("yyyyMMdd-HHmmss").format(new Date()) + "." + this.format).getAbsolutePath();
         }
         return file;


### PR DESCRIPTION
The output file location of the profiler cannot be specified