### PR TITLE
Improper validation of certificate with host mismatch in Apache Log4j SMTP appender 

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -205,7 +205,7 @@
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-core</artifactId>
-            <version>2.12.4</version>
+            <version>2.17.1</version>
             <scope>provided</scope>
             <optional>true</optional>
         </dependency>


### PR DESCRIPTION
Improper validation of certificate with host mismatch in Apache Log4j SMTP appender prior to version 2.13.2. This could allow an SMTPS connection to be intercepted by a man-in-the-middle attack which could leak any log messages sent through that appender.

**CVE-2020-9488**
`CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:L/I:N/A:N`
**Low** `3.7/ 10`