### PR TITLE
修复高并发下 watch,stack,trace 可能乱序的问题

### DIFF
--- a/core/src/main/java/com/taobao/arthas/core/advisor/Advice.java
+++ b/core/src/main/java/com/taobao/arthas/core/advisor/Advice.java
@@ -106,12 +106,12 @@ public class Advice {
         );
     }
 
-    public static Advice newForAfterRetuning(ClassLoader loader,
-                                             Class<?> clazz,
-                                             ArthasMethod method,
-                                             Object target,
-                                             Object[] params,
-                                             Object returnObj) {
+    public static Advice newForAfterReturning(ClassLoader loader,
+                                              Class<?> clazz,
+                                              ArthasMethod method,
+                                              Object target,
+                                              Object[] params,
+                                              Object returnObj) {
         return new Advice(
                 loader,
                 clazz,

--- a/core/src/main/java/com/taobao/arthas/core/command/monitor200/AbstractTraceAdviceListener.java
+++ b/core/src/main/java/com/taobao/arthas/core/command/monitor200/AbstractTraceAdviceListener.java
@@ -3,8 +3,8 @@ package com.taobao.arthas.core.command.monitor200;
 import com.alibaba.arthas.deps.org.slf4j.Logger;
 import com.alibaba.arthas.deps.org.slf4j.LoggerFactory;
 import com.taobao.arthas.core.advisor.Advice;
-import com.taobao.arthas.core.advisor.ArthasMethod;
 import com.taobao.arthas.core.advisor.AdviceListenerAdapter;
+import com.taobao.arthas.core.advisor.ArthasMethod;
 import com.taobao.arthas.core.shell.command.CommandProcess;
 import com.taobao.arthas.core.util.LogUtil;
 import com.taobao.arthas.core.util.ThreadLocalWatch;
@@ -56,7 +56,7 @@ public class AbstractTraceAdviceListener extends AdviceListenerAdapter {
     public void afterReturning(ClassLoader loader, Class<?> clazz, ArthasMethod method, Object target, Object[] args,
                                Object returnObject) throws Throwable {
         threadLocalTraceEntity(loader).tree.end();
-        final Advice advice = Advice.newForAfterRetuning(loader, clazz, method, target, args, returnObject);
+        final Advice advice = Advice.newForAfterReturning(loader, clazz, method, target, args, returnObject);
         finishing(loader, advice);
     }
 

--- a/core/src/main/java/com/taobao/arthas/core/command/monitor200/GroovyAdviceListener.java
+++ b/core/src/main/java/com/taobao/arthas/core/command/monitor200/GroovyAdviceListener.java
@@ -1,10 +1,10 @@
 package com.taobao.arthas.core.command.monitor200;
 
+import com.taobao.arthas.core.advisor.Advice;
 import com.taobao.arthas.core.advisor.AdviceListenerAdapter;
+import com.taobao.arthas.core.advisor.ArthasMethod;
 import com.taobao.arthas.core.command.ScriptSupportCommand;
 import com.taobao.arthas.core.shell.command.CommandProcess;
-import com.taobao.arthas.core.advisor.Advice;
-import com.taobao.arthas.core.advisor.ArthasMethod;
 
 /**
  * Groovy support has been completed dropped in Arthas 3.0 because of severer memory leak.
@@ -39,7 +39,7 @@ public class GroovyAdviceListener extends AdviceListenerAdapter {
     @Override
     public void afterReturning(ClassLoader loader, Class<?> clazz, ArthasMethod method, Object target, Object[] args,
                                Object returnObject) throws Throwable {
-        scriptListener.afterReturning(output, Advice.newForAfterRetuning(loader, clazz, method, target, args, returnObject));
+        scriptListener.afterReturning(output, Advice.newForAfterReturning(loader, clazz, method, target, args, returnObject));
     }
 
     @Override

--- a/core/src/main/java/com/taobao/arthas/core/command/monitor200/MonitorAdviceListener.java
+++ b/core/src/main/java/com/taobao/arthas/core/command/monitor200/MonitorAdviceListener.java
@@ -4,18 +4,14 @@ import com.alibaba.arthas.deps.org.slf4j.Logger;
 import com.alibaba.arthas.deps.org.slf4j.LoggerFactory;
 import com.taobao.arthas.core.advisor.Advice;
 import com.taobao.arthas.core.advisor.AdviceListenerAdapter;
+import com.taobao.arthas.core.advisor.ArthasMethod;
 import com.taobao.arthas.core.command.express.ExpressException;
 import com.taobao.arthas.core.command.model.MonitorModel;
 import com.taobao.arthas.core.shell.command.CommandProcess;
-import com.taobao.arthas.core.advisor.ArthasMethod;
 import com.taobao.arthas.core.util.StringUtils;
 import com.taobao.arthas.core.util.ThreadLocalWatch;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-import java.util.Timer;
-import java.util.TimerTask;
+import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -122,7 +118,7 @@ class MonitorAdviceListener extends AdviceListenerAdapter {
     @Override
     public void afterReturning(ClassLoader loader, Class<?> clazz, ArthasMethod method, Object target,
                                Object[] args, Object returnObject) throws Throwable {
-        finishing(clazz, method, false, Advice.newForAfterRetuning(loader, clazz, method, target, args, returnObject));
+        finishing(clazz, method, false, Advice.newForAfterReturning(loader, clazz, method, target, args, returnObject));
     }
 
     @Override

--- a/core/src/main/java/com/taobao/arthas/core/command/monitor200/StackAdviceListener.java
+++ b/core/src/main/java/com/taobao/arthas/core/command/monitor200/StackAdviceListener.java
@@ -1,12 +1,12 @@
 package com.taobao.arthas.core.command.monitor200;
 
-import com.taobao.arthas.core.advisor.AdviceListenerAdapter;
-import com.taobao.arthas.core.command.model.StackModel;
-import com.taobao.arthas.core.shell.command.CommandProcess;
 import com.alibaba.arthas.deps.org.slf4j.Logger;
 import com.alibaba.arthas.deps.org.slf4j.LoggerFactory;
 import com.taobao.arthas.core.advisor.Advice;
+import com.taobao.arthas.core.advisor.AdviceListenerAdapter;
 import com.taobao.arthas.core.advisor.ArthasMethod;
+import com.taobao.arthas.core.command.model.StackModel;
+import com.taobao.arthas.core.shell.command.CommandProcess;
 import com.taobao.arthas.core.util.LogUtil;
 import com.taobao.arthas.core.util.ThreadLocalWatch;
 import com.taobao.arthas.core.util.ThreadUtil;
@@ -46,7 +46,7 @@ public class StackAdviceListener extends AdviceListenerAdapter {
     @Override
     public void afterReturning(ClassLoader loader, Class<?> clazz, ArthasMethod method, Object target, Object[] args,
                                Object returnObject) throws Throwable {
-        Advice advice = Advice.newForAfterRetuning(loader, clazz, method, target, args, returnObject);
+        Advice advice = Advice.newForAfterReturning(loader, clazz, method, target, args, returnObject);
         finishing(advice);
     }
 

--- a/core/src/main/java/com/taobao/arthas/core/command/monitor200/TimeTunnelAdviceListener.java
+++ b/core/src/main/java/com/taobao/arthas/core/command/monitor200/TimeTunnelAdviceListener.java
@@ -55,7 +55,7 @@ public class TimeTunnelAdviceListener extends AdviceListenerAdapter {
                                Object returnObject) throws Throwable {
         //取出入参时的 args，因为在函数执行过程中 args可能被修改
         args = (Object[]) argsRef.get().pop();
-        afterFinishing(Advice.newForAfterRetuning(loader, clazz, method, target, args, returnObject));
+        afterFinishing(Advice.newForAfterReturning(loader, clazz, method, target, args, returnObject));
     }
 
     @Override

--- a/core/src/main/java/com/taobao/arthas/core/command/monitor200/WatchAdviceListener.java
+++ b/core/src/main/java/com/taobao/arthas/core/command/monitor200/WatchAdviceListener.java
@@ -4,8 +4,8 @@ import com.alibaba.arthas.deps.org.slf4j.Logger;
 import com.alibaba.arthas.deps.org.slf4j.LoggerFactory;
 import com.taobao.arthas.core.advisor.AccessPoint;
 import com.taobao.arthas.core.advisor.Advice;
-import com.taobao.arthas.core.advisor.ArthasMethod;
 import com.taobao.arthas.core.advisor.AdviceListenerAdapter;
+import com.taobao.arthas.core.advisor.ArthasMethod;
 import com.taobao.arthas.core.command.model.WatchModel;
 import com.taobao.arthas.core.shell.command.CommandProcess;
 import com.taobao.arthas.core.util.LogUtil;
@@ -46,7 +46,7 @@ class WatchAdviceListener extends AdviceListenerAdapter {
     @Override
     public void afterReturning(ClassLoader loader, Class<?> clazz, ArthasMethod method, Object target, Object[] args,
                                Object returnObject) throws Throwable {
-        Advice advice = Advice.newForAfterRetuning(loader, clazz, method, target, args, returnObject);
+        Advice advice = Advice.newForAfterReturning(loader, clazz, method, target, args, returnObject);
         if (command.isSuccess()) {
             watching(advice);
         }

--- a/core/src/main/java/com/taobao/arthas/core/shell/term/impl/http/HttpRequestHandler.java
+++ b/core/src/main/java/com/taobao/arthas/core/shell/term/impl/http/HttpRequestHandler.java
@@ -5,19 +5,11 @@ import com.alibaba.arthas.deps.org.slf4j.LoggerFactory;
 import com.taobao.arthas.common.IOUtils;
 import com.taobao.arthas.core.server.ArthasBootstrap;
 import com.taobao.arthas.core.shell.term.impl.http.api.HttpApiHandler;
-import com.taobao.arthas.core.shell.term.impl.httptelnet.HttpTelnetTermServer;
 import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelFutureListener;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.SimpleChannelInboundHandler;
-import io.netty.handler.codec.http.DefaultFullHttpResponse;
-import io.netty.handler.codec.http.FullHttpRequest;
-import io.netty.handler.codec.http.FullHttpResponse;
-import io.netty.handler.codec.http.HttpHeaderNames;
-import io.netty.handler.codec.http.HttpResponse;
-import io.netty.handler.codec.http.HttpResponseStatus;
-import io.netty.handler.codec.http.HttpUtil;
-import io.netty.handler.codec.http.LastHttpContent;
+import io.netty.handler.codec.http.*;
 import io.termd.core.http.HttpTtyConnection;
 import io.termd.core.util.Logging;
 
@@ -37,7 +29,7 @@ import static io.netty.handler.codec.http.HttpVersion.HTTP_1_1;
  * @author gongdewei 2020-03-18
  */
 public class HttpRequestHandler extends SimpleChannelInboundHandler<FullHttpRequest> {
-    private static final Logger logger = LoggerFactory.getLogger(HttpTelnetTermServer.class);
+    private static final Logger logger = LoggerFactory.getLogger(HttpRequestHandler.class);
 
     private final String wsUri;
 


### PR DESCRIPTION
在并发条件下，watch等命令的 -n 可能无法正常工作。因此做了同步的限制