### PR TITLE
change RetransformCommand and DumpClassCommand limit option description to match @DefaultValue annotation

### DIFF
--- a/core/src/main/java/com/taobao/arthas/core/command/klass100/DumpClassCommand.java
+++ b/core/src/main/java/com/taobao/arthas/core/command/klass100/DumpClassCommand.java
@@ -92,7 +92,7 @@ public class DumpClassCommand extends AnnotatedCommand {
     }
 
     @Option(shortName = "l", longName = "limit")
-    @Description("The limit of dump classes size, default value is 5")
+    @Description("The limit of dump classes size, default value is 50")
     @DefaultValue("50")
     public void setLimit(int limit) {
         this.limit = limit;

--- a/core/src/main/java/com/taobao/arthas/core/command/klass100/RetransformCommand.java
+++ b/core/src/main/java/com/taobao/arthas/core/command/klass100/RetransformCommand.java
@@ -124,7 +124,7 @@ public class RetransformCommand extends AnnotatedCommand {
     }
 
     @Option(longName = "limit")
-    @Description("The limit of dump classes size, default value is 5")
+    @Description("The limit of dump classes size, default value is 50")
     @DefaultValue("50")
     public void setLimit(int limit) {
         this.limit = limit;


### PR DESCRIPTION
change RetransformCommand and DumpClassCommand limit option description to match @DefaultValue annotation

description annotation says the default is 5 but defaultValue annotation set it's default to 50