### PR TITLE
Upgrade action start resume part3

### DIFF
--- a/core/src/main/java/com/taobao/arthas/core/command/monitor200/ProfilerCommand.java
+++ b/core/src/main/java/com/taobao/arthas/core/command/monitor200/ProfilerCommand.java
@@ -149,11 +149,6 @@ public class ProfilerCommand extends AnnotatedCommand {
     private boolean lib;
 
     /**
-     * include only kernel-mode events
-     */
-    private boolean allkernel;
-
-    /**
      * include only user-mode events
      */
     private boolean alluser;
@@ -365,13 +360,7 @@ public class ProfilerCommand extends AnnotatedCommand {
         this.lib = lib;
     }
 
-    @Option(longName = "allkernel", flag = true)
-    @Description("include only kernel-mode events")
-    public void setAllkernel(boolean allkernel) {
-        this.allkernel = allkernel;
-    }
-
-    @Option(longName = "alluser", flag = true)
+    @Option(longName = "all-user", flag = true)
     @Description("include only user-mode events")
     public void setAlluser(boolean alluser) {
         this.alluser = alluser;
@@ -566,9 +555,6 @@ public class ProfilerCommand extends AnnotatedCommand {
         }
         if (this.lib) {
             sb.append("lib").append(COMMA);
-        }
-        if (this.allkernel) {
-            sb.append("allkernel").append(COMMA);
         }
         if (this.alluser) {
             sb.append("alluser").append(COMMA);

--- a/core/src/main/java/com/taobao/arthas/core/command/monitor200/ProfilerCommand.java
+++ b/core/src/main/java/com/taobao/arthas/core/command/monitor200/ProfilerCommand.java
@@ -173,6 +173,15 @@ public class ProfilerCommand extends AnnotatedCommand {
      */
     private List<String> excludes;
 
+    /**
+     * automatically start profiling when the specified native function is executed.
+     */
+    private String begin;
+
+    /**
+     * automatically stop profiling when the specified native function is executed.
+     */
+    private String end;
 
     /**
      * FlameGraph title
@@ -380,6 +389,18 @@ public class ProfilerCommand extends AnnotatedCommand {
         this.excludes = excludes;
     }
 
+    @Option(longName = "begin")
+    @Description("automatically start profiling when the specified native function is executed")
+    public void setBegin(String begin) {
+        this.begin = begin;
+    }
+
+    @Option(longName = "end")
+    @Description("automatically stop profiling when the specified native function is executed")
+    public void setEnd(String end) {
+        this.end = end;
+    }
+
     @Option(longName = "title")
     @Description("FlameGraph title")
     public void setTitle(String title) {
@@ -548,6 +569,12 @@ public class ProfilerCommand extends AnnotatedCommand {
             for (String exclude : excludes) {
                 sb.append("exclude=").append(exclude).append(COMMA);
             }
+        }
+        if (this.begin != null) {
+            sb.append("begin=").append(this.begin).append(COMMA);
+        }
+        if (this.end != null) {
+            sb.append("end=").append(this.end).append(COMMA);
         }
 
         if (this.title != null) {

--- a/core/src/main/java/com/taobao/arthas/core/command/monitor200/ProfilerCommand.java
+++ b/core/src/main/java/com/taobao/arthas/core/command/monitor200/ProfilerCommand.java
@@ -184,6 +184,12 @@ public class ProfilerCommand extends AnnotatedCommand {
     private String end;
 
     /**
+     * time-to-safepoint profiling.
+     * An alias for --begin SafepointSynchronize::begin --end RuntimeService::record_safepoint_synchronized
+     */
+    private boolean ttsp;
+
+    /**
      * FlameGraph title
      */
     private String title;
@@ -401,6 +407,13 @@ public class ProfilerCommand extends AnnotatedCommand {
         this.end = end;
     }
 
+    @Option(longName = "ttsp", flag = true)
+    @Description("time-to-safepoint profiling. "
+        + "An alias for --begin SafepointSynchronize::begin --end RuntimeService::record_safepoint_synchronized")
+    public void setTtsp(boolean ttsp) {
+        this.ttsp = ttsp;
+    }
+
     @Option(longName = "title")
     @Description("FlameGraph title")
     public void setTitle(String title) {
@@ -569,6 +582,10 @@ public class ProfilerCommand extends AnnotatedCommand {
             for (String exclude : excludes) {
                 sb.append("exclude=").append(exclude).append(COMMA);
             }
+        }
+        if (this.ttsp) {
+            this.begin = "SafepointSynchronize::begin";
+            this.end = "RuntimeService::record_safepoint_synchronized";
         }
         if (this.begin != null) {
             sb.append("begin=").append(this.begin).append(COMMA);

--- a/core/src/main/java/com/taobao/arthas/core/command/monitor200/ProfilerCommand.java
+++ b/core/src/main/java/com/taobao/arthas/core/command/monitor200/ProfilerCommand.java
@@ -113,6 +113,11 @@ public class ProfilerCommand extends AnnotatedCommand {
     private boolean threads;
 
     /**
+     * group threads by scheduling policy
+     */
+    private boolean sched;
+
+    /**
      * use simple class names instead of FQN
      */
     private boolean simple;
@@ -290,6 +295,12 @@ public class ProfilerCommand extends AnnotatedCommand {
     @Description("profile different threads separately")
     public void setThreads(boolean threads) {
         this.threads = threads;
+    }
+
+    @Option(longName = "sched", flag = true)
+    @Description("group threads by scheduling policy")
+    public void setSched(boolean sched) {
+        this.sched = sched;
     }
 
     @Option(shortName = "s", flag = true)
@@ -477,6 +488,9 @@ public class ProfilerCommand extends AnnotatedCommand {
         }
         if (this.threads) {
             sb.append("threads").append(COMMA);
+        }
+        if (this.sched) {
+            sb.append("sched").append(COMMA);
         }
         if (this.simple) {
             sb.append("simple").append(COMMA);

--- a/core/src/main/java/com/taobao/arthas/core/command/monitor200/ProfilerCommand.java
+++ b/core/src/main/java/com/taobao/arthas/core/command/monitor200/ProfilerCommand.java
@@ -82,6 +82,11 @@ public class ProfilerCommand extends AnnotatedCommand {
     private String alloc;
 
     /**
+     * build allocation profile from live objects only
+     */
+    private boolean live;
+
+    /**
      * profile contended locks longer than DURATION ns
      * according to async-profiler README, alloc may contains non-numeric charactors
      */
@@ -285,6 +290,12 @@ public class ProfilerCommand extends AnnotatedCommand {
         this.alloc = alloc;
     }
 
+    @Option(longName = "live", flag = true)
+    @Description("build allocation profile from live objects only")
+    public void setLive(boolean live) {
+        this.live = live;
+    }
+
     @Option(longName = "lock")
     @Description("lock profiling threshold in nanoseconds")
     public void setLock(String lock) {
@@ -470,6 +481,9 @@ public class ProfilerCommand extends AnnotatedCommand {
         }
         if (this.alloc!= null) {
             sb.append("alloc=").append(this.alloc).append(COMMA);
+        }
+        if (this.live) {
+            sb.append(this.live).append(COMMA);
         }
         if (this.lock!= null) {
             sb.append("lock=").append(this.lock).append(COMMA);

--- a/core/src/main/java/com/taobao/arthas/core/command/monitor200/ProfilerCommand.java
+++ b/core/src/main/java/com/taobao/arthas/core/command/monitor200/ProfilerCommand.java
@@ -123,6 +123,12 @@ public class ProfilerCommand extends AnnotatedCommand {
     private boolean sched;
 
     /**
+     * how to collect C stack frames in addition to Java stack
+     * MODE is 'fp' (Frame Pointer), 'dwarf', 'lbr' (Last Branch Record) or 'no'
+     */
+    private String cstack;
+
+    /**
      * use simple class names instead of FQN
      */
     private boolean simple;
@@ -312,6 +318,12 @@ public class ProfilerCommand extends AnnotatedCommand {
     @Description("group threads by scheduling policy")
     public void setSched(boolean sched) {
         this.sched = sched;
+    }
+
+    @Option(longName = "cstack")
+    @Description("how to traverse C stack: fp|dwarf|lbr|no")
+    public void setCstack(String cstack) {
+        this.cstack = cstack;
     }
 
     @Option(shortName = "s", flag = true)
@@ -505,6 +517,9 @@ public class ProfilerCommand extends AnnotatedCommand {
         }
         if (this.sched) {
             sb.append("sched").append(COMMA);
+        }
+        if (this.cstack != null) {
+            sb.append("cstack=").append(this.cstack).append(COMMA);
         }
         if (this.simple) {
             sb.append("simple").append(COMMA);


### PR DESCRIPTION
## 升级 start/resume action

L240 --all-user 格式不一致，arthas 中为 --alluser，根据 pr #2647 讨论结果修改，并去掉 --allkernel 选项。

L243 --sched。L246 --live。

L249 --cstack|--call-graph 两个选项完全等价，仅实现前者，因为 async-profiler 的文档和 help message 中都只列出前者。

L253 begin，end。

L257 ttsp，对 begin，end 有影响，async-profiler 设计为晚出现的选项优先级高，但 Arthas 似乎无法实现此行为，决定设计为 ttsp 优先级更高。


### 相关 issue

issue #2164 