### PR TITLE
fix issue: packaging arthas-vmtool failed in 32-bit windows.

### DIFF
--- a/arthas-vmtool/pom.xml
+++ b/arthas-vmtool/pom.xml
@@ -47,6 +47,30 @@
 
         <!-- windows -->
         <profile>
+            <id>windows</id>
+            <activation>
+                <os>
+                    <family>windows</family>
+                </os>
+            </activation>
+            <properties>
+                <os_name>windows</os_name>
+            </properties>
+        </profile>
+        <profile>
+            <id>windows-32</id>
+            <activation>
+                <os>
+                    <family>windows</family>
+                    <arch>x86</arch>
+                </os>
+            </activation>
+            <properties>
+                <os_arch_option>-m32</os_arch_option>
+                <lib_name>libArthasJniLibrary-x86.dll</lib_name>
+            </properties>
+        </profile>
+        <profile>
             <id>windows-amd64</id>
             <activation>
                 <os>
@@ -55,7 +79,6 @@
                 </os>
             </activation>
             <properties>
-                <os_name>windows</os_name>
                 <os_arch_option>-m64</os_arch_option>
                 <lib_name>libArthasJniLibrary-x64.dll</lib_name>
             </properties>

--- a/common/src/main/java/com/taobao/arthas/common/OSUtils.java
+++ b/common/src/main/java/com/taobao/arthas/common/OSUtils.java
@@ -67,6 +67,10 @@ public class OSUtils {
 		return "aarch_64".equals(arch);
 	}
 
+	public static boolean isX86() {
+    	return "x86_32".equals(arch);
+	}
+
 	private static String normalizeArch(String value) {
 		value = normalize(value);
 		if (value.matches("^(x8664|amd64|ia32e|em64t|x64)$")) {

--- a/common/src/main/java/com/taobao/arthas/common/VmToolUtils.java
+++ b/common/src/main/java/com/taobao/arthas/common/VmToolUtils.java
@@ -21,6 +21,9 @@ public class VmToolUtils {
         }
         if (OSUtils.isWindows()) {
             libName = "libArthasJniLibrary-x64.dll";
+            if (OSUtils.isX86()) {
+                libName = "libArthasJniLibrary-x86.dll";
+            }
         }
     }
 


### PR DESCRIPTION
修复#2309 中arthas-vmtool在win 32位系统中打包失败的问题。

具体失败的原因和解决方案：
[comment-1281818755](https://github.com/alibaba/arthas/issues/2309#issuecomment-1281818755)