### PR TITLE
update DynamicCompiler add -g option for generate LocalVariableTable

### DIFF
--- a/memorycompiler/src/main/java/com/taobao/arthas/compiler/DynamicCompiler.java
+++ b/memorycompiler/src/main/java/com/taobao/arthas/compiler/DynamicCompiler.java
@@ -33,6 +33,7 @@ public class DynamicCompiler {
         standardFileManager = javaCompiler.getStandardFileManager(null, null, null);
 
         options.add("-Xlint:unchecked");
+        options.add("-g");
         dynamicClassLoader = new DynamicClassLoader(classLoader);
     }
 


### PR DESCRIPTION
Currently, when use arthas's DynamicCompiler compile java code will discard the LocalVariableTable. By add option -g causes the compiler to generate the LocalVariableTable attribute in the class file.