### PR TITLE
Update spring-boot-starter.md,arthas-all-3.7.2版本后已经支持springboot3了

### DIFF
--- a/site/docs/doc/spring-boot-starter.md
+++ b/site/docs/doc/spring-boot-starter.md
@@ -2,6 +2,7 @@
 
 ::: tip
 只支持 spring boot 2
+arthas 3.7.2及以后的版本支持springboot3
 :::
 
 最新版本：[查看](https://search.maven.org/search?q=arthas-spring-boot-starter)


### PR DESCRIPTION
arthas-all-3.7.2版本后已经支持springboot3了,避免用户升级springboot3后，对此产生误解