### PR TITLE
WebConsole支持配置向上回滚的数据行数

### DIFF
--- a/core/src/main/resources/com/taobao/arthas/core/http/web-console.js
+++ b/core/src/main/resources/com/taobao/arthas/core/http/web-console.js
@@ -1,5 +1,8 @@
 var ws;
 var xterm;
+const DEFAULT_SCROLL_BACK = 1000
+const MAX_SCROLL_BACK = 9999999
+const MIN_SCROLL_BACK = 1
 
 $(function () {
     var url = window.location.href;
@@ -87,14 +90,21 @@ function initWs (ip, port) {
 }
 
 /** init xterm **/
-function initXterm (cols, rows) {
+function initXterm (cols, rows,scrollback) {
+    let scrollNumber = parseInt(scrollback,10)
     xterm = new Terminal({
         cols: cols,
         rows: rows,
         screenReaderMode: false,
         rendererType: 'canvas',
-        convertEol: true
+        convertEol: true,
+        scrollback: isValidNumber(scrollNumber) ? scrollNumber : DEFAULT_SCROLL_BACK
     });
+}
+
+function isValidNumber(scrollNumber){
+    return  scrollNumber >= MIN_SCROLL_BACK &&
+        scrollNumber <= MAX_SCROLL_BACK;
 }
 
 /** begin connect **/
@@ -120,10 +130,11 @@ function startConnect (silent) {
         console.log('open');
         $('#fullSc').show();
         var terminalSize = getTerminalSize()
+        let scrollback = getUrlParam('scrollback');
         console.log('terminalSize')
         console.log(terminalSize)
         // init xterm
-        initXterm(terminalSize.cols, terminalSize.rows)
+        initXterm(terminalSize.cols, terminalSize.rows, scrollback)
         ws.onmessage = function (event) {
             if (event.type === 'message') {
                 var data = event.data;

--- a/tunnel-server/src/main/resources/static/web-console.js
+++ b/tunnel-server/src/main/resources/static/web-console.js
@@ -1,5 +1,8 @@
 var ws;
 var xterm;
+const DEFAULT_SCROLL_BACK = 1000
+const MAX_SCROLL_BACK = 9999999
+const MIN_SCROLL_BACK = 1
 
 $(function () {
     var url = window.location.href;
@@ -92,14 +95,21 @@ function initWs (ip, port, path, agentId, targetServer) {
 }
 
 /** init xterm **/
-function initXterm (cols, rows) {
+function initXterm (cols, rows,scrollback) {
+    let scrollNumber = parseInt(scrollback,10)
     xterm = new Terminal({
         cols: cols,
         rows: rows,
         screenReaderMode: false,
         rendererType: 'canvas',
-        convertEol: true
+        convertEol: true,
+        scrollback: isValidNumber(scrollNumber) ? scrollNumber : DEFAULT_SCROLL_BACK
     });
+}
+
+function isValidNumber(scrollNumber){
+    return  scrollNumber >= MIN_SCROLL_BACK &&
+        scrollNumber <= MAX_SCROLL_BACK;
 }
 
 /** begin connect **/
@@ -148,8 +158,9 @@ function startConnect (silent) {
         var terminalSize = getTerminalSize()
         console.log('terminalSize')
         console.log(terminalSize)
+        let scrollback = getUrlParam('scrollback');
         // init xterm
-        initXterm(terminalSize.cols, terminalSize.rows)
+        initXterm(terminalSize.cols, terminalSize.rows,scrollback)
         ws.onmessage = function (event) {
             if (event.type === 'message') {
                 var data = event.data;


### PR DESCRIPTION
WebConsole的xterm终端目前只支持向上回滚1000条数据行数，经常出现执行几条命令后，前面数据就不可见的问题，另外其他终端都不止1000条的回滚行数。所以添加了用户可配置的scrollback参数。