### PR TITLE
Add dump action

### DIFF
--- a/core/src/main/java/com/taobao/arthas/core/command/monitor200/ProfilerCommand.java
+++ b/core/src/main/java/com/taobao/arthas/core/command/monitor200/ProfilerCommand.java
@@ -515,7 +515,7 @@ public class ProfilerCommand extends AnnotatedCommand {
                             //在异步线程执行，profiler命令已经结束，不能输出到客户端
                             try {
                                 logger.info("stopping profiler ...");
-                                ProfilerModel model = processStop(asyncProfiler);
+                                ProfilerModel model = processStop(asyncProfiler, ProfilerAction.stop);
                                 logger.info("profiler output file: " + model.getOutputFile());
                                 logger.info("stop profiler successfully.");
                             } catch (Throwable e) {
@@ -526,7 +526,7 @@ public class ProfilerCommand extends AnnotatedCommand {
                 }
                 process.appendResult(profilerModel);
             } else if (ProfilerAction.stop.equals(profilerAction)) {
-                ProfilerModel profilerModel = processStop(asyncProfiler);
+                ProfilerModel profilerModel = processStop(asyncProfiler, profilerAction);
                 process.appendResult(profilerModel);
             } else if (ProfilerAction.resume.equals(profilerAction)) {
                 String executeArgs = executeArgs(ProfilerAction.resume);
@@ -578,9 +578,9 @@ public class ProfilerCommand extends AnnotatedCommand {
         }
     }
 
-    private ProfilerModel processStop(AsyncProfiler asyncProfiler) throws IOException {
+    private ProfilerModel processStop(AsyncProfiler asyncProfiler, ProfilerAction profilerAction) throws IOException {
         String outputFile = outputFile();
-        String executeArgs = executeArgs(ProfilerAction.stop);
+        String executeArgs = executeArgs(profilerAction);
         String result = execute(asyncProfiler, executeArgs);
 
         ProfilerModel profilerModel = createProfilerModel(result);

--- a/core/src/main/java/com/taobao/arthas/core/command/monitor200/ProfilerCommand.java
+++ b/core/src/main/java/com/taobao/arthas/core/command/monitor200/ProfilerCommand.java
@@ -528,6 +528,9 @@ public class ProfilerCommand extends AnnotatedCommand {
             } else if (ProfilerAction.stop.equals(profilerAction)) {
                 ProfilerModel profilerModel = processStop(asyncProfiler, profilerAction);
                 process.appendResult(profilerModel);
+            } else if (ProfilerAction.dump.equals(profilerAction)) {
+                ProfilerModel profilerModel = processStop(asyncProfiler, profilerAction);
+                process.appendResult(profilerModel);
             } else if (ProfilerAction.resume.equals(profilerAction)) {
                 String executeArgs = executeArgs(ProfilerAction.resume);
                 String result = execute(asyncProfiler, executeArgs);

--- a/core/src/main/java/com/taobao/arthas/core/command/monitor200/ProfilerCommand.java
+++ b/core/src/main/java/com/taobao/arthas/core/command/monitor200/ProfilerCommand.java
@@ -381,14 +381,16 @@ public class ProfilerCommand extends AnnotatedCommand {
     }
 
     /**
-     * https://github.com/jvm-profiling-tools/async-profiler/blob/v2.5/src/arguments.cpp#L50
-     *
+     * https://github.com/async-profiler/async-profiler/blob/v2.9/profiler.sh#L154
      */
     public enum ProfilerAction {
-        execute, start, stop, resume, list, version, status, load,
+        // start, resume, stop, dump, check, status, meminfo, list, collect,
+        start, resume, stop, dump, status, list,
+        version,
 
+        load,
+        execute,
         dumpCollapsed, dumpFlat, dumpTraces, getSamples,
-
         actions
     }
 

--- a/site/docs/doc/profiler.md
+++ b/site/docs/doc/profiler.md
@@ -144,6 +144,15 @@ Started [cpu] profiling
 
 通过执行`profiler getSamples`可以查看 samples 的数量来验证。
 
+## Dump 分析结果
+
+```bash
+$ profiler dump
+OK
+```
+
+`dump` action 将性能分析的结果保存到默认文件或指定的文件中，但 profiling 过程不会停止。例如，如果使用 `start` action 启动 profiling，5 秒后执行 `dump` action，2 秒后再次执行 `dump` action，将会得到 2 个结果文件，第一个文件包括 0\~5 秒的分析结果，第二个文件包括 0\~7 秒的分析结果。
+
 ## 使用`execute`来执行复杂的命令
 
 比如开始采样：

--- a/site/docs/en/doc/profiler.md
+++ b/site/docs/en/doc/profiler.md
@@ -144,6 +144,15 @@ The difference between `start` and `resume` is: `start` will clean existing resu
 
 You can verify the number of samples by executing `profiler getSamples`.
 
+## Dump action
+
+```bash
+$ profiler dump
+OK
+```
+
+The `dump` action saves profiling result to default file or specified file, but profiling will continue. That means if you start profiling and dump after 5 seconds, then dump after 2 seconds again, you will get 2 result files, the first one contains profiling result of 0\~5 seconds and the second one contains that of 0\~7 seconds.
+
 ## Use `execute` action to execute complex commands
 
 For example, start sampling:


### PR DESCRIPTION
### 添加 dump action

在 `ProfilerAction` 枚举类中添加 dump 即可捕获，action 排列顺序尽量与原 sh 脚本保持一致，方便后续升级。

修改 `processStop` method 使其接收多种 action，因为除了 `stop` 之外还有其他（`dump`）action 需要调用此方法。

`dump` action 的选项与 `stop` 完全一致，没有引入新的 Option。

### 相关 issue

issue #2164