### PR TITLE
fix TelnetConsole#process() return status

### DIFF
--- a/client/src/main/java/com/taobao/arthas/client/TelnetConsole.java
+++ b/client/src/main/java/com/taobao/arthas/client/TelnetConsole.java
@@ -215,7 +215,7 @@ public class TelnetConsole {
 
         if (telnetConsole.isHelp()) {
             System.out.println(usage(cli));
-            return STATUS_ERROR;
+            return STATUS_OK;
         }
 
         // Try to read cmds


### PR DESCRIPTION
I'm confused that why return STATUS_ERROR at  line 218;

maybe it should retrun STATUS_OK?