### PR TITLE
add look command to watch local variables before specify line number

### DIFF
--- a/core/src/main/java/com/taobao/arthas/core/advisor/AccessPoint.java
+++ b/core/src/main/java/com/taobao/arthas/core/advisor/AccessPoint.java
@@ -1,7 +1,7 @@
 package com.taobao.arthas.core.advisor;
 
 public enum AccessPoint {
-    ACCESS_BEFORE(1, "AtEnter"), ACCESS_AFTER_RETUNING(1 << 1, "AtExit"), ACCESS_AFTER_THROWING(1 << 2, "AtExceptionExit");
+    ACCESS_BEFORE(1, "AtEnter"), ACCESS_AFTER_RETUNING(1 << 1, "AtExit"), ACCESS_AFTER_THROWING(1 << 2, "AtExceptionExit"),ACCESS_BEFORE_LINE(1 << 3, "atLineBefore");
 
     private int value;
 

--- a/core/src/main/java/com/taobao/arthas/core/advisor/Advice.java
+++ b/core/src/main/java/com/taobao/arthas/core/advisor/Advice.java
@@ -1,5 +1,7 @@
 package com.taobao.arthas.core.advisor;
 
+import java.util.Map;
+
 /**
  * 通知点 Created by vlinux on 15/5/20.
  */
@@ -12,6 +14,7 @@ public class Advice {
     private final Object[] params;
     private final Object returnObj;
     private final Throwable throwExp;
+    private final Map<String,Object> varMap;
     private final boolean isBefore;
     private final boolean isThrow;
     private final boolean isReturn;
@@ -66,6 +69,7 @@ public class Advice {
      * @param params    调用参数
      * @param returnObj 返回值
      * @param throwExp  抛出异常
+     * @param varMap    本地变量
      * @param access    进入场景
      */
     private Advice(
@@ -76,6 +80,7 @@ public class Advice {
             Object[] params,
             Object returnObj,
             Throwable throwExp,
+            Map<String, Object> varMap,
             int access) {
         this.loader = loader;
         this.clazz = clazz;
@@ -84,6 +89,7 @@ public class Advice {
         this.params = params;
         this.returnObj = returnObj;
         this.throwExp = throwExp;
+        this.varMap = varMap;
         isBefore = (access & AccessPoint.ACCESS_BEFORE.getValue()) == AccessPoint.ACCESS_BEFORE.getValue();
         isThrow = (access & AccessPoint.ACCESS_AFTER_THROWING.getValue()) == AccessPoint.ACCESS_AFTER_THROWING.getValue();
         isReturn = (access & AccessPoint.ACCESS_AFTER_RETUNING.getValue()) == AccessPoint.ACCESS_AFTER_RETUNING.getValue();
@@ -102,6 +108,7 @@ public class Advice {
                 params,
                 null, //returnObj
                 null, //throwExp
+                null, //varMap
                 AccessPoint.ACCESS_BEFORE.getValue()
         );
     }
@@ -120,6 +127,7 @@ public class Advice {
                 params,
                 returnObj,
                 null, //throwExp
+                null, //varMap
                 AccessPoint.ACCESS_AFTER_RETUNING.getValue()
         );
     }
@@ -138,7 +146,29 @@ public class Advice {
                 params,
                 null, //returnObj
                 throwExp,
+                null, //varMap
                 AccessPoint.ACCESS_AFTER_THROWING.getValue()
+        );
+
+    }
+
+
+    public static Advice newForLooking(ClassLoader loader,
+                                       Class<?> clazz,
+                                       ArthasMethod method,
+                                       Object target,
+                                       Object[] params,
+                                       Map<String, Object> varMap) {
+        return new Advice(
+                loader,
+                clazz,
+                method,
+                target,
+                params,
+                null, //returnObj
+                null, //returnObj
+                varMap,
+                AccessPoint.ACCESS_BEFORE_LINE.getValue()
         );
 
     }

--- a/core/src/main/java/com/taobao/arthas/core/advisor/AdviceListener.java
+++ b/core/src/main/java/com/taobao/arthas/core/advisor/AdviceListener.java
@@ -70,4 +70,20 @@ public interface AdviceListener {
             Object target, Object[] args,
             Throwable throwable) throws Throwable;
 
+    /**
+     * 指定行之前，look命令中使用，查看本地变量
+     *
+     * @param clazz      类
+     * @param methodName 方法名
+     * @param methodDesc 方法描述
+     * @param target     目标类实例
+     *                   若目标为静态方法,则为null
+     * @param args       参数列表
+     * @param line       指定行，-1代表是方法退出前
+     * @param vars       本地变量数组
+     * @param varNames   本地变量名数组
+     * @throws Throwable 通知过程出错
+     */
+    void beforeLine(Class<?> clazz, String methodName, String methodDesc, Object target, Object[] args, int line, Object[] vars, String[] varNames) throws Throwable;
+
 }

--- a/core/src/main/java/com/taobao/arthas/core/advisor/AdviceListenerAdapter.java
+++ b/core/src/main/java/com/taobao/arthas/core/advisor/AdviceListenerAdapter.java
@@ -65,6 +65,11 @@ public abstract class AdviceListenerAdapter implements AdviceListener, ProcessAw
                 throwable);
     }
 
+    @Override
+    public void beforeLine(Class<?> clazz, String methodName, String methodDesc, Object target, Object[] args, int line, Object[] vars, String[] varNames) throws Throwable {
+        beforeLine(clazz.getClassLoader(), clazz, new ArthasMethod(clazz, methodName, methodDesc), target, args, line, vars, varNames);
+    }
+
     /**
      * 前置通知
      *
@@ -105,6 +110,24 @@ public abstract class AdviceListenerAdapter implements AdviceListener, ProcessAw
      */
     public abstract void afterThrowing(ClassLoader loader, Class<?> clazz, ArthasMethod method, Object target,
             Object[] args, Throwable throwable) throws Throwable;
+
+    /**
+     * 指定行之前，look命令中使用，查看本地变量
+     *
+     * @param loader    类加载器
+     * @param clazz      类
+     * @param method    方法
+     * @param target     目标类实例
+     *                   若目标为静态方法,则为null
+     * @param args       参数列表
+     * @param line       指定行，-1代表是方法退出前
+     * @param vars       本地变量数组
+     * @param varNames   本地变量名数组
+     * @throws Throwable 通知过程出错
+     */
+    public void beforeLine(ClassLoader loader, Class<?> clazz, ArthasMethod method, Object target, Object[] args, int line, Object[] vars, String[] varNames) throws Throwable{
+        //empty
+    }
 
     /**
      * 判断条件是否满足，满足的情况下需要输出结果

--- a/core/src/main/java/com/taobao/arthas/core/advisor/SpyImpl.java
+++ b/core/src/main/java/com/taobao/arthas/core/advisor/SpyImpl.java
@@ -73,6 +73,30 @@ public class SpyImpl extends AbstractSpy {
     }
 
     @Override
+    public void atLineBefore(Class<?> clazz, String methodInfo, Object target, Object[] args, int line, Object[] vars, String[] varNames) {
+        ClassLoader classLoader = clazz.getClassLoader();
+
+        String[] info = StringUtils.splitMethodInfo(methodInfo);
+        String methodName = info[0];
+        String methodDesc = info[1];
+
+        List<AdviceListener> listeners = AdviceListenerManager.queryLookAdviceListeners(classLoader, clazz.getName(), line,
+                methodName, methodDesc);
+        if (listeners != null) {
+            for (AdviceListener adviceListener : listeners) {
+                try {
+                    if (skipAdviceListener(adviceListener)) {
+                        continue;
+                    }
+                    adviceListener.beforeLine(clazz, methodName, methodDesc, target, args, line, vars, varNames);
+                } catch (Throwable e) {
+                    logger.error("class: {}, methodInfo: {}", clazz.getName(), methodInfo, e);
+                }
+            }
+        }
+    }
+
+    @Override
     public void atExceptionExit(Class<?> clazz, String methodInfo, Object target, Object[] args, Throwable throwable) {
         ClassLoader classLoader = clazz.getClassLoader();
 

--- a/core/src/main/java/com/taobao/arthas/core/advisor/SpyInterceptors.java
+++ b/core/src/main/java/com/taobao/arthas/core/advisor/SpyInterceptors.java
@@ -3,11 +3,7 @@ package com.taobao.arthas.core.advisor;
 import java.arthas.SpyAPI;
 
 import com.alibaba.bytekit.asm.binding.Binding;
-import com.alibaba.bytekit.asm.interceptor.annotation.AtEnter;
-import com.alibaba.bytekit.asm.interceptor.annotation.AtExceptionExit;
-import com.alibaba.bytekit.asm.interceptor.annotation.AtExit;
-import com.alibaba.bytekit.asm.interceptor.annotation.AtInvoke;
-import com.alibaba.bytekit.asm.interceptor.annotation.AtInvokeException;
+import com.alibaba.bytekit.asm.interceptor.annotation.*;
 
 /**
  * 
@@ -40,6 +36,18 @@ public class SpyInterceptors {
                 @Binding.Throwable Throwable throwable) {
             SpyAPI.atExceptionExit(clazz, methodInfo, target, args, throwable);
         }
+    }
+
+    public static class SpyLookInterceptor {
+
+        public static void atLineBefore(@Binding.This Object target, @Binding.Class Class<?> clazz,
+                                        @Binding.MethodInfo String methodInfo, @Binding.Args Object[] args,
+                                        @Binding.LineBefore int line,
+                                        @Binding.LocalVars Object[] vars,
+                                        @Binding.LocalVarNames String[] varNames) {
+            SpyAPI.atLineBefore(clazz, methodInfo, target, args, line, vars, varNames);
+        }
+
     }
 
     public static class SpyTraceInterceptor1 {

--- a/core/src/main/java/com/taobao/arthas/core/command/BuiltinCommandPack.java
+++ b/core/src/main/java/com/taobao/arthas/core/command/BuiltinCommandPack.java
@@ -20,20 +20,7 @@ import com.taobao.arthas.core.command.klass100.RetransformCommand;
 import com.taobao.arthas.core.command.klass100.SearchClassCommand;
 import com.taobao.arthas.core.command.klass100.SearchMethodCommand;
 import com.taobao.arthas.core.command.logger.LoggerCommand;
-import com.taobao.arthas.core.command.monitor200.DashboardCommand;
-import com.taobao.arthas.core.command.monitor200.HeapDumpCommand;
-import com.taobao.arthas.core.command.monitor200.JvmCommand;
-import com.taobao.arthas.core.command.monitor200.MBeanCommand;
-import com.taobao.arthas.core.command.monitor200.MemoryCommand;
-import com.taobao.arthas.core.command.monitor200.MonitorCommand;
-import com.taobao.arthas.core.command.monitor200.PerfCounterCommand;
-import com.taobao.arthas.core.command.monitor200.ProfilerCommand;
-import com.taobao.arthas.core.command.monitor200.StackCommand;
-import com.taobao.arthas.core.command.monitor200.ThreadCommand;
-import com.taobao.arthas.core.command.monitor200.TimeTunnelCommand;
-import com.taobao.arthas.core.command.monitor200.TraceCommand;
-import com.taobao.arthas.core.command.monitor200.VmToolCommand;
-import com.taobao.arthas.core.command.monitor200.WatchCommand;
+import com.taobao.arthas.core.command.monitor200.*;
 import com.taobao.arthas.core.shell.command.AnnotatedCommand;
 import com.taobao.arthas.core.shell.command.Command;
 import com.taobao.arthas.core.shell.command.CommandResolver;
@@ -57,7 +44,7 @@ public class BuiltinCommandPack implements CommandResolver {
     }
 
     private void initCommands(List<String> disabledCommands) {
-        List<Class<? extends AnnotatedCommand>> commandClassList = new ArrayList<Class<? extends AnnotatedCommand>>(33);
+        List<Class<? extends AnnotatedCommand>> commandClassList = new ArrayList<Class<? extends AnnotatedCommand>>(34);
         commandClassList.add(HelpCommand.class);
         commandClassList.add(AuthCommand.class);
         commandClassList.add(KeymapCommand.class);
@@ -105,6 +92,7 @@ public class BuiltinCommandPack implements CommandResolver {
         commandClassList.add(ProfilerCommand.class);
         commandClassList.add(VmToolCommand.class);
         commandClassList.add(StopCommand.class);
+        commandClassList.add(LookCommand.class);
         try {
             if (ClassLoader.getSystemClassLoader().getResource("jdk/jfr/Recording.class") != null) {
                 commandClassList.add(JFRCommand.class);

--- a/core/src/main/java/com/taobao/arthas/core/command/Constants.java
+++ b/core/src/main/java/com/taobao/arthas/core/command/Constants.java
@@ -46,4 +46,14 @@ public interface Constants {
                                 "  FALSE : 1==2\n" +
                                 "  '#cost>100'\n";
 
+
+    String LOOK_CONDITION_EXPRESS =  "Conditional expression in ognl style, for example:\n" +
+                                "  TRUE  : 1==1\n" +
+                                "  TRUE  : true\n" +
+                                "  FALSE : false\n" +
+                                "  TRUE  : 'params.length>=0'\n" +
+                                "  FALSE : 1==2\n" +
+                                "  'varMap[\"varName\"]==1'\n"+
+                                "  'varMap[\"varName\"].equals(\"value\")'\n";
+
 }

--- a/core/src/main/java/com/taobao/arthas/core/command/model/LookModel.java
+++ b/core/src/main/java/com/taobao/arthas/core/command/model/LookModel.java
@@ -1,0 +1,74 @@
+package com.taobao.arthas.core.command.model;
+
+import java.util.Date;
+
+/**
+ * Look command result model
+ *
+ */
+public class LookModel extends ResultModel {
+
+    private Date ts;
+    private ObjectVO value;
+
+    private Integer sizeLimit;
+    private String className;
+    private String methodName;
+    private String accessPoint;
+
+    public LookModel() {
+    }
+
+    @Override
+    public String getType() {
+        return "look";
+    }
+
+    public Date getTs() {
+        return ts;
+    }
+
+    public void setTs(Date ts) {
+        this.ts = ts;
+    }
+
+    public ObjectVO getValue() {
+        return value;
+    }
+
+    public void setValue(ObjectVO value) {
+        this.value = value;
+    }
+
+    public void setSizeLimit(Integer sizeLimit) {
+        this.sizeLimit = sizeLimit;
+    }
+
+    public Integer getSizeLimit() {
+        return sizeLimit;
+    }
+
+    public String getClassName() {
+        return className;
+    }
+
+    public void setClassName(String className) {
+        this.className = className;
+    }
+
+    public String getMethodName() {
+        return methodName;
+    }
+
+    public void setMethodName(String methodName) {
+        this.methodName = methodName;
+    }
+
+    public String getAccessPoint() {
+        return accessPoint;
+    }
+
+    public void setAccessPoint(String accessPoint) {
+        this.accessPoint = accessPoint;
+    }
+}

--- a/core/src/main/java/com/taobao/arthas/core/command/monitor200/EnhancerCommand.java
+++ b/core/src/main/java/com/taobao/arthas/core/command/monitor200/EnhancerCommand.java
@@ -35,6 +35,9 @@ public abstract class EnhancerCommand extends AnnotatedCommand {
     protected static final List<String> EMPTY = Collections.emptyList();
     public static final String[] EXPRESS_EXAMPLES = { "params", "returnObj", "throwExp", "target", "clazz", "method",
                                                        "{params,returnObj}", "params[0]" };
+
+    public static final String[] LOOK_EXPRESS_EXAMPLES = {"target", "clazz", "method", "params", "varMap"};
+
     private String excludeClassPattern;
 
     protected Matcher classNameMatcher;
@@ -157,6 +160,12 @@ public abstract class EnhancerCommand extends AnnotatedCommand {
             }
 
             Enhancer enhancer = new Enhancer(listener, listener instanceof InvokeTraceable, skipJDKTrace, getClassNameMatcher(), getClassNameExcludeMatcher(), getMethodNameMatcher());
+            if(listener instanceof LookAdviceListener) {
+                int lineNum = ((LookAdviceListener) listener).getCommand().getLineNum();
+                enhancer.setLooking(true);
+                enhancer.setLookingLineNum(lineNum);
+            }
+
             // 注册通知监听器
             process.register(listener, enhancer);
             effect = enhancer.enhance(inst);
@@ -177,6 +186,8 @@ public abstract class EnhancerCommand extends AnnotatedCommand {
                 String optionsCommand = Ansi.ansi().fg(Ansi.Color.GREEN).a("options unsafe true").reset().toString();
                 String javaPackage = Ansi.ansi().fg(Ansi.Color.GREEN).a("java.*").reset().toString();
                 String resetCommand = Ansi.ansi().fg(Ansi.Color.GREEN).a("reset CLASS_NAME").reset().toString();
+                String jadCommand = Ansi.ansi().fg(Ansi.Color.GREEN).a("jad CLASS_NAME").reset().toString();
+                String lookCommand = Ansi.ansi().fg(Ansi.Color.GREEN).a("look").reset().toString();
                 String logStr = Ansi.ansi().fg(Ansi.Color.GREEN).a(LogUtil.loggingFile()).reset().toString();
                 String issueStr = Ansi.ansi().fg(Ansi.Color.GREEN).a("https://github.com/alibaba/arthas/issues/47").reset().toString();
                 String msg = "No class or method is affected, try:\n"
@@ -184,8 +195,9 @@ public abstract class EnhancerCommand extends AnnotatedCommand {
                         + "2. Execute `" + optionsCommand + "`, if you want to enhance the classes under the `" + javaPackage + "` package.\n"
                         + "3. Execute `" + resetCommand + "` and try again, your method body might be too large.\n"
                         + "4. Match the constructor, use `<init>`, for example: `watch demo.MathGame <init>`\n"
-                        + "5. Check arthas log: " + logStr + "\n"
-                        + "6. Visit " + issueStr + " for more details.";
+                        + "5. If you are using `" + lookCommand + "` command, use `" + jadCommand + "` to comfirm the line exist first\n"
+                        + "6. Check arthas log: " + logStr + "\n"
+                        + "7. Visit " + issueStr + " for more details.";
                 process.end(-1, msg);
                 return;
             }

--- a/core/src/main/java/com/taobao/arthas/core/command/monitor200/LookAdviceListener.java
+++ b/core/src/main/java/com/taobao/arthas/core/command/monitor200/LookAdviceListener.java
@@ -1,0 +1,112 @@
+package com.taobao.arthas.core.command.monitor200;
+
+import com.alibaba.arthas.deps.org.slf4j.Logger;
+import com.alibaba.arthas.deps.org.slf4j.LoggerFactory;
+import com.taobao.arthas.core.advisor.AccessPoint;
+import com.taobao.arthas.core.advisor.Advice;
+import com.taobao.arthas.core.advisor.AdviceListenerAdapter;
+import com.taobao.arthas.core.advisor.ArthasMethod;
+import com.taobao.arthas.core.command.express.ExpressException;
+import com.taobao.arthas.core.command.express.ExpressFactory;
+import com.taobao.arthas.core.command.model.LookModel;
+import com.taobao.arthas.core.command.model.ObjectVO;
+import com.taobao.arthas.core.command.model.WatchModel;
+import com.taobao.arthas.core.shell.command.CommandProcess;
+import com.taobao.arthas.core.util.Constants;
+import com.taobao.arthas.core.util.LogUtil;
+import com.taobao.arthas.core.util.StringUtils;
+import com.taobao.arthas.core.util.ThreadLocalWatch;
+
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
+
+class LookAdviceListener extends AdviceListenerAdapter {
+
+    private static final Logger logger = LoggerFactory.getLogger(LookAdviceListener.class);
+    private LookCommand command;
+    private CommandProcess process;
+
+    public LookAdviceListener(LookCommand command, CommandProcess process, boolean verbose) {
+        this.command = command;
+        this.process = process;
+        super.setVerbose(verbose);
+    }
+
+    @Override
+    public void before(ClassLoader loader, Class<?> clazz, ArthasMethod method, Object target, Object[] args)
+            throws Throwable {
+
+    }
+
+    @Override
+    public void afterReturning(ClassLoader loader, Class<?> clazz, ArthasMethod method, Object target, Object[] args,
+                               Object returnObject) throws Throwable {
+
+    }
+
+    @Override
+    public void afterThrowing(ClassLoader loader, Class<?> clazz, ArthasMethod method, Object target, Object[] args,
+                              Throwable throwable) {
+
+    }
+
+    @Override
+    public void beforeLine(ClassLoader loader, Class<?> clazz, ArthasMethod method, Object target, Object[] args, int line, Object[] vars, String[] varNames) throws Throwable {
+        try {
+
+            Map<String,Object> varMap = new HashMap<String,Object>(vars.length);
+            for (int i = 0; i < vars.length; i++) {
+                //不放入this
+                if ("this".equals(varNames[i]))continue;
+                varMap.put(varNames[i],vars[i]);
+            }
+
+            Advice advice = Advice.newForLooking(loader,clazz,method,target,args,varMap);
+            boolean conditionResult = isConditionMet(command.getConditionExpress(), advice);
+            if (this.isVerbose()) {
+                process.write("Condition express: " + command.getConditionExpress() + " , result: " + conditionResult + "\n");
+            }
+            if (conditionResult) {
+                Object value = getExpressionResult(command.getExpress(), advice);
+
+                LookModel model = new LookModel();
+                model.setTs(new Date());
+                model.setValue(new ObjectVO(value, command.getExpand()));
+                model.setSizeLimit(command.getSizeLimit());
+                model.setClassName(advice.getClazz().getName());
+                model.setMethodName(advice.getMethod().getName());
+                model.setAccessPoint(AccessPoint.ACCESS_BEFORE_LINE.getKey() + ":" + line);
+
+                process.appendResult(model);
+                process.times().incrementAndGet();
+                if (isLimitExceeded(command.getNumberOfLimit(), process.times().get())) {
+                    abortProcess(process, command.getNumberOfLimit());
+                }
+            }
+        } catch (Throwable e) {
+            logger.warn("look failed.", e);
+            process.end(-1, "look failed, condition is: " + command.getConditionExpress() + ", express is: "
+                    + command.getExpress() + ", " + e.getMessage() + ", visit " + LogUtil.loggingFile()
+                    + " for more details.");
+        }
+    }
+
+    boolean isConditionMet(String conditionExpress, Advice advice) throws ExpressException {
+        return StringUtils.isEmpty(conditionExpress)
+                || ExpressFactory.threadLocalExpress(advice).is(conditionExpress);
+
+    }
+
+    Object getExpressionResult(String express, Advice advice) throws ExpressException {
+        return ExpressFactory.threadLocalExpress(advice).get(express);
+    }
+
+    public LookCommand getCommand() {
+        return command;
+    }
+
+    public void setCommand(LookCommand command) {
+        this.command = command;
+    }
+}

--- a/core/src/main/java/com/taobao/arthas/core/command/monitor200/LookCommand.java
+++ b/core/src/main/java/com/taobao/arthas/core/command/monitor200/LookCommand.java
@@ -1,0 +1,176 @@
+package com.taobao.arthas.core.command.monitor200;
+
+import com.taobao.arthas.core.GlobalOptions;
+import com.taobao.arthas.core.advisor.AdviceListener;
+import com.taobao.arthas.core.command.Constants;
+import com.taobao.arthas.core.shell.cli.Completion;
+import com.taobao.arthas.core.shell.cli.CompletionUtils;
+import com.taobao.arthas.core.shell.command.CommandProcess;
+import com.taobao.arthas.core.util.SearchUtils;
+import com.taobao.arthas.core.util.matcher.Matcher;
+import com.taobao.arthas.core.view.ObjectView;
+import com.taobao.middleware.cli.annotations.*;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+@Name("look")
+@Summary("Display the local variables, input parameter before specified line number")
+@Description(
+        "  The express may be one of the following expression:\n" +
+        "               target : the object\n" +
+        "                clazz : the object's class\n" +
+        "               method : the constructor or method\n" +
+        "               params : the parameters array of method\n" +
+        "         params[0..n] : the element of parameters array\n" +
+        "               varMap : the local variables map\n" +
+        "  varMap[\"varName\"] : the local variable value of varName\n" +
+        "\nExamples:\n" +
+        "  look com.seewo.xxx.controller.StateController getState -1 \n"+
+        "  look com.seewo.xxx.controller.StateController getState 35 \n"+
+        "  look com.seewo.xxx.controller.StateController getState 35 'varMap' \n"+
+        "  look com.seewo.xxx.controller.StateController getState 35 'varMap'  'varMap[\"varName\"].equals(\"12345678\")' -n 1\n"+
+        "  look *StateController getState 35 '{params,varMap}'  \n"+
+        "  look OuterClass$InnerClass getState 128 '{params,varMap}'  \n"+
+        Constants.WIKI + Constants.WIKI_HOME + "look")
+
+public class LookCommand extends EnhancerCommand {
+
+    private String classPattern;
+    private String methodPattern;
+    private String express;
+    private Integer lineNum;
+    private String conditionExpress;
+    private Integer expand = 1;
+    private Integer sizeLimit = 10 * 1024 * 1024;
+    private boolean isRegEx = false;
+    private int numberOfLimit = 100;
+    
+    @Argument(index = 0, argName = "class-pattern")
+    @Description("The full qualified class name you want to watch")
+    public void setClassPattern(String classPattern) {
+        this.classPattern = classPattern;
+    }
+
+    @Argument(index = 1, argName = "method-pattern")
+    @Description("The method name you want to watch")
+    public void setMethodPattern(String methodPattern) {
+        this.methodPattern = methodPattern;
+    }
+
+    @Argument(index = 2, argName = "lineNum")
+    @Description("The line number will be look before. -1 as method exit")
+    public void setLineNum(Integer lineNum) {
+        this.lineNum = lineNum;
+    }
+
+    @Argument(index = 3, argName = "express", required = false)
+    @DefaultValue("varMap")
+    @Description("The content you want to watch, written by ognl. Default value is 'varMap'\n")
+    public void setExpress(String express) {
+        this.express = express;
+    }
+
+    @Argument(index = 4, argName = "condition-express", required = false)
+    @Description(Constants.LOOK_CONDITION_EXPRESS)
+    public void setConditionExpress(String conditionExpress) {
+        this.conditionExpress = conditionExpress;
+    }
+
+    @Option(shortName = "M", longName = "sizeLimit")
+    @Description("Upper size limit in bytes for the result (10 * 1024 * 1024 by default)")
+    public void setSizeLimit(Integer sizeLimit) {
+        this.sizeLimit = sizeLimit;
+    }
+
+    @Option(shortName = "x", longName = "expand")
+    @Description("Expand level of object (1 by default), the max value is " + ObjectView.MAX_DEEP)
+    public void setExpand(Integer expand) {
+        this.expand = expand;
+    }
+
+    @Option(shortName = "E", longName = "regex", flag = true)
+    @Description("Enable regular expression to match (wildcard matching by default)")
+    public void setRegEx(boolean regEx) {
+        isRegEx = regEx;
+    }
+
+    @Option(shortName = "n", longName = "limits")
+    @Description("Threshold of execution times")
+    public void setNumberOfLimit(int numberOfLimit) {
+        this.numberOfLimit = numberOfLimit;
+    }
+
+    public String getClassPattern() {
+        return classPattern;
+    }
+    public String getMethodPattern() {
+        return methodPattern;
+    }
+
+    public String getExpress() {
+        return express;
+    }
+
+    public String getConditionExpress() {
+        return conditionExpress;
+    }
+
+    public Integer getExpand() {
+        return expand;
+    }
+
+    public Integer getSizeLimit() {
+        return sizeLimit;
+    }
+
+    public boolean isRegEx() {
+        return isRegEx;
+    }
+
+    public int getNumberOfLimit() {
+        return numberOfLimit;
+    }
+
+    public Integer getLineNum() {
+        return lineNum;
+    }
+
+    @Override
+    protected Matcher getClassNameMatcher() {
+        if (classNameMatcher == null) {
+            classNameMatcher = SearchUtils.classNameMatcher(getClassPattern(), isRegEx());
+        }
+        return classNameMatcher;
+    }
+
+    @Override
+    protected Matcher getClassNameExcludeMatcher() {
+        if (classNameExcludeMatcher == null && getExcludeClassPattern() != null) {
+            classNameExcludeMatcher = SearchUtils.classNameMatcher(getExcludeClassPattern(), isRegEx());
+        }
+        return classNameExcludeMatcher;
+    }
+
+    @Override
+    protected Matcher getMethodNameMatcher() {
+        if (methodNameMatcher == null) {
+            methodNameMatcher = SearchUtils.classNameMatcher(getMethodPattern(), isRegEx());
+        }
+        return methodNameMatcher;
+    }
+
+    @Override
+    protected AdviceListener getAdviceListener(CommandProcess process) {
+        return new LookAdviceListener(this, process, GlobalOptions.verbose || this.verbose);
+    }
+
+    /**
+     * 命令补齐
+     */
+    @Override
+    protected void completeArgument3(Completion completion) {
+        CompletionUtils.complete(completion, Arrays.asList(LOOK_EXPRESS_EXAMPLES));
+    }
+}

--- a/core/src/main/java/com/taobao/arthas/core/command/view/LookView.java
+++ b/core/src/main/java/com/taobao/arthas/core/command/view/LookView.java
@@ -1,0 +1,25 @@
+package com.taobao.arthas.core.command.view;
+
+import com.taobao.arthas.core.command.model.LookModel;
+import com.taobao.arthas.core.command.model.ObjectVO;
+import com.taobao.arthas.core.command.model.WatchModel;
+import com.taobao.arthas.core.shell.command.CommandProcess;
+import com.taobao.arthas.core.util.DateUtils;
+import com.taobao.arthas.core.util.StringUtils;
+import com.taobao.arthas.core.view.ObjectView;
+
+/**
+ * Term view for LookModel
+ *
+ */
+public class LookView extends ResultView<LookModel> {
+
+    @Override
+    public void draw(CommandProcess process, LookModel model) {
+        ObjectVO objectVO = model.getValue();
+        String result = StringUtils.objectToString(
+                objectVO.needExpand() ? new ObjectView(model.getSizeLimit(), objectVO).draw() : objectVO.getObject());
+        process.write("method=" + model.getClassName() + "." + model.getMethodName() + " location=" + model.getAccessPoint() + "\n");
+        process.write("ts=" + DateUtils.formatDate(model.getTs()) + "; result=" + result + "\n");
+    }
+}

--- a/core/src/main/java/com/taobao/arthas/core/command/view/ResultViewResolver.java
+++ b/core/src/main/java/com/taobao/arthas/core/command/view/ResultViewResolver.java
@@ -81,6 +81,9 @@ public class ResultViewResolver {
             registerView(VmToolView.class);
             registerView(JFRView.class);
 
+            //look
+            registerView(LookView.class);
+
         } catch (Throwable e) {
             logger.error("register result view failed", e);
         }

--- a/pom.xml
+++ b/pom.xml
@@ -94,7 +94,7 @@
             <dependency>
                 <groupId>com.alibaba</groupId>
                 <artifactId>bytekit-core</artifactId>
-                <version>0.0.7</version>
+                <version>0.0.8-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>org.benf</groupId>

--- a/spy/src/main/java/java/arthas/SpyAPI.java
+++ b/spy/src/main/java/java/arthas/SpyAPI.java
@@ -64,6 +64,10 @@ public class SpyAPI {
         spyInstance.atExit(clazz, methodInfo, target, args, returnObject);
     }
 
+    public static void atLineBefore(Class<?> clazz, String methodInfo, Object target, Object[] args, int line, Object[] vars, String[] varNames) {
+        spyInstance.atLineBefore(clazz, methodInfo, target, args, line, vars, varNames);
+    }
+
     public static void atExceptionExit(Class<?> clazz, String methodInfo, Object target,
             Object[] args, Throwable throwable) {
         spyInstance.atExceptionExit(clazz, methodInfo, target, args, throwable);
@@ -88,6 +92,9 @@ public class SpyAPI {
         public abstract void atExit(Class<?> clazz, String methodInfo, Object target, Object[] args,
                 Object returnObject);
 
+        public abstract void atLineBefore(Class<?> clazz, String methodInfo, Object target, Object[] args,
+                                          int line, Object[] vars, String[] varNames);
+
         public abstract void atExceptionExit(Class<?> clazz, String methodInfo, Object target,
                 Object[] args, Throwable throwable);
 
@@ -107,6 +114,11 @@ public class SpyAPI {
         @Override
         public void atExit(Class<?> clazz, String methodInfo, Object target, Object[] args,
                 Object returnObject) {
+        }
+
+        @Override
+        public void atLineBefore(Class<?> clazz, String methodInfo, Object target, Object[] args, int line, Object[] vars, String[] varNames) {
+
         }
 
         @Override


### PR DESCRIPTION
第二次提交PR,有描述不清楚的地方还请见谅并沟通,thanks

### 为什么要做这个呢?
- 协助快速定位排查数据问题
- 有看到isuues里边也有一些小伙伴提到这个

### 为什么要定义新的命令?
- 跟观测非常契合的命令是`watch`,但是watch的对象是`method`,而我们观测`local variables`的时候,用`line number`来作为定位点是比较合适的,这样会导致`watch`的`listener`的`key`跟根据参数而有所差异,在处理注册监听时会比较麻烦
- 独立一个命令也能降低对旧命令的影响

### 实现思路?
- 定义新的`Advice`变量 `varMap`,类型是`HashMap`,key是变量名,value是变量值
- 插桩的位置是命令参数传入的目标行号之前,并使用-1来表示方法退出前的插桩点
- 行号插桩的实现依赖了bytekit,因为已有的`LineLocation`在本场景下会有重复插桩、多行插桩等问题,所以是定义了新的`BeforeLineLocation`
- 监听器的注册等也作了相应的区分处理

### 已经做的基本测试:
- 基础功能实现,能观测到定义的`local variables`,并能在`condition-express`中使用
- 重复插桩处理,增加了对应的`LocationFilter`,避免重复插桩
- 多监听的兼容支持
- 与`trace`及`watch`命令的同时使用的兼容处理

### 其它:
- 依赖了bytekit,已经提了PR:https://github.com/alibaba/bytekit/pull/27
- 这边打包好的版本(arthas-bin.zip): https://cstore-public.seewo.com/running-wechat-mp/6ca0fea2c11b4838827ffa64b753813e
- 我需要做其它的步骤嘛?

thanks again