### PR TITLE
fix issue:sc command throws NPE.

### DIFF
--- a/core/src/main/java/com/taobao/arthas/core/util/SearchUtils.java
+++ b/core/src/main/java/com/taobao/arthas/core/util/SearchUtils.java
@@ -82,7 +82,7 @@ public class SearchUtils {
         Set<Class<?>> result = new HashSet<Class<?>>();
         if (matchedClasses != null) {
             for (Class<?> c : matchedClasses) {
-                if (Integer.toHexString(c.getClassLoader().hashCode()).equals(code)) {
+                if (c.getClassLoader() != null && Integer.toHexString(c.getClassLoader().hashCode()).equals(code)) {
                     result.add(c);
                 }
             }


### PR DESCRIPTION
Fixes #2277

问题原因并非issue中描述的“必须提供至少特定数量字符”才能正确匹配，而是当匹配的类中有jvm根类加载器加载的类时（即null），会抛NullPointException。