### PR TITLE
Fix thread examples from 'thread -n -1' to 'thread -1'

### DIFF
--- a/core/src/main/java/com/taobao/arthas/core/command/monitor200/ThreadCommand.java
+++ b/core/src/main/java/com/taobao/arthas/core/command/monitor200/ThreadCommand.java
@@ -38,7 +38,7 @@ import java.util.Set;
 @Description(Constants.EXAMPLE +
         "  thread\n" +
         "  thread 51\n" +
-        "  thread -n -1\n" +
+        "  thread -1\n" +
         "  thread -n 5\n" +
         "  thread -b\n" +
         "  thread -i 2000\n" +


### PR DESCRIPTION
'thread -n -1' command throw IllegalArgumentException error, and I try 'thread -1' command and works well