### PR TITLE
FIX(arthas.core):修复javaagent指定arthas.properties路径加载错误

### DIFF
--- a/core/src/main/java/com/taobao/arthas/core/server/ArthasBootstrap.java
+++ b/core/src/main/java/com/taobao/arthas/core/server/ArthasBootstrap.java
@@ -308,7 +308,7 @@ public class ArthasBootstrap {
 
         String configName = "arthas";
         if (arthasEnvironment.containsProperty(CONFIG_NAME_PROPERTY)) {
-            configName = arthasEnvironment.resolvePlaceholders(arthasEnvironment.getProperty(CONFIG_LOCATION_PROPERTY));
+            configName = arthasEnvironment.resolvePlaceholders(arthasEnvironment.getProperty(CONFIG_NAME_PROPERTY));
         }
 
         if (location != null) {

--- a/core/src/main/java/com/taobao/arthas/core/server/ArthasBootstrap.java
+++ b/core/src/main/java/com/taobao/arthas/core/server/ArthasBootstrap.java
@@ -299,7 +299,7 @@ public class ArthasBootstrap {
         String location = null;
 
         if (arthasEnvironment.containsProperty(CONFIG_LOCATION_PROPERTY)) {
-            location = arthasEnvironment.resolvePlaceholders(CONFIG_LOCATION_PROPERTY);
+            location = arthasEnvironment.getProperty(CONFIG_LOCATION_PROPERTY);
         }
 
         if (location == null) {

--- a/core/src/main/java/com/taobao/arthas/core/server/ArthasBootstrap.java
+++ b/core/src/main/java/com/taobao/arthas/core/server/ArthasBootstrap.java
@@ -299,7 +299,7 @@ public class ArthasBootstrap {
         String location = null;
 
         if (arthasEnvironment.containsProperty(CONFIG_LOCATION_PROPERTY)) {
-            location = arthasEnvironment.getProperty(CONFIG_LOCATION_PROPERTY);
+            location = arthasEnvironment.resolvePlaceholders(arthasEnvironment.getProperty(CONFIG_LOCATION_PROPERTY));
         }
 
         if (location == null) {
@@ -308,7 +308,7 @@ public class ArthasBootstrap {
 
         String configName = "arthas";
         if (arthasEnvironment.containsProperty(CONFIG_NAME_PROPERTY)) {
-            configName = arthasEnvironment.resolvePlaceholders(CONFIG_NAME_PROPERTY);
+            configName = arthasEnvironment.resolvePlaceholders(arthasEnvironment.getProperty(CONFIG_LOCATION_PROPERTY));
         }
 
         if (location != null) {


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/47874534/124858806-54e71c80-dfe1-11eb-82cc-c9ce5d6d87b9.png)
原bug，可以看到指定配置文件路径后，参数传递正常，但是通过resolvePlaceholders无法拿到路径。
故修改为arthasEnvironment.getProperty(CONFIG_LOCATION_PROPERTY); 之后便可以正常获取路径参数。