### PR TITLE
新增threadpool指定，用来监控线程池核心线程数、最大线程数、当前繁忙线程数、当前队列堆积数，同时输出调用栈来帮助定位线程池

### DIFF
--- a/core/src/main/java/com/taobao/arthas/core/command/BuiltinCommandPack.java
+++ b/core/src/main/java/com/taobao/arthas/core/command/BuiltinCommandPack.java
@@ -35,19 +35,7 @@ import com.taobao.arthas.core.command.klass100.RetransformCommand;
 import com.taobao.arthas.core.command.klass100.SearchClassCommand;
 import com.taobao.arthas.core.command.klass100.SearchMethodCommand;
 import com.taobao.arthas.core.command.logger.LoggerCommand;
-import com.taobao.arthas.core.command.monitor200.DashboardCommand;
-import com.taobao.arthas.core.command.monitor200.HeapDumpCommand;
-import com.taobao.arthas.core.command.monitor200.JvmCommand;
-import com.taobao.arthas.core.command.monitor200.MBeanCommand;
-import com.taobao.arthas.core.command.monitor200.MonitorCommand;
-import com.taobao.arthas.core.command.monitor200.PerfCounterCommand;
-import com.taobao.arthas.core.command.monitor200.ProfilerCommand;
-import com.taobao.arthas.core.command.monitor200.StackCommand;
-import com.taobao.arthas.core.command.monitor200.ThreadCommand;
-import com.taobao.arthas.core.command.monitor200.TimeTunnelCommand;
-import com.taobao.arthas.core.command.monitor200.TraceCommand;
-import com.taobao.arthas.core.command.monitor200.VmToolCommand;
-import com.taobao.arthas.core.command.monitor200.WatchCommand;
+import com.taobao.arthas.core.command.monitor200.*;
 import com.taobao.arthas.core.shell.command.AnnotatedCommand;
 import com.taobao.arthas.core.shell.command.Command;
 import com.taobao.arthas.core.shell.command.CommandResolver;
@@ -118,7 +106,7 @@ public class BuiltinCommandPack implements CommandResolver {
         commandClassList.add(ProfilerCommand.class);
         commandClassList.add(VmToolCommand.class);
         commandClassList.add(StopCommand.class);
-
+        commandClassList.add(ThreadPoolCommand.class);
         for (Class<? extends AnnotatedCommand> clazz : commandClassList) {
             Name name = clazz.getAnnotation(Name.class);
             if (name != null && name.value() != null) {

--- a/core/src/main/java/com/taobao/arthas/core/command/model/ThreadPoolModel.java
+++ b/core/src/main/java/com/taobao/arthas/core/command/model/ThreadPoolModel.java
@@ -1,0 +1,25 @@
+package com.taobao.arthas.core.command.model;
+
+import java.util.Collection;
+
+/**
+ * @author HJ
+ * @date 2021-07-09
+ **/
+public class ThreadPoolModel extends ResultModel {
+
+    private Collection<ThreadPoolVO> threadPools;
+
+    @Override
+    public String getType() {
+        return "threadpool";
+    }
+
+    public Collection<ThreadPoolVO> getThreadPools() {
+        return threadPools;
+    }
+
+    public void setThreadPools(Collection<ThreadPoolVO> threadPools) {
+        this.threadPools = threadPools;
+    }
+}

--- a/core/src/main/java/com/taobao/arthas/core/command/model/ThreadPoolVO.java
+++ b/core/src/main/java/com/taobao/arthas/core/command/model/ThreadPoolVO.java
@@ -10,43 +10,43 @@ public class ThreadPoolVO implements Comparable<ThreadPoolVO> {
 
     private String stackInfo;
 
-    private Integer corePoolSize;
+    private int corePoolSize;
 
-    private Integer maximumPoolSize;
+    private int maximumPoolSize;
 
-    private Integer currentSizeOfWorkQueue;
+    private int currentSizeOfWorkQueue;
 
-    private Integer activeThreadCount;
+    private int activeThreadCount;
 
-    public Integer getCorePoolSize() {
+    public int getCorePoolSize() {
         return corePoolSize;
     }
 
-    public void setCorePoolSize(Integer corePoolSize) {
+    public void setCorePoolSize(int corePoolSize) {
         this.corePoolSize = corePoolSize;
     }
 
-    public Integer getMaximumPoolSize() {
+    public int getMaximumPoolSize() {
         return maximumPoolSize;
     }
 
-    public void setMaximumPoolSize(Integer maximumPoolSize) {
+    public void setMaximumPoolSize(int maximumPoolSize) {
         this.maximumPoolSize = maximumPoolSize;
     }
 
-    public Integer getCurrentSizeOfWorkQueue() {
+    public int getCurrentSizeOfWorkQueue() {
         return currentSizeOfWorkQueue;
     }
 
-    public void setCurrentSizeOfWorkQueue(Integer currentSizeOfWorkQueue) {
+    public void setCurrentSizeOfWorkQueue(int currentSizeOfWorkQueue) {
         this.currentSizeOfWorkQueue = currentSizeOfWorkQueue;
     }
 
-    public Integer getActiveThreadCount() {
+    public int getActiveThreadCount() {
         return activeThreadCount;
     }
 
-    public void setActiveThreadCount(Integer activeThreadCount) {
+    public void setActiveThreadCount(int activeThreadCount) {
         this.activeThreadCount = activeThreadCount;
     }
 
@@ -64,30 +64,17 @@ public class ThreadPoolVO implements Comparable<ThreadPoolVO> {
         if (this == o1) {
             return 0;
         }
-        int compareActiveThreadCount = compareIntegerWithNull(getActiveThreadCount(),o1.getActiveThreadCount());
+        int compareActiveThreadCount = o1.getActiveThreadCount() - getActiveThreadCount();
         // 优先按繁忙线程数排序
         if(compareActiveThreadCount != 0 ){
             return compareActiveThreadCount;
         }
         // 其次按队列堆积数排序
-        int compareCurrentSizeOfWorkQueue = compareIntegerWithNull(getCurrentSizeOfWorkQueue(),o1.getCurrentSizeOfWorkQueue());
+        int compareCurrentSizeOfWorkQueue = o1.getCurrentSizeOfWorkQueue() - getCurrentSizeOfWorkQueue();
         if(compareCurrentSizeOfWorkQueue != 0){
             return compareCurrentSizeOfWorkQueue;
         }
         // 最后按最大线程数排序
-        return compareIntegerWithNull(getMaximumPoolSize(),o1.getMaximumPoolSize());
-    }
-
-    private int compareIntegerWithNull(Integer i1,Integer i2){
-        if (i1 == null || i2 == null) {
-            if (i1 != null) {
-                return -1;
-            } else if (i2 != null) {
-                return 1;
-            }
-            return 0;
-        }
-
-        return i2 - i1;
+        return o1.getMaximumPoolSize() - getMaximumPoolSize();
     }
 }

--- a/core/src/main/java/com/taobao/arthas/core/command/model/ThreadPoolVO.java
+++ b/core/src/main/java/com/taobao/arthas/core/command/model/ThreadPoolVO.java
@@ -1,0 +1,93 @@
+package com.taobao.arthas.core.command.model;
+
+/**
+ * Thread VO of 'threadpool' command
+ *
+ * @author HJ
+ * @date 2021-07-09
+ **/
+public class ThreadPoolVO implements Comparable<ThreadPoolVO> {
+
+    private String stackInfo;
+
+    private Integer corePoolSize;
+
+    private Integer maximumPoolSize;
+
+    private Integer currentSizeOfWorkQueue;
+
+    private Integer activeThreadCount;
+
+    public Integer getCorePoolSize() {
+        return corePoolSize;
+    }
+
+    public void setCorePoolSize(Integer corePoolSize) {
+        this.corePoolSize = corePoolSize;
+    }
+
+    public Integer getMaximumPoolSize() {
+        return maximumPoolSize;
+    }
+
+    public void setMaximumPoolSize(Integer maximumPoolSize) {
+        this.maximumPoolSize = maximumPoolSize;
+    }
+
+    public Integer getCurrentSizeOfWorkQueue() {
+        return currentSizeOfWorkQueue;
+    }
+
+    public void setCurrentSizeOfWorkQueue(Integer currentSizeOfWorkQueue) {
+        this.currentSizeOfWorkQueue = currentSizeOfWorkQueue;
+    }
+
+    public Integer getActiveThreadCount() {
+        return activeThreadCount;
+    }
+
+    public void setActiveThreadCount(Integer activeThreadCount) {
+        this.activeThreadCount = activeThreadCount;
+    }
+
+    public String getStackInfo() {
+        return stackInfo;
+    }
+
+    public void setStackInfo(String stackInfo) {
+        this.stackInfo = stackInfo;
+    }
+
+
+    @Override
+    public int compareTo(ThreadPoolVO o1) {
+        if (this == o1) {
+            return 0;
+        }
+        int compareActiveThreadCount = compareIntegerWithNull(getActiveThreadCount(),o1.getActiveThreadCount());
+        // 优先按繁忙线程数排序
+        if(compareActiveThreadCount != 0 ){
+            return compareActiveThreadCount;
+        }
+        // 其次按队列堆积数排序
+        int compareCurrentSizeOfWorkQueue = compareIntegerWithNull(getCurrentSizeOfWorkQueue(),o1.getCurrentSizeOfWorkQueue());
+        if(compareCurrentSizeOfWorkQueue != 0){
+            return compareCurrentSizeOfWorkQueue;
+        }
+        // 最后按最大线程数排序
+        return compareIntegerWithNull(getMaximumPoolSize(),o1.getMaximumPoolSize());
+    }
+
+    private int compareIntegerWithNull(Integer i1,Integer i2){
+        if (i1 == null || i2 == null) {
+            if (i1 != null) {
+                return -1;
+            } else if (i2 != null) {
+                return 1;
+            }
+            return 0;
+        }
+
+        return i2 - i1;
+    }
+}

--- a/core/src/main/java/com/taobao/arthas/core/command/monitor200/ThreadPoolAdviceListener.java
+++ b/core/src/main/java/com/taobao/arthas/core/command/monitor200/ThreadPoolAdviceListener.java
@@ -8,6 +8,7 @@ import com.taobao.arthas.core.command.model.ThreadPoolModel;
 import com.taobao.arthas.core.command.model.ThreadPoolVO;
 import com.taobao.arthas.core.shell.command.CommandProcess;
 import com.taobao.arthas.core.util.ArthasCheckUtils;
+import com.taobao.arthas.core.util.LogUtil;
 
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
@@ -115,16 +116,20 @@ public class ThreadPoolAdviceListener extends AdviceListenerAdapter {
     private class ThreadPoolTimer extends TimerTask {
         @Override
         public void run() {
-            ThreadPoolModel threadPoolModel = new ThreadPoolModel();
-            List<ThreadPoolVO> threadPools = new ArrayList<ThreadPoolVO>(threadPoolDataMap.values());
-            // 按繁忙线程数从多到少排序
-            Collections.sort(threadPools);
-            if (threadPoolCommand.getTopNActiveThreadCount() > 0) {
-                threadPools = threadPools.subList(0, Math.min(threadPoolCommand.getTopNActiveThreadCount(), threadPools.size()));
+            try{
+                ThreadPoolModel threadPoolModel = new ThreadPoolModel();
+                List<ThreadPoolVO> threadPools = new ArrayList<ThreadPoolVO>(threadPoolDataMap.values());
+                // 按繁忙线程数从多到少排序
+                Collections.sort(threadPools);
+                if (threadPoolCommand.getTopNActiveThreadCount() > 0) {
+                    threadPools = threadPools.subList(0, Math.min(threadPoolCommand.getTopNActiveThreadCount(), threadPools.size()));
+                }
+                threadPoolModel.setThreadPools(threadPools);
+                process.appendResult(threadPoolModel);
+                process.end();
+            } catch (Throwable e){
+                process.end(1, e.getMessage() + ", visit " + LogUtil.loggingFile() + " for more detail");
             }
-            threadPoolModel.setThreadPools(threadPools);
-            process.appendResult(threadPoolModel);
-            process.end();
         }
 
     }

--- a/core/src/main/java/com/taobao/arthas/core/command/monitor200/ThreadPoolAdviceListener.java
+++ b/core/src/main/java/com/taobao/arthas/core/command/monitor200/ThreadPoolAdviceListener.java
@@ -1,0 +1,152 @@
+package com.taobao.arthas.core.command.monitor200;
+
+import com.taobao.arthas.core.GlobalOptions;
+import com.taobao.arthas.core.advisor.AdviceListenerAdapter;
+import com.taobao.arthas.core.advisor.ArthasMethod;
+import com.taobao.arthas.core.advisor.Enhancer;
+import com.taobao.arthas.core.command.model.ThreadPoolModel;
+import com.taobao.arthas.core.command.model.ThreadPoolVO;
+import com.taobao.arthas.core.shell.command.CommandProcess;
+import com.taobao.arthas.core.util.ArthasCheckUtils;
+
+import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ThreadPoolExecutor;
+
+/**
+ * @author HJ
+ * @date 2021-07-08
+ **/
+public class ThreadPoolAdviceListener extends AdviceListenerAdapter {
+
+    private static final String STEP_FIRST_CHAR = "`-";
+    private static final String STEP_EMPTY_BOARD = "    ";
+
+    // 输出定时任务
+    private Timer timer;
+
+    private CommandProcess process;
+
+    private ConcurrentHashMap<ThreadPoolExecutor, ThreadPoolVO> threadPoolDataMap = new ConcurrentHashMap<ThreadPoolExecutor, ThreadPoolVO>();
+
+    private ThreadPoolCommand threadPoolCommand;
+
+    ThreadPoolAdviceListener(ThreadPoolCommand threadPoolCommand, CommandProcess process) {
+        this.process = process;
+        this.threadPoolCommand = threadPoolCommand;
+    }
+
+
+    @Override
+    public synchronized void create() {
+        if (timer == null) {
+            timer = new Timer("Timer-for-arthas-threadpool-" + process.session().getSessionId(), true);
+            timer.schedule(new ThreadPoolTimer(), threadPoolCommand.getSampleInterval());
+        }
+        // 由于是jvm自带的类，所以开启该标识
+        GlobalOptions.isUnsafe = true;
+    }
+
+    @Override
+    public synchronized void destroy() {
+        if (null != timer) {
+            timer.cancel();
+            timer = null;
+        }
+        // 结束时，将标识改为false
+        GlobalOptions.isUnsafe = false;
+    }
+
+
+    @Override
+    public void before(ClassLoader loader, Class<?> clazz, ArthasMethod method, Object target, Object[] args) {
+        if (target instanceof ThreadPoolExecutor) {
+            ThreadPoolExecutor tp = (ThreadPoolExecutor) target;
+            if (threadPoolDataMap.get(tp) == null) {
+                ThreadPoolVO vo = new ThreadPoolVO();
+                StackTraceElement[] stacks = Thread.currentThread().getStackTrace();
+                StringBuilder stackSb = new StringBuilder();
+                int stackTraceDepth = threadPoolCommand.getStackTraceDepth();
+                // i从1开始是为了跳过getStackTrace的调用栈信息
+                StringBuilder prefix = new StringBuilder(STEP_FIRST_CHAR);
+                for (int i = 1; i < stacks.length; i++) {
+                    StackTraceElement ste = stacks[i];
+                    // 过滤arthas增强类的调用栈
+                    if (shoudSkip(ste)) {
+                        continue;
+                    }
+                    stackSb.append(prefix)
+                            .append(ste.getClassName())
+                            .append(".")
+                            .append(ste.getMethodName())
+                            .append("(")
+                            .append(ste.getFileName())
+                            .append(":")
+                            .append(ste.getLineNumber())
+                            .append(")");
+                    if (--stackTraceDepth == 0) {
+                        break;
+                    }
+                    prefix.insert(0, STEP_EMPTY_BOARD);
+                    stackSb.append('\n');
+                }
+                vo.setStackInfo(stackSb.toString());
+                vo.setCorePoolSize(tp.getCorePoolSize());
+                vo.setCurrentSizeOfWorkQueue(tp.getQueue().size());
+                vo.setMaximumPoolSize(tp.getMaximumPoolSize());
+                vo.setActiveThreadCount(tp.getActiveCount());
+                // ConcurrentHashMap的get方法没有做同步，所以put前再check一次，如果已经存在，则不用调用带同步锁机制的put方法
+                if (threadPoolDataMap.get(tp) == null) {
+                    threadPoolDataMap.put(tp, vo);
+                }
+            }
+        }
+    }
+
+    @Override
+    public void afterReturning(ClassLoader loader, Class<?> clazz, ArthasMethod method, Object target, Object[] args, Object returnObject) {
+    }
+
+    @Override
+    public void afterThrowing(ClassLoader loader, Class<?> clazz, ArthasMethod method, Object target, Object[] args, Throwable throwable) {
+    }
+
+
+    private class ThreadPoolTimer extends TimerTask {
+        @Override
+        public void run() {
+            ThreadPoolModel threadPoolModel = new ThreadPoolModel();
+            List<ThreadPoolVO> threadPools = new ArrayList<ThreadPoolVO>(threadPoolDataMap.values());
+            // 按繁忙线程数从多到少排序
+            Collections.sort(threadPools);
+            if (threadPoolCommand.getTopNActiveThreadCount() > 0) {
+                threadPools = threadPools.subList(0, Math.min(threadPoolCommand.getTopNActiveThreadCount(), threadPools.size()));
+            }
+            threadPoolModel.setThreadPools(threadPools);
+            process.appendResult(threadPoolModel);
+            process.end();
+        }
+
+    }
+
+    private boolean shoudSkip(StackTraceElement ste) {
+        String className = ste.getClassName();
+        try {
+            // 跳过arthas自己的增强类
+            if ("java.arthas.SpyAPI".equals(className)) {
+                return true;
+            }
+            Class clazz = Class.forName(className);
+            if (null != clazz && ArthasCheckUtils.isEquals(clazz.getClassLoader(), Enhancer.class.getClassLoader())) {
+                return true;
+            }
+            // 跳过被增强的类和方法本身
+            if (threadPoolCommand.getClassNameMatcher().matching(ste.getClassName()) && threadPoolCommand.getMethodNameMatcher().matching(ste.getMethodName())) {
+                return true;
+            }
+        } catch (Exception e) {
+            // ignore
+        }
+        return false;
+    }
+}

--- a/core/src/main/java/com/taobao/arthas/core/command/monitor200/ThreadPoolCommand.java
+++ b/core/src/main/java/com/taobao/arthas/core/command/monitor200/ThreadPoolCommand.java
@@ -21,7 +21,7 @@ import com.taobao.middleware.cli.annotations.Summary;
 @Name("threadpool")
 @Summary("Display thread pool info")
 @Description(Constants.EXAMPLE +
-        "  threadpool -n 5"+  // 输出5个线程池信息，优先按繁忙线程数排序，其次按最大线程数排序
+        "  threadpool -n 5"+  // 输出5个线程池信息，优先按繁忙线程数排序，其次按队列堆积数排序，最后按最大线程数排序
         "  threadpool -sd 3"+ // 输出3行调用栈信息，用于判断是哪个业务线程池
         "  threadpool -i 2000" // 采集2000毫秒内，有提交过任务的线程池的信息
 

--- a/core/src/main/java/com/taobao/arthas/core/command/monitor200/ThreadPoolCommand.java
+++ b/core/src/main/java/com/taobao/arthas/core/command/monitor200/ThreadPoolCommand.java
@@ -1,0 +1,100 @@
+package com.taobao.arthas.core.command.monitor200;
+
+import com.taobao.arthas.core.advisor.AdviceListener;
+import com.taobao.arthas.core.command.Constants;
+import com.taobao.arthas.core.shell.command.CommandProcess;
+import com.taobao.arthas.core.util.SearchUtils;
+import com.taobao.arthas.core.util.matcher.Matcher;
+import com.taobao.middleware.cli.annotations.Description;
+import com.taobao.middleware.cli.annotations.Name;
+import com.taobao.middleware.cli.annotations.Option;
+import com.taobao.middleware.cli.annotations.Summary;
+
+/**
+ * 监控线程池的主要数据
+ * 包括线程池execute方法调用栈信息（用来判断是那个业务线程池）、配置的核心线程数、配置的最大线程数、当前繁忙线程数、队列堆积数
+ *
+ *
+ * @author HJ
+ * @date 2021-07-08
+ **/
+@Name("threadpool")
+@Summary("Display thread pool info")
+@Description(Constants.EXAMPLE +
+        "  threadpool -n 5"+  // 输出5个线程池信息，优先按繁忙线程数排序，其次按最大线程数排序
+        "  threadpool -sd 3"+ // 输出3行调用栈信息，用于判断是哪个业务线程池
+        "  threadpool -i 2000" // 采集2000毫秒内，有提交过任务的线程池的信息
+
+)
+public class ThreadPoolCommand extends EnhancerCommand {
+
+    /**
+     * 采样时间，默认1秒，即：记录1秒内有提交任务动作的线程池
+     */
+    private Integer sampleInterval = 1000;
+    /**
+     * 默认打印2个栈信息，这样有助于从堆栈里判断是哪个地方的线程池
+     */
+    private Integer stackTraceDepth = 2;
+    /**
+     * 默认展示所有线程池，按繁忙线程数排序
+     */
+    private Integer topNActiveThreadCount = -1;
+
+    @Option(shortName = "i", longName = "sample-interval")
+    @Description("Specify the sampling interval (in ms) ")
+    public void setSampleInterval(int sampleInterval) {
+        this.sampleInterval = sampleInterval;
+    }
+
+
+    @Option(shortName = "sd", longName = "stack-depth")
+    @Description("Display the stack info of specified depth")
+    public void setStackTraceDepth(int stackTraceDepth) {
+        this.stackTraceDepth = stackTraceDepth;
+    }
+
+
+    @Option(shortName = "n", longName = "top-n-threadpools")
+    @Description("The number of thread pool(s) to show, ordered by activeThreadCount, Show all by default")
+    public void setTopNBusy(Integer topNActiveThreadCount) {
+        this.topNActiveThreadCount = topNActiveThreadCount;
+    }
+
+    public ThreadPoolCommand() {
+    }
+
+    @Override
+    protected Matcher<String> getClassNameMatcher() {
+        // 指定ThreadPoolExecutor类
+        return SearchUtils.classNameMatcher("java.util.concurrent.ThreadPoolExecutor", false);
+    }
+
+    @Override
+    protected Matcher getClassNameExcludeMatcher() {
+        return null;
+    }
+
+    @Override
+    protected Matcher<String> getMethodNameMatcher() {
+        // 指定任务提交的方法
+        return SearchUtils.classNameMatcher("execute", false);
+    }
+
+    @Override
+    protected AdviceListener getAdviceListener(CommandProcess process) {
+        return new ThreadPoolAdviceListener(this, process);
+    }
+
+    Integer getSampleInterval() {
+        return sampleInterval;
+    }
+
+    Integer getStackTraceDepth() {
+        return stackTraceDepth;
+    }
+
+    Integer getTopNActiveThreadCount() {
+        return topNActiveThreadCount;
+    }
+}

--- a/core/src/main/java/com/taobao/arthas/core/command/view/ResultViewResolver.java
+++ b/core/src/main/java/com/taobao/arthas/core/command/view/ResultViewResolver.java
@@ -77,7 +77,7 @@ public class ResultViewResolver {
             registerView(TimeTunnelView.class);
             registerView(TraceView.class);
             registerView(WatchView.class);
-
+            registerView(ThreadPoolView.class);
         } catch (Throwable e) {
             logger.error("register result view failed", e);
         }

--- a/core/src/main/java/com/taobao/arthas/core/command/view/ThreadPoolView.java
+++ b/core/src/main/java/com/taobao/arthas/core/command/view/ThreadPoolView.java
@@ -1,0 +1,60 @@
+package com.taobao.arthas.core.command.view;
+
+import com.taobao.arthas.core.command.model.ThreadPoolModel;
+import com.taobao.arthas.core.command.model.ThreadPoolVO;
+import com.taobao.arthas.core.shell.command.CommandProcess;
+import com.taobao.text.Color;
+import com.taobao.text.Decoration;
+import com.taobao.text.Style;
+import com.taobao.text.ui.*;
+import com.taobao.text.util.RenderUtil;
+
+import java.util.Collection;
+
+/**
+ * @author HJ
+ * @date 2021-07-09
+ **/
+public class ThreadPoolView extends ResultView<ThreadPoolModel> {
+
+    @Override
+    public void draw(CommandProcess process, ThreadPoolModel result) {
+        TableElement table = new TableElement(6, 3, 3, 3, 3)
+                .rightCellPadding(1);
+
+        // Header
+        table.add(
+                new RowElement().style(Decoration.bold.bold()).add(
+                        "stackInfo",
+                        "corePoolSize",
+                        "maximumPoolSize",
+                        "activeThreadCount",
+                        "currentSizeOfWorkQueue"
+                )
+        );
+
+        Collection<ThreadPoolVO> threadPoolVOS = result.getThreadPools();
+        if (threadPoolVOS != null && threadPoolVOS.size() > 0) {
+            for (ThreadPoolVO threadPool : threadPoolVOS) {
+                LabelElement currentSizeOfWorkQueueLabel = new LabelElement(threadPool.getCurrentSizeOfWorkQueue());
+                if (threadPool.getCurrentSizeOfWorkQueue() > 0) {
+                    currentSizeOfWorkQueueLabel.style(Style.style(Color.red));
+                }
+                LabelElement activeThreadCountLabel = new LabelElement(threadPool.getActiveThreadCount());
+                if (threadPool.getActiveThreadCount() >= threadPool.getMaximumPoolSize()) {
+                    activeThreadCountLabel.style(Style.style(Color.red));
+                }
+                table.row(true,
+                        new LabelElement(threadPool.getStackInfo()),
+                        new LabelElement(threadPool.getCorePoolSize()),
+                        new LabelElement(threadPool.getMaximumPoolSize()),
+                        activeThreadCountLabel,
+                        currentSizeOfWorkQueueLabel
+                );
+            }
+        }
+        process.write(RenderUtil.render(table, process.width()));
+    }
+
+
+}


### PR DESCRIPTION
压测时，经常需要关注线程池的情况，所以增加这个命令来展示线程池关键信息。
输出参数如下：
stackInfo：由于线程池没有名字，所以侧面通过execute方法调用栈信息来判断是那个业务线程池
corePoolSize：配置的核心线程数
maximumPoolSize：配置的最大线程数
activeThreadCount：当前繁忙线程数
currentSizeOfWorkQueue：当前队列堆积数

tomcat线程池：
![image](https://user-images.githubusercontent.com/23580304/125190804-8e35bb80-e271-11eb-90cf-90a507d84981.png)

dubbo线程池：
![20210711185513](https://user-images.githubusercontent.com/23580304/125192292-af020f00-e279-11eb-8d13-26f543058f6a.jpeg)


支持指令：
threadpool -n ：输出指定个数的线程池信息，优先按繁忙线程数排序，其次按队列堆积数排序，最后按最大线程数排序，默认输出全部线程池信息，如：threadpool -n 5 表示指定输出前5个
threadpool -sd ： 输出指定深度的调用栈信息，当输出的栈信息无法判断是哪个业务线程池时，可以调大这个参数，负数表示输出全部调用栈信息，该调用栈指java.util.concurrent.ThreadPoolExecutor的execute方法调用栈，已经过滤了arthas增强类的调用栈信息，默认是2行，如：threadpool -sd 5 指定输出5行调用栈信息
threadpool -i：记录指定毫秒数内触发过execute方法的线程池的信息，默认1000毫秒，如：threadpool -i 3000 表示记录3秒内触发过execute方法的线程池

实现原理：增强java.util.concurrent.ThreadPoolExecutor类的execute方法，在有任务提交时，将线程池对象放入concurrentHashMap中（会先后两次通过无锁的get来判断是否已经加入到map中，只有不存在时才通过有锁的put加入map，减少性能影响），通过timer定时任务，在指定时间结束后输出收集的线程池信息

关注点：由于增强的是jvm自带的系统类，所以开启了GlobalOptions.isUnsafe标识，在命令结束后会关闭该标识
