### PR TITLE
增加新选项 --wall

### DIFF
--- a/core/src/main/java/com/taobao/arthas/core/command/monitor200/ProfilerCommand.java
+++ b/core/src/main/java/com/taobao/arthas/core/command/monitor200/ProfilerCommand.java
@@ -118,6 +118,11 @@ public class ProfilerCommand extends AnnotatedCommand {
     private Integer jstackdepth;
 
     /**
+     * Enable wall clock profiling in addition to CPU profiling
+     */
+    private boolean wall;
+
+    /**
      * profile different threads separately
      */
     private boolean threads;
@@ -337,6 +342,12 @@ public class ProfilerCommand extends AnnotatedCommand {
     @Description("start Java Flight Recording with the given config along with the profiler")
     public void setJfrsync(String jfrsync) {
         this.jfrsync = jfrsync;
+    }
+
+    @Option(longName = "wall", flag = true)
+    @Description("Enable wall clock profiling in addition to CPU profiling")
+    public void setWall(boolean wall) {
+        this.wall = wall;
     }
 
     @Option(shortName = "t", longName = "threads", flag = true)
@@ -581,6 +592,9 @@ public class ProfilerCommand extends AnnotatedCommand {
         }
         if (this.threads) {
             sb.append("threads").append(COMMA);
+        }
+        if (this.wall) {
+            sb.append("wall").append(COMMA);
         }
         if (this.sched) {
             sb.append("sched").append(COMMA);


### PR DESCRIPTION
根据 [async-profiler issue #740](https://github.com/async-profiler/async-profiler/issues/740) 的描述，这个 PR 引入了一个新特性，允许同时进行 CPU 和 Wall clock 的联合分析。

![image](https://github.com/user-attachments/assets/0bcd5eb8-5e50-401a-b63c-6c9c057f3c6d)
