### PR TITLE
动态trace追加跟踪方法后自动结束命令

### DIFF
--- a/core/src/main/java/com/taobao/arthas/core/command/monitor200/EnhancerCommand.java
+++ b/core/src/main/java/com/taobao/arthas/core/command/monitor200/EnhancerCommand.java
@@ -215,6 +215,11 @@ public abstract class EnhancerCommand extends AnnotatedCommand {
 
             process.appendResult(new EnhancerModel(effect, true));
 
+            // 追加trace方法后，终止命令
+            if (listener.id() == listenerId) {
+                process.end(0, "Enhance classes with specified advice listener successfully.");
+            }
+
             //异步执行，在AdviceListener中结束
         } catch (Throwable e) {
             String msg = "error happens when enhancing class: "+e.getMessage();


### PR DESCRIPTION
新终端窗口执行动态trace追加跟踪方法后，可以结束命令，不影响执行效果。