### PR TITLE
Bump logback from 1.2.11 to 1.2.12

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -120,12 +120,12 @@
             <dependency>
                 <groupId>ch.qos.logback</groupId>
                 <artifactId>logback-classic</artifactId>
-                <version>1.2.11</version>
+                <version>1.2.12</version>
             </dependency>
             <dependency>
                 <groupId>ch.qos.logback</groupId>
                 <artifactId>logback-core</artifactId>
-                <version>1.2.11</version>
+                <version>1.2.12</version>
             </dependency>
             <dependency>
                 <groupId>com.alibaba.arthas</groupId>


### PR DESCRIPTION
#2530
* Set dependency `ch.qos.logback:logback-classic` version to 1.2.12 in `pom.xml`
* Set dependency `ch.qos.logback:logback-core` version to 1.2.12 in `pom.xml`

(It seems that spring-boot 2.7.x does not work with logback 1.3.x because it uses slf4j 1.7.x instead of 2.0.x, so I haven't bumped logback to 1.3.x)
