### PR TITLE
为使用Alpine Linux作为Docker基础镜像的Java应用提供profiler命令支持

### DIFF
--- a/.github/workflows/build-async-profiler.yml
+++ b/.github/workflows/build-async-profiler.yml
@@ -1,0 +1,100 @@
+name: build async-profiler
+
+on:
+  workflow_dispatch:
+
+jobs:
+  build-alpine-linux-x64:
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          repository: async-profiler/async-profiler
+          fetch-depth: 0
+      - run: |
+          LATEST_TAG=$(git describe --tags `git rev-list --tags --max-count=1`)
+          echo "Checkout tag $LATEST_TAG"
+          git checkout $LATEST_TAG
+
+      - name: Setup Alpine Linux x86-64 environment
+        uses: jirutka/setup-alpine@v1
+        with:
+          arch: x86_64
+          branch: v3.16
+          shell-name: alpine-x86_64.sh
+          packages: >
+            build-base linux-headers openjdk11
+      - name: Run script inside Alpine Linux x86-64 environment
+        run: |
+          JAVA_HOME=/usr/lib/jvm/java-11-openjdk
+          java -version
+          sed -i 's/CXXFLAGS=/CXXFLAGS=-static-libgcc -static-libstdc++ /' Makefile && make
+          file build/lib/libasyncProfiler.so
+          ldd build/lib/libasyncProfiler.so
+          cp build/lib/libasyncProfiler.so libasyncProfiler-linux-musl-x64.so
+        shell: alpine-x86_64.sh {0}
+      - uses: actions/upload-artifact@v3
+        with:
+          name: async-profiler
+          path: libasyncProfiler-linux-musl-x64.so
+          if-no-files-found: error
+
+  build-alpine-linux-arm64:
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          repository: async-profiler/async-profiler
+          fetch-depth: 0
+      - run: |
+          LATEST_TAG=$(git describe --tags `git rev-list --tags --max-count=1`)
+          echo "Checkout tag $LATEST_TAG"
+          git checkout $LATEST_TAG
+      - name: Setup Alpine Linux aarch64 environment
+        uses: jirutka/setup-alpine@v1
+        with:
+          arch: aarch64
+          branch: v3.16
+          shell-name: alpine-aarch64.sh
+          packages: >
+            build-base linux-headers openjdk11
+      - name: Run script inside Alpine Linux aarch64 environment
+        run: |
+          JAVA_HOME=/usr/lib/jvm/java-11-openjdk
+          java -version
+          sed -i 's/CXXFLAGS=/CXXFLAGS=-static-libgcc -static-libstdc++ /' Makefile && make
+          file build/lib/libasyncProfiler.so
+          ldd build/lib/libasyncProfiler.so
+          cp build/lib/libasyncProfiler.so libasyncProfiler-linux-musl-arm64.so
+        shell: alpine-aarch64.sh {0}
+      - uses: actions/upload-artifact@v3
+        with:
+          name: async-profiler
+          path: libasyncProfiler-linux-musl-arm64.so
+          if-no-files-found: error
+
+  upload-libasyncProfiler-files:
+    runs-on: ubuntu-20.04
+    needs: [build-alpine-linux-x64, build-alpine-linux-arm64]
+    steps:
+      - name: Checkout arthas upstream repo
+        uses: actions/checkout@v3
+      - uses: actions/download-artifact@v3
+        with:
+          name: async-profiler
+          path: tmp-async-profiler
+      - name: Display structure of downloaded files
+        run: ls -R
+        working-directory: tmp-async-profiler
+      - name: Commit and Push libasyncProfiler files
+        run: |
+          git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git config --local user.name "github-actions[bot]"
+          mv tmp-async-profiler/* async-profiler/
+          git add async-profiler/
+          git commit -m "Upload arthas async-profiler lib for Alpine Linux"
+      - name: Push changes
+        uses: ad-m/github-push-action@master
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          branch: ${{ github.ref }}

--- a/.github/workflows/build-async-profiler.yml
+++ b/.github/workflows/build-async-profiler.yml
@@ -2,36 +2,182 @@ name: build async-profiler
 
 on:
   workflow_dispatch:
+    inputs:
+      async-profiler-tag-name:
+        description: 'Enter the async-profiler tag name in https://github.com/async-profiler/async-profiler/tags(e.g. v2.9) please.'
+        type: string
+        required: true
 
 jobs:
-  build-alpine-linux-x64:
-    runs-on: ubuntu-20.04
+  build-mac:
+    runs-on: macos-12
+    if: ${{ inputs.async-profiler-tag-name }} 
     steps:
+      # 检出 async-profiler/async-profiler 项目指定的 tag
       - uses: actions/checkout@v3
         with:
           repository: async-profiler/async-profiler
           fetch-depth: 0
-      - run: |
-          LATEST_TAG=$(git describe --tags `git rev-list --tags --max-count=1`)
-          echo "Checkout tag $LATEST_TAG"
-          git checkout $LATEST_TAG
-
+      - name: Checkout the async-profiler repository by input tag name ${{ inputs.async-profiler-tag-name }}
+        run: git checkout ${{ inputs.async-profiler-tag-name }}
+      # 安装 Liberica JDK 11
+      - uses: actions/setup-java@v3
+        with:
+          distribution: "liberica"
+          java-version: "11"
+      # 从 async-profiler 源码编译出 libasyncProfiler-mac.so(兼容 arthas-core 中 ProfilerCommand.java 固定的 so 文件名称未使用 libasyncProfiler.dylib)
+      # grep -m1 PROFILER_VERSION Makefile 用于输出 async-profiler 版本, 下同
+      - name: Execute compile inside macOS 12 environment
+        run: |
+          grep -m1 PROFILER_VERSION Makefile
+          echo "JAVA_HOME=${JAVA_HOME}"
+          java -version
+          echo "FAT_BINARY variable that make libasyncProfiler-mac.so works both on macOS x86-64 and arm64"
+          make FAT_BINARY=true
+          LIB_PROFILER_PATH=$(find build -type f \( -name libasyncProfiler.so -o -name libasyncProfiler.dylib \) 2>/dev/null)
+          [ -z "${LIB_PROFILER_PATH}" ] && echo "Can not find libasyncProfiler.so or libasyncProfiler.dylib file under build directory." && exit 1
+          echo "LIB_PROFILER_PATH=${LIB_PROFILER_PATH}"
+          file ${LIB_PROFILER_PATH}
+          otool -L ${LIB_PROFILER_PATH}
+          cp ${LIB_PROFILER_PATH} libasyncProfiler-mac.so
+      # 暂存编译出来的 libasyncProfiler-mac.so 文件
+      - uses: actions/upload-artifact@v3
+        with:
+          name: async-profiler
+          path: libasyncProfiler-mac.so
+          if-no-files-found: error
+  
+  build-generic-linux-x64:
+    runs-on: ubuntu-20.04
+    if: ${{ inputs.async-profiler-tag-name }}
+    steps:
+      # 检出 async-profiler/async-profiler 项目指定的 tag
+      - uses: actions/checkout@v3
+        with:
+          repository: async-profiler/async-profiler
+          fetch-depth: 0
+      - name: Checkout the async-profiler repository by input tag name ${{ inputs.async-profiler-tag-name }}
+        run: git checkout ${{ inputs.async-profiler-tag-name }}
+      # 从 async-profiler 源码编译出适用于 glibc-based Linux 主机的 libasyncProfiler-linux-x64.so
+      - name: Execute compile inside CentOS 6 x86_64 docker container environment
+        uses: uraimo/run-on-arch-action@v2
+        with:
+          arch: none
+          distro: none
+          base_image: amd64/centos:6.10
+          run: |
+            cat /etc/system-release
+            uname -m
+            minorver=6.10
+            sed -e "s|^mirrorlist=|#mirrorlist=|g" \
+            -e "s|^#baseurl=http://mirror.centos.org/centos/\$releasever|baseurl=https://mirrors.aliyun.com/centos-vault/$minorver|g" \
+            -i.bak /etc/yum.repos.d/CentOS-*.repo
+            yum -y update && yum install -y wget
+            wget --no-check-certificate https://people.centos.org/tru/devtools-1.1/devtools-1.1.repo -O /etc/yum.repos.d/devtools-1.1.repo
+            yum install -y devtoolset-1.1-gcc devtoolset-1.1-gcc-c++ devtoolset-1.1-binutils
+            export CC=/opt/centos/devtoolset-1.1/root/usr/bin/gcc
+            export CPP=/opt/centos/devtoolset-1.1/root/usr/bin/cpp
+            export CXX=/opt/centos/devtoolset-1.1/root/usr/bin/c++
+            ln -sf /opt/centos/devtoolset-1.1/root/usr/bin/* /usr/local/bin/
+            hash -r
+            wget https://download.java.net/java/GA/jdk11/9/GPL/openjdk-11.0.2_linux-x64_bin.tar.gz -O openjdk-11.tar.gz
+            tar zxf openjdk-11.tar.gz
+            mv jdk-11.0.2 /usr/local/
+            export JAVA_HOME=/usr/local/jdk-11.0.2
+            export PATH=${JAVA_HOME}/bin:${PATH}
+            java -version
+            which java
+            grep -m1 PROFILER_VERSION Makefile
+            make
+            LIB_PROFILER_PATH=$(find build -type f -name libasyncProfiler.so 2>/dev/null)
+            [ -z "${LIB_PROFILER_PATH}" ] && echo "Can not find libasyncProfiler.so file under build directory." && exit 1
+            echo "LIB_PROFILER_PATH=${LIB_PROFILER_PATH}"
+            file ${LIB_PROFILER_PATH}
+            ldd ${LIB_PROFILER_PATH}
+            cp ${LIB_PROFILER_PATH} libasyncProfiler-linux-x64.so
+      # 暂存编译出来的 libasyncProfiler-linux-x64.so 文件
+      - uses: actions/upload-artifact@v3
+        with:
+          name: async-profiler
+          path: libasyncProfiler-linux-x64.so
+          if-no-files-found: error
+          
+  build-generic-linux-arm64:
+    runs-on: ubuntu-20.04
+    if: ${{ inputs.async-profiler-tag-name }}
+    steps:
+      # 检出 async-profiler/async-profiler 项目指定的 tag
+      - uses: actions/checkout@v3
+        with:
+          repository: async-profiler/async-profiler
+          fetch-depth: 0
+      - name: Checkout the async-profiler repository by input tag name ${{ inputs.async-profiler-tag-name }}
+        run: git checkout ${{ inputs.async-profiler-tag-name }}
+      # 从 async-profiler 源码编译出适用于 glibc-based Linux 主机的 libasyncProfiler-linux-arm64.so
+      - name: Execute compile inside CentOS 7 aarch64 docker container environment via QEMU
+        uses: uraimo/run-on-arch-action@v2
+        with:
+          arch: none
+          distro: none
+          base_image: arm64v8/centos:7
+          run: |
+            cat /etc/system-release
+            uname -m
+            yum -y update && yum install -y java-11-openjdk-devel gcc-c++ make which file
+            JAVA_HOME=/usr/lib/jvm/java-11-openjdk
+            java -version
+            which java
+            grep -m1 PROFILER_VERSION Makefile
+            make
+            LIB_PROFILER_PATH=$(find build -type f -name libasyncProfiler.so 2>/dev/null)
+            [ -z "${LIB_PROFILER_PATH}" ] && echo "Can not find libasyncProfiler.so file under build directory." && exit 1
+            echo "LIB_PROFILER_PATH=${LIB_PROFILER_PATH}"
+            file ${LIB_PROFILER_PATH}
+            ldd ${LIB_PROFILER_PATH}
+            cp ${LIB_PROFILER_PATH} libasyncProfiler-linux-arm64.so
+      # 暂存编译出来的 libasyncProfiler-linux-arm64.so 文件
+      - uses: actions/upload-artifact@v3
+        with:
+          name: async-profiler
+          path: libasyncProfiler-linux-arm64.so
+          if-no-files-found: error
+        
+          
+  build-alpine-linux-x64:
+    runs-on: ubuntu-20.04
+    if: ${{ inputs.async-profiler-tag-name }}
+    steps:
+      # 检出 async-profiler/async-profiler 项目指定的 tag
+      - uses: actions/checkout@v3
+        with:
+          repository: async-profiler/async-profiler
+          fetch-depth: 0
+      - name: Checkout the async-profiler repository by input tag name ${{ inputs.async-profiler-tag-name }}
+        run: git checkout ${{ inputs.async-profiler-tag-name }}
       - name: Setup Alpine Linux x86-64 environment
         uses: jirutka/setup-alpine@v1
         with:
           arch: x86_64
-          branch: v3.16
+          branch: v3.15
           shell-name: alpine-x86_64.sh
           packages: >
             build-base linux-headers openjdk11
+      # 从 async-profiler 源码编译出适用于 musl-based Linux 主机的 libasyncProfiler-linux-musl-x64.so
+      # grep -m1 PROFILER_VERSION Makefile 用于输出 async-profiler 版本, 下同
       - name: Run script inside Alpine Linux x86-64 environment
         run: |
+          grep -m1 PROFILER_VERSION Makefile
           JAVA_HOME=/usr/lib/jvm/java-11-openjdk
           java -version
+          which java
+          echo "Append -static-libgcc -static-libstdc++ options to CXXFLAGS for user no need to install libstdc++ and libgcc manually."
           sed -i 's/CXXFLAGS=/CXXFLAGS=-static-libgcc -static-libstdc++ /' Makefile && make
-          file build/lib/libasyncProfiler.so
-          ldd build/lib/libasyncProfiler.so
-          cp build/lib/libasyncProfiler.so libasyncProfiler-linux-musl-x64.so
+          LIB_PROFILER_PATH=$(find build -type f -name libasyncProfiler.so 2>/dev/null)
+          [ -z "${LIB_PROFILER_PATH}" ] && echo "Can not find libasyncProfiler.so file under build directory." && exit 1
+          echo "LIB_PROFILER_PATH=${LIB_PROFILER_PATH}"
+          file ${LIB_PROFILER_PATH}
+          ldd ${LIB_PROFILER_PATH}
+          cp ${LIB_PROFILER_PATH} libasyncProfiler-linux-musl-x64.so
         shell: alpine-x86_64.sh {0}
       - uses: actions/upload-artifact@v3
         with:
@@ -41,31 +187,39 @@ jobs:
 
   build-alpine-linux-arm64:
     runs-on: ubuntu-20.04
+    if: ${{ inputs.async-profiler-tag-name }}
     steps:
+      # 检出 async-profiler/async-profiler 项目指定的 tag
       - uses: actions/checkout@v3
         with:
           repository: async-profiler/async-profiler
           fetch-depth: 0
-      - run: |
-          LATEST_TAG=$(git describe --tags `git rev-list --tags --max-count=1`)
-          echo "Checkout tag $LATEST_TAG"
-          git checkout $LATEST_TAG
+      - name: Checkout the async-profiler repository by input tag name ${{ inputs.async-profiler-tag-name }}
+        run: git checkout ${{ inputs.async-profiler-tag-name }}
       - name: Setup Alpine Linux aarch64 environment
         uses: jirutka/setup-alpine@v1
         with:
           arch: aarch64
-          branch: v3.16
+          branch: v3.15
           shell-name: alpine-aarch64.sh
           packages: >
             build-base linux-headers openjdk11
+      # 从 async-profiler 源码编译出适用于 musl-based Linux 主机的 libasyncProfiler-linux-musl-arm64.so
+      # grep -m1 PROFILER_VERSION Makefile 用于输出 async-profiler 版本, 下同
       - name: Run script inside Alpine Linux aarch64 environment
         run: |
+          grep -m1 PROFILER_VERSION Makefile
           JAVA_HOME=/usr/lib/jvm/java-11-openjdk
           java -version
+          which java
+          echo "Append -static-libgcc -static-libstdc++ options to CXXFLAGS for user no need to install libstdc++ and libgcc manually."
           sed -i 's/CXXFLAGS=/CXXFLAGS=-static-libgcc -static-libstdc++ /' Makefile && make
-          file build/lib/libasyncProfiler.so
-          ldd build/lib/libasyncProfiler.so
-          cp build/lib/libasyncProfiler.so libasyncProfiler-linux-musl-arm64.so
+          LIB_PROFILER_PATH=$(find build -type f -name libasyncProfiler.so 2>/dev/null)
+          [ -z "${LIB_PROFILER_PATH}" ] && echo "Can not find libasyncProfiler.so file under build directory." && exit 1
+          echo "LIB_PROFILER_PATH=${LIB_PROFILER_PATH}"
+          file ${LIB_PROFILER_PATH}
+          ldd ${LIB_PROFILER_PATH}
+          cp ${LIB_PROFILER_PATH} libasyncProfiler-linux-musl-arm64.so
         shell: alpine-aarch64.sh {0}
       - uses: actions/upload-artifact@v3
         with:
@@ -75,26 +229,33 @@ jobs:
 
   upload-libasyncProfiler-files:
     runs-on: ubuntu-20.04
-    needs: [build-alpine-linux-x64, build-alpine-linux-arm64]
+    needs: [build-mac, build-generic-linux-x64, build-generic-linux-arm64, build-alpine-linux-x64, build-alpine-linux-arm64]
     steps:
+      # 检出当前 arthas 代码仓库
       - name: Checkout arthas upstream repo
         uses: actions/checkout@v3
+      # 将上面编译任务暂存的 libasyncProfiler 动态链接库文件上传到此工作流的 artifact 包中
       - uses: actions/download-artifact@v3
         with:
           name: async-profiler
           path: tmp-async-profiler
-      - name: Display structure of downloaded files
-        run: ls -R
+      # 查看上面编译任务暂存的 libasyncProfiler 动态链接库文件
+      - name: Modify permissions and Display structure of downloaded files
+        run: |
+          chmod 755 libasyncProfiler-*
+          ls -lrt
         working-directory: tmp-async-profiler
+      # 将编译好的 libasyncProfiler 动态链接库文件 push 到 arthas 代码仓库的 master 分支 async-profiler/ 目录下
       - name: Commit and Push libasyncProfiler files
         run: |
           git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git config --local user.name "github-actions[bot]"
           mv tmp-async-profiler/* async-profiler/
           git add async-profiler/
-          git commit -m "Upload arthas async-profiler lib for Alpine Linux"
+          git commit -m "Upload arthas async-profiler libs"
       - name: Push changes
         uses: ad-m/github-push-action@master
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           branch: ${{ github.ref }}
+          force: true

--- a/common/src/main/java/com/taobao/arthas/common/OSUtils.java
+++ b/common/src/main/java/com/taobao/arthas/common/OSUtils.java
@@ -1,5 +1,6 @@
 package com.taobao.arthas.common;
 
+import java.io.IOException;
 import java.util.Locale;
 
 /**
@@ -132,6 +133,22 @@ public class OSUtils {
 			return "s390_64";
 		}
 		return value;
+	}
+
+	public static boolean isMuslLibc() {
+		String commandStr = "ldd --version 2>&1 | head -1 | awk 'END{if($1==\"musl\") exit 200}'";
+		Process process = null;
+		try {
+			process = new ProcessBuilder("/bin/sh", "-c", commandStr).start();
+			process.waitFor();
+		} catch (InterruptedException e) {
+			throw new RuntimeException(e);
+		} catch (IOException e) {
+			throw new RuntimeException(e);
+		}
+
+		//仅在Linux系统中判断libc类型.
+		return isLinux() && 200 == process.exitValue();
 	}
 
 	private static String normalize(String value) {

--- a/common/src/main/java/com/taobao/arthas/common/OSUtils.java
+++ b/common/src/main/java/com/taobao/arthas/common/OSUtils.java
@@ -1,6 +1,6 @@
 package com.taobao.arthas.common;
 
-import java.io.IOException;
+import java.io.File;
 import java.util.Locale;
 
 /**
@@ -136,19 +136,14 @@ public class OSUtils {
 	}
 
 	public static boolean isMuslLibc() {
-		String commandStr = "ldd --version 2>&1 | head -1 | awk 'END{if($1==\"musl\") exit 200}'";
-		Process process = null;
-		try {
-			process = new ProcessBuilder("/bin/sh", "-c", commandStr).start();
-			process.waitFor();
-		} catch (InterruptedException e) {
-			throw new RuntimeException(e);
-		} catch (IOException e) {
-			throw new RuntimeException(e);
+		File ld_musl_x86_64_file = new File("/lib/ld-musl-x86_64.so.1");
+		File ld_musl_aarch64_file = new File("/lib/ld-musl-aarch64.so.1");
+
+		if(ld_musl_x86_64_file.exists() || ld_musl_aarch64_file.exists()){
+			return true;
 		}
 
-		//仅在Linux系统中判断libc类型.
-		return isLinux() && 200 == process.exitValue();
+		return false;
 	}
 
 	private static String normalize(String value) {

--- a/core/src/main/java/com/taobao/arthas/core/command/monitor200/ProfilerCommand.java
+++ b/core/src/main/java/com/taobao/arthas/core/command/monitor200/ProfilerCommand.java
@@ -129,8 +129,13 @@ public class ProfilerCommand extends AnnotatedCommand {
             profierSoPath = "async-profiler/libasyncProfiler-mac.so";
         }
         if (OSUtils.isLinux()) {
-            profierSoPath = "async-profiler/libasyncProfiler-linux-x64.so";
-            if (OSUtils.isArm64()) {
+            if (OSUtils.isX86_64() && OSUtils.isMuslLibc()) {
+                profierSoPath = "async-profiler/libasyncProfiler-linux-musl-amd64.so";
+            } else if(OSUtils.isX86_64()){
+                profierSoPath = "async-profiler/libasyncProfiler-linux-x64.so";
+            } else if (OSUtils.isArm64() && OSUtils.isMuslLibc()) {
+                profierSoPath = "async-profiler/libasyncProfiler-linux-musl-arm64.so";
+            } else if (OSUtils.isArm64()) {
                 profierSoPath = "async-profiler/libasyncProfiler-linux-arm64.so";
             }
         }

--- a/core/src/main/java/com/taobao/arthas/core/command/monitor200/ProfilerCommand.java
+++ b/core/src/main/java/com/taobao/arthas/core/command/monitor200/ProfilerCommand.java
@@ -130,7 +130,7 @@ public class ProfilerCommand extends AnnotatedCommand {
         }
         if (OSUtils.isLinux()) {
             if (OSUtils.isX86_64() && OSUtils.isMuslLibc()) {
-                profierSoPath = "async-profiler/libasyncProfiler-linux-musl-amd64.so";
+                profierSoPath = "async-profiler/libasyncProfiler-linux-musl-x64.so";
             } else if(OSUtils.isX86_64()){
                 profierSoPath = "async-profiler/libasyncProfiler-linux-x64.so";
             } else if (OSUtils.isArm64() && OSUtils.isMuslLibc()) {


### PR DESCRIPTION
### 问题背景
在 arthas cli 命令行，可使用 profiler 命令支持生成应用热点的火焰图，背后使用了 async-profiler 提供支持。在 Linux 环境下，async-profiler 默认只对 x86-64、aarch64 这两种操作系统架构提供了 glibc 版的动态链接库文件：
```txt
libasyncProfiler-linux-x64.so
libasyncProfiler-linux-arm64.so
```

但是在基于 musl libc 实现的 Alpine Linux 环境下，执行 profiler 命令会误加载到 libasyncProfiler-linux-x64.so 或者 libasyncProfiler-linux-arm64.so ，首先会提示缺少 libstdc++、libgcc 库文件，手工执行下面的命令安装后，再次执行 profiler 命令会造成应用 jvm 进程 crash :
hs_err_pid17.log
```log
Stack: [0x0000ffff60bf0000,0x0000ffff60dffac8],  sp=0x0000ffff60dfe520,  free space=2105k
Native frames: (J=compiled Java code, j=interpreted, Vv=VM code, C=native code)
C  [libstdc++.so.6+0x1683dc]
C  [libstdc++.so.6+0xd9b9c]  std::locale::operator=(std::locale const&)+0x54
C  [libstdc++.so.6+0xd9094]  std::ios_base::_M_init()+0x4c
C  [libstdc++.so.6+0x1153c0]  std::basic_ios<char, std::char_traits<char> >::init(std::basic_streambuf<char, std::char_traits<char> >*)+0x18
C  [ArthasJniLibrary5656461273075369895.tmp+0x273ac]  Symbols::parseLibraries(NativeCodeCache**, int volatile&, int, bool)+0xf4
C  [ArthasJniLibrary5656461273075369895.tmp+0x20208]  VM::ready()+0x28
C  [ArthasJniLibrary5656461273075369895.tmp+0x20c48]  VM::init(JavaVM_*, bool)+0x430
C  [ArthasJniLibrary5656461273075369895.tmp+0x210e0]  JNI_OnLoad+0x14
C  [libjava.so+0xecc4]  Java_java_lang_ClassLoader_00024NativeLibrary_load+0xb4
j  java.lang.ClassLoader$NativeLibrary.load(Ljava/lang/String;Z)V+0
j  java.lang.ClassLoader.loadLibrary0(Ljava/lang/Class;Ljava/io/File;)Z+328
j  java.lang.ClassLoader.loadLibrary(Ljava/lang/Class;Ljava/lang/String;Z)V+48
j  java.lang.Runtime.load0(Ljava/lang/Class;Ljava/lang/String;)V+57
j  java.lang.System.load(Ljava/lang/String;)V+7
j  one.profiler.AsyncProfiler.getInstance(Ljava/lang/String;)Lone/profiler/AsyncProfiler;+23
j  com.taobao.arthas.core.command.monitor200.ProfilerCommand.profilerInstance()Lone/profiler/AsyncProfiler;+165
j  com.taobao.arthas.core.command.monitor200.ProfilerCommand.process(Lcom/taobao/arthas/core/shell/command/CommandProcess;)V+43
j  com.taobao.arthas.core.shell.command.impl.AnnotatedCommandImpl.process(Lcom/taobao/arthas/core/shell/command/CommandProcess;)V+34
j  com.taobao.arthas.core.shell.command.impl.AnnotatedCommandImpl.access$100(Lcom/taobao/arthas/core/shell/command/impl/AnnotatedCommandImpl;Lcom/taobao/arthas/core/shell/command/CommandProcess;)V+2
j  com.taobao.arthas.core.shell.command.impl.AnnotatedCommandImpl$ProcessHandler.handle(Lcom/taobao/arthas/core/shell/command/CommandProcess;)V+5
j  com.taobao.arthas.core.shell.command.impl.AnnotatedCommandImpl$ProcessHandler.handle(Ljava/lang/Object;)V+5
j  com.taobao.arthas.core.shell.system.impl.ProcessImpl$CommandProcessTask.run()V+11
..........................
.............
```

然后在 Alpine Linux 环境下查看基于 Alpine Linux 环境手工编译的 libasyncProfiler 和原始的基于 glibc + xxx Linux 环境编译的 libasyncProfiler，可以看到如下区别：
![image](https://user-images.githubusercontent.com/4214030/233587566-d3938308-4684-41af-a9ae-cc9691f1b92d.png)

我提了一个 issue [#741](https://github.com/async-profiler/async-profiler/issues/741)给 async-profiler ，async-profiler 的开发者建议我根据需要自行编译 libasyncProfiler

考虑到在 K8s 集群环境下，使用 Alpine Linux 作为 Java 应用基础镜像的用户比较多，所以这里考虑增加对 Alpine Linux x86-64 和 aarch64 这两种操作系统环境下使用 profiler 进行支持。

### 主要改动代码
基于 async-profiler 源码和Alpine Linux x86-64 和 aarch64 这两种操作系统的 docker 镜像构建环境打包  libasyncProfiler so
```Dockerfile
FROM --platform=$TARGETPLATFORM base-registry.cn-hangzhou.cr.aliyuncs.com/cnstack/alpine-linux-gcc-builder-env:gcc-openjdk11

ARG TARGETOS
ARG TARGETARCH
ARG OSS_ENDPOINT
ARG ALIYUN_USER_AK
ARG ALIYUN_USER_SK

WORKDIR /root

RUN wget https://github.com/async-profiler/async-profiler/archive/refs/tags/v2.9.tar.gz -O async-profiler-2.9.tar.gz && \
    tar zxvf async-profiler-2.9.tar.gz && cd async-profiler-2.9 && \
    sed -i 's/CXXFLAGS=/CXXFLAGS=-static-libgcc -static-libstdc++ /' Makefile && make && \
    curl https://gosspublic.alicdn.com/ossutil/install.sh | bash && \
    ossutil -e ${OSS_ENDPOINT} -i ${ALIYUN_USER_AK} -k ${ALIYUN_USER_SK} \
    cp build/libasyncProfiler.so oss://async-profiler/alpine/libasyncProfiler-${TARGETOS}-musl-${TARGETARCH}.so -u
```

Note: 这里默认将 libstdc++ 和 libgcc 作为静态依赖打进 libasyncProfiler so 文件，使客户在 Alpine Linux 环境下为了使用 arthas 的 profiler 命令时，不再需要单独安装 libstdc++ 和 libgcc.

生成的两个 libasyncProfiler so 文件：
[libasyncProfiler-linux-musl-amd64.so](http://async-profiler.oss-cn-hangzhou.aliyuncs.com/alpine/libasyncProfiler-linux-musl-amd64.so)
[libasyncProfiler-linux-musl-arm64.so](http://async-profiler.oss-cn-hangzhou.aliyuncs.com/alpine/libasyncProfiler-linux-musl-arm64.so)

libasyncProfiler so 文件加载入口处代码：
core/src/main/java/com/taobao/arthas/core/command/monitor200/ProfilerCommand.java
```java
if (OSUtils.isLinux()) {
    if (OSUtils.isX86_64() && OSUtils.isMuslLibc()) {
       profierSoPath = "async-profiler/libasyncProfiler-linux-musl-amd64.so";
    } else if(OSUtils.isX86_64()){
        profierSoPath = "async-profiler/libasyncProfiler-linux-x64.so";
    } else if (OSUtils.isArm64() && OSUtils.isMuslLibc()) {
       profierSoPath = "async-profiler/libasyncProfiler-linux-musl-arm64.so";
    } else if (OSUtils.isArm64()) {
       profierSoPath = "async-profiler/libasyncProfiler-linux-arm64.so";
    }
}
```

### 测试情况
![image](https://user-images.githubusercontent.com/4214030/233592853-ec1e61ab-50ab-4c20-a43f-0667db58954e.png)

![image](https://user-images.githubusercontent.com/4214030/233592907-452067f3-75e4-4221-b697-677335c455ae.png)

![image](https://user-images.githubusercontent.com/4214030/233593019-2359e197-1ad6-49ea-a34b-55b89162790e.png)

![image](https://user-images.githubusercontent.com/4214030/233593112-c5b26bf8-4b2a-40f2-b200-df184f4b7a16.png)



