### PR TITLE
fix: agent-attach携带的arthasHome参数未生效

### DIFF
--- a/arthas-agent-attach/src/main/java/com/taobao/arthas/agent/attach/ArthasAgent.java
+++ b/arthas-agent-attach/src/main/java/com/taobao/arthas/agent/attach/ArthasAgent.java
@@ -71,7 +71,7 @@ public class ArthasAgent {
      * @param arthasHome arthas directory
      */
     public static void attach(String arthasHome) {
-        new ArthasAgent().init();
+        new ArthasAgent(arthasHome).init();
     }
 
     public void init() throws IllegalStateException {


### PR DESCRIPTION
非springboot工程使用代码方式启动agent时如果要手动指定arthasHome无法生效，看了下是参数没传。