### PR TITLE
Upgrade Profiler Command: update stop action and add dump action

### DIFF
--- a/core/src/main/java/com/taobao/arthas/core/command/monitor200/ProfilerCommand.java
+++ b/core/src/main/java/com/taobao/arthas/core/command/monitor200/ProfilerCommand.java
@@ -110,6 +110,11 @@ public class ProfilerCommand extends AnnotatedCommand {
     private boolean ann;
 
     /**
+     * prepend library names
+     */
+    private boolean lib;
+
+    /**
      * include only kernel-mode events
      */
     private boolean allkernel;
@@ -245,6 +250,12 @@ public class ProfilerCommand extends AnnotatedCommand {
         this.ann = ann;
     }
 
+    @Option(shortName = "l", flag = true)
+    @Description("prepend library names")
+    public void setLib(boolean lib) {
+        this.lib = lib;
+    }
+
     @Option(longName = "allkernel", flag = true)
     @Description("include only kernel-mode events")
     public void setAllkernel(boolean allkernel) {
@@ -364,6 +375,9 @@ public class ProfilerCommand extends AnnotatedCommand {
         }
         if (this.ann) {
             sb.append("ann").append(",");
+        }
+        if (this.lib) {
+            sb.append("lib").append(",");
         }
         if (this.allkernel) {
             sb.append("allkernel").append(',');

--- a/core/src/main/java/com/taobao/arthas/core/command/monitor200/ProfilerCommand.java
+++ b/core/src/main/java/com/taobao/arthas/core/command/monitor200/ProfilerCommand.java
@@ -274,13 +274,13 @@ public class ProfilerCommand extends AnnotatedCommand {
         this.duration = duration;
     }
 
-    @Option(longName = "include")
+    @Option(shortName = "I", longName = "include")
     @Description("include stack traces containing PATTERN, for example: 'java/*'")
     public void setInclude(List<String> includes) {
         this.includes = includes;
     }
 
-    @Option(longName = "exclude")
+    @Option(shortName = "X", longName = "exclude")
     @Description("exclude stack traces containing PATTERN, for example: '*Unsafe.park*'")
     public void setExclude(List<String> excludes) {
         this.excludes = excludes;

--- a/core/src/main/java/com/taobao/arthas/core/command/monitor200/ProfilerCommand.java
+++ b/core/src/main/java/com/taobao/arthas/core/command/monitor200/ProfilerCommand.java
@@ -100,6 +100,11 @@ public class ProfilerCommand extends AnnotatedCommand {
     private boolean simple;
 
     /**
+     * print method signatures
+     */
+    private boolean sig;
+
+    /**
      * include only kernel-mode events
      */
     private boolean allkernel;
@@ -223,6 +228,12 @@ public class ProfilerCommand extends AnnotatedCommand {
         this.simple = simple;
     }
 
+    @Option(shortName = "g", flag = true)
+    @Description("print method signatures")
+    public void setSig(boolean sig) {
+        this.sig = sig;
+    }
+
     @Option(longName = "allkernel", flag = true)
     @Description("include only kernel-mode events")
     public void setAllkernel(boolean allkernel) {
@@ -336,6 +347,9 @@ public class ProfilerCommand extends AnnotatedCommand {
         }
         if (this.simple) {
             sb.append("simple").append(",");
+        }
+        if (this.sig) {
+            sb.append("sig").append(",");
         }
         if (this.allkernel) {
             sb.append("allkernel").append(',');

--- a/core/src/main/java/com/taobao/arthas/core/command/monitor200/ProfilerCommand.java
+++ b/core/src/main/java/com/taobao/arthas/core/command/monitor200/ProfilerCommand.java
@@ -515,7 +515,7 @@ public class ProfilerCommand extends AnnotatedCommand {
                             //在异步线程执行，profiler命令已经结束，不能输出到客户端
                             try {
                                 logger.info("stopping profiler ...");
-                                ProfilerModel model = processStop(asyncProfiler);
+                                ProfilerModel model = processStop(asyncProfiler, ProfilerAction.stop);
                                 logger.info("profiler output file: " + model.getOutputFile());
                                 logger.info("stop profiler successfully.");
                             } catch (Throwable e) {
@@ -526,7 +526,7 @@ public class ProfilerCommand extends AnnotatedCommand {
                 }
                 process.appendResult(profilerModel);
             } else if (ProfilerAction.stop.equals(profilerAction)) {
-                ProfilerModel profilerModel = processStop(asyncProfiler);
+                ProfilerModel profilerModel = processStop(asyncProfiler, profilerAction);
                 process.appendResult(profilerModel);
             } else if (ProfilerAction.resume.equals(profilerAction)) {
                 String executeArgs = executeArgs(ProfilerAction.resume);
@@ -578,9 +578,9 @@ public class ProfilerCommand extends AnnotatedCommand {
         }
     }
 
-    private ProfilerModel processStop(AsyncProfiler asyncProfiler) throws IOException {
+    private ProfilerModel processStop(AsyncProfiler asyncProfiler, ProfilerAction profilerAction) throws IOException {
         String outputFile = outputFile();
-        String executeArgs = executeArgs(ProfilerAction.stop);
+        String executeArgs = executeArgs(profilerAction);
         String result = execute(asyncProfiler, executeArgs);
 
         ProfilerModel profilerModel = createProfilerModel(result);

--- a/core/src/main/java/com/taobao/arthas/core/command/monitor200/ProfilerCommand.java
+++ b/core/src/main/java/com/taobao/arthas/core/command/monitor200/ProfilerCommand.java
@@ -281,14 +281,16 @@ public class ProfilerCommand extends AnnotatedCommand {
     }
 
     /**
-     * https://github.com/jvm-profiling-tools/async-profiler/blob/v2.5/src/arguments.cpp#L50
-     *
+     * https://github.com/async-profiler/async-profiler/blob/v2.9/profiler.sh#L154
      */
     public enum ProfilerAction {
-        execute, start, stop, resume, list, version, status, load,
+        // start, resume, stop, dump, check, status, meminfo, list, collect,
+        start, resume, stop, dump, status, list,
+        version,
 
+        load,
+        execute,
         dumpCollapsed, dumpFlat, dumpTraces, getSamples,
-
         actions
     }
 

--- a/core/src/main/java/com/taobao/arthas/core/command/monitor200/ProfilerCommand.java
+++ b/core/src/main/java/com/taobao/arthas/core/command/monitor200/ProfilerCommand.java
@@ -145,6 +145,11 @@ public class ProfilerCommand extends AnnotatedCommand {
      */
     private String title;
 
+    /**
+     * FlameGraph minimum frame width in percent
+     */
+    private String minwidth;
+
     private static String libPath;
     private static AsyncProfiler profiler = null;
 
@@ -306,6 +311,13 @@ public class ProfilerCommand extends AnnotatedCommand {
         this.title = title;
     }
 
+
+    @Option(longName = "minwidth")
+    @Description("FlameGraph minimum frame width in percent")
+    public void setMinwidth(String minwidth) {
+        this.minwidth = minwidth;
+    }
+
     private AsyncProfiler profilerInstance() {
         if (profiler != null) {
             return profiler;
@@ -418,6 +430,9 @@ public class ProfilerCommand extends AnnotatedCommand {
 
         if (this.title != null) {
             sb.append("title=").append(this.title).append(',');
+        }
+        if (this.minwidth != null) {
+            sb.append("minwidth=").append(this.minwidth).append(',');
         }
 
         return sb.toString();

--- a/core/src/main/java/com/taobao/arthas/core/command/monitor200/ProfilerCommand.java
+++ b/core/src/main/java/com/taobao/arthas/core/command/monitor200/ProfilerCommand.java
@@ -528,6 +528,9 @@ public class ProfilerCommand extends AnnotatedCommand {
             } else if (ProfilerAction.stop.equals(profilerAction)) {
                 ProfilerModel profilerModel = processStop(asyncProfiler, profilerAction);
                 process.appendResult(profilerModel);
+            } else if (ProfilerAction.dump.equals(profilerAction)) {
+                ProfilerModel profilerModel = processStop(asyncProfiler, profilerAction);
+                process.appendResult(profilerModel);
             } else if (ProfilerAction.resume.equals(profilerAction)) {
                 String executeArgs = executeArgs(ProfilerAction.resume);
                 String result = execute(asyncProfiler, executeArgs);

--- a/core/src/main/java/com/taobao/arthas/core/command/monitor200/ProfilerCommand.java
+++ b/core/src/main/java/com/taobao/arthas/core/command/monitor200/ProfilerCommand.java
@@ -139,6 +139,12 @@ public class ProfilerCommand extends AnnotatedCommand {
      */
     private List<String> excludes;
 
+
+    /**
+     * FlameGraph title
+     */
+    private String title;
+
     private static String libPath;
     private static AsyncProfiler profiler = null;
 
@@ -286,6 +292,20 @@ public class ProfilerCommand extends AnnotatedCommand {
         this.excludes = excludes;
     }
 
+    @Option(longName = "title")
+    @Description("FlameGraph title")
+    public void setTitle(String title) {
+        // escape HTML special characters
+        // and escape comma to avoid conflicts with JVM TI
+        title = title.replace("&", "&amp;")
+                .replace("<", "&lt;")
+                .replace(">", "&gt;")
+                .replace("\"", "&quot;")
+                .replace("'", "&apos;")
+                .replace(",", "&#44;");
+        this.title = title;
+    }
+
     private AsyncProfiler profilerInstance() {
         if (profiler != null) {
             return profiler;
@@ -394,6 +414,10 @@ public class ProfilerCommand extends AnnotatedCommand {
             for (String exclude : excludes) {
                 sb.append("exclude=").append(exclude).append(',');
             }
+        }
+
+        if (this.title != null) {
+            sb.append("title=").append(this.title).append(',');
         }
 
         return sb.toString();

--- a/core/src/main/java/com/taobao/arthas/core/command/monitor200/ProfilerCommand.java
+++ b/core/src/main/java/com/taobao/arthas/core/command/monitor200/ProfilerCommand.java
@@ -95,6 +95,11 @@ public class ProfilerCommand extends AnnotatedCommand {
     private boolean threads;
 
     /**
+     * use simple class names instead of FQN
+     */
+    private boolean simple;
+
+    /**
      * include only kernel-mode events
      */
     private boolean allkernel;
@@ -212,6 +217,12 @@ public class ProfilerCommand extends AnnotatedCommand {
         this.threads = threads;
     }
 
+    @Option(shortName = "s", flag = true)
+    @Description("use simple class names instead of FQN")
+    public void setSimple(boolean simple) {
+        this.simple = simple;
+    }
+
     @Option(longName = "allkernel", flag = true)
     @Description("include only kernel-mode events")
     public void setAllkernel(boolean allkernel) {
@@ -322,6 +333,9 @@ public class ProfilerCommand extends AnnotatedCommand {
         }
         if (this.threads) {
             sb.append("threads").append(',');
+        }
+        if (this.simple) {
+            sb.append("simple").append(",");
         }
         if (this.allkernel) {
             sb.append("allkernel").append(',');

--- a/core/src/main/java/com/taobao/arthas/core/command/monitor200/ProfilerCommand.java
+++ b/core/src/main/java/com/taobao/arthas/core/command/monitor200/ProfilerCommand.java
@@ -155,6 +155,11 @@ public class ProfilerCommand extends AnnotatedCommand {
      */
     private boolean reverse;
 
+    /**
+     * count the total value (time, bytes, etc.) instead of samples
+     */
+    private boolean total;
+
     private static String libPath;
     private static AsyncProfiler profiler = null;
 
@@ -328,6 +333,12 @@ public class ProfilerCommand extends AnnotatedCommand {
         this.reverse = reverse;
     }
 
+    @Option(longName = "total", flag = true)
+    @Description("count the total value (time, bytes, etc.) instead of samples")
+    public void setTotal(boolean total) {
+        this.total = total;
+    }
+
     private AsyncProfiler profilerInstance() {
         if (profiler != null) {
             return profiler;
@@ -446,6 +457,9 @@ public class ProfilerCommand extends AnnotatedCommand {
         }
         if (this.reverse) {
             sb.append("reverse").append(',');
+        }
+        if (this.total) {
+            sb.append("total").append(',');
         }
 
         return sb.toString();

--- a/core/src/main/java/com/taobao/arthas/core/command/monitor200/ProfilerCommand.java
+++ b/core/src/main/java/com/taobao/arthas/core/command/monitor200/ProfilerCommand.java
@@ -150,6 +150,11 @@ public class ProfilerCommand extends AnnotatedCommand {
      */
     private String minwidth;
 
+    /**
+     * generate stack-reversed FlameGraph / Call tree
+     */
+    private boolean reverse;
+
     private static String libPath;
     private static AsyncProfiler profiler = null;
 
@@ -311,11 +316,16 @@ public class ProfilerCommand extends AnnotatedCommand {
         this.title = title;
     }
 
-
     @Option(longName = "minwidth")
     @Description("FlameGraph minimum frame width in percent")
     public void setMinwidth(String minwidth) {
         this.minwidth = minwidth;
+    }
+
+    @Option(longName = "reverse", flag = true)
+    @Description("generate stack-reversed FlameGraph / Call tree")
+    public void setReverse(boolean reverse) {
+        this.reverse = reverse;
     }
 
     private AsyncProfiler profilerInstance() {
@@ -433,6 +443,9 @@ public class ProfilerCommand extends AnnotatedCommand {
         }
         if (this.minwidth != null) {
             sb.append("minwidth=").append(this.minwidth).append(',');
+        }
+        if (this.reverse) {
+            sb.append("reverse").append(',');
         }
 
         return sb.toString();

--- a/core/src/main/java/com/taobao/arthas/core/command/monitor200/ProfilerCommand.java
+++ b/core/src/main/java/com/taobao/arthas/core/command/monitor200/ProfilerCommand.java
@@ -105,6 +105,11 @@ public class ProfilerCommand extends AnnotatedCommand {
     private boolean sig;
 
     /**
+     * annotate Java methods
+     */
+    private boolean ann;
+
+    /**
      * include only kernel-mode events
      */
     private boolean allkernel;
@@ -234,6 +239,12 @@ public class ProfilerCommand extends AnnotatedCommand {
         this.sig = sig;
     }
 
+    @Option(shortName = "a", flag = true)
+    @Description("annotate Java methods")
+    public void setAnn(boolean ann) {
+        this.ann = ann;
+    }
+
     @Option(longName = "allkernel", flag = true)
     @Description("include only kernel-mode events")
     public void setAllkernel(boolean allkernel) {
@@ -350,6 +361,9 @@ public class ProfilerCommand extends AnnotatedCommand {
         }
         if (this.sig) {
             sb.append("sig").append(",");
+        }
+        if (this.ann) {
+            sb.append("ann").append(",");
         }
         if (this.allkernel) {
             sb.append("allkernel").append(',');


### PR DESCRIPTION
## stop/dump

stop action 主要涉及测试结果的输出，需处理 [profiler.sh](https://github.com/async-profiler/async-profiler/blob/32601bccd9e49adda9510a2ed79d142ac6ef0ff9/profiler.sh#L354C15-L354C15) 中 FIEL、OUTPUT、FORMAT 三个变量对应的选项。在 sh 脚本中分析结果允许输出到标准输出或文件，且与输出内容格式是完全解耦的。Arthas 的设计可能是：要求必须将分析结果保存到文件，因此在 `processStop` 方法中只要判断 file 选项为空就会指定一个默认文件名。

目前对 file 选项的捕捉本身没有问题，可以对应到 sh 中的 FILE 变量。

### OUTPUT 变量：

在 sh 中通过 `-o` 选项转换为此变量。但目前 arthas 中没有该选项，仅有一个相关的 format 选项，它仅用于构造默认文件名的后缀（未传递给 execute 方法）且只有两个可选值，【分析结果】的内容格式是让 async-profiler 通过这个后缀名推断的。在 sh 中，通过设置 OUTPUT 可以得到其他格式的输出（如 flat 等格式）。要想在 profiler command 中支持这些格式，可以将 format 选项的值也用于构造 executeArgs，将其与 sh 的 `-o` 选项对应起来。

根据 sh 脚本中的使用说明，`-o` 选项可选值为 `flat|traces|collapsed|flamegraph|tree|jfr`，且均可在 arguments.cpp 中找到详细解释，其中 flat 和 traces 可加 `[=N] ` 格式参数，在 Arthas 中，用 format 选项捕捉这些值，并为选项添加短名称 `o`。本选项的值直接拼接到 JVM TI 格式参数中，与 file 选项不同，在 Arthas 中需要注意 `executeArgs` 方法构造 JVMTI 格式字符串的过程。

在需要生成默认文件名时，不直接使用 format 选项的值而是添加一层判断：先判断 format 是否有效，若无效就让后缀取 html（或其他值），然后根据 format 的各种情况确定后缀名，然后再生成文件名。

format 选项不要设定默认值，否则当用户不指定 format 但指定 file 时，用 file 后缀名推断输出格式（async profiler 内部会处理这一过程）会失效。例如，假设 format 默认值为 flamegraph，用户指定了 file 后缀为 jfr 但未指定 format，用户预期是输出 jfr 格式，但 flamegraph 会被传递给 async profiler，因此将输出火焰图格式（虽然后缀名是 jfr）。

### FORMAT 变量：

shell 脚本中对此变量的处理分散在多处，但都位于 L149 开始的循环块中。L184 -s。L187 -g。L190 -a。L193 `-l`。L200 `-I`。

L208 --filter 选项**暂不实现**，未出现在 shell 脚本说明中。

L213 --title 需要转义 XML 特殊字符，以及逗号（防止与 JVM TI 冲突）。

L219 仅实现 --minwidth 即可。L223 --reverse。L226 仅需要 --total。

### dump action

在 `ProfilerAction` 枚举类中添加 dump 即可捕获，排列顺序尽量与原 sh 脚本保持一致。

修改 `processStop` method 使其接收多种 action。