### PR TITLE
Add -n command example to mbean commands

### DIFF
--- a/site/docs/en/doc/mbean.md
+++ b/site/docs/en/doc/mbean.md
@@ -66,3 +66,9 @@ Real-time monitoring using `-i` command:
 ```bash
 mbean -i 1000 java.lang:type=Threading *Count
 ```
+
+Real-time monitoring using `-i` with number of times the command will be executed using `-n` command (100 times by default):
+
+```bash
+mbean -i 1000 -n 50 java.lang:type=Threading *Count
+```


### PR DESCRIPTION
The current MD file only mentions the `n` command without giving an actual example. If people want to monitor mbeans for a long time it's unclear how to do it. The command in this commit shows an example on how to combine `-i` along with `'-n`