### PR TITLE
Introduce fixed JDK versions

### DIFF
--- a/.github/workflows/build-vmtool.yaml
+++ b/.github/workflows/build-vmtool.yaml
@@ -5,14 +5,16 @@ on: [push]
 jobs:
   linux:
     runs-on: ubuntu-18.04
-
+    strategy:
+      matrix:
+        java: [8, 8.0.192]
     steps:
       - uses: actions/checkout@v2
       - name: Set up JDK 8
         uses: actions/setup-java@v2
         with:
-          java-version: '8'
-          distribution: 'adopt'
+          java-version: ${{ matrix.java }}
+          distribution: 'zulu'
       - name: Build with Maven
         run: ./mvnw package
       - uses: actions/upload-artifact@v2
@@ -22,14 +24,16 @@ jobs:
 
   mac:
     runs-on: macos-10.15
-
+    strategy:
+      matrix:
+        java: [8, 8.0.192]
     steps:
       - uses: actions/checkout@v2
       - name: Set up JDK 8
         uses: actions/setup-java@v2
         with:
-          java-version: '8'
-          distribution: 'adopt'
+          java-version: ${{ matrix.java }}
+          distribution: 'zulu'
       - name: Build with Maven
         run: ./mvnw package
       - uses: actions/upload-artifact@v2
@@ -39,14 +43,16 @@ jobs:
 
   windows:
     runs-on: windows-2016
-
+    strategy:
+      matrix:
+        java: [8, 8.0.192]
     steps:
       - uses: actions/checkout@v2
       - name: Set up JDK 8
         uses: actions/setup-java@v2
         with:
-          java-version: '8'
-          distribution: 'adopt'
+          java-version: ${{ matrix.java }}
+          distribution: 'zulu'
       - name: Build with Maven
         run: ./mvnw package
       - uses: actions/upload-artifact@v2


### PR DESCRIPTION
Fixed JDK versions will allow you to more easily identify the reasons for when a build fails, i.e., if the fixed version is green and the latest is red, you'll know the problem is connected to the latest version, Zulu can help with that since it provides historically complete major and minor JDK versions.