### PR TITLE
fix TelnetClient disconnect

### DIFF
--- a/client/src/main/java/com/taobao/arthas/client/TelnetConsole.java
+++ b/client/src/main/java/com/taobao/arthas/client/TelnetConsole.java
@@ -243,6 +243,7 @@ public class TelnetConsole {
             ((UnixTerminal) terminal).disableLitteralNextCharacter();
         }
 
+        final TelnetClient telnet = new TelnetClient();
         try {
             int width = TerminalSupport.DEFAULT_WIDTH;
             int height = TerminalSupport.DEFAULT_HEIGHT;
@@ -273,7 +274,6 @@ public class TelnetConsole {
                 }
             }
 
-            final TelnetClient telnet = new TelnetClient();
             telnet.setConnectTimeout(DEFAULT_CONNECTION_TIMEOUT);
 
             // send init terminal size
@@ -320,17 +320,16 @@ public class TelnetConsole {
                     System.out.println("Execute commands error: " + e.getMessage());
                     e.printStackTrace();
                     return STATUS_EXEC_ERROR;
-                } finally {
-                    try {
-                        telnet.disconnect();
-                    } catch (IOException e) {
-                        //ignore ex
-                    }
                 }
             }
 
             return STATUS_OK;
         } finally {
+            try {
+                telnet.disconnect();
+            } catch (IOException e) {
+                //ignore ex
+            }
             //reset terminal setting, fix https://github.com/alibaba/arthas/issues/1412
             try {
                 terminal.restore();


### PR DESCRIPTION
if cmds is empty,  telnetClient will never be  disconnected.


```
            if (cmds.isEmpty()) {
                IOUtil.readWrite(telnet.getInputStream(), telnet.getOutputStream(), consoleReader.getInput(),
                        consoleReader.getOutput());
            } else {
                try {
                    return batchModeRun(telnet, cmds, telnetConsole.getExecutionTimeout());
                } catch (Throwable e) {
                    System.out.println("Execute commands error: " + e.getMessage());
                    e.printStackTrace();
                    return STATUS_EXEC_ERROR;
                } finally {
                    try {
                        telnet.disconnect();
                    } catch (IOException e) {
                        //ignore ex
                    }
                }
            }
```