### PR TITLE
Set the priority and daemon for the binding thread

### DIFF
--- a/agent/src/main/java/com/taobao/arthas/agent334/AgentBootstrap.java
+++ b/agent/src/main/java/com/taobao/arthas/agent334/AgentBootstrap.java
@@ -157,6 +157,8 @@ public class AgentBootstrap {
             };
 
             bindingThread.setName("arthas-binding-thread");
+            bindingThread.setPriority(Thread.MIN_PRIORITY);
+            bindingThread.setDaemon(Boolean.TRUE);
             bindingThread.start();
             bindingThread.join();
         } catch (Throwable t) {

--- a/agent/src/main/java/com/taobao/arthas/agent334/AgentBootstrap.java
+++ b/agent/src/main/java/com/taobao/arthas/agent334/AgentBootstrap.java
@@ -157,7 +157,6 @@ public class AgentBootstrap {
             };
 
             bindingThread.setName("arthas-binding-thread");
-            bindingThread.setPriority(Thread.MIN_PRIORITY);
             bindingThread.setDaemon(Boolean.TRUE);
             bindingThread.start();
             bindingThread.join();


### PR DESCRIPTION
Configured the binding thread by setting the priority to the minimum and daemon to true. It is because the thread is aimed at preventing possible memory leak.

