### PR TITLE
添加 http api 的 tunnel 端的 proxy

### DIFF
--- a/tunnel-client/src/main/java/com/alibaba/arthas/tunnel/client/ProxyClient.java
+++ b/tunnel-client/src/main/java/com/alibaba/arthas/tunnel/client/ProxyClient.java
@@ -9,6 +9,8 @@ import io.netty.channel.*;
 import io.netty.channel.local.LocalAddress;
 import io.netty.channel.local.LocalChannel;
 import io.netty.channel.nio.NioEventLoopGroup;
+import io.netty.channel.socket.SocketChannel;
+import io.netty.channel.socket.nio.NioSocketChannel;
 import io.netty.handler.codec.http.*;
 import io.netty.util.concurrent.DefaultThreadFactory;
 import io.netty.util.concurrent.GlobalEventExecutor;
@@ -103,17 +105,17 @@ public class ProxyClient {
         try {
             Bootstrap b = new Bootstrap();
             b.option(ChannelOption.CONNECT_TIMEOUT_MILLIS, 5000);
-            b.group(group).channel(LocalChannel.class).handler(new ChannelInitializer<LocalChannel>() {
+            b.group(group).channel(NioSocketChannel.class).handler(new ChannelInitializer<SocketChannel>() {
                 @Override
-                protected void initChannel(LocalChannel ch) {
+                protected void initChannel(SocketChannel ch) {
                     ChannelPipeline p = ch.pipeline();
                     p.addLast(new HttpClientCodec(), new HttpObjectAggregator(ArthasConstants.MAX_HTTP_CONTENT_LENGTH),
                             new HttpProxyClientHandler(httpResponsePromise));
                 }
             });
 
-            LocalAddress localAddress = new LocalAddress(ArthasConstants.NETTY_LOCAL_ADDRESS);
-            Channel localChannel = b.connect(localAddress).sync().channel();
+//            LocalAddress localAddress = new LocalAddress(ArthasConstants.NETTY_LOCAL_ADDRESS);
+            Channel localChannel = b.connect("127.0.0.1", 8563).sync().channel();
 
             localChannel.writeAndFlush(request);
 

--- a/tunnel-client/src/main/java/com/alibaba/arthas/tunnel/client/ProxyClient.java
+++ b/tunnel-client/src/main/java/com/alibaba/arthas/tunnel/client/ProxyClient.java
@@ -1,44 +1,23 @@
 package com.alibaba.arthas.tunnel.client;
 
-import java.io.UnsupportedEncodingException;
-import java.util.concurrent.TimeUnit;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import com.alibaba.arthas.tunnel.common.SimpleHttpResponse;
 import com.taobao.arthas.common.ArthasConstants;
-
 import io.netty.bootstrap.Bootstrap;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
-import io.netty.channel.Channel;
-import io.netty.channel.ChannelFuture;
-import io.netty.channel.ChannelFutureListener;
-import io.netty.channel.ChannelHandlerContext;
-import io.netty.channel.ChannelInitializer;
-import io.netty.channel.ChannelOption;
-import io.netty.channel.ChannelPipeline;
-import io.netty.channel.EventLoopGroup;
-import io.netty.channel.SimpleChannelInboundHandler;
+import io.netty.channel.*;
 import io.netty.channel.local.LocalAddress;
 import io.netty.channel.local.LocalChannel;
 import io.netty.channel.nio.NioEventLoopGroup;
-import io.netty.handler.codec.http.DefaultFullHttpRequest;
-import io.netty.handler.codec.http.HttpClientCodec;
-import io.netty.handler.codec.http.HttpContent;
-import io.netty.handler.codec.http.HttpHeaderNames;
-import io.netty.handler.codec.http.HttpHeaderValues;
-import io.netty.handler.codec.http.HttpMethod;
-import io.netty.handler.codec.http.HttpObject;
-import io.netty.handler.codec.http.HttpObjectAggregator;
-import io.netty.handler.codec.http.HttpRequest;
-import io.netty.handler.codec.http.HttpResponse;
-import io.netty.handler.codec.http.HttpVersion;
-import io.netty.handler.codec.http.LastHttpContent;
+import io.netty.handler.codec.http.*;
 import io.netty.util.concurrent.DefaultThreadFactory;
 import io.netty.util.concurrent.GlobalEventExecutor;
 import io.netty.util.concurrent.Promise;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.UnsupportedEncodingException;
+import java.util.concurrent.TimeUnit;
 
 /**
  * 
@@ -103,11 +82,74 @@ public class ProxyClient {
         return httpResponse;
     }
 
+    public SimpleHttpResponse apiRequest(String apiRequest) throws UnsupportedEncodingException {
+        // Prepare the HTTP request.
+        byte[] bytes = apiRequest.getBytes("UTF-8");
+        logger.info("send apiRequest: {}, bytes length: {}", apiRequest, bytes.length);
+        HttpRequest request = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.POST, "/api",
+                Unpooled.wrappedBuffer(bytes));
+        request.headers().set(HttpHeaderNames.CONNECTION, HttpHeaderValues.CLOSE);
+        request.headers().set(HttpHeaderNames.CONTENT_TYPE, HttpHeaderValues.APPLICATION_JSON);
+        request.headers().set(HttpHeaderNames.CONTENT_LENGTH, bytes.length);
+
+        return request(request);
+    }
+
+    private SimpleHttpResponse request(HttpRequest request) {
+        final Promise<SimpleHttpResponse> httpResponsePromise = GlobalEventExecutor.INSTANCE.newPromise();
+
+        final EventLoopGroup group = new NioEventLoopGroup(1, new DefaultThreadFactory("arthas-proxyClient", true));
+        ChannelFuture closeFuture = null;
+        try {
+            Bootstrap b = new Bootstrap();
+            b.option(ChannelOption.CONNECT_TIMEOUT_MILLIS, 5000);
+            b.group(group).channel(LocalChannel.class).handler(new ChannelInitializer<LocalChannel>() {
+                @Override
+                protected void initChannel(LocalChannel ch) {
+                    ChannelPipeline p = ch.pipeline();
+                    p.addLast(new HttpClientCodec(), new HttpObjectAggregator(ArthasConstants.MAX_HTTP_CONTENT_LENGTH),
+                            new HttpProxyClientHandler(httpResponsePromise));
+                }
+            });
+
+            LocalAddress localAddress = new LocalAddress(ArthasConstants.NETTY_LOCAL_ADDRESS);
+            Channel localChannel = b.connect(localAddress).sync().channel();
+
+            localChannel.writeAndFlush(request);
+
+            closeFuture = localChannel.closeFuture();
+            logger.info("proxy client connect to server success");
+
+            return httpResponsePromise.get(5000, TimeUnit.MILLISECONDS);
+        } catch (Throwable e) {
+            logger.error("ProxyClient error", e);
+        } finally {
+            if (closeFuture != null) {
+                closeFuture.addListener(new ChannelFutureListener() {
+                    @Override
+                    public void operationComplete(ChannelFuture channelFuture) throws Exception {
+                        group.shutdownGracefully();
+                    }
+                });
+            } else {
+                group.shutdownGracefully();
+            }
+        }
+
+        SimpleHttpResponse httpResponse = new SimpleHttpResponse();
+        try {
+            httpResponse.setContent("error".getBytes("utf-8"));
+        } catch (UnsupportedEncodingException e) {
+            // ignore
+        }
+        return httpResponse;
+    }
+
     static class HttpProxyClientHandler extends SimpleChannelInboundHandler<HttpObject> {
 
-        private Promise<SimpleHttpResponse> promise;
+        private final Promise<SimpleHttpResponse> promise;
 
-        private SimpleHttpResponse simpleHttpResponse = new SimpleHttpResponse();
+        private final SimpleHttpResponse simpleHttpResponse = new SimpleHttpResponse();
 
         public HttpProxyClientHandler(Promise<SimpleHttpResponse> promise) {
             this.promise = promise;

--- a/tunnel-client/src/main/java/com/alibaba/arthas/tunnel/client/TunnelClientSocketClientHandler.java
+++ b/tunnel-client/src/main/java/com/alibaba/arthas/tunnel/client/TunnelClientSocketClientHandler.java
@@ -1,18 +1,9 @@
 
 package com.alibaba.arthas.tunnel.client;
 
-import java.net.URI;
-import java.util.List;
-import java.util.Map;
-import java.util.concurrent.TimeUnit;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import com.alibaba.arthas.tunnel.common.MethodConstants;
 import com.alibaba.arthas.tunnel.common.SimpleHttpResponse;
 import com.alibaba.arthas.tunnel.common.URIConstans;
-
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.ChannelFuture;
@@ -27,6 +18,14 @@ import io.netty.handler.codec.http.websocketx.TextWebSocketFrame;
 import io.netty.handler.codec.http.websocketx.WebSocketFrame;
 import io.netty.handler.timeout.IdleStateEvent;
 import io.netty.util.CharsetUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.net.URI;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
 
 /**
  * 
@@ -134,6 +133,49 @@ public class TunnelClientSocketClientHandler extends SimpleChannelInboundHandler
                 }
             }
 
+            if (MethodConstants.HTTP_API_PROXY.equals(method)) {
+                /*
+                  <pre>
+                  1. 从 proxy 请求里读取到目标的 requestId 和 apiHttpRequest
+                  2. 然后通过 ProxyClient直接请求得到结果
+                  3. 把response结果转为 byte[]，再转为base64，再统一组合的一个url，再用 TextWebSocketFrame 发回去
+                  </pre>
+                 */
+                apiProxy(parameters, ctx);
+            }
+
+        }
+    }
+
+    private void apiProxy(Map<String, List<String>> parameters, ChannelHandlerContext ctx) throws IOException {
+        ProxyClient proxyClient = new ProxyClient();
+        List<String> apiRequestBodies = parameters.get(URIConstans.API_REQUEST_BODY);
+
+        List<String> requestIDs = parameters.get(URIConstans.PROXY_REQUEST_ID);
+        String id = null;
+        if (requestIDs != null && !requestIDs.isEmpty()) {
+            id = requestIDs.get(0);
+        }
+        if (id == null) {
+            logger.error("error, http proxy need {}", URIConstans.PROXY_REQUEST_ID);
+            return;
+        }
+
+        if (apiRequestBodies != null && !apiRequestBodies.isEmpty()) {
+            String apiRequestBody = apiRequestBodies.get(0);
+            SimpleHttpResponse simpleHttpResponse = proxyClient.apiRequest(apiRequestBody);
+
+            ByteBuf byteBuf = Base64
+                    .encode(Unpooled.wrappedBuffer(SimpleHttpResponse.toBytes(simpleHttpResponse)));
+            String requestData = byteBuf.toString(CharsetUtil.UTF_8);
+
+            QueryStringEncoder queryEncoder = new QueryStringEncoder("");
+            queryEncoder.addParam(URIConstans.METHOD, MethodConstants.HTTP_PROXY);
+            queryEncoder.addParam(URIConstans.PROXY_REQUEST_ID, id);
+            queryEncoder.addParam(URIConstans.PROXY_RESPONSE_DATA, requestData);
+
+            String url = queryEncoder.toString();
+            ctx.writeAndFlush(new TextWebSocketFrame(url));
         }
     }
 

--- a/tunnel-client/src/main/java/com/alibaba/arthas/tunnel/client/TunnelClientSocketClientHandler.java
+++ b/tunnel-client/src/main/java/com/alibaba/arthas/tunnel/client/TunnelClientSocketClientHandler.java
@@ -170,7 +170,7 @@ public class TunnelClientSocketClientHandler extends SimpleChannelInboundHandler
             String requestData = byteBuf.toString(CharsetUtil.UTF_8);
 
             QueryStringEncoder queryEncoder = new QueryStringEncoder("");
-            queryEncoder.addParam(URIConstans.METHOD, MethodConstants.HTTP_PROXY);
+            queryEncoder.addParam(URIConstans.METHOD, MethodConstants.HTTP_API_PROXY);
             queryEncoder.addParam(URIConstans.PROXY_REQUEST_ID, id);
             queryEncoder.addParam(URIConstans.PROXY_RESPONSE_DATA, requestData);
 

--- a/tunnel-common/src/main/java/com/alibaba/arthas/tunnel/common/MethodConstants.java
+++ b/tunnel-common/src/main/java/com/alibaba/arthas/tunnel/common/MethodConstants.java
@@ -49,12 +49,19 @@ public class MethodConstants {
      * </pre>
      */
     public static final String OPEN_TUNNEL = "openTunnel";
-    
+
     /**
      * <pre>
      * tunnel server向 tunnel client请求 http中转，比如访问 http://localhost:3658/arthas-output/xxx.svg
      * </pre>
      */
     public static final String HTTP_PROXY = "httpProxy";
+
+    /**
+     * <pre>
+     * tunnel server向 tunnel client请求 http api 中转，参考：https://arthas.aliyun.com/doc/http-api.html
+     * </pre>
+     */
+    public static final String HTTP_API_PROXY = "httpApiProxy";
 
 }

--- a/tunnel-common/src/main/java/com/alibaba/arthas/tunnel/common/URIConstans.java
+++ b/tunnel-common/src/main/java/com/alibaba/arthas/tunnel/common/URIConstans.java
@@ -18,6 +18,8 @@ public class URIConstans {
      */
     public static final String ID = "id";
 
+    public static final String API_REQUEST_BODY = "apiRequestBody";
+
     /**
      * tunnel server用于区分不同 tunnel client的内部 id
      */
@@ -25,7 +27,7 @@ public class URIConstans {
 
     /**
      * tunnel server向 tunnel client请求http代理时的目标 url
-     * 
+     *
      * @see com.alibaba.arthas.tunnel.common.MethodConstants#HTTP_PROXY
      */
     public static final String TARGET_URL = "targetUrl";

--- a/tunnel-server/src/main/java/com/alibaba/arthas/tunnel/server/app/web/ApiRequest.java
+++ b/tunnel-server/src/main/java/com/alibaba/arthas/tunnel/server/app/web/ApiRequest.java
@@ -1,0 +1,75 @@
+package com.alibaba.arthas.tunnel.server.app.web;
+
+/**
+ * Http Api request
+ *
+ * @author gongdewei 2020-03-19
+ */
+public class ApiRequest {
+    private String action;
+    private String command;
+    private String requestId;
+    private String sessionId;
+    private String consumerId;
+    private Integer execTimeout;
+
+    @Override
+    public String toString() {
+        return "ApiRequest{" +
+                "action='" + action + '\'' +
+                ", command='" + command + '\'' +
+                ", requestId='" + requestId + '\'' +
+                ", sessionId='" + sessionId + '\'' +
+                ", consumerId='" + consumerId + '\'' +
+                ", execTimeout=" + execTimeout +
+                '}';
+    }
+
+    public String getAction() {
+        return action;
+    }
+
+    public void setAction(String action) {
+        this.action = action;
+    }
+
+    public String getCommand() {
+        return command;
+    }
+
+    public void setCommand(String command) {
+        this.command = command;
+    }
+
+    public String getRequestId() {
+        return requestId;
+    }
+
+    public void setRequestId(String requestId) {
+        this.requestId = requestId;
+    }
+
+    public String getSessionId() {
+        return sessionId;
+    }
+
+    public void setSessionId(String sessionId) {
+        this.sessionId = sessionId;
+    }
+
+    public String getConsumerId() {
+        return consumerId;
+    }
+
+    public void setConsumerId(String consumerId) {
+        this.consumerId = consumerId;
+    }
+
+    public Integer getExecTimeout() {
+        return execTimeout;
+    }
+
+    public void setExecTimeout(Integer execTimeout) {
+        this.execTimeout = execTimeout;
+    }
+}

--- a/tunnel-server/src/main/java/com/alibaba/arthas/tunnel/server/app/web/HttpApiProxyController.java
+++ b/tunnel-server/src/main/java/com/alibaba/arthas/tunnel/server/app/web/HttpApiProxyController.java
@@ -1,0 +1,83 @@
+package com.alibaba.arthas.tunnel.server.app.web;
+
+import com.alibaba.arthas.tunnel.common.MethodConstants;
+import com.alibaba.arthas.tunnel.common.SimpleHttpResponse;
+import com.alibaba.arthas.tunnel.common.URIConstans;
+import com.alibaba.arthas.tunnel.server.AgentInfo;
+import com.alibaba.arthas.tunnel.server.TunnelServer;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.handler.codec.http.websocketx.TextWebSocketFrame;
+import io.netty.util.concurrent.GlobalEventExecutor;
+import io.netty.util.concurrent.Promise;
+import org.apache.commons.lang3.RandomStringUtils;
+import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import javax.annotation.Resource;
+import java.net.URI;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+/**
+ * @author haidao
+ * @date 2021/11/3
+ */
+@Controller
+public class HttpApiProxyController {
+    private final static Logger logger = LoggerFactory.getLogger(HttpApiProxyController.class);
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    @Resource
+    private TunnelServer tunnelServer;
+
+    @RequestMapping(value = "/apiProxy/{agentId}/api", method = RequestMethod.POST)
+    @ResponseBody
+    public ResponseEntity<?> execute(@PathVariable(name = "agentId") String agentId,
+                                     @RequestBody ApiRequest apiRequest) throws JsonProcessingException, ExecutionException, InterruptedException, TimeoutException {
+        Optional<AgentInfo> findAgent = tunnelServer.findAgent(agentId);
+        if (!findAgent.isPresent()) {
+            logger.error("can not find agent by agentId: {}", agentId);
+            return ResponseEntity.notFound().build();
+        }
+
+        String requestId = apiRequest.getRequestId();
+        // if requestId from frontend is blank, then generate it
+        if (StringUtils.isBlank(requestId)) {
+            requestId = RandomStringUtils.random(20, true, true).toUpperCase();
+            apiRequest.setRequestId(requestId);
+        }
+
+        ChannelHandlerContext agentCtx = findAgent.get().getChannelHandlerContext();
+
+        Promise<SimpleHttpResponse> httpResponsePromise = GlobalEventExecutor.INSTANCE.newPromise();
+
+        tunnelServer.addProxyRequestPromise(requestId, httpResponsePromise);
+
+        URI uri = UriComponentsBuilder.newInstance().scheme(URIConstans.RESPONSE).path("/")
+                .queryParam(URIConstans.METHOD, MethodConstants.HTTP_API_PROXY)
+                .queryParam(URIConstans.API_REQUEST_BODY, MAPPER.writeValueAsString(apiRequest))
+                .queryParam(URIConstans.PROXY_REQUEST_ID, requestId)
+                .build().toUri();
+
+        agentCtx.channel().writeAndFlush(new TextWebSocketFrame(uri.toString()));
+        logger.info("waiting for arthas agent http proxy, agentId: {}, apiRequest: {}", agentId, apiRequest);
+
+        SimpleHttpResponse simpleHttpResponse = httpResponsePromise.get(15, TimeUnit.SECONDS);
+
+        ResponseEntity.BodyBuilder bodyBuilder = ResponseEntity.status(simpleHttpResponse.getStatus());
+        for (Map.Entry<String, String> entry : simpleHttpResponse.getHeaders().entrySet()) {
+            bodyBuilder.header(entry.getKey(), entry.getValue());
+        }
+        return bodyBuilder.body(simpleHttpResponse.getContent());
+    }
+}


### PR DESCRIPTION
我想在 tunnel server 端加上 http api 的代理；如代码所示，tunnel server 请求 /apiProxy/{agentId}/api，最终会被 tunnel client 转为 localhost/api

