### PR TITLE
处理heapDump命令outPut路径，优先采用用户配置路径

### DIFF
--- a/core/src/main/java/com/taobao/arthas/core/command/monitor200/HeapDumpCommand.java
+++ b/core/src/main/java/com/taobao/arthas/core/command/monitor200/HeapDumpCommand.java
@@ -51,7 +51,7 @@ public class HeapDumpCommand extends AnnotatedCommand {
     @Override
     public void process(CommandProcess process) {
         try {
-            String dumpFile = file;
+            String dumpFile = file == null ? process.getArthasOutput().getAbsolutePath() : null;
             if (dumpFile == null || dumpFile.isEmpty()) {
                 String date = new SimpleDateFormat("yyyy-MM-dd-HH-mm").format(new Date());
                 File file = File.createTempFile("heapdump" + date + (live ? "-live" : ""), ".hprof");

--- a/core/src/main/java/com/taobao/arthas/core/shell/command/CommandProcess.java
+++ b/core/src/main/java/com/taobao/arthas/core/shell/command/CommandProcess.java
@@ -8,6 +8,7 @@ import com.taobao.arthas.core.shell.session.Session;
 import com.taobao.arthas.core.shell.term.Tty;
 import com.taobao.middleware.cli.CommandLine;
 
+import java.io.File;
 import java.lang.instrument.ClassFileTransformer;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -181,5 +182,10 @@ public interface CommandProcess extends Tty {
      * @param result a phased result of the command
      */
     void appendResult(ResultModel result);
+
+    /**
+     * add custom output file
+     */
+    File getArthasOutput();
 
 }

--- a/core/src/main/java/com/taobao/arthas/core/shell/system/impl/ProcessImpl.java
+++ b/core/src/main/java/com/taobao/arthas/core/shell/system/impl/ProcessImpl.java
@@ -25,6 +25,7 @@ import com.taobao.middleware.cli.CLIException;
 import com.taobao.middleware.cli.CommandLine;
 import io.termd.core.function.Function;
 
+import java.io.File;
 import java.lang.instrument.ClassFileTransformer;
 import java.util.Date;
 import java.util.LinkedList;
@@ -367,8 +368,10 @@ public class ProcessImpl implements Process {
             process.echoTips("job id  : " + this.jobId + "\n");
             process.echoTips("cache location  : " + cacheLocation() + "\n");
         }
+        ArthasBootstrap arthasBootstrap = ArthasBootstrap.getInstance();
+        process.setArthasOutput(arthasBootstrap.getOutputPath());
         Runnable task = new CommandProcessTask(process);
-        ArthasBootstrap.getInstance().execute(task);
+        arthasBootstrap.execute(task);
     }
 
     private class CommandProcessTask implements Runnable {
@@ -400,10 +403,21 @@ public class ProcessImpl implements Process {
         private AtomicInteger times = new AtomicInteger();
         private AdviceListener listener = null;
         private ClassFileTransformer transformer;
+        private File arthasOutput;
+
 
         public CommandProcessImpl(Process process, Tty tty) {
             this.process = process;
             this.tty = tty;
+        }
+
+        public void setArthasOutput(File arthasOutput){
+            this.arthasOutput = arthasOutput;
+        }
+
+        @Override
+        public File getArthasOutput(){
+            return this.arthasOutput;
         }
 
         @Override


### PR DESCRIPTION
解决配置arthas.outputPath在heapdump指令下无效的问题