### PR TITLE
Unsafe deserialization in com.alibaba:fastjson

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -132,7 +132,7 @@
             <dependency>
                 <groupId>com.alibaba</groupId>
                 <artifactId>fastjson</artifactId>
-                <version>1.2.83_noneautotype</version>
+                <version>1.2.83</version>
             </dependency>
             <dependency>
                 <groupId>com.taobao.text</groupId>


### PR DESCRIPTION
The package com.alibaba:fastjson before 1.2.83 is vulnerable to Deserialization of Untrusted Data by bypassing the default autoType shutdown restrictions, which is possible under certain conditions. Exploiting this vulnerability allows attacking remote servers. Workaround: If upgrading is not possible, you can enable [safeMode](https://github.com/alibaba/fastjson/wiki/fastjson_safemode).

**CVE-2022-25845**
``CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:H``
**High** `8.1/ 10`