### PR TITLE
fix: update platform name in Arthas tutorials

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,4 @@
-# Interactive Katacoda Online Tutorials for Arthas
-
-[![](http://shields.katacoda.com/katacoda/arthas/count.svg)](https://www.katacoda.com/arthas "Get your profile on Katacoda.com")
+# Interactive Killercoda Online Tutorials for Arthas
 
 [中文说明/Chinese Documentation](README_CN.md)
 
@@ -22,7 +20,7 @@
 
 If you want to contribute to the Arthas online tutorials, you are welcome to submit pull requests for the Arthas online tutorials.
 
-Visit https://killercoda.com/creators to learn more about creating Katacoda scenarios.
+Visit https://killercoda.com/creators to learn more about creating Killercoda scenarios.
 
 For examples of the scenarios folder, visit https://github.com/killercoda/scenario-examples
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -1,6 +1,4 @@
-# Arthas 交互式 Katacoda 在线教程
-
-[![](http://shields.katacoda.com/katacoda/arthas/count.svg)](https://www.katacoda.com/arthas "Get your profile on Katacoda.com")
+# Arthas 交互式 Killercoda 在线教程
 
 English version goes [here](README.md).
 

--- a/arthas-tutorials-cn/command/dump/dump.md
+++ b/arthas-tutorials-cn/command/dump/dump.md
@@ -21,6 +21,6 @@
 
 `dump --classLoaderClass jdk.internal.loader.ClassLoaders$AppClassLoader demo.*`{{execute T2}}
 
-- 注：这里 classLoaderClass 在 java 8 是 sun.misc.Launcher$AppClassLoader，而 java 11 的 classloader 是 jdk.internal.loader.ClassLoaders$AppClassLoader，katacoda 目前环境是 java8。
+- 注：这里 classLoaderClass 在 java 8 是 sun.misc.Launcher$AppClassLoader，而 java 11 的 classloader 是 jdk.internal.loader.ClassLoaders$AppClassLoader，killercoda 目前环境是 java11。
 
 `--classLoaderClass`{{}} 的值是 ClassLoader 的类名，只有匹配到唯一的 ClassLoader 实例时才能工作，目的是方便输入通用命令，而`-c <hashcode>`{{}} 是动态变化的。

--- a/arthas-tutorials-cn/command/getstatic/getstatic.md
+++ b/arthas-tutorials-cn/command/getstatic/getstatic.md
@@ -11,7 +11,7 @@
 
 `getstatic --classLoaderClass jdk.internal.loader.ClassLoaders$AppClassLoader demo.MathGame random`{{execute T2}}
 
-- 注：这里 classLoaderClass 在 java 8 是 sun.misc.Launcher$AppClassLoader，而 java 11 的 classloader 是 jdk.internal.loader.ClassLoaders$AppClassLoader，katacoda 目前环境是 java8。
+- 注：这里 classLoaderClass 在 java 8 是 sun.misc.Launcher$AppClassLoader，而 java 11 的 classloader 是 jdk.internal.loader.ClassLoaders$AppClassLoader，killercoda 目前环境是 java11。
 
 `--classLoaderClass`{{}} 的值是 ClassLoader 的类名，只有匹配到唯一的 ClassLoader 实例时才能工作，目的是方便输入通用命令，而`-c <hashcode>`{{}} 是动态变化的。
 

--- a/arthas-tutorials-cn/command/jfr/arthas-boot.md
+++ b/arthas-tutorials-cn/command/jfr/arthas-boot.md
@@ -1,6 +1,6 @@
 手动新建一个终端于 `Tab 2`{{}} ，在 `Tab 2`{{}} 里，下载`arthas-boot.jar`{{}} ，再用`java -jar`{{}} 命令启动：
 
-`wget https://arthas.aliyun.com/arthas-boot.jar; java -jar arthas-boot.jar --target-ip 0.0.0.0`{{execute T2}}
+`wget https://arthas.aliyun.com/arthas-boot.jar; java -jar arthas-boot.jar --target-ip 0.0.0.0 --username arthas --password arthas`{{execute T2}}
 
 `arthas-boot`{{}} 是`Arthas`{{}} 的启动程序，它启动后，会列出所有的 Java 进程，用户可以选择需要诊断的目标进程。
 

--- a/arthas-tutorials-cn/command/jfr/jfr.md
+++ b/arthas-tutorials-cn/command/jfr/jfr.md
@@ -61,9 +61,7 @@ Started recording 1. No limit specified, using maxsize=250MB as default.
 
 ## 通过浏览器查看 arthas-output 下面 JFR 记录的结果
 
-默认情况下，arthas 使用 8563 端口，则可以打开： [/arthas-output]({{TRAFFIC_HOST1_8563}}/arthas-output) 查看到`arthas-output`{{}} 目录下面的 JFR 记录结果：
-
-![](../../assets/arthas-output-recording.png)
+默认情况下，arthas 使用 8563 端口，则可以打开： [/arthas-output]({{TRAFFIC_HOST1_8563}}/arthas-output) 输入账号 `arthas` 和密码 `arthas` 查看到 `arthas-output`{{}} 目录下面的 JFR 记录结果：
 
 生成的结果可以用支持 jfr 格式的工具来查看。比如：
 

--- a/arthas-tutorials-cn/command/profiler/arthas-boot.md
+++ b/arthas-tutorials-cn/command/profiler/arthas-boot.md
@@ -1,6 +1,6 @@
 手动新建一个终端于 `Tab 2`{{}} ，在 `Tab 2`{{}} 里，下载`arthas-boot.jar`{{}} ，再用`java -jar`{{}} 命令启动：
 
-`wget https://arthas.aliyun.com/arthas-boot.jar; java -jar arthas-boot.jar --target-ip 0.0.0.0`{{execute T2}}
+`wget https://arthas.aliyun.com/arthas-boot.jar; java -jar arthas-boot.jar --target-ip 0.0.0.0 --username arthas --password arthas`{{execute T2}}
 
 `arthas-boot`{{}} 是`Arthas`{{}} 的启动程序，它启动后，会列出所有的 Java 进程，用户可以选择需要诊断的目标进程。
 

--- a/arthas-tutorials-cn/command/profiler/profiler.md
+++ b/arthas-tutorials-cn/command/profiler/profiler.md
@@ -40,7 +40,7 @@
 
 ### 通过浏览器查看 arthas-output 下面的 profiler 结果
 
-默认情况下，arthas 使用 8563http 端口，[点击打开]({{TRAFFIC_HOST1_8563}}/arthas-output/) arthas-output/ 目录下面的 profiler 结果：
+默认情况下，arthas 使用 8563http 端口，[点击打开]({{TRAFFIC_HOST1_8563}}/arthas-output/) 输入账号 `arthas` 和密码 `arthas` 查看 arthas-output/ 目录下面的 profiler 结果：
 
 ![](https://arthas.aliyun.com/doc/_images/arthas-output.jpg)
 

--- a/arthas-tutorials-cn/command/profiler/profiler.md
+++ b/arthas-tutorials-cn/command/profiler/profiler.md
@@ -40,7 +40,7 @@
 
 ### 通过浏览器查看 arthas-output 下面的 profiler 结果
 
-默认情况下，arthas 使用 8563http 端口，[点击打开]({{TRAFFIC_HOST1_8563}}/arthas-output/) 输入账号 `arthas` 和密码 `arthas` 查看 arthas-output/ 目录下面的 profiler 结果：
+默认情况下，arthas 使用 8563 http 端口，[点击打开]({{TRAFFIC_HOST1_8563}}/arthas-output/) 输入账号 `arthas` 和密码 `arthas` 查看 arthas-output/ 目录下面的 profiler 结果：
 
 ![](https://arthas.aliyun.com/doc/_images/arthas-output.jpg)
 

--- a/arthas-tutorials-cn/command/sc/sc.md
+++ b/arthas-tutorials-cn/command/sc/sc.md
@@ -35,7 +35,7 @@
 
 `sc --classLoaderClass jdk.internal.loader.ClassLoaders$AppClassLoader -d demo*`{{execute T2}}
 
-- 注：这里 classLoaderClass 在 java 8 是 sun.misc.Launcher$AppClassLoader，而 java 11 的 classloader 是 jdk.internal.loader.ClassLoaders$AppClassLoader，katacoda 目前环境是 java8。
+- 注：这里 classLoaderClass 在 java 8 是 sun.misc.Launcher$AppClassLoader，而 java 11 的 classloader 是 jdk.internal.loader.ClassLoaders$AppClassLoader，killercoda 目前环境是 java11。
 
 `--classLoaderClass`{{}} 的值是 ClassLoader 的类名，只有匹配到唯一的 ClassLoader 实例时才能工作，目的是方便输入通用命令，而`-c <hashcode>`{{}} 是动态变化的。
 

--- a/arthas-tutorials-cn/command/sm/sm.md
+++ b/arthas-tutorials-cn/command/sm/sm.md
@@ -40,7 +40,7 @@
 
 `sm --classLoaderClass sun.misc.Launcher$AppClassLoader demo.MathGame`{{execute T2}}
 
-- 注：这里 classLoaderClass 在 java 8 是 sun.misc.Launcher$AppClassLoader，而 java 11 的 classloader 是 jdk.internal.loader.ClassLoaders$AppClassLoader，katacoda 目前环境是 java8。
+- 注：这里 classLoaderClass 在 java 8 是 sun.misc.Launcher$AppClassLoader，而 java 11 的 classloader 是 jdk.internal.loader.ClassLoaders$AppClassLoader，killercoda 目前环境是 java11。
 
 `--classLoaderClass`{{}} 的值是 ClassLoader 的类名，只有匹配到唯一的 ClassLoader 实例时才能工作，目的是方便输入通用命令，而`-c <hashcode>`{{}} 是动态变化的。
 

--- a/arthas-tutorials-en/command/dump/dump.md
+++ b/arthas-tutorials-en/command/dump/dump.md
@@ -21,6 +21,6 @@ Loading class bytecode with specifying a directory
 
 `dump --classLoaderClass jdk.internal.loader.ClassLoaders$AppClassLoader demo.*`{{execute T2}}
 
-- PS: Here the classLoaderClass in java 8 is sun.misc.Launcher$AppClassLoader, while in java 11 it's jdk.internal.loader.ClassLoaders$AppClassLoader. Currently katacoda using java 8.
+- PS: Here the classLoaderClass in java 8 is sun.misc.Launcher$AppClassLoader, while in java 11 it's jdk.internal.loader.ClassLoaders$AppClassLoader. Currently killercoda using java 11.
 
 The value of `--classloaderclass`{{}} is the class name of classloader. It can only work when it matches a unique classloader instance. The purpose is to facilitate the input of general commands. However, `-c <hashcode>`{{}} is dynamic.

--- a/arthas-tutorials-en/command/getstatic/getstatic.md
+++ b/arthas-tutorials-en/command/getstatic/getstatic.md
@@ -11,7 +11,7 @@ Use [getstatic command](https://arthas.aliyun.com/en/doc/getstatic.html) to Chec
 
 `getstatic --classLoaderClass jdk.internal.loader.ClassLoaders$AppClassLoader random`{{execute T2}}
 
-- PS: Here the classLoaderClass in java 8 is sun.misc.Launcher$AppClassLoader, while in java 11 it's jdk.internal.loader.ClassLoaders$AppClassLoader. Currently katacoda using java 8.
+- PS: Here the classLoaderClass in java 8 is sun.misc.Launcher$AppClassLoader, while in java 11 it's jdk.internal.loader.ClassLoaders$AppClassLoader. Currently killercoda using java11.
 
 The value of `--classloaderclass`{{}} is the class name of classloader. It can only work when it matches a unique classloader instance. The purpose is to facilitate the input of general commands. However, `-c <hashcode>`{{}} is dynamic.
 

--- a/arthas-tutorials-en/command/jfr/arthas-boot.md
+++ b/arthas-tutorials-en/command/jfr/arthas-boot.md
@@ -1,6 +1,6 @@
 Open a new tab, and then in the terminal of `Tab 2`{{}} , download `arthas-boot.jar`{{}} and start with the `java -jar`{{}} command:
 
-`wget https://arthas.aliyun.com/arthas-boot.jar; java -jar arthas-boot.jar`{{execute T2}}
+`wget https://arthas.aliyun.com/arthas-boot.jar; java -jar arthas-boot.jar --target-ip 0.0.0.0 --username arthas --password arthas`{{execute T2}}
 
 `arthas-boot`{{}} is the launcher for `Arthas`{{}} . It lists all the Java processes, and the user can select the target process to be diagnosed.
 

--- a/arthas-tutorials-en/command/jfr/jfr.md
+++ b/arthas-tutorials-en/command/jfr/jfr.md
@@ -61,7 +61,7 @@ You can also specify the record output path.
 
 ## View JFR recording results under arthas-output via browser
 
-By default, arthas uses http port 8563 , which can be opened: [/arthas-output]({{TRAFFIC_HOST1_8563}}/arthas-output) View the `arthas-output`{{}} directory below JFR recording results:
+By default, arthas uses http port 8563 , which can be opened: [/arthas-output]({{TRAFFIC_HOST1_8563}}/arthas-output) and enter the username `arthas` and password `arthas` to view the `arthas-output`{{}} directory below JFR recording results:
 
 ![](../../assets/arthas-output-recording.png)
 

--- a/arthas-tutorials-en/command/profiler/arthas-boot.md
+++ b/arthas-tutorials-en/command/profiler/arthas-boot.md
@@ -1,6 +1,6 @@
 Open a new tab, and then in the terminal of `Tab 2`{{}} , download `arthas-boot.jar`{{}} and start with the `java -jar`{{}} command:
 
-`wget https://arthas.aliyun.com/arthas-boot.jar; java -jar arthas-boot.jar --target-ip 0.0.0.0`{{execute T2}}
+`wget https://arthas.aliyun.com/arthas-boot.jar; java -jar arthas-boot.jar --target-ip 0.0.0.0 --username arthas --password arthas`{{execute T2}}
 
 `arthas-boot`{{}} is the launcher for `Arthas`{{}} . It lists all the Java processes, and the user can select the target process to be diagnosed.
 

--- a/arthas-tutorials-en/command/profiler/profiler.md
+++ b/arthas-tutorials-en/command/profiler/profiler.md
@@ -40,7 +40,7 @@ Or use the file name name format in the `--file`{{}} parameter. For example, `--
 
 ### View profiler results under arthas-output via browser
 
-By default, arthas uses http port 8563, [click to open]({{TRAFFIC_HOST1_8563}}/arthas-output/) View the `arthas-output`{{}} directory below Profiler results:
+By default, arthas uses http port 8563, [click to open]({{TRAFFIC_HOST1_8563}}/arthas-output/) and enter username `arthas` and password `arthas` to view the `arthas-output`{{}} directory below Profiler results:
 
 ![](https://arthas.aliyun.com/doc/_images/arthas-output.jpg)
 

--- a/arthas-tutorials-en/command/sc/sc.md
+++ b/arthas-tutorials-en/command/sc/sc.md
@@ -32,7 +32,7 @@
 
 `sc --classLoaderClass jdk.internal.loader.ClassLoaders$AppClassLoader -d demo*`{{execute T2}}
 
-- PS: Here the classLoaderClass in java 8 is sun.misc.Launcher$AppClassLoader, while in java 11 it's jdk.internal.loader.ClassLoaders$AppClassLoader. Currently katacoda using java 8.
+- PS: Here the classLoaderClass in java 8 is sun.misc.Launcher$AppClassLoader, while in java 11 it's jdk.internal.loader.ClassLoaders$AppClassLoader. Currently killercoda using java 11.
 
 The value of `--classloaderclass`{{}} is the class name of classloader. It can only work when it matches a unique classloader instance. The purpose is to facilitate the input of general commands. However, `-c <hashcode>`{{}} is dynamic.
 

--- a/arthas-tutorials-en/command/sm/sm.md
+++ b/arthas-tutorials-en/command/sm/sm.md
@@ -38,7 +38,7 @@ For classloader with only one instance, it can be specified by `--classLoaderCla
 
 `sm --classLoaderClass sun.misc.Launcher$AppClassLoader demo.MathGame`{{execute T2}}
 
-- PS: Here the classLoaderClass in java 8 is sun.misc.Launcher$AppClassLoader, while in java 11 it's jdk.internal.loader.ClassLoaders$AppClassLoader. Currently katacoda using java 8.
+- PS: Here the classLoaderClass in java 8 is sun.misc.Launcher$AppClassLoader, while in java 11 it's jdk.internal.loader.ClassLoaders$AppClassLoader. Currently killercoda using java 11.
 
 The value of `--classloaderclass`{{}} is the class name of classloader. It can only work when it matches a unique classloader instance. The purpose is to facilitate the input of general commands. However, `-c <hashcode>`{{}} is dynamic.
 


### PR DESCRIPTION
- 修改平台名称 Katacoda 修改为 Killercoda
- 为 `jfr` 和 `profile` 命令教程添加设置账号密码