### PR TITLE
Bump AssertJ Core from 2.9.1 to 3.24.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -167,7 +167,7 @@
             <dependency>
                 <groupId>org.assertj</groupId>
                 <artifactId>assertj-core</artifactId>
-                <version>2.9.1</version>
+                <version>3.24.2</version>
                 <scope>test</scope>
             </dependency>
             <dependency>


### PR DESCRIPTION
#2530
* Set assertj-core version to 3.24.2 in `pom.xml`