### PR TITLE
修改ProfilerCommand的错误样例

### DIFF
--- a/core/src/main/java/com/taobao/arthas/core/command/monitor200/ProfilerCommand.java
+++ b/core/src/main/java/com/taobao/arthas/core/command/monitor200/ProfilerCommand.java
@@ -54,7 +54,7 @@ import one.profiler.Counter;
         + "  profiler stop --format html   # output file format, support flat[=N]|traces[=N]|collapsed|flamegraph|tree|jfr\n"
         + "  profiler stop --file /tmp/result.html\n"
         + "  profiler stop --threads \n"
-        + "  profiler start --include 'java/*' --include 'com/demo/*' --exclude '*Unsafe.park*'\n"
+        + "  profiler stop --include 'java/*' --include 'com/demo/*' --exclude '*Unsafe.park*'\n"
         + "  profiler status\n"
         + "  profiler resume              # Start or resume profiling without resetting collected data.\n"
         + "  profiler getSamples          # Get the number of samples collected during the profiling session\n"

--- a/site/docs/doc/profiler.md
+++ b/site/docs/doc/profiler.md
@@ -208,10 +208,11 @@ profiler start --framebuf 5000000
 如果应用比较复杂，生成的内容很多，想只关注部分 stack traces，可以通过 `--include/--exclude` 过滤 stack traces，`--include` 表示定义的匹配表达式必须出现在 stack traces，相反 `--exclude` 表示定义的匹配表达式一定不会出现在 stack traces。 匹配表达式可以以`*`开始或者结束,`*` 表示任何（可能为空）字符序列。 比如
 
 ```bash
-profiler start --include 'java/*' --include 'com/demo/*' --exclude '*Unsafe.park*'
+profiler stop --include 'java/*' --include 'com/demo/*' --exclude '*Unsafe.park*'
 ```
 
 > `--include/--exclude` 都支持多次设置，但是需要配置在命令行的最后。也可使用短参数格式 `-I/-X`。
+> 注意`--include/--exclude`只支持在`stop`action或者带有`-d`/`--duration`参数的`start`action中指定，否则不生效。
 
 ## 指定执行时间
 

--- a/site/docs/en/doc/profiler.md
+++ b/site/docs/en/doc/profiler.md
@@ -210,10 +210,11 @@ profiler start --framebuf 5000000
 If the application is complex and generates a lot of content, and you want to focus on only part of stack traces, you can filter stack traces by `--include/--exclude`. `--include` defines the name pattern that must be present in the stack traces, while `--exclude` is the pattern that must not occur in any of stack traces in the output.A pattern may begin or end with a star `*` that denotes any (possibly empty) sequence of characters. such as
 
 ```bash
-profiler start --include'java/*' --include 'com/demo/*' --exclude'*Unsafe.park*'
+profiler stop --include'java/*' --include 'com/demo/*' --exclude'*Unsafe.park*'
 ```
 
 > Both `--include/--exclude` support being set multiple times, but need to be configured at the end of the command line. You can also use short parameter format `-I/-X`.
+> Note that `--include/--exclude` only supports configuration at `stop` action or `start` action with `-d`/`--duration` parameter, otherwise it will not take effect.
 
 ## Specify execution time
 


### PR DESCRIPTION
根据Async-profiler，include，exclude参数在采样的时候是不起作用的，只在dump的时候起作用。
如果profiler start带--include，--exclude参数而stop没有带是无法排出指定包的，因此样例
```
profiler start --include 'java/*' --include 'com/demo/*' --exclude '*Unsafe.park*'
```
中的"start"应该改为"stop"