### PR TITLE
Improve Travis CI build Performance

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,7 +41,7 @@ cache:
 
 script:
   - ./mvnw -version
-  - travis_wait 30 ./mvnw clean package --batch-mode -P full
+  - ./mvnw clean package --batch-mode -P full
 
 after_success:
   - bash <(curl -s https://codecov.io/bash)
@@ -62,4 +62,3 @@ deploy:
   skip_cleanup: true
   on:
     tags: true
-


### PR DESCRIPTION

According to [Build times out because no output was received](https://docs.travis-ci.com/user/common-build-problems/#build-times-out-because-no-output-was-received), we should carefully use travis_wait, as it may make the build unstable and extend the build time.

=====================
If there are any inappropriate modifications in this PR, please give me a reply and I will change them.
