### PR TITLE
fix directory check for DumpClassCommand

### DIFF
--- a/core/src/main/java/com/taobao/arthas/core/command/klass100/DumpClassCommand.java
+++ b/core/src/main/java/com/taobao/arthas/core/command/klass100/DumpClassCommand.java
@@ -104,7 +104,7 @@ public class DumpClassCommand extends AnnotatedCommand {
         try {
             if (directory != null) {
                 File dir = new File(directory);
-                if (dir.isFile()) {
+                if (!dir.isDirectory()) {
                     process.end(-1, directory + " :is not a directory, please check it");
                     return;
                 }


### PR DESCRIPTION
dump命令检测-d参数指定路径是否为目录的条件不准确，
例如路径对应的是linux的设备文件，此时就会有问题