### PR TITLE
Fix error of enhancing dynamically generated classes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -94,7 +94,7 @@
             <dependency>
                 <groupId>com.alibaba</groupId>
                 <artifactId>bytekit-core</artifactId>
-                <version>0.0.8</version>
+                <version>0.0.9</version>
             </dependency>
             <dependency>
                 <groupId>org.benf</groupId>


### PR DESCRIPTION
Upgrade `bytekit` to `0.0.9` to load dynamical classes.
(cherry picked from commit 4dc65baf7f21012fb302e6615cda58a5d2a676fa)