### PR TITLE
fix: syntax error in the jdwpTransport.h

### DIFF
--- a/arthas-vmtool/src/main/native/head/jdwpTransport.h
+++ b/arthas-vmtool/src/main/native/head/jdwpTransport.h
@@ -262,7 +262,7 @@ struct _jdwpTransportEnv {
     }
 
     /*  SetTransportConfiguration added in JDWPTRANSPORT_VERSION_1_1 */
-    jdwpTransportError SetTransportConfiguration(jdwpTransportEnv* env,
+    jdwpTransportError SetTransportConfiguration(jdwpTransportConfiguration *config) {
         return functions->SetTransportConfiguration(this, config);
     }
 


### PR DESCRIPTION
jdwpTransport.h 有语法错误，编译该文件会报错。