### PR TITLE
Async profiler api upgrade

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,6 @@ pom.xml.versionsBackup
 **/.flattened-pom.xml
 **/.idea/**
 **/cmake-build-debug/**
+
+# VSCode
+.vscode/

--- a/core/src/main/java/one/profiler/AsyncProfiler.java
+++ b/core/src/main/java/one/profiler/AsyncProfiler.java
@@ -16,7 +16,10 @@
 
 package one.profiler;
 
+import java.io.File;
+import java.io.FileOutputStream;
 import java.io.IOException;
+import java.io.InputStream;
 
 /**
  * Java API for in-process profiling. Serves as a wrapper around
@@ -39,20 +42,85 @@ public class AsyncProfiler implements AsyncProfilerMXBean {
             return instance;
         }
 
-        if (libPath == null) {
-            System.loadLibrary("asyncProfiler");
-        } else {
+        AsyncProfiler profiler = new AsyncProfiler();
+        if (libPath != null) {
             System.load(libPath);
+        } else {
+            try {
+                // No need to load library, if it has been preloaded with -agentpath
+                profiler.getVersion();
+            } catch (UnsatisfiedLinkError e) {
+                File file = extractEmbeddedLib();
+                if (file != null) {
+                    try {
+                        System.load(file.getPath());
+                    } finally {
+                        file.delete();
+                    }
+                } else {
+                    System.loadLibrary("asyncProfiler");
+                }
+            }
         }
 
-        instance = new AsyncProfiler();
-        return instance;
+        instance = profiler;
+        return profiler;
+    }
+
+    private static File extractEmbeddedLib() {
+        String resourceName = "/" + getPlatformTag() + "/libasyncProfiler.so";
+        InputStream in = AsyncProfiler.class.getResourceAsStream(resourceName);
+        if (in == null) {
+            return null;
+        }
+
+        try {
+            String extractPath = System.getProperty("one.profiler.extractPath");
+            File file = File.createTempFile("libasyncProfiler-", ".so",
+                    extractPath == null || extractPath.isEmpty() ? null : new File(extractPath));
+            try (FileOutputStream out = new FileOutputStream(file)) {
+                byte[] buf = new byte[32000];
+                for (int bytes; (bytes = in.read(buf)) >= 0; ) {
+                    out.write(buf, 0, bytes);
+                }
+            }
+            return file;
+        } catch (IOException e) {
+            throw new IllegalStateException(e);
+        } finally {
+            try {
+                in.close();
+            } catch (IOException e) {
+                // ignore
+            }
+        }
+    }
+
+    private static String getPlatformTag() {
+        String os = System.getProperty("os.name").toLowerCase();
+        String arch = System.getProperty("os.arch").toLowerCase();
+        if (os.contains("linux")) {
+            if (arch.equals("amd64") || arch.equals("x86_64") || arch.contains("x64")) {
+                return "linux-x64";
+            } else if (arch.equals("aarch64") || arch.contains("arm64")) {
+                return "linux-arm64";
+            } else if (arch.equals("aarch32") || arch.contains("arm")) {
+                return "linux-arm32";
+            } else if (arch.contains("86")) {
+                return "linux-x86";
+            } else if (arch.contains("ppc64")) {
+                return "linux-ppc64le";
+            }
+        } else if (os.contains("mac")) {
+            return "macos";
+        }
+        throw new UnsupportedOperationException("Unsupported platform: " + os + "-" + arch);
     }
 
     /**
      * Start profiling
      *
-     * @param event Profiling event, see {@link Events}
+     * @param event    Profiling event, see {@link Events}
      * @param interval Sampling interval, e.g. nanoseconds for Events.CPU
      * @throws IllegalStateException If profiler is already running
      */
@@ -68,7 +136,7 @@ public class AsyncProfiler implements AsyncProfilerMXBean {
      * Start or resume profiling without resetting collected data.
      * Note that event and interval may change since the previous profiling session.
      *
-     * @param event Profiling event, see {@link Events}
+     * @param event    Profiling event, see {@link Events}
      * @param interval Sampling interval, e.g. nanoseconds for Events.CPU
      * @throws IllegalStateException If profiler is already running
      */
@@ -119,7 +187,7 @@ public class AsyncProfiler implements AsyncProfilerMXBean {
      * @param command Profiling command
      * @return The command result
      * @throws IllegalArgumentException If failed to parse the command
-     * @throws IOException If failed to create output file
+     * @throws IOException              If failed to create output file
      */
     @Override
     public String execute(String command) throws IllegalArgumentException, IllegalStateException, IOException {
@@ -209,7 +277,10 @@ public class AsyncProfiler implements AsyncProfilerMXBean {
     }
 
     private native void start0(String event, long interval, boolean reset) throws IllegalStateException;
+
     private native void stop0() throws IllegalStateException;
+
     private native String execute0(String command) throws IllegalArgumentException, IllegalStateException, IOException;
+
     private native void filterThread0(Thread thread, boolean enable);
 }

--- a/core/src/main/java/one/profiler/package-info.java
+++ b/core/src/main/java/one/profiler/package-info.java
@@ -1,5 +1,5 @@
-
 /**
- * from https://github.com/jvm-profiling-tools/async-profiler
+ * This package is from https://github.com/async-profiler/async-profiler/
+ * tag v2.9 commit 32601bc
  */
 package one.profiler;


### PR DESCRIPTION
参考 issue #2164 中的说明，首先需要升级 one.profiler。

首先分析此包本身的差异，实质性的改动有：修改了 `getInstance` 方法，添加了 `extractEmbeddedLib` 和 `getPlatformTag` 方法，其中 `getPlatformTag` 仅被 `extractEmbeddedLib` 调用，`extractEmbeddedLib` 仅被 `getInstance` 调用。

### getInstance

此方法在 one.profiler 内部仅被同名无参重载方法调用。

在 ProfilerCommand 类中，此方法仅被 `profilerInstance` 调用（L249/271），且同名无参重载方法未被调用。

此方法内部，实际上仅改动了 `libPath == null` 情况的对应逻辑。L51 表示如果 jvm 进程启动时已经加载 lib，就直接返回。否则，L53\~59 尝试从类路径中获取对应平台的 lib.so，复制到一个临时文件用于加载，加载后 L58 删除临时文件。如果类路径中未事先按规则准备这些 lib 文件，那么 `extractEmbeddedLib` 方法将返回 null，此时将与旧代码行为一致，直接从操作系统库搜索路径中查找加载 lib（若未找到则抛出错误，不会返回 profiler 实例）。总而言之，这是对已有行为的扩展而不是修改。

### profilerInstance

在 ProfilerCommand.profilerInstance 方法中，在 L271 处的调用不可能传入 null 参数，因此前述改动对此无任何影响。在 L249 处的调用只有 `profiler load` 命令不加额外参数时才会向 `getInstance` 传入 null，而前述改动不会引入破坏性。