### PR TITLE
Release netty ByteBuf after use

### DIFF
--- a/core/src/main/java/com/taobao/arthas/core/command/basic1000/Base64Command.java
+++ b/core/src/main/java/com/taobao/arthas/core/command/basic1000/Base64Command.java
@@ -112,12 +112,12 @@ public class Base64Command extends AnnotatedCommand {
         }
 
         InputStream input = null;
+        ByteBuf convertResult = null;
 
         try {
             input = new FileInputStream(f);
             byte[] bytes = IOUtils.getBytes(input);
 
-            ByteBuf convertResult = null;
             if (this.decode) {
                 convertResult = Base64.decode(Unpooled.wrappedBuffer(bytes));
             } else {
@@ -138,6 +138,9 @@ public class Base64Command extends AnnotatedCommand {
             process.end(1, "read file error: " + e.getMessage());
             return;
         } finally {
+            if (convertResult != null) {
+                convertResult.release();
+            }
             IOUtils.close(input);
         }
 

--- a/tunnel-client/src/main/java/com/alibaba/arthas/tunnel/client/ProxyClient.java
+++ b/tunnel-client/src/main/java/com/alibaba/arthas/tunnel/client/ProxyClient.java
@@ -134,17 +134,25 @@ public class ProxyClient {
             if (msg instanceof HttpContent) {
                 HttpContent content = (HttpContent) msg;
 
-                ByteBuf byteBuf = content.content();
-                byte[] bytes = new byte[byteBuf.readableBytes()];
-                byteBuf.readBytes(bytes);
+                ByteBuf byteBuf = null;
+                try{
+                    byteBuf = content.content();
+                    byte[] bytes = new byte[byteBuf.readableBytes()];
+                    byteBuf.readBytes(bytes);
 
-                simpleHttpResponse.setContent(bytes);
+                    simpleHttpResponse.setContent(bytes);
 
-                promise.setSuccess(simpleHttpResponse);
+                    promise.setSuccess(simpleHttpResponse);
 
-                if (content instanceof LastHttpContent) {
-                    ctx.close();
+                    if (content instanceof LastHttpContent) {
+                        ctx.close();
+                    }
+                }finally {
+                    if (byteBuf != null) {
+                        byteBuf.release();
+                    }
                 }
+
             }
         }
 

--- a/tunnel-client/src/main/java/com/alibaba/arthas/tunnel/client/TunnelClientSocketClientHandler.java
+++ b/tunnel-client/src/main/java/com/alibaba/arthas/tunnel/client/TunnelClientSocketClientHandler.java
@@ -120,17 +120,24 @@ public class TunnelClientSocketClientHandler extends SimpleChannelInboundHandler
                     String targetUrl = targetUrls.get(0);
                     SimpleHttpResponse simpleHttpResponse = proxyClient.query(targetUrl);
 
-                    ByteBuf byteBuf = Base64
-                            .encode(Unpooled.wrappedBuffer(SimpleHttpResponse.toBytes(simpleHttpResponse)));
-                    String requestData = byteBuf.toString(CharsetUtil.UTF_8);
+                    ByteBuf byteBuf = null;
+                    try{
+                        byteBuf = Base64
+                                .encode(Unpooled.wrappedBuffer(SimpleHttpResponse.toBytes(simpleHttpResponse)));
+                        String requestData = byteBuf.toString(CharsetUtil.UTF_8);
 
-                    QueryStringEncoder queryEncoder = new QueryStringEncoder("");
-                    queryEncoder.addParam(URIConstans.METHOD, MethodConstants.HTTP_PROXY);
-                    queryEncoder.addParam(URIConstans.PROXY_REQUEST_ID, id);
-                    queryEncoder.addParam(URIConstans.PROXY_RESPONSE_DATA, requestData);
+                        QueryStringEncoder queryEncoder = new QueryStringEncoder("");
+                        queryEncoder.addParam(URIConstans.METHOD, MethodConstants.HTTP_PROXY);
+                        queryEncoder.addParam(URIConstans.PROXY_REQUEST_ID, id);
+                        queryEncoder.addParam(URIConstans.PROXY_RESPONSE_DATA, requestData);
 
-                    String url = queryEncoder.toString();
-                    ctx.writeAndFlush(new TextWebSocketFrame(url));
+                        String url = queryEncoder.toString();
+                        ctx.writeAndFlush(new TextWebSocketFrame(url));
+                    }finally {
+                        if (byteBuf != null) {
+                            byteBuf.release();
+                        }
+                    }
                 }
             }
 


### PR DESCRIPTION
#2834 
1. Base64Command
2. TunnelClientSocketClientHandler
3. ProxyClient
 使用netty的ByteBuf没有释放导致netty堆外内存泄漏