### PR TITLE
fix issue: support ClassLoader#toString() for sc command.

### DIFF
--- a/core/src/main/java/com/taobao/arthas/core/command/klass100/SearchClassCommand.java
+++ b/core/src/main/java/com/taobao/arthas/core/command/klass100/SearchClassCommand.java
@@ -50,6 +50,7 @@ public class SearchClassCommand extends AnnotatedCommand {
     private boolean isRegEx = false;
     private String hashCode = null;
     private String classLoaderClass;
+    private String classLoaderToString;
     private Integer expand;
     private int numberOfLimit = 100;
 
@@ -101,6 +102,12 @@ public class SearchClassCommand extends AnnotatedCommand {
         this.numberOfLimit = numberOfLimit;
     }
 
+    @Option(shortName = "cs", longName = "classLoaderStr")
+    @Description("The return value of the ClassLoader#toString().")
+    public void setClassLoaderToString(String classLoaderToString) {
+        this.classLoaderToString = classLoaderToString;
+    }
+
     @Override
     public void process(final CommandProcess process) {
         // TODO: null check
@@ -126,6 +133,9 @@ public class SearchClassCommand extends AnnotatedCommand {
         }
 
         List<Class<?>> matchedClasses = new ArrayList<Class<?>>(SearchUtils.searchClass(inst, classPattern, isRegEx, hashCode));
+        if (!StringUtils.isEmpty(classLoaderToString)) {
+            matchedClasses = filterByClassLoaderToStr(matchedClasses);
+        }
         Collections.sort(matchedClasses, new Comparator<Class<?>>() {
             @Override
             public int compare(Class<?> c1, Class<?> c2) {
@@ -157,6 +167,16 @@ public class SearchClassCommand extends AnnotatedCommand {
         affect.rCnt(matchedClasses.size());
         process.appendResult(new RowAffectModel(affect));
         process.end();
+    }
+
+    private List<Class<?>> filterByClassLoaderToStr(List<Class<?>> classes) {
+        List<Class<?>> list = new ArrayList<Class<?>>();
+        for (Class<?> clazz : classes) {
+            if (clazz.getClassLoader() !=null && clazz.getClassLoader().toString().equals(classLoaderToString)) {
+                list.add(clazz);
+            }
+        }
+        return list;
     }
 
     @Override

--- a/core/src/main/java/com/taobao/arthas/core/command/klass100/SearchClassCommand.java
+++ b/core/src/main/java/com/taobao/arthas/core/command/klass100/SearchClassCommand.java
@@ -115,27 +115,12 @@ public class SearchClassCommand extends AnnotatedCommand {
         Instrumentation inst = process.session().getInstrumentation();
 
         if (hashCode == null && (classLoaderClass != null || classLoaderToString != null)) {
-            List<ClassLoader> matchedClassLoaders = new ArrayList<ClassLoader>();
+            List<ClassLoader> matchedClassLoaders = ClassLoaderUtils.getClassLoader(inst, classLoaderClass, classLoaderToString);
             String tips = "";
             if (classLoaderClass != null) {
-                List<ClassLoader> matchedByClassName = ClassLoaderUtils.getClassLoaderByClassName(inst, classLoaderClass);
-                if (matchedByClassName != null) {
-                    matchedClassLoaders.addAll(matchedByClassName);
-                }
                 tips = "class name: " + classLoaderClass;
             }
             if (classLoaderToString != null) {
-                if (matchedClassLoaders.size() <= 0 && classLoaderClass != null) {
-                } else {
-                    List<ClassLoader> matchedByClassLoaderToStr = ClassLoaderUtils.getClassLoaderByClassLoaderToStr(inst, classLoaderToString);
-                    if (matchedByClassLoaderToStr != null) {
-                        if (matchedClassLoaders.size() > 0) {
-                            matchedClassLoaders.retainAll(matchedByClassLoaderToStr);
-                        } else {
-                            matchedClassLoaders.addAll(matchedByClassLoaderToStr);
-                        }
-                    }
-                }
                 tips = tips + (StringUtils.isEmpty(tips) ? "ClassLoader#toString(): " : ", ClassLoader#toString(): ") + classLoaderToString;
             }
             if (matchedClassLoaders.size() == 1) {

--- a/core/src/main/java/com/taobao/arthas/core/util/ClassLoaderUtils.java
+++ b/core/src/main/java/com/taobao/arthas/core/util/ClassLoaderUtils.java
@@ -78,21 +78,45 @@ public class ClassLoaderUtils {
     }
 
     /**
-     * 通过ClassLoader#toString()返回值查找classloader
+     * Find List<ClassLoader> by the class name of ClassLoader or the return value of ClassLoader#toString().
      * @param inst
+     * @param classLoaderClassName
      * @param classLoaderToString
      * @return
      */
-    public static List<ClassLoader> getClassLoaderByClassLoaderToStr(Instrumentation inst, String classLoaderToString) {
-        if (classLoaderToString == null || classLoaderToString.isEmpty()) {
-            return null;
+    public static List<ClassLoader> getClassLoader(Instrumentation inst, String classLoaderClassName, String classLoaderToString) {
+        List<ClassLoader> matchClassLoaders = new ArrayList<ClassLoader>();
+        if (StringUtils.isEmpty(classLoaderClassName) && StringUtils.isEmpty(classLoaderToString)) {
+            return matchClassLoaders;
         }
         Set<ClassLoader> classLoaderSet = getAllClassLoader(inst);
-        List<ClassLoader> matchClassLoaders = new ArrayList<ClassLoader>();
+        List<ClassLoader> matchedByClassLoaderToStr = new ArrayList<ClassLoader>();
         for (ClassLoader classLoader : classLoaderSet) {
-            if (classLoader.toString().equals(classLoaderToString)) {
-                matchClassLoaders.add(classLoader);
+            // only classLoaderClassName
+            if (!StringUtils.isEmpty(classLoaderClassName) && StringUtils.isEmpty(classLoaderToString)) {
+                if (classLoader.getClass().getName().equals(classLoaderClassName)) {
+                    matchClassLoaders.add(classLoader);
+                }
             }
+            // only classLoaderToString
+            else if (!StringUtils.isEmpty(classLoaderToString) && StringUtils.isEmpty(classLoaderClassName)) {
+                if (classLoader.toString().equals(classLoaderToString)) {
+                    matchClassLoaders.add(classLoader);
+                }
+            }
+            // classLoaderClassName and classLoaderToString
+            else {
+                if (classLoader.getClass().getName().equals(classLoaderClassName)) {
+                    matchClassLoaders.add(classLoader);
+                }
+                if (classLoader.toString().equals(classLoaderToString)) {
+                    matchedByClassLoaderToStr.add(classLoader);
+                }
+            }
+        }
+        // classLoaderClassName and classLoaderToString
+        if (!StringUtils.isEmpty(classLoaderClassName) && !StringUtils.isEmpty(classLoaderToString)) {
+            matchClassLoaders.retainAll(matchedByClassLoaderToStr);
         }
         return matchClassLoaders;
     }

--- a/core/src/main/java/com/taobao/arthas/core/util/ClassLoaderUtils.java
+++ b/core/src/main/java/com/taobao/arthas/core/util/ClassLoaderUtils.java
@@ -76,4 +76,24 @@ public class ClassLoaderUtils {
         }
         return Integer.toHexString(hashCode);
     }
+
+    /**
+     * 通过ClassLoader#toString()返回值查找classloader
+     * @param inst
+     * @param classLoaderToString
+     * @return
+     */
+    public static List<ClassLoader> getClassLoaderByClassLoaderToStr(Instrumentation inst, String classLoaderToString) {
+        if (classLoaderToString == null || classLoaderToString.isEmpty()) {
+            return null;
+        }
+        Set<ClassLoader> classLoaderSet = getAllClassLoader(inst);
+        List<ClassLoader> matchClassLoaders = new ArrayList<ClassLoader>();
+        for (ClassLoader classLoader : classLoaderSet) {
+            if (classLoader.toString().equals(classLoaderToString)) {
+                matchClassLoaders.add(classLoader);
+            }
+        }
+        return matchClassLoaders;
+    }
 }

--- a/site/docs/doc/sc.md
+++ b/site/docs/doc/sc.md
@@ -106,3 +106,13 @@ sc 默认开启了子类匹配功能，也就是说所有当前类的子类也�
 
   Affect(row-cnt:1) cost in 19 ms.
   ```
+
+- 通过 ClassLoader#toString 查找类（前提：有一个toString()返回值是`apo`的类加载器，加载的类中包含`demo.MathGame`, `demo.MyBar`,` demo.MyFoo`3个类）
+
+  ```bash
+  $ sc -cs apo *demo*
+  demo.MathGame
+  demo.MyBar
+  demo.MyFoo
+  Affect(row-cnt:3) cost in 56 ms.
+  ```

--- a/site/docs/doc/sc.md
+++ b/site/docs/doc/sc.md
@@ -21,6 +21,7 @@
 |                `[c:]` | 指定 class 的 ClassLoader 的 hashcode                                                                                                                 |
 | `[classLoaderClass:]` | 指定执行表达式的 ClassLoader 的 class name                                                                                                            |
 |                `[n:]` | 具有详细信息的匹配类的最大数量（默认为 100）                                                                                                          |
+|`[cs <arg>]` | 指定 class 的 ClassLoader#toString() 返回值。长格式`[classLoaderStr <arg>]`|
 
 ::: tip
 class-pattern 支持全限定名，如 com.taobao.test.AAA，也支持 com/taobao/test/AAA 这样的格式，这样，我们从异常堆栈里面把类名拷贝过来的时候，不需要在手动把`/`替换为`.`啦。

--- a/site/docs/en/doc/sc.md
+++ b/site/docs/en/doc/sc.md
@@ -21,7 +21,7 @@ Search classes loaded by JVM.
 |                `[c:]` | The hash code of the special class's classLoader                                                                                                                                                                                 |
 | `[classLoaderClass:]` | The class name of the ClassLoader that executes the expression.                                                                                                                                                                  |
 |                `[n:]` | Maximum number of matching classes with details (100 by default)                                                                                                                                                                 |
-|`[cs <arg>]` | specify the return value of class's ClassLoader#toString(). Long format is`[classLoaderStr <arg>]`|
+|`[cs <arg>]` | Specify the return value of class's ClassLoader#toString(). Long format is`[classLoaderStr <arg>]`|
 
 ::: tip
 _class-patten_ supports full qualified class name, e.g. com.taobao.test.AAA and com/taobao/test/AAA. It also supports the format of 'com/taobao/test/AAA', so that it is convenient to directly copy class name from the exception stack trace without replacing '/' to '.'.

--- a/site/docs/en/doc/sc.md
+++ b/site/docs/en/doc/sc.md
@@ -21,6 +21,7 @@ Search classes loaded by JVM.
 |                `[c:]` | The hash code of the special class's classLoader                                                                                                                                                                                 |
 | `[classLoaderClass:]` | The class name of the ClassLoader that executes the expression.                                                                                                                                                                  |
 |                `[n:]` | Maximum number of matching classes with details (100 by default)                                                                                                                                                                 |
+|`[cs <arg>]` | specify the return value of class's ClassLoader#toString(). Long format is`[classLoaderStr <arg>]`|
 
 ::: tip
 _class-patten_ supports full qualified class name, e.g. com.taobao.test.AAA and com/taobao/test/AAA. It also supports the format of 'com/taobao/test/AAA', so that it is convenient to directly copy class name from the exception stack trace without replacing '/' to '.'.

--- a/site/docs/en/doc/sc.md
+++ b/site/docs/en/doc/sc.md
@@ -106,3 +106,13 @@ _class-patten_ supports full qualified class name, e.g. com.taobao.test.AAA and 
 
   Affect(row-cnt:1) cost in 19 ms.
   ```
+
+- Search class by ClassLoader#toString (on the premise that a ClassLoader instance whose `toString()` returns `apo` has loaded some classes including `demo.MathGame`, `demo.MyBar`, `demo.MyFoo`)
+
+  ```bash
+  $ sc -cs apo *demo*
+  demo.MathGame
+  demo.MyBar
+  demo.MyFoo
+  Affect(row-cnt:3) cost in 56 ms.
+  ```


### PR DESCRIPTION
Fixes #2283 

**Feature**: enhance the `sc` command. This PR will make `sc` can search class according to the value of target class's `ClassLoader#toString()`.

**Usage**: `sc -cs {the value of ClassLoader#toString()} {other param}` or `sc --classLoaderStr {the value of ClassLoader#toString()} {other param}`.