### PR TITLE
Upgrade action start resume part2

### DIFF
--- a/core/src/main/java/com/taobao/arthas/core/command/monitor200/ProfilerCommand.java
+++ b/core/src/main/java/com/taobao/arthas/core/command/monitor200/ProfilerCommand.java
@@ -76,6 +76,12 @@ public class ProfilerCommand extends AnnotatedCommand {
     private String event;
 
     /**
+     * profile allocations with BYTES interval
+     * according to async-profiler README, alloc may contains non-numeric charactors
+     */
+    private String alloc;
+
+    /**
      * output file name for dumping
      */
     private String file;
@@ -252,6 +258,12 @@ public class ProfilerCommand extends AnnotatedCommand {
         this.event = event;
     }
 
+    @Option(longName = "alloc")
+    @Description("allocation profiling interval in bytes")
+    public void setAlloc(String alloc) {
+        this.alloc = alloc;
+    }
+
     @Option(shortName = "t", longName = "threads", flag = true)
     @Description("profile different threads separately")
     public void setThreads(boolean threads) {
@@ -410,6 +422,9 @@ public class ProfilerCommand extends AnnotatedCommand {
 
         if (this.event != null) {
             sb.append("event=").append(this.event).append(COMMA);
+        }
+        if (this.alloc!= null) {
+            sb.append("alloc=").append(this.alloc).append(COMMA);
         }
         if (this.file != null) {
             sb.append("file=").append(this.file).append(COMMA);

--- a/core/src/main/java/com/taobao/arthas/core/command/monitor200/ProfilerCommand.java
+++ b/core/src/main/java/com/taobao/arthas/core/command/monitor200/ProfilerCommand.java
@@ -82,6 +82,12 @@ public class ProfilerCommand extends AnnotatedCommand {
     private String alloc;
 
     /**
+     * profile contended locks longer than DURATION ns
+     * according to async-profiler README, alloc may contains non-numeric charactors
+     */
+    private String lock;
+
+    /**
      * output file name for dumping
      */
     private String file;
@@ -264,6 +270,12 @@ public class ProfilerCommand extends AnnotatedCommand {
         this.alloc = alloc;
     }
 
+    @Option(longName = "lock")
+    @Description("lock profiling threshold in nanoseconds")
+    public void setLock(String lock) {
+        this.lock = lock;
+    }
+
     @Option(shortName = "t", longName = "threads", flag = true)
     @Description("profile different threads separately")
     public void setThreads(boolean threads) {
@@ -425,6 +437,9 @@ public class ProfilerCommand extends AnnotatedCommand {
         }
         if (this.alloc!= null) {
             sb.append("alloc=").append(this.alloc).append(COMMA);
+        }
+        if (this.lock!= null) {
+            sb.append("lock=").append(this.lock).append(COMMA);
         }
         if (this.file != null) {
             sb.append("file=").append(this.file).append(COMMA);

--- a/core/src/main/java/com/taobao/arthas/core/command/monitor200/ProfilerCommand.java
+++ b/core/src/main/java/com/taobao/arthas/core/command/monitor200/ProfilerCommand.java
@@ -178,6 +178,16 @@ public class ProfilerCommand extends AnnotatedCommand {
      */
     private boolean total;
 
+    /**
+     * approximate size of JFR chunk in bytes (default: 100 MB)
+     */
+    private String chunksize;
+
+    /**
+     * duration of JFR chunk in seconds (default: 1 hour)
+     */
+    private String chunktime;
+
     private static String libPath;
     private static AsyncProfiler profiler = null;
 
@@ -368,6 +378,18 @@ public class ProfilerCommand extends AnnotatedCommand {
         this.total = total;
     }
 
+    @Option(longName = "chunksize")
+    @Description("approximate size limits for a single JFR chunk in bytes (default: 100 MB) or other units")
+    public void setChunksize(String chunksize) {
+        this.chunksize = chunksize;
+    }
+
+    @Option(longName = "chunktime")
+    @Description("approximate time limits for a single JFR chunk in second (default: 1 hour) or other units")
+    public void setChunktime(String chunktime) {
+        this.chunktime = chunktime;
+    }
+
     private AsyncProfiler profilerInstance() {
         if (profiler != null) {
             return profiler;
@@ -496,6 +518,12 @@ public class ProfilerCommand extends AnnotatedCommand {
         }
         if (this.total) {
             sb.append("total").append(COMMA);
+        }
+        if (this.chunksize != null) {
+            sb.append("chunksize=").append(this.chunksize).append(COMMA);
+        }
+        if (this.chunktime!= null) {
+            sb.append("chunktime=").append(this.chunktime).append(COMMA);
         }
 
         return sb.toString();

--- a/site/docs/doc/profiler.md
+++ b/site/docs/doc/profiler.md
@@ -262,3 +262,22 @@ profiler stop -s -g -a -l --title <flametitle> --minwidth 15 --reverse
 ## 生成的火焰图里的 unknown
 
 - https://github.com/jvm-profiling-tools/async-profiler/discussions/409
+
+## 配置 locks/allocations 模式的阈值
+
+当使用 lock 或 alloc event 进行 profiling 时，可以使用 `--lock` 或 `--alloc` 配置阈值，比如下列命令：
+
+```bash
+profiler start -e lock --lock 10ms
+profiler start -e alloc --alloc 2m
+```
+
+会记录竞争时间超过 10ms 的锁（如果不指定时间单位，则使用 ns 为单位），或者以 2MB 的单位记录对内存的分配。
+
+## 配置 JFR 块
+
+当使用 JFR 作为输出格式时，可以使用 `--chunksize` 或 `--chunktime` 配置单个 JFR 块的大致容量（以 byte 为单位，默认 100 MB）和时间限制（默认值为 1 小时），比如：
+
+```bash
+profiler start -f profile.jfr --chunksize 100m --chunktime 1h
+```

--- a/site/docs/en/doc/profiler.md
+++ b/site/docs/en/doc/profiler.md
@@ -262,3 +262,22 @@ profiler stop -s -g -a -l --title <flametitle> --minwidth 15 --reverse
 ## The 'unknown' in profiler result
 
 - https://github.com/jvm-profiling-tools/async-profiler/discussions/409
+
+## Config locks/allocations profiling threshold
+
+When profiling in locks or allocations event, you can use `--lock` or `--alloc` to config thresholds, for example:
+
+```bash
+profiler start -e lock --lock 10ms
+profiler start -e alloc --alloc 2m
+```
+
+will profile contended locks longer than 10ms (default unit is ns if no unit is specified), or profile allocations with 2m BYTES interval.
+
+## Config JFR chunks
+
+When using JFR as output format, you can use `--chunksize` or `--chunktime` to config approximate size (in bytes, default value is 100MB) and time limits (default value is 1 hour) for a single JFR chunk. For example:
+
+```bash
+profiler start -f profile.jfr --chunksize 100m --chunktime 1h
+```


### PR DESCRIPTION
## 升级 start/resume action

添加 shell 脚本 L229 --alloc|--lock|--chunksize|--chunktime 选项。

在 async-profiler 中，"include only user-mode events" 功能对应的 JVM TI 格式参数为 alluser 但 CLI 选项为 `--all-user`（shell 脚本 [L240](https://github.com/async-profiler/async-profiler/blob/32601bccd9e49adda9510a2ed79d142ac6ef0ff9/profiler.sh#L240)）。目前 arthas 中 CLI 格式为 `--alluser`，是否考虑更换为兼容上游的格式？

另外，arthas 实现了 `--allkernel` 选项，但 async-profiler 的 README 和命令 help message 中都没有这个选项，具体原因可参考  [Why allkernel option is not in README or help message?](https://github.com/async-profiler/async-profiler/discussions/810)，是否考虑去掉该选项？

### 相关 issue

issue #2164 