### PR TITLE
Set the screenReaderMode of xterm to false

### DIFF
--- a/core/src/main/resources/com/taobao/arthas/core/http/web-console.js
+++ b/core/src/main/resources/com/taobao/arthas/core/http/web-console.js
@@ -91,7 +91,7 @@ function initXterm (cols, rows) {
     xterm = new Terminal({
         cols: cols,
         rows: rows,
-        screenReaderMode: true,
+        screenReaderMode: false,
         rendererType: 'canvas',
         convertEol: true
     });

--- a/tunnel-server/src/main/resources/static/web-console.js
+++ b/tunnel-server/src/main/resources/static/web-console.js
@@ -96,7 +96,7 @@ function initXterm (cols, rows) {
     xterm = new Terminal({
         cols: cols,
         rows: rows,
-        screenReaderMode: true,
+        screenReaderMode: false,
         rendererType: 'canvas',
         convertEol: true
     });


### PR DESCRIPTION
原webConsole中初始化xterm时screenReaderMode参数为true，导致webConsole右侧滚动条不可鼠标点击拖动，同时鼠标右击也不可复制粘贴。鉴于screenReaderMode使用场景目前几乎没有，希望默认改为false提升用户体验。