### PR TITLE
Add action collect

### DIFF
--- a/site/docs/doc/profiler.md
+++ b/site/docs/doc/profiler.md
@@ -226,10 +226,10 @@ profiler stop --include 'java/*' --include 'com/demo/*' --exclude '*Unsafe.park*
 
 ## 指定执行时间
 
-比如，希望 profiler 执行 300 秒自动结束，可以用 `-d`/`--duration` 参数指定：
+比如，希望 profiler 执行 300 秒自动结束，可以用 `-d`/`--duration` 参数为 collect action 指定时间：
 
 ```bash
-profiler start --duration 300
+profiler collect --duration 300
 ```
 
 ## 生成 jfr 格式结果
@@ -338,3 +338,14 @@ profiler --ttsp
 ```bash
 profiler start -e cpu --jfrsync profile -f combined.jfr
 ```
+## 周期性保存结果
+
+使用 `--loop TIME` 可以持续运行 profiler 并周期性保存结果。选项格式可以是具体时间 hh:mm:ss 或以秒、分钟、小时或天计算的时间间隔。需要确保指定的输出文件名中包含时间戳，否则每次输出的结果都会覆盖上次保存的结果。以下命令持续执行 profiling 并将每个小时内的记录保存到一个 jfr 文件中。
+
+```bash
+profiler start --loop 1h -f /var/log/profile-%t.jfr
+```
+
+## `--timeout` 选项
+
+这个选项指定 profiling 自动在多久后停止。该选项和 `--loop` 选项的格式一致，可以是时间点，也可以是一个时间间隔。这两个选项都是用于 `start` action 而不是 `collect` action 的。可参考 [async-profiler Github Discussions](https://github.com/async-profiler/async-profiler/discussions/789) 了解更多信息。

--- a/site/docs/en/doc/profiler.md
+++ b/site/docs/en/doc/profiler.md
@@ -226,10 +226,10 @@ profiler stop --include'java/*' --include 'com/demo/*' --exclude'*Unsafe.park*'
 
 ## Specify execution time
 
-For example, if you want the profiler to automatically end after 300 seconds, you can specify it with the `-d`/`--duration` parameter:
+For example, if you want the profiler to automatically end after 300 seconds, you can specify it with the `-d`/`--duration` parameter in collect action:
 
 ```bash
-profiler start --duration 300
+profiler collect --duration 300
 ```
 
 ## Generate jfr format result
@@ -338,3 +338,16 @@ For example, command below use "profile" config of JFR:
 ```bash
 profiler start -e cpu --jfrsync profile -f combined.jfr
 ```
+## Run profiler in a loop
+
+Use `--loop TIME` to run profiler in a loop (continuous profiling). The argument is either a clock time (hh:mm:ss) or a loop duration in seconds, minutes, hours, or days. Make sure the filename includes a timestamp pattern, or the output will be overwritten on each iteration. The command below will run profiling endlessly and save records of each hour to a jfr file.
+
+```bash
+profiler start --loop 1h -f /var/log/profile-%t.jfr
+```
+
+## `--timeout` option
+
+This option specifies the time when profiling will automatically stop. The format is the same as in loop: it is either a wall clock time (12:34:56) or a relative time interval (2h).
+
+Both `--loop` and `--timeout` are used for `start` action but not for `collect` action, for further information refer to [async-profiler Github Discussions](https://github.com/async-profiler/async-profiler/discussions/789).


### PR DESCRIPTION
## 添加 collect action

经过[讨论](https://github.com/alibaba/arthas/issues/2164#issuecomment-1718945907)选择方案一。在捕捉选项的部分，捕捉 timeout 和 loop 选项的分支中，检测 action 为 collect 时转换为 start。

在处理 action 的部分，当 action 为 start 时，不涉及 duration 变量的值，所以即使用户指定了 -d 选项 arthas 也不会按指定的时间结束 profiling，在这种情况下可以接收 timeout 和 loop 控制 profiling 过程；当 action 为 collect 时必然不存在 timeout 或 loop 选项，直接使用 executeArgs 方法拼接参数字符串也没有问题，并且接收 -d 选项指定的 duration 控制时间，如果未指定 duration，则仍需输入 stop 命令才能停止 profiling。

另外，删除了指定 format 为 jfr 时需要在 start 之前生成文件名的逻辑，因为目前 format 是 JVMTI 字符串的一部分。

### 相关 issue

issue #2164 
