### PR TITLE
Upgrade "stop action" in profiler command

### DIFF
--- a/core/src/main/java/com/taobao/arthas/core/command/monitor200/ProfilerCommand.java
+++ b/core/src/main/java/com/taobao/arthas/core/command/monitor200/ProfilerCommand.java
@@ -150,6 +150,11 @@ public class ProfilerCommand extends AnnotatedCommand {
      */
     private String minwidth;
 
+    /**
+     * generate stack-reversed FlameGraph / Call tree
+     */
+    private boolean reverse;
+
     private static String libPath;
     private static AsyncProfiler profiler = null;
 
@@ -311,11 +316,16 @@ public class ProfilerCommand extends AnnotatedCommand {
         this.title = title;
     }
 
-
     @Option(longName = "minwidth")
     @Description("FlameGraph minimum frame width in percent")
     public void setMinwidth(String minwidth) {
         this.minwidth = minwidth;
+    }
+
+    @Option(longName = "reverse", flag = true)
+    @Description("generate stack-reversed FlameGraph / Call tree")
+    public void setReverse(boolean reverse) {
+        this.reverse = reverse;
     }
 
     private AsyncProfiler profilerInstance() {
@@ -431,6 +441,9 @@ public class ProfilerCommand extends AnnotatedCommand {
         }
         if (this.minwidth != null) {
             sb.append("minwidth=").append(this.minwidth).append(',');
+        }
+        if (this.reverse) {
+            sb.append("reverse").append(',');
         }
 
         return sb.toString();

--- a/core/src/main/java/com/taobao/arthas/core/command/monitor200/ProfilerCommand.java
+++ b/core/src/main/java/com/taobao/arthas/core/command/monitor200/ProfilerCommand.java
@@ -155,6 +155,11 @@ public class ProfilerCommand extends AnnotatedCommand {
      */
     private boolean reverse;
 
+    /**
+     * count the total value (time, bytes, etc.) instead of samples
+     */
+    private boolean total;
+
     private static String libPath;
     private static AsyncProfiler profiler = null;
 
@@ -328,6 +333,12 @@ public class ProfilerCommand extends AnnotatedCommand {
         this.reverse = reverse;
     }
 
+    @Option(longName = "total", flag = true)
+    @Description("count the total value (time, bytes, etc.) instead of samples")
+    public void setTotal(boolean total) {
+        this.total = total;
+    }
+
     private AsyncProfiler profilerInstance() {
         if (profiler != null) {
             return profiler;
@@ -444,6 +455,9 @@ public class ProfilerCommand extends AnnotatedCommand {
         }
         if (this.reverse) {
             sb.append("reverse").append(',');
+        }
+        if (this.total) {
+            sb.append("total").append(',');
         }
 
         return sb.toString();

--- a/core/src/main/java/com/taobao/arthas/core/command/monitor200/ProfilerCommand.java
+++ b/core/src/main/java/com/taobao/arthas/core/command/monitor200/ProfilerCommand.java
@@ -145,6 +145,11 @@ public class ProfilerCommand extends AnnotatedCommand {
      */
     private String title;
 
+    /**
+     * FlameGraph minimum frame width in percent
+     */
+    private String minwidth;
+
     private static String libPath;
     private static AsyncProfiler profiler = null;
 
@@ -306,6 +311,13 @@ public class ProfilerCommand extends AnnotatedCommand {
         this.title = title;
     }
 
+
+    @Option(longName = "minwidth")
+    @Description("FlameGraph minimum frame width in percent")
+    public void setMinwidth(String minwidth) {
+        this.minwidth = minwidth;
+    }
+
     private AsyncProfiler profilerInstance() {
         if (profiler != null) {
             return profiler;
@@ -416,6 +428,9 @@ public class ProfilerCommand extends AnnotatedCommand {
 
         if (this.title != null) {
             sb.append("title=").append(this.title).append(',');
+        }
+        if (this.minwidth != null) {
+            sb.append("minwidth=").append(this.minwidth).append(',');
         }
 
         return sb.toString();

--- a/core/src/main/java/com/taobao/arthas/core/command/monitor200/ProfilerCommand.java
+++ b/core/src/main/java/com/taobao/arthas/core/command/monitor200/ProfilerCommand.java
@@ -95,6 +95,11 @@ public class ProfilerCommand extends AnnotatedCommand {
     private boolean threads;
 
     /**
+     * use simple class names instead of FQN
+     */
+    private boolean simple;
+
+    /**
      * include only kernel-mode events
      */
     private boolean allkernel;
@@ -212,6 +217,12 @@ public class ProfilerCommand extends AnnotatedCommand {
         this.threads = threads;
     }
 
+    @Option(shortName = "s", flag = true)
+    @Description("use simple class names instead of FQN")
+    public void setSimple(boolean simple) {
+        this.simple = simple;
+    }
+
     @Option(longName = "allkernel", flag = true)
     @Description("include only kernel-mode events")
     public void setAllkernel(boolean allkernel) {
@@ -320,6 +331,9 @@ public class ProfilerCommand extends AnnotatedCommand {
         }
         if (this.threads) {
             sb.append("threads").append(',');
+        }
+        if (this.simple) {
+            sb.append("simple").append(",");
         }
         if (this.allkernel) {
             sb.append("allkernel").append(',');

--- a/core/src/main/java/com/taobao/arthas/core/command/monitor200/ProfilerCommand.java
+++ b/core/src/main/java/com/taobao/arthas/core/command/monitor200/ProfilerCommand.java
@@ -274,13 +274,13 @@ public class ProfilerCommand extends AnnotatedCommand {
         this.duration = duration;
     }
 
-    @Option(longName = "include")
+    @Option(shortName = "I", longName = "include")
     @Description("include stack traces containing PATTERN, for example: 'java/*'")
     public void setInclude(List<String> includes) {
         this.includes = includes;
     }
 
-    @Option(longName = "exclude")
+    @Option(shortName = "X", longName = "exclude")
     @Description("exclude stack traces containing PATTERN, for example: '*Unsafe.park*'")
     public void setExclude(List<String> excludes) {
         this.excludes = excludes;

--- a/core/src/main/java/com/taobao/arthas/core/command/monitor200/ProfilerCommand.java
+++ b/core/src/main/java/com/taobao/arthas/core/command/monitor200/ProfilerCommand.java
@@ -105,6 +105,11 @@ public class ProfilerCommand extends AnnotatedCommand {
     private boolean sig;
 
     /**
+     * annotate Java methods
+     */
+    private boolean ann;
+
+    /**
      * include only kernel-mode events
      */
     private boolean allkernel;
@@ -234,6 +239,12 @@ public class ProfilerCommand extends AnnotatedCommand {
         this.sig = sig;
     }
 
+    @Option(shortName = "a", flag = true)
+    @Description("annotate Java methods")
+    public void setAnn(boolean ann) {
+        this.ann = ann;
+    }
+
     @Option(longName = "allkernel", flag = true)
     @Description("include only kernel-mode events")
     public void setAllkernel(boolean allkernel) {
@@ -348,6 +359,9 @@ public class ProfilerCommand extends AnnotatedCommand {
         }
         if (this.sig) {
             sb.append("sig").append(",");
+        }
+        if (this.ann) {
+            sb.append("ann").append(",");
         }
         if (this.allkernel) {
             sb.append("allkernel").append(',');

--- a/core/src/main/java/com/taobao/arthas/core/command/monitor200/ProfilerCommand.java
+++ b/core/src/main/java/com/taobao/arthas/core/command/monitor200/ProfilerCommand.java
@@ -110,6 +110,11 @@ public class ProfilerCommand extends AnnotatedCommand {
     private boolean ann;
 
     /**
+     * prepend library names
+     */
+    private boolean lib;
+
+    /**
      * include only kernel-mode events
      */
     private boolean allkernel;
@@ -245,6 +250,12 @@ public class ProfilerCommand extends AnnotatedCommand {
         this.ann = ann;
     }
 
+    @Option(shortName = "l", flag = true)
+    @Description("prepend library names")
+    public void setLib(boolean lib) {
+        this.lib = lib;
+    }
+
     @Option(longName = "allkernel", flag = true)
     @Description("include only kernel-mode events")
     public void setAllkernel(boolean allkernel) {
@@ -362,6 +373,9 @@ public class ProfilerCommand extends AnnotatedCommand {
         }
         if (this.ann) {
             sb.append("ann").append(",");
+        }
+        if (this.lib) {
+            sb.append("lib").append(",");
         }
         if (this.allkernel) {
             sb.append("allkernel").append(',');

--- a/core/src/main/java/com/taobao/arthas/core/command/monitor200/ProfilerCommand.java
+++ b/core/src/main/java/com/taobao/arthas/core/command/monitor200/ProfilerCommand.java
@@ -100,6 +100,11 @@ public class ProfilerCommand extends AnnotatedCommand {
     private boolean simple;
 
     /**
+     * print method signatures
+     */
+    private boolean sig;
+
+    /**
      * include only kernel-mode events
      */
     private boolean allkernel;
@@ -223,6 +228,12 @@ public class ProfilerCommand extends AnnotatedCommand {
         this.simple = simple;
     }
 
+    @Option(shortName = "g", flag = true)
+    @Description("print method signatures")
+    public void setSig(boolean sig) {
+        this.sig = sig;
+    }
+
     @Option(longName = "allkernel", flag = true)
     @Description("include only kernel-mode events")
     public void setAllkernel(boolean allkernel) {
@@ -334,6 +345,9 @@ public class ProfilerCommand extends AnnotatedCommand {
         }
         if (this.simple) {
             sb.append("simple").append(",");
+        }
+        if (this.sig) {
+            sb.append("sig").append(",");
         }
         if (this.allkernel) {
             sb.append("allkernel").append(',');

--- a/core/src/main/java/com/taobao/arthas/core/command/monitor200/ProfilerCommand.java
+++ b/core/src/main/java/com/taobao/arthas/core/command/monitor200/ProfilerCommand.java
@@ -184,15 +184,18 @@ public class ProfilerCommand extends AnnotatedCommand {
     }
 
     @Option(shortName = "f", longName = "file")
-    @Description("dump output to <filename>")
+    @Description("dump output to <filename>, if ends with html or jfr, content format can be infered")
     public void setFile(String file) {
         this.file = file;
     }
 
-    @Option(longName = "format")
-    @Description("dump output file format(html, jfr), default valut is html")
-    @DefaultValue("html")
+    @Option(shortName = "o", longName = "format")
+    @Description("dump output content format(flat[=N]|traces[=N]|collapsed|flamegraph|tree|jfr)")
     public void setFormat(String format) {
+        // only for backward compatibility
+        if ("html".equals(format)) {
+            format = "flamegraph";
+        }
         this.format = format;
     }
 
@@ -305,6 +308,9 @@ public class ProfilerCommand extends AnnotatedCommand {
         }
         if (this.file != null) {
             sb.append("file=").append(this.file).append(',');
+        }
+        if (this.format != null) {
+            sb.append(this.format).append(',');
         }
         if (this.interval != null) {
             sb.append("interval=").append(this.interval).append(',');
@@ -460,16 +466,38 @@ public class ProfilerCommand extends AnnotatedCommand {
 
     private String outputFile() throws IOException {
         if (this.file == null) {
+            String fileExt = outputFileExt();
             File outputPath = ArthasBootstrap.getInstance().getOutputPath();
             if (outputPath != null) {
                 this.file = new File(outputPath,
-                        new SimpleDateFormat("yyyyMMdd-HHmmss").format(new Date()) + "." + this.format)
+                        new SimpleDateFormat("yyyyMMdd-HHmmss").format(new Date()) + "." + fileExt)
                                 .getAbsolutePath();
             } else {
-                this.file = File.createTempFile("arthas-output", "." + this.format).getAbsolutePath();
+                this.file = File.createTempFile("arthas-output", "." + fileExt).getAbsolutePath();
             }
         }
         return file;
+    }
+
+    /**
+     * This method should only be called when {@code this.file == null} is true.
+     */
+    private String outputFileExt() {
+        String fileExt = "";
+        if (this.format == null) {
+            fileExt = "html";
+        } else if (this.format.startsWith("flat") || this.format.startsWith("traces") 
+                || this.format.equals("collapsed")) {
+            fileExt = "txt";
+        } else if (this.format.equals("flamegraph") || this.format.equals("tree")) {
+            fileExt = "html";
+        } else if (this.format.equals("jfr")) {
+            fileExt = "jfr";
+        } else {
+            // illegal -o option makes async-profiler use flat
+            fileExt = "txt";
+        }
+        return fileExt;
     }
 
     private void appendExecuteResult(CommandProcess process, String result) {

--- a/core/src/main/java/com/taobao/arthas/core/command/monitor200/ProfilerCommand.java
+++ b/core/src/main/java/com/taobao/arthas/core/command/monitor200/ProfilerCommand.java
@@ -139,6 +139,12 @@ public class ProfilerCommand extends AnnotatedCommand {
      */
     private List<String> excludes;
 
+
+    /**
+     * FlameGraph title
+     */
+    private String title;
+
     private static String libPath;
     private static AsyncProfiler profiler = null;
 
@@ -286,6 +292,20 @@ public class ProfilerCommand extends AnnotatedCommand {
         this.excludes = excludes;
     }
 
+    @Option(longName = "title")
+    @Description("FlameGraph title")
+    public void setTitle(String title) {
+        // escape HTML special characters
+        // and escape comma to avoid conflicts with JVM TI
+        title = title.replace("&", "&amp;")
+                .replace("<", "&lt;")
+                .replace(">", "&gt;")
+                .replace("\"", "&quot;")
+                .replace("'", "&apos;")
+                .replace(",", "&#44;");
+        this.title = title;
+    }
+
     private AsyncProfiler profilerInstance() {
         if (profiler != null) {
             return profiler;
@@ -392,6 +412,10 @@ public class ProfilerCommand extends AnnotatedCommand {
             for (String exclude : excludes) {
                 sb.append("exclude=").append(exclude).append(',');
             }
+        }
+
+        if (this.title != null) {
+            sb.append("title=").append(this.title).append(',');
         }
 
         return sb.toString();

--- a/core/src/main/java/com/taobao/arthas/core/command/monitor200/ProfilerCommand.java
+++ b/core/src/main/java/com/taobao/arthas/core/command/monitor200/ProfilerCommand.java
@@ -51,7 +51,7 @@ import one.profiler.Counter;
         + "  profiler list                # list all supported events\n"
         + "  profiler actions             # list all supported actions\n"
         + "  profiler start --event alloc\n"
-        + "  profiler stop --format html   # output file format, support html,jfr\n"
+        + "  profiler stop --format html   # output file format, support flat[=N]|traces[=N]|collapsed|flamegraph|tree|jfr\n"
         + "  profiler stop --file /tmp/result.html\n"
         + "  profiler stop --threads \n"
         + "  profiler start --include 'java/*' --include 'com/demo/*' --exclude '*Unsafe.park*'\n"

--- a/site/docs/doc/profiler.md
+++ b/site/docs/doc/profiler.md
@@ -10,6 +10,8 @@
 
 `profiler` 命令基本运行结构是 `profiler action [actionArg]`
 
+`profiler` 命令的格式基本与上游项目 [async-profiler](https://github.com/async-profiler/async-profiler) 保持一致，详细的使用方式可参考上游项目的 README、Github Disscussions 以及其他文档资料。
+
 ## 参数说明
 
 |    参数名称 | 参数说明                                                        |
@@ -29,7 +31,7 @@ Started [cpu] profiling
 ```
 
 ::: tip
-默认情况下，生成的是 cpu 的火焰图，即 event 为`cpu`。可以用`--event`参数来指定。
+默认情况下，生成的是 cpu 的火焰图，即 event 为`cpu`。可以用`--event`参数指定其他性能分析模式，见下文。
 :::
 
 ## 获取已采集的 sample 的数量
@@ -50,17 +52,17 @@ $ profiler status
 
 ## 停止 profiler
 
-### 生成 html 格式结果
+### 生成火焰图格式结果
 
-默认情况下，结果文件是`html`格式，也可以用`--format`参数指定：
+默认情况下，结果是 [Flame Graph](https://github.com/BrendanGregg/FlameGraph) 格式的 `html` 文件，也可以用 `-o` 或 `--format` 参数指定其他内容格式，包括 flat、traces、collapsed、flamegraph、tree、jfr。
 
 ```bash
-$ profiler stop --format html
+$ profiler stop --format flamegraph
 profiler output file: /tmp/test/arthas-output/20211207-111550.html
 OK
 ```
 
-或者在`--file`参数里用文件名指名格式。比如`--file /tmp/result.html` 。
+在`--file`参数指定的文件名后缀为 `html` 或 `jfr` 时，文件格式可以被推断出来。比如`--file /tmp/result.html` 将自动生成火焰图。
 
 ## 通过浏览器查看 arthas-output 下面的 profiler 结果
 
@@ -100,6 +102,8 @@ Basic events:
   lock
   wall
   itimer
+Java method calls:
+  ClassName.methodName
 Perf events:
   page-faults
   context-switches
@@ -107,19 +111,23 @@ Perf events:
   instructions
   cache-references
   cache-misses
-  branches
+  branch-instructions
   branch-misses
   bus-cycles
   L1-dcache-load-misses
   LLC-load-misses
   dTLB-load-misses
+  rNNN
+  pmu/event-descriptor/
   mem:breakpoint
   trace:tracepoint
+  kprobe:func
+  uprobe:path
 ```
 
-如果遇到 OS 本身的权限/配置问题，然后  缺少部分 event，可以参考`async-profiler`本身文档：[async-profiler](https://github.com/jvm-profiling-tools/async-profiler)
+如果遇到 OS 本身的权限/配置问题，然后缺少部分 event，可以参考 [async-profiler 的文档](https://github.com/jvm-profiling-tools/async-profiler)。
 
-可以用`--event`参数指定要采样的事件，比如对`alloc`事件进入采样：
+可以用`--event`参数指定要采样的事件，比如 `alloc` 表示分析内存分配情况：
 
 ```bash
 $ profiler start --event alloc
@@ -132,7 +140,7 @@ $ profiler resume
 Started [cpu] profiling
 ```
 
-`start`和`resume`的区别是：`start`是新开始采样，`resume`会保留上次`stop`时的数据。
+`start`和`resume`的区别是：`start`会清除已有的分析结果重新开始，`resume`则会保留已有的结果，将新的分析结果附加到已有结果中。
 
 通过执行`profiler getSamples`可以查看 samples 的数量来验证。
 
@@ -183,7 +191,7 @@ profiler start --framebuf 5000000
 profiler start --include 'java/*' --include 'com/demo/*' --exclude '*Unsafe.park*'
 ```
 
-> `--include/--exclude` 都支持设置多个值 ，但是需要配置在命令行的最后。
+> `--include/--exclude` 都支持多次设置，但是需要配置在命令行的最后。也可使用短参数格式 `-I/-X`。
 
 ## 指定执行时间
 
@@ -199,6 +207,7 @@ profiler start --duration 300
 
 ```
 profiler start --file /tmp/test.jfr
+profiler start -o jfr
 ```
 
 `file`参数支持一些变量：
@@ -210,6 +219,10 @@ profiler start --file /tmp/test.jfr
 
 - JDK Mission Control ： https://github.com/openjdk/jmc
 - JProfiler ： https://github.com/alibaba/arthas/issues/1416
+
+## 控制分析结果的格式
+
+使用 `-s` 选项将结果中的 Fully qualified name 替换为简单名称，如 `demo.MathGame.main` 替换为 `MathGame.main`。使用 `-g` 选项指定输出方法签名，如 `demo.MathGame.main` 替换为 `demo.MathGame.main([Ljava/lang/String;)V`。此外还有许多可调整分析结果格式的选项，可参考 [async-profiler 的 README 文档](https://github.com/async-profiler/async-profiler#readme) 以及 [async-profiler 的 Github Discussions](https://github.com/async-profiler/async-profiler/discussions) 等材料。
 
 ## 生成的火焰图里的 unknown
 

--- a/site/docs/doc/profiler.md
+++ b/site/docs/doc/profiler.md
@@ -224,6 +224,12 @@ profiler start -o jfr
 
 使用 `-s` 选项将结果中的 Fully qualified name 替换为简单名称，如 `demo.MathGame.main` 替换为 `MathGame.main`。使用 `-g` 选项指定输出方法签名，如 `demo.MathGame.main` 替换为 `demo.MathGame.main([Ljava/lang/String;)V`。此外还有许多可调整分析结果格式的选项，可参考 [async-profiler 的 README 文档](https://github.com/async-profiler/async-profiler#readme) 以及 [async-profiler 的 Github Discussions](https://github.com/async-profiler/async-profiler/discussions) 等材料。
 
+例如，以下命令中，`-s` 将输出中的类名称指定为简短格式，`-g` 显示方法的完整签名，`-a` 标注出 Java 方法，`-l` 为原生方法增加库名称，`--title` 为生成火焰图页面指定标题，`--minwidth` 将过滤火焰图中宽度为 15% 以下的帧，`--reverse` 将火焰图倒置。
+
+```
+profiler stop -s -g -a -l --title <flametitle> --minwidth 15 --reverse
+```
+
 ## 生成的火焰图里的 unknown
 
 - https://github.com/jvm-profiling-tools/async-profiler/discussions/409

--- a/site/docs/en/doc/profiler.md
+++ b/site/docs/en/doc/profiler.md
@@ -226,6 +226,12 @@ The generated results can be viewed with tools that support the jfr format. such
 
 The `-s` parameter will use simple name instead of Fully qualified name, e.g. `MathGame.main` instead of `demo.MathGame.main`. The `-g` parameter will use method signatures instead of method names, e.g. `demo.MathGame.main([Ljava/lang/String;)V` instead of `demo.MathGame.main`. There are many parameters related to result format details, you can refer to [async-profiler README](https://github.com/async-profiler/async-profiler#readme) and [async-profiler Github Discussions](https://github.com/async-profiler/async-profiler/discussions) and other information.
 
+For example, in command below, `-s` use simple name for Java class, `-g` show method signatures, `-a` will annotate Java methods, `-l` will prepend library names for native method, `--title` specify a title for flame graph page, `--minwidth` will skip frames smaller than 15% in flame graph, `--reverse` will generate stack-reversed FlameGraph / Call tree.
+
+```
+profiler stop -s -g -a -l --title <flametitle> --minwidth 15 --reverse
+```
+
 ## The 'unknown' in profiler result
 
 - https://github.com/jvm-profiling-tools/async-profiler/discussions/409

--- a/site/docs/en/doc/profiler.md
+++ b/site/docs/en/doc/profiler.md
@@ -6,9 +6,11 @@
 Generate a flame graph using [async-profiler](https://github.com/jvm-profiling-tools/async-profiler)
 :::
 
-The `profiler` command supports generate flame graph for application hotspots.
+The `profiler` command supports generating flame graph for application hotspots.
 
 The basic usage of the `profiler` command is `profiler action [actionArg]`
+
+The arguments of `profiler` command basically keeps consistent with upstream project [async-profiler](https://github.com/async-profiler/async-profiler), you can refer to its README, Github Discussions and other documentations for further information of usage.
 
 ## Supported Options
 
@@ -29,7 +31,7 @@ Started [cpu] profiling
 ```
 
 ::: tip
-By default, the sample event is `cpu`. Can be specified with the `--event` parameter.
+By default, the sample event is `cpu`. Other valid profiling modes can be specified with the `--event` parameter, see relevant contents below.
 :::
 
 ## Get the number of samples collected
@@ -50,17 +52,17 @@ Can view which `event` and sampling time.
 
 ## Stop profiler
 
-### Generating html format results
+### Generating flame graph results
 
-By default, the result file is `html` format. You can also specify it with the `--format` parameter:
+By default, the result file is `html` file in [Flame Graph](https://github.com/BrendanGregg/FlameGraph) format. You can also specify other format with the `-o` or `--format` parameter, including flat, traces, collapsed, flamegraph, tree, jfr:
 
 ```bash
-$ profiler stop --format html
+$ profiler stop --format flamegraph
 profiler output file: /tmp/test/arthas-output/20211207-111550.html
 OK
 ```
 
-Or use the file name name format in the `--file` parameter. For example, `--file /tmp/result.html`.
+When extension of filename in `--file` parameter is `html` or `jfr`, the output format can be infered. For example, `--file /tmp/result.html` will generate flamegraph automatically.
 
 ## View profiler results under arthas-output via browser
 
@@ -100,6 +102,8 @@ Basic events:
   lock
   wall
   itimer
+Java method calls:
+  ClassName.methodName
 Perf events:
   page-faults
   context-switches
@@ -107,19 +111,23 @@ Perf events:
   instructions
   cache-references
   cache-misses
-  branches
+  branch-instructions
   branch-misses
   bus-cycles
   L1-dcache-load-misses
   LLC-load-misses
   dTLB-load-misses
+  rNNN
+  pmu/event-descriptor/
   mem:breakpoint
   trace:tracepoint
+  kprobe:func
+  uprobe:path
 ```
 
 If you encounter the permissions/configuration issues of the OS itself and then missing some events, you can refer to the [async-profiler](https://github.com/jvm-profiling-tools/async-profiler) documentation.
 
-You can use the `--event` parameter to specify the event to sample, such as sampling the `alloc` event:
+You can use the `--event` parameter to specify the event to sample, for example, `alloc` event means heap memory allocation profiling:
 
 ```bash
 $ profiler start --event alloc
@@ -132,7 +140,7 @@ $ profiler resume
 Started [cpu] profiling
 ```
 
-The difference between `start` and `resume` is: `start` is the new start sampling, `resume` will retain the data of the last `stop`.
+The difference between `start` and `resume` is: `start` will clean existing result of last profiling before starting, `resume` will retain the existing result and add result of this time to it.
 
 You can verify the number of samples by executing `profiler getSamples`.
 
@@ -185,7 +193,7 @@ If the application is complex and generates a lot of content, and you want to fo
 profiler start --include'java/*' --include 'com/demo/*' --exclude'*Unsafe.park*'
 ```
 
-> Both `--include/--exclude` support setting multiple values, but need to be configured at the end of the command line.
+> Both `--include/--exclude` support being set multiple times, but need to be configured at the end of the command line. You can also use short parameter format `-I/-X`.
 
 ## Specify execution time
 
@@ -201,6 +209,7 @@ profiler start --duration 300
 
 ```
 profiler start --file /tmp/test.jfr
+profiler start -o jfr
 ```
 
 The `file` parameter supports some variables:
@@ -212,6 +221,10 @@ The generated results can be viewed with tools that support the jfr format. such
 
 - JDK Mission Control: https://github.com/openjdk/jmc
 - JProfiler: https://github.com/alibaba/arthas/issues/1416
+
+## Control details in result
+
+The `-s` parameter will use simple name instead of Fully qualified name, e.g. `MathGame.main` instead of `demo.MathGame.main`. The `-g` parameter will use method signatures instead of method names, e.g. `demo.MathGame.main([Ljava/lang/String;)V` instead of `demo.MathGame.main`. There are many parameters related to result format details, you can refer to [async-profiler README](https://github.com/async-profiler/async-profiler#readme) and [async-profiler Github Discussions](https://github.com/async-profiler/async-profiler/discussions) and other information.
 
 ## The 'unknown' in profiler result
 


### PR DESCRIPTION
## 升级 stop action，适配其支持的选项

stop action 主要涉及测试结果的输出，需处理 [profiler.sh](https://github.com/async-profiler/async-profiler/blob/32601bccd9e49adda9510a2ed79d142ac6ef0ff9/profiler.sh#L354C15-L354C15) 中 FIEL、OUTPUT、FORMAT 三个变量对应的选项。在 sh 脚本中分析结果允许输出到标准输出或文件，且与输出内容格式是完全解耦的。Arthas 的设计可能是：要求必须将分析结果保存到文件，因此在 `processStop` 方法中只要判断 file 选项为空就会指定一个默认文件名。

目前对 file 选项的捕捉本身没有问题，可以对应到 sh 中的 FILE 变量。

### OUTPUT 变量：

在 sh 中通过 `-o` 选项转换为此变量，但目前 arthas 中没有该选项，仅有一个相关的 format 选项，它仅用于构造默认文件名的后缀（未传递给 execute 方法）且只有两个可选值，【分析结果】的内容格式是让 async-profiler 通过这个后缀名推断的。在 sh 中，通过设置 OUTPUT 可以得到其他格式的输出（如 flat 等格式）。要想在 profiler command 中支持这些格式，可以将 format 选项的值也用于构造 executeArgs，将其与 sh 的 `-o` 选项对应起来。

根据 sh 脚本中的使用说明，`-o` 选项可选值为 `flat|traces|collapsed|flamegraph|tree|jfr`，且均可在 arguments.cpp 中找到详细解释，其中 flat 和 traces 可加 `[=N] ` 格式参数，在 Arthas 中，用 format 选项捕捉这些值，并为选项添加短名称 `o`。本选项的值直接拼接到 JVM TI 格式参数中，与 file 选项不同，在 Arthas 中需要注意 `executeArgs` 方法构造 JVMTI 格式字符串的过程。

在需要生成默认文件名时，不直接使用 format 选项的值而是添加一层判断：先判断 format 是否有效，若无效就让后缀取 html（或其他值），然后根据 format 的各种情况确定后缀名，然后再生成文件名。

format 选项不要设定默认值，否则当用户不指定 format 但指定 file 时，用 file 后缀名推断输出格式（async profiler 内部会处理这一过程）会失效。例如，假设 format 默认值为 flamegraph，用户指定了 file 后缀为 jfr 但未指定 format，用户预期是输出 jfr 格式，但 flamegraph 会被传递给 async profiler，因此将输出火焰图格式（虽然后缀名是 jfr）。

### FORMAT 变量：

shell 脚本中对此变量的处理分散在多处，但都位于 L149 开始的循环块中。L184 -s。L187 -g。L190 -a。L193 `-l`。L200 `-I`。

L208 --filter 选项**暂不实现**，未出现在 shell 脚本说明中，其参数格式不明确。

L213 --title 需要转义 XML 特殊字符，以及逗号（防止与 JVM TI 冲突）。

L219 仅实现 --minwidth 即可。L223 --reverse。L226 仅需要 --total。

### 相关 issue

issue #2164