### PR TITLE
remove env JAVA_TOOL_OPTIONS

### DIFF
--- a/bin/as.bat
+++ b/bin/as.bat
@@ -24,6 +24,7 @@ if ["%~1"]==[""] (
   goto exit_bat
 )
 
+set JAVA_TOOL_OPTIONS
 set AGENT_JAR=%BASEDIR%\arthas-agent.jar
 set CORE_JAR=%BASEDIR%\arthas-core.jar
 

--- a/bin/as.sh
+++ b/bin/as.sh
@@ -232,6 +232,7 @@ check_permission()
 # reset some options for env
 reset_for_env()
 {
+    unset JAVA_TOOL_OPTIONS
 
     # init ARTHAS' lib
     mkdir -p "${ARTHAS_LIB_DIR}" \


### PR DESCRIPTION
很多APM工具、调试工具，都是通过设置环境变量 `JAVA_TOOL_OPTIONS` 来实现相关功能（比如[Aliyun ARMS](https://help.aliyun.com/document_detail/85906.html#title-v0c-bbr-dn0)、[GCP Cloud Profiler](https://spring-gcp.saturnism.me/app-dev/observability/profiling#agent-configurations)）。
最终用户在通过`./as.sh`启动arthas时，也会加载APM agent。
但使用Arthas的人，即没有必要管理Arthas的性能、没有必要调试Arthas内部代码，这个行为也增加了arthas的启动时间。

所以在`./as.sh`脚本中，忽略`JAVA_TOOL_OPTIONS`环境变量，以便更快的启动、更方便的使用。