### PR TITLE
Upgrade action start resume part4

### DIFF
--- a/core/src/main/java/com/taobao/arthas/core/command/monitor200/ProfilerCommand.java
+++ b/core/src/main/java/com/taobao/arthas/core/command/monitor200/ProfilerCommand.java
@@ -504,7 +504,7 @@ public class ProfilerCommand extends AnnotatedCommand {
      */
     public enum ProfilerAction {
         // start, resume, stop, dump, check, status, meminfo, list, collect,
-        start, resume, stop, dump, status, meminfo, list,
+        start, resume, stop, dump, check, status, meminfo, list,
         version,
 
         load,
@@ -685,6 +685,10 @@ public class ProfilerCommand extends AnnotatedCommand {
                 process.appendResult(profilerModel);
             } else if (ProfilerAction.resume.equals(profilerAction)) {
                 String executeArgs = executeArgs(ProfilerAction.resume);
+                String result = execute(asyncProfiler, executeArgs);
+                appendExecuteResult(process, result);
+            } else if (ProfilerAction.check.equals(profilerAction)) {
+                String executeArgs = executeArgs(ProfilerAction.check);
                 String result = execute(asyncProfiler, executeArgs);
                 appendExecuteResult(process, result);
             } else if (ProfilerAction.version.equals(profilerAction)) {

--- a/core/src/main/java/com/taobao/arthas/core/command/monitor200/ProfilerCommand.java
+++ b/core/src/main/java/com/taobao/arthas/core/command/monitor200/ProfilerCommand.java
@@ -93,6 +93,11 @@ public class ProfilerCommand extends AnnotatedCommand {
     private String lock;
 
     /**
+     * start Java Flight Recording with the given config along with the profiler
+     */
+    private String jfrsync;
+
+    /**
      * output file name for dumping
      */
     private String file;
@@ -318,6 +323,12 @@ public class ProfilerCommand extends AnnotatedCommand {
         this.lock = lock;
     }
 
+    @Option(longName = "jfrsync")
+    @Description("start Java Flight Recording with the given config along with the profiler")
+    public void setJfrsync(String jfrsync) {
+        this.jfrsync = jfrsync;
+    }
+
     @Option(shortName = "t", longName = "threads", flag = true)
     @Description("profile different threads separately")
     public void setThreads(boolean threads) {
@@ -522,6 +533,10 @@ public class ProfilerCommand extends AnnotatedCommand {
         }
         if (this.lock!= null) {
             sb.append("lock=").append(this.lock).append(COMMA);
+        }
+        if (this.jfrsync != null) {
+            this.format = "jfr";
+            sb.append("jfrsync=").append(this.jfrsync).append(COMMA);
         }
         if (this.file != null) {
             sb.append("file=").append(this.file).append(COMMA);

--- a/site/docs/doc/profiler.md
+++ b/site/docs/doc/profiler.md
@@ -180,7 +180,7 @@ profiler execute 'start,framebuf=5000000'
 profiler execute 'stop,file=/tmp/result.html'
 ```
 
-具体的格式参考： [arguments.cpp](https://github.com/async-profiler/async-profiler/blob/32601bccd9e49adda9510a2ed79d142ac6ef0ff9/src/arguments.cpp#L52)
+具体的格式参考： [arguments.cpp](https://github.com/async-profiler/async-profiler/blob/v2.9/src/arguments.cpp#L52)
 
 ## 查看所有支持的 action
 
@@ -330,3 +330,11 @@ profiler --ttsp
 ## 使用 profiler 记录的 event 生成 JFR 文件
 
 用 `--jfrsync CONFIG` 选项可以指定配置启动 Java Flight Recording，输出的 jfr 文件会包含所有常规的 JFR event，但采样的来源是由 profiler 提供的。
+
+`CONFIG` 选项可以是 `profile`，表示使用在 `$JAVA_HOME/lib/jfr` 目录下预置的“profile”配置，也可以是自定义的 JFR 配置文件（.jfc），此选项的值采用与 [JFR.start 命令的 settings 选项](https://docs.oracle.com/en/java/javase/17/docs/specs/man/jcmd.html) 相同的格式。
+
+比如，以下命令使用“profile”配置启动 JFR：
+
+```bash
+profiler start -e cpu --jfrsync profile -f combined.jfr
+```

--- a/site/docs/doc/profiler.md
+++ b/site/docs/doc/profiler.md
@@ -138,6 +138,8 @@ Perf events:
 
 如果遇到 OS 本身的权限/配置问题，然后缺少部分 event，可以参考 [async-profiler 的文档](https://github.com/jvm-profiling-tools/async-profiler)。
 
+可以使用 `check` action 测试某个 event 是否可用，此 action 的参数格式与 start 一致。
+
 可以用`--event`参数指定要采样的事件，比如 `alloc` 表示分析内存分配情况：
 
 ```bash
@@ -178,13 +180,13 @@ profiler execute 'start,framebuf=5000000'
 profiler execute 'stop,file=/tmp/result.html'
 ```
 
-具体的格式参考： [arguments.cpp](https://github.com/jvm-profiling-tools/async-profiler/blob/v2.5/src/arguments.cpp#L50)
+具体的格式参考： [arguments.cpp](https://github.com/async-profiler/async-profiler/blob/32601bccd9e49adda9510a2ed79d142ac6ef0ff9/src/arguments.cpp#L52)
 
 ## 查看所有支持的 action
 
 ```bash
 $ profiler actions
-Supported Actions: [resume, dumpCollapsed, getSamples, start, list, version, execute, meminfo, stop, load, dumpFlat, dump, actions, dumpTraces, status]
+Supported Actions: [resume, dumpCollapsed, getSamples, start, list, version, execute, meminfo, stop, load, dumpFlat, dump, actions, dumpTraces, status, check]
 ```
 
 ## 查看版本
@@ -324,3 +326,7 @@ profiler --cstack fp
 profiler start --begin SafepointSynchronize::begin --end RuntimeService::record_safepoint_synchronized
 profiler --ttsp
 ```
+
+## 使用 profiler 记录的 event 生成 JFR 文件
+
+用 `--jfrsync CONFIG` 选项可以指定配置启动 Java Flight Recording，输出的 jfr 文件会包含所有常规的 JFR event，但采样的来源是由 profiler 提供的。

--- a/site/docs/en/doc/profiler.md
+++ b/site/docs/en/doc/profiler.md
@@ -138,6 +138,8 @@ Perf events:
 
 If you encounter the permissions/configuration issues of the OS itself and then missing some events, you can refer to the [async-profiler](https://github.com/jvm-profiling-tools/async-profiler) documentation.
 
+You can use `check` action to check if a profiling event is available, this action receives the same format options with `start`.
+
 You can use the `--event` parameter to specify the event to sample, for example, `alloc` event means heap memory allocation profiling:
 
 ```bash
@@ -178,13 +180,13 @@ Stop sampling and save to the specified file:
 profiler execute 'stop,file=/tmp/result.html'
 ```
 
-Specific format reference: [arguments.cpp](https://github.com/jvm-profiling-tools/async-profiler/blob/v2.5/src/arguments.cpp#L50)
+Specific format reference: [arguments.cpp](https://github.com/async-profiler/async-profiler/blob/32601bccd9e49adda9510a2ed79d142ac6ef0ff9/src/arguments.cpp#L52)
 
 ## View all supported actions
 
 ```bash
 $ profiler actions
-Supported Actions: [resume, dumpCollapsed, getSamples, start, list, version, execute, meminfo, stop, load, dumpFlat, dump, actions, dumpTraces, status]
+Supported Actions: [resume, dumpCollapsed, getSamples, start, list, version, execute, meminfo, stop, load, dumpFlat, dump, actions, dumpTraces, status, check]
 ```
 
 ## View version
@@ -324,3 +326,7 @@ The `--ttsp` option is an alias for `--begin SafepointSynchronize::begin --end R
 profiler start --begin SafepointSynchronize::begin --end RuntimeService::record_safepoint_synchronized
 profiler --ttsp
 ```
+
+## Use events from profiler for Java Flight Recording
+
+Use `--jfrsync CONFIG` to start Java Flight Recording with the given configuration synchronously with the profiler. The output .jfr file will include all regular JFR events, except that execution samples will be obtained from async-profiler. This option implies -o jfr.

--- a/site/docs/en/doc/profiler.md
+++ b/site/docs/en/doc/profiler.md
@@ -180,7 +180,7 @@ Stop sampling and save to the specified file:
 profiler execute 'stop,file=/tmp/result.html'
 ```
 
-Specific format reference: [arguments.cpp](https://github.com/async-profiler/async-profiler/blob/32601bccd9e49adda9510a2ed79d142ac6ef0ff9/src/arguments.cpp#L52)
+Specific format reference: [arguments.cpp](https://github.com/async-profiler/async-profiler/blob/v2.9/src/arguments.cpp#L52)
 
 ## View all supported actions
 
@@ -330,3 +330,11 @@ profiler --ttsp
 ## Use events from profiler for Java Flight Recording
 
 Use `--jfrsync CONFIG` to start Java Flight Recording with the given configuration synchronously with the profiler. The output .jfr file will include all regular JFR events, except that execution samples will be obtained from async-profiler. This option implies -o jfr.
+
+`CONFIG` can be `profile`, means using the predefined JFR config "profile" in `$JAVA_HOME/lib/jfr/`, or full path of a JFR configuration file (.jfc), this value has the same format with [settings option of JFR.start](https://docs.oracle.com/en/java/javase/17/docs/specs/man/jcmd.html).
+
+For example, command below use "profile" config of JFR:
+
+```bash
+profiler start -e cpu --jfrsync profile -f combined.jfr
+```


### PR DESCRIPTION
## 升级 start/resume action

L260 jfrsync，在拼接 executeArgs 时，需要放在 format 之前，否则 executeArgs 将可能使用错误的 format。即使在捕捉参数时已经做过一次处理，但如果用户重复指定 format 参数仍可修改 format 变量，所以此处拼接字符串时仍需处理且需要注意顺序。

L272 safemode，选项值的格式不明，意义不明。根据 [async-profiler 的说明](https://github.com/async-profiler/async-profiler/discussions/797)，**不需要实现此选项**。

### check action

在 async-profiler 中，check option 的处理逻辑和 start/resume 的唯一区别就是是否启动 fdtransfer，鉴于目前 Arthas 中 start/resume 并未启动 fdtransfer，所以 check action 可以直接使用 resume 的逻辑。


### 相关 issue

issue #2164 

