### PR TITLE
jad命令优化

### DIFF
--- a/core/src/main/java/com/taobao/arthas/core/command/klass100/ClassDumpTransformer.java
+++ b/core/src/main/java/com/taobao/arthas/core/command/klass100/ClassDumpTransformer.java
@@ -52,18 +52,23 @@ class ClassDumpTransformer implements ClassFileTransformer {
         return dumpResult;
     }
 
-    private void dumpClassIfNecessary(Class<?> clazz, byte[] data) {
-        String className = clazz.getName();
-        ClassLoader classLoader = clazz.getClassLoader();
+    public File dumpDir() {
         String classDumpDir = "classdump";
-
-        // 创建类所在的包路径
-        File dumpDir = null;
+        final File dumpDir;
         if (directory != null) {
             dumpDir = directory;
         } else {
             dumpDir = new File(arthasLogHome, classDumpDir);
         }
+        return dumpDir;
+    }
+
+    private void dumpClassIfNecessary(Class<?> clazz, byte[] data) {
+        String className = clazz.getName();
+        ClassLoader classLoader = clazz.getClassLoader();
+
+        // 创建类所在的包路径
+        File dumpDir = dumpDir();
         if (!dumpDir.mkdirs() && !dumpDir.exists()) {
             logger.warn("create dump directory:{} failed.", dumpDir.getAbsolutePath());
             return;

--- a/site/docs/doc/jad.md
+++ b/site/docs/doc/jad.md
@@ -176,3 +176,11 @@ Affect(row-cnt:1) cost in 190 ms.
 对于只有唯一实例的 ClassLoader 还可以通过`--classLoaderClass`指定 class name，使用起来更加方便：
 
 `--classLoaderClass` 的值是 ClassLoader 的类名，只有匹配到唯一的 ClassLoader 实例时才能工作，目的是方便输入通用命令，而`-c <hashcode>`是动态变化的。
+
+### 反编译时指定dump class文件目录 
+
+`jad`反编译需要将class dump到文件，默认会dump到logback.xml中配置的log目录下，使用`-d/--directory`可以将文件dump到指定目录。
+
+```java
+$ jad demo.MathGame -d /tmp/jad/dump
+```

--- a/site/docs/en/doc/jad.md
+++ b/site/docs/en/doc/jad.md
@@ -176,3 +176,7 @@ Affect(row-cnt:1) cost in 190 ms.
 For classloader with only one instance, it can be specified by `--classLoaderClass` using class name, which is more convenient to use.
 
 The value of `--classloaderclass` is the class name of classloader. It can only work when it matches a unique classloader instance. The purpose is to facilitate the input of general commands. However, `-c <hashcode>` is dynamic.
+
+### Decompile with specified directory for dumpping class
+
+Decompile class with `jad` need to dump corresponding classes into files. The default directory for dumpping classes is the directory of log file specified in logback.xml, we can use `-d/--directory` to specify the directory for dummping class.

--- a/site/docs/en/doc/jad.md
+++ b/site/docs/en/doc/jad.md
@@ -180,3 +180,7 @@ The value of `--classloaderclass` is the class name of classloader. It can only 
 ### Decompile with specified directory for dumpping class
 
 Decompile class with `jad` need to dump corresponding classes into files. The default directory for dumpping classes is the directory of log file specified in logback.xml, we can use `-d/--directory` to specify the directory for dummping class.
+
+```java
+$ jad demo.MathGame -d /tmp/jad/dump
+```


### PR DESCRIPTION
jad命令需要dump class到文件，默认dump目录为logback指定的日志文件所在目录，当目标进程没有该目录写权限时，反编译失败，控制台输出"jad: fail to decompile class: XXXX"，由于没有权限，日志文件也看不到什么信息，用户很难定位该问题，因此做了2点优化
1. 增加`-d/--directory`选项用来指定dump文件目录，这样用户可以指定一个有写权限的目录dump文件
2. 当dump文件失败时提示用户确认默认dump目录的权限或者指定dump目录