### PR TITLE
Upgrade profiler action: version, meminfo

### DIFF
--- a/core/src/main/java/com/taobao/arthas/core/command/monitor200/ProfilerCommand.java
+++ b/core/src/main/java/com/taobao/arthas/core/command/monitor200/ProfilerCommand.java
@@ -385,7 +385,7 @@ public class ProfilerCommand extends AnnotatedCommand {
      */
     public enum ProfilerAction {
         // start, resume, stop, dump, check, status, meminfo, list, collect,
-        start, resume, stop, dump, status, list,
+        start, resume, stop, dump, status, meminfo, list,
         version,
 
         load,
@@ -535,14 +535,13 @@ public class ProfilerCommand extends AnnotatedCommand {
                 String executeArgs = executeArgs(ProfilerAction.resume);
                 String result = execute(asyncProfiler, executeArgs);
                 appendExecuteResult(process, result);
-            } else if (ProfilerAction.list.equals(profilerAction)) {
-                String result = asyncProfiler.execute("list");
-                appendExecuteResult(process, result);
             } else if (ProfilerAction.version.equals(profilerAction)) {
                 String result = asyncProfiler.execute("version=full");
                 appendExecuteResult(process, result);
-            } else if (ProfilerAction.status.equals(profilerAction)) {
-                String result = asyncProfiler.execute("status");
+            } else if (ProfilerAction.status.equals(profilerAction)
+                    || ProfilerAction.meminfo.equals(profilerAction)
+                    || ProfilerAction.list.equals(profilerAction)) {
+                String result = asyncProfiler.execute(profilerAction.toString());
                 appendExecuteResult(process, result);
             } else if (ProfilerAction.dumpCollapsed.equals(profilerAction)) {
                 if (actionArg == null) {

--- a/core/src/main/java/com/taobao/arthas/core/command/monitor200/ProfilerCommand.java
+++ b/core/src/main/java/com/taobao/arthas/core/command/monitor200/ProfilerCommand.java
@@ -539,7 +539,7 @@ public class ProfilerCommand extends AnnotatedCommand {
                 String result = asyncProfiler.execute("list");
                 appendExecuteResult(process, result);
             } else if (ProfilerAction.version.equals(profilerAction)) {
-                String result = asyncProfiler.execute("version");
+                String result = asyncProfiler.execute("version=full");
                 appendExecuteResult(process, result);
             } else if (ProfilerAction.status.equals(profilerAction)) {
                 String result = asyncProfiler.execute("status");

--- a/site/docs/doc/profiler.md
+++ b/site/docs/doc/profiler.md
@@ -41,7 +41,7 @@ $ profiler getSamples
 23
 ```
 
-## 查看 profiler 状态
+## 查看 profiling 状态
 
 ```bash
 $ profiler status
@@ -49,6 +49,17 @@ $ profiler status
 ```
 
 可以查看当前 profiler 在采样哪种`event`和采样时间。
+
+## 查看 profiler 自身的内存占用
+
+```
+$ profiler meminfo
+Call trace storage:   10244 KB
+      Dictionaries:      72 KB
+        Code cache:   12890 KB
+------------------------------
+             Total:   23206 KB
+```
 
 ## 停止 profiler
 
@@ -173,15 +184,15 @@ profiler execute 'stop,file=/tmp/result.html'
 
 ```bash
 $ profiler actions
-Supported Actions: [resume, dumpCollapsed, getSamples, start, list, execute, version, stop, load, dumpFlat, actions, dumpTraces, status]
+Supported Actions: [resume, dumpCollapsed, getSamples, start, list, version, execute, meminfo, stop, load, dumpFlat, dump, actions, dumpTraces, status]
 ```
 
 ## 查看版本
 
 ```bash
 $ profiler version
-Async-profiler 1.6 built on Sep  9 2019
-Copyright 2019 Andrei Pangin
+Async-profiler 2.9 built on May  8 2023
+Copyright 2016-2021 Andrei Pangin
 ```
 
 ## 配置 framebuf 参数

--- a/site/docs/en/doc/profiler.md
+++ b/site/docs/en/doc/profiler.md
@@ -41,7 +41,7 @@ $ profiler getSamples
 23
 ```
 
-## View profiler status
+## View profiling status
 
 ```bash
 $ profiler status
@@ -49,6 +49,17 @@ $ profiler status
 ```
 
 Can view which `event` and sampling time.
+
+## View profiler memory usage
+
+```
+$ profiler meminfo
+Call trace storage:   10244 KB
+      Dictionaries:      72 KB
+        Code cache:   12890 KB
+------------------------------
+             Total:   23206 KB
+```
 
 ## Stop profiler
 
@@ -173,15 +184,15 @@ Specific format reference: [arguments.cpp](https://github.com/jvm-profiling-tool
 
 ```bash
 $ profiler actions
-Supported Actions: [resume, dumpCollapsed, getSamples, start, list, execute, version, stop, load, dumpFlat, actions, dumpTraces, status]
+Supported Actions: [resume, dumpCollapsed, getSamples, start, list, version, execute, meminfo, stop, load, dumpFlat, dump, actions, dumpTraces, status]
 ```
 
 ## View version
 
 ```bash
 $ profiler version
-Async-profiler 1.6 built on Sep  9 2019
-Copyright 2019 Andrei Pangin
+Async-profiler 2.9 built on May  8 2023
+Copyright 2016-2021 Andrei Pangin
 ```
 
 ## Configure framebuf option


### PR DESCRIPTION
## 两组简单 action

### status/meminfo/list

在 async-profiler 的 shell 脚本中这些 ACTION 仅使用 FILE 变量构造 JVM TI 参数，且此时的 FILE 变量仅是为了指定临时文件用于输出到屏幕。因此，在 arthas 中，直接仅传递 action 到 execute 方法即可，将这三种 action 合并到一个分支中。

### version

async-profiler 对 version ACTION 的处理有些奇怪，在 CLI 中表现为一个选项，但在 shell 脚本中却捕获为 ACTION。在 Arthas 中目前直接作为 CLI 的 action 处理，这是更合理的做法，因此虽然与上游不一致，但仍然保留这种处理。不过，注意到 version 存在 `=full` 的可选格式，shell 脚本中均采用完整格式而 arthas 目前打印的是简短格式，将其修改为 full 格式以与上游和旧版 arthas 的行为一致。

### 相关 issue

issue #2164