### PR TITLE
fix jad completion

### DIFF
--- a/common/src/main/java/com/taobao/arthas/common/VisibleForTesting.java
+++ b/common/src/main/java/com/taobao/arthas/common/VisibleForTesting.java
@@ -1,0 +1,4 @@
+package com.taobao.arthas.common;
+
+public @interface VisibleForTesting {
+}

--- a/core/src/main/java/com/taobao/arthas/core/command/klass100/JadCommand.java
+++ b/core/src/main/java/com/taobao/arthas/core/command/klass100/JadCommand.java
@@ -236,7 +236,7 @@ public class JadCommand extends AnnotatedCommand {
 
     @Override
     public void complete(Completion completion) {
-        int argumentIndex = CompletionUtils.detectArgumentIndex(completion);
+        int argumentIndex = CompletionUtils.detectArgumentIndex(completion, JadCommand.class);
 
         if (argumentIndex == 1) {
             if (!CompletionUtils.completeClassName(completion)) {

--- a/core/src/main/java/com/taobao/arthas/core/shell/cli/CompletionUtils.java
+++ b/core/src/main/java/com/taobao/arthas/core/shell/cli/CompletionUtils.java
@@ -1,7 +1,9 @@
 package com.taobao.arthas.core.shell.cli;
 
+import com.taobao.arthas.common.VisibleForTesting;
 import com.taobao.arthas.core.shell.session.Session;
 import com.taobao.arthas.core.shell.term.Tty;
+import com.taobao.arthas.core.util.OptionUtils;
 import com.taobao.arthas.core.util.SearchUtils;
 import com.taobao.arthas.core.util.StringUtils;
 import com.taobao.arthas.core.util.usage.StyledUsageFormatter;
@@ -13,13 +15,7 @@ import io.termd.core.util.Helper;
 import java.io.File;
 import java.lang.instrument.Instrumentation;
 import java.lang.reflect.Method;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Set;
+import java.util.*;
 
 /**
  * @author beiwei30 on 09/11/2016.
@@ -254,8 +250,19 @@ public class CompletionUtils {
      * @return
      */
     public static int detectArgumentIndex(Completion completion) {
-        List<CliToken> tokens = completion.lineTokens();
+       return detectArgumentIndex(completion.lineTokens(), null);
+    }
+
+    public static int detectArgumentIndex(Completion completion, Class<?> commandClazz) {
+        return detectArgumentIndex(completion.lineTokens(), commandClazz);
+    }
+
+
+
+    @VisibleForTesting
+    static int detectArgumentIndex(List<CliToken> tokens, Class<?> commandClazz) {
         CliToken lastToken = tokens.get(tokens.size() - 1);
+        List<com.taobao.middleware.cli.annotations.Option> options = OptionUtils.findNonFlagOptions(commandClazz);
 
         if (lastToken.value().startsWith("-") || lastToken.value().startsWith("--")) {
             return -1;
@@ -267,12 +274,27 @@ public class CompletionUtils {
 
         int tokenCount = 0;
 
+        boolean skipNext = false;
         for (CliToken token : tokens) {
-            if (StringUtils.isBlank(token.value()) || token.value().startsWith("-") || token.value().startsWith("--")) {
+            if (StringUtils.isBlank(token.value())) {
                 // filter irrelevant tokens
                 continue;
+            } else if (token.value().startsWith("--")) {
+                if (OptionUtils.containsLongOption(options, token.value().substring(2))) {
+                    skipNext = true;
+                }
+                continue;
+            } else if (token.value().startsWith("-")) {
+                if (OptionUtils.containsShortOption(options, token.value().substring(1))) {
+                    skipNext = true;
+                }
+                continue;
             }
-            tokenCount++;
+            if (skipNext) {
+                skipNext = false;
+            } else {
+                tokenCount++;
+            }
         }
 
         if (StringUtils.isBlank((lastToken.value())) && tokens.size() != 1) {

--- a/core/src/main/java/com/taobao/arthas/core/util/OptionUtils.java
+++ b/core/src/main/java/com/taobao/arthas/core/util/OptionUtils.java
@@ -1,0 +1,56 @@
+package com.taobao.arthas.core.util;
+
+import com.alibaba.bytekit.utils.AnnotationUtils;
+import com.taobao.middleware.cli.annotations.Option;
+
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.function.Predicate;
+
+public class OptionUtils {
+
+    public static List<Option> findOptions(Class<?> cmdClazz, Predicate<Option> filter) {
+        if (cmdClazz == null) {
+            return Collections.emptyList();
+        }
+        List<Option> options = new ArrayList<>();
+        for (Method method : cmdClazz.getDeclaredMethods()) {
+            Option option = AnnotationUtils.findAnnotation(method, Option.class);
+            if (option != null && (filter == null || filter.test(option))) {
+                options.add(option);
+            }
+        }
+        return options;
+    }
+
+    public static List<Option> findNonFlagOptions(Class<?> cmdClazz) {
+        return findOptions(cmdClazz, op -> !op.flag());
+    }
+
+    public static boolean containsShortOption(List<com.taobao.middleware.cli.annotations.Option> options, String name) {
+        if (options == null || options.isEmpty()) {
+            return false;
+        }
+        for (com.taobao.middleware.cli.annotations.Option option : options) {
+            if (Objects.equals(option.shortName(), name)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    public static boolean containsLongOption(List<com.taobao.middleware.cli.annotations.Option> options, String name) {
+        if (options == null || options.isEmpty()) {
+            return false;
+        }
+        for (com.taobao.middleware.cli.annotations.Option option : options) {
+            if (Objects.equals(option.longName(), name)) {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/core/src/test/java/com/taobao/arthas/core/shell/cli/CompletionUtilsTest.java
+++ b/core/src/test/java/com/taobao/arthas/core/shell/cli/CompletionUtilsTest.java
@@ -1,0 +1,56 @@
+package com.taobao.arthas.core.shell.cli;
+
+import com.taobao.arthas.core.command.klass100.JadCommand;
+import com.taobao.arthas.core.shell.cli.impl.CliTokenImpl;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class CompletionUtilsTest {
+
+    @Test
+    void testDetectArgumentIndex() {
+
+        List<CliToken> tokens = removeCommandHeadTokens(CliTokenImpl.tokenize("jad --lineNumber true demo.MathGame"), "jad");
+        assertEquals(1, CompletionUtils.detectArgumentIndex(tokens, JadCommand.class));
+
+        tokens = removeCommandHeadTokens(CliTokenImpl.tokenize("jad demo.MathGame"), "jad");
+        assertEquals(1, CompletionUtils.detectArgumentIndex(tokens, JadCommand.class));
+
+        tokens = removeCommandHeadTokens(CliTokenImpl.tokenize("jad -d /root --lineNumber true demo.MathGame"), "jad");
+        assertEquals(1, CompletionUtils.detectArgumentIndex(tokens, JadCommand.class));
+
+        tokens = removeCommandHeadTokens(CliTokenImpl.tokenize("jad -d /root --lineNumber true -E demo.MathGame"), "jad");
+        assertEquals(1, CompletionUtils.detectArgumentIndex(tokens, JadCommand.class));
+
+        tokens = removeCommandHeadTokens(CliTokenImpl.tokenize("jad -d /root --lineNumber true -E -c xxx demo.MathGame"), "jad");
+        assertEquals(1, CompletionUtils.detectArgumentIndex(tokens, JadCommand.class));
+
+        tokens = removeCommandHeadTokens(CliTokenImpl.tokenize("jad --source-only -d /root --lineNumber true -E -c xxx demo.MathGame"), "jad");
+        assertEquals(1, CompletionUtils.detectArgumentIndex(tokens, JadCommand.class));
+
+        tokens = removeCommandHeadTokens(CliTokenImpl.tokenize("jad --source-only -d /root --lineNumber true -E -c xxx demo.MathGame "), "jad");
+        assertEquals(2, CompletionUtils.detectArgumentIndex(tokens, JadCommand.class));
+
+        tokens = removeCommandHeadTokens(CliTokenImpl.tokenize("jad --source-only   --lineNumber true -E -c xxx demo.MathGame -d /root pri"), "jad");
+        assertEquals(2, CompletionUtils.detectArgumentIndex(tokens, JadCommand.class));
+
+
+    }
+
+    private static List<CliToken> removeCommandHeadTokens(List<CliToken> tokens, String cmd) {
+        int idx = 0;
+        for (int i = 0; i < tokens.size(); i++) {
+            if (tokens.get(i).isText() && !Objects.equals(tokens.get(i).value(), cmd)) {
+                idx = i;
+                break;
+            }
+        }
+        return new ArrayList<>(tokens.subList(idx, tokens.size()));
+
+    }
+}

--- a/core/src/test/java/com/taobao/arthas/core/util/OptionUtilsTest.java
+++ b/core/src/test/java/com/taobao/arthas/core/util/OptionUtilsTest.java
@@ -1,0 +1,66 @@
+package com.taobao.arthas.core.util;
+
+import com.taobao.arthas.core.command.basic1000.OptionsCommand;
+import com.taobao.arthas.core.command.klass100.JadCommand;
+import com.taobao.arthas.core.command.monitor200.ThreadCommand;
+import com.taobao.middleware.cli.annotations.Option;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class OptionUtilsTest {
+
+    @Test
+    void testFindOptions() {
+        assertEquals(Arrays.asList("classLoaderClass", "code", "directory", "hideUnicode","lineNumber", "regex", "source-only"),
+                sortedNames(OptionUtils.findOptions(JadCommand.class, null)));
+        assertEquals(Collections.emptyList(),
+                sortedNames(OptionUtils.findOptions(OptionsCommand.class, null)));
+    }
+
+    @Test
+    void testFindNonFlagOptions() {
+        assertEquals(Arrays.asList("classLoaderClass", "code", "directory", "lineNumber"),
+                sortedNames(OptionUtils.findNonFlagOptions(JadCommand.class)));
+        assertEquals(Arrays.asList("sample-interval", "state", "top-n-threads"),
+                sortedNames(OptionUtils.findNonFlagOptions(ThreadCommand.class)));
+        assertEquals(Collections.emptyList(),
+                sortedNames(OptionUtils.findOptions(OptionsCommand.class, null)));
+    }
+
+    @Test
+    void testContainsShortOption() {
+        List<Option> options = OptionUtils.findOptions(JadCommand.class, null);
+        assertTrue(OptionUtils.containsShortOption(options, "c"));
+        assertTrue(OptionUtils.containsShortOption(options, "E"));
+        assertTrue(OptionUtils.containsShortOption(options, "d"));
+        assertFalse(OptionUtils.containsShortOption(options, "F"));
+        assertFalse(OptionUtils.containsShortOption(options, null));
+        assertFalse(OptionUtils.containsShortOption(options, ""));
+        assertFalse(OptionUtils.containsShortOption(options, "code"));
+    }
+
+    @Test
+    void testContainsLongOption() {
+        List<Option> options = OptionUtils.findOptions(JadCommand.class, null);
+        assertTrue(OptionUtils.containsLongOption(options, "classLoaderClass"));
+        assertTrue(OptionUtils.containsLongOption(options, "code"));
+        assertTrue(OptionUtils.containsLongOption(options, "directory"));
+        assertTrue(OptionUtils.containsLongOption(options, "hideUnicode"));
+        assertTrue(OptionUtils.containsLongOption(options, "lineNumber"));
+        assertTrue(OptionUtils.containsLongOption(options, "regex"));
+        assertTrue(OptionUtils.containsLongOption(options, "source-only"));
+        assertFalse(OptionUtils.containsLongOption(options, null));
+        assertFalse(OptionUtils.containsLongOption(options, ""));
+        assertFalse(OptionUtils.containsLongOption(options, "c"));
+    }
+
+    private static List<String> sortedNames(List<Option> options) {
+        return options.stream().map(Option::longName).sorted().collect(Collectors.toList());
+    }
+}


### PR DESCRIPTION
jad命令中有带参数的option，命令无法正确补全, 例如`jad --lineNumber false `无法对类名补全
原因是detectArgumentIndex这个方法没有考虑带参option