### PR TITLE
Make thread id uniformly displayed in decimal format

### DIFF
--- a/core/src/main/java/com/taobao/arthas/core/command/view/TraceView.java
+++ b/core/src/main/java/com/taobao/arthas/core/command/view/TraceView.java
@@ -89,10 +89,10 @@ public class TraceView extends ResultView<TraceModel> {
             //render thread info
             ThreadNode threadNode = (ThreadNode) node;
             //ts=2020-04-29 10:34:00;thread_name=main;id=1;is_daemon=false;priority=5;TCCL=sun.misc.Launcher$AppClassLoader@18b4aac2
-            sb.append(format("ts=%s;thread_name=%s;id=%s;is_daemon=%s;priority=%d;TCCL=%s",
+            sb.append(format("ts=%s;thread_name=%s;id=%d;is_daemon=%s;priority=%d;TCCL=%s",
                     DateUtils.formatDate(threadNode.getTimestamp()),
                     threadNode.getThreadName(),
-                    Long.toHexString(threadNode.getThreadId()),
+                    threadNode.getThreadId(),
                     threadNode.isDaemon(),
                     threadNode.getPriority(),
                     threadNode.getClassloader()));

--- a/core/src/main/java/com/taobao/arthas/core/util/ThreadUtil.java
+++ b/core/src/main/java/com/taobao/arthas/core/util/ThreadUtil.java
@@ -399,7 +399,7 @@ abstract public class ThreadUtil {
     public static StackModel getThreadStackModel(ClassLoader loader, Thread currentThread) {
         StackModel stackModel = new StackModel();
         stackModel.setThreadName(currentThread.getName());
-        stackModel.setThreadId(Long.toHexString(currentThread.getId()));
+        stackModel.setThreadId(Long.toString(currentThread.getId()));
         stackModel.setDaemon(currentThread.isDaemon());
         stackModel.setPriority(currentThread.getPriority());
         stackModel.setClassloader(getTCCL(currentThread));


### PR DESCRIPTION
Currently, the thread id format displayed by different commands is different. For example, the thread id in the dashboard is in decimal format, and the thread id in the trace command is in hexadecimal format and does not start with `0x`, which is easy to confuse. Refer to the thread id format in the JDK stack frame. It is recommended to use decimal format uniformly.