### PR TITLE
wiki: not support 'trace java.lang.Thread getName'

### DIFF
--- a/site/src/site/sphinx/en/trace.md
+++ b/site/src/site/sphinx/en/trace.md
@@ -38,6 +38,8 @@ Many times what we are interested is the exact trace result when the method call
 
 After version 3.3.0, you can use the Dynamic Trace feature to add new matching classes/methods, see the following example.
 
+Currently `trace java.lang.Thread getName` is not supported, please refer to issue: [#1610](https://github.com/alibaba/arthas/issues/1610), considering that it is not very necessary and it is difficult to repair , So it won’t be fixed for now
+
 ### Usage
 
 #### Start Demo

--- a/site/src/site/sphinx/trace.md
+++ b/site/src/site/sphinx/trace.md
@@ -40,6 +40,7 @@ trace
 
 3.3.0 版本后，可以使用动态Trace功能，不断增加新的匹配类，参考下面的示例。
 
+目前不支持 `trace  java.lang.Thread getName`，参考issue: [#1610](https://github.com/alibaba/arthas/issues/1610) ，考虑到不是非常必要场景，且修复有一定难度，因此当前暂不修复
 
 ### 使用参考
 


### PR DESCRIPTION
Update the wiki, adding that trace does not support `trace java.lang.Thread getName` description