### PR TITLE
Load class from class path if not found

### DIFF
--- a/agent/src/main/java/com/taobao/arthas/agent/ArthasClassloader.java
+++ b/agent/src/main/java/com/taobao/arthas/agent/ArthasClassloader.java
@@ -1,7 +1,13 @@
 package com.taobao.arthas.agent;
 
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
 import java.net.URL;
 import java.net.URLClassLoader;
+import java.util.jar.JarEntry;
+import java.util.jar.JarFile;
 
 /**
  * @author beiwei30 on 09/12/2016.
@@ -28,9 +34,73 @@ public class ArthasClassloader extends URLClassLoader {
                 resolveClass(aClass);
             }
             return aClass;
+        } catch (ClassNotFoundException e) {
+            // ignore
+        }
+
+        try {
+            Class<?> aClass = loadClassFromClassPath(name);
+            if (resolve) {
+                resolveClass(aClass);
+            }
+            return aClass;
         } catch (Exception e) {
             // ignore
         }
+
         return super.loadClass(name, resolve);
+    }
+
+    private Class<?> loadClassFromClassPath(String name) throws ClassNotFoundException {
+        String classpath = System.getProperty("java.class.path");
+        String[] paths = classpath.split(File.pathSeparator);
+
+        byte[] classData = null;
+        for (String path : paths) {
+            if (path.endsWith(".jar")) {
+                classData = loadClassDataFromJar(name, path);
+            } else {
+                classData = loadClassDataFromDirectory(name, path);
+            }
+
+            if (classData != null) {
+                break;
+            }
+        }
+
+        if (classData == null) {
+            throw new ClassNotFoundException("Class " + name + " not found in CLASSPATH.");
+        }
+        return defineClass(name, classData, 0, classData.length);
+    }
+
+    private byte[] loadClassDataFromDirectory(String className, String classpath) {
+        String path = classpath + File.separator
+            + className.replace('.', File.separatorChar) + ".class";
+        try (InputStream input = new FileInputStream(path)) {
+            byte[] buffer = new byte[input.available()];
+            input.read(buffer);
+            return buffer;
+        } catch (IOException e) {
+            return null;
+        }
+    }
+
+    private byte[] loadClassDataFromJar(String className, String jarPath) {
+        String entryName = className.replace('.', '/') + ".class";
+        try (JarFile jarFile = new JarFile(jarPath)) {
+            JarEntry entry = jarFile.getJarEntry(entryName);
+            if (entry == null) {
+                return null;
+            }
+
+            try (InputStream input = jarFile.getInputStream(entry)) {
+                byte[] buffer = new byte[(int) entry.getSize()];
+                input.read(buffer);
+                return buffer;
+            }
+        } catch (IOException e) {
+            return null;
+        }
     }
 }


### PR DESCRIPTION
I encountered TypeNotPresentException/ClassNotFoundException exceptions frequently for the following type programs

- The program has a main/default class loader for the main program
- Each extension supported by the program uses a specific extension class loader
- Some classes are loaded by the main/default class loader but also used in classes loaded by the specific extension class loader

then when I stack/watch a class method loaded by specific extension class loader, it will encounter the exception.

This PR can resolve this exception.

Below is an example from Alluxio

```txt
$ stack alluxio.underfs.hdfs.HdfsUnderFileSystem *
Affect(class count: 0 , method count: 52) cost in 239 ms, listenerId: 1
Enhance error! exception: java.lang.TypeNotPresentException: Type alluxio/underfs/UfsFileStatus not present
```

and "arthas.log" has the following content

```
2024-10-16 15:38:54 [arthas-command-execute] WARN  c.t.arthas.core.advisor.Enhancer -transform loader[alluxio.extensions.ExtensionsClassLoader@6c8d1c2b]:class[alluxio/underfs/hdfs/HdfsUnderFileSystem] failed.
java.lang.TypeNotPresentException: Type alluxio/underfs/UfsFileStatus not present
        at com.alibaba.deps.org.objectweb.asm.ClassWriter.getCommonSuperClass(ClassWriter.java:1045)
        at com.alibaba.bytekit.asm.ClassMetaClassWriter.getCommonSuperClass(ClassMetaClassWriter.java:39)
        at com.alibaba.deps.org.objectweb.asm.SymbolTable.addMergedType(SymbolTable.java:1202)
        at com.alibaba.deps.org.objectweb.asm.Frame.merge(Frame.java:1300)
        at com.alibaba.deps.org.objectweb.asm.Frame.merge(Frame.java:1198)
        at com.alibaba.deps.org.objectweb.asm.MethodWriter.computeAllFrames(MethodWriter.java:1611)
        at com.alibaba.deps.org.objectweb.asm.MethodWriter.visitMaxs(MethodWriter.java:1547)
        at com.alibaba.deps.org.objectweb.asm.tree.MethodNode.accept(MethodNode.java:767)
        at com.alibaba.deps.org.objectweb.asm.tree.MethodNode.accept(MethodNode.java:647)
        at com.alibaba.deps.org.objectweb.asm.tree.ClassNode.accept(ClassNode.java:468)
        at com.alibaba.bytekit.utils.AsmUtils.toBytes(AsmUtils.java:80)
        at com.taobao.arthas.core.advisor.Enhancer.transform(Enhancer.java:256)
        at com.taobao.arthas.core.advisor.TransformerManager$1.transform(TransformerManager.java:51)
        at sun.instrument.TransformerManager.transform(TransformerManager.java:188)
        at sun.instrument.InstrumentationImpl.transform(InstrumentationImpl.java:428)
        at sun.instrument.InstrumentationImpl.retransformClasses0(Native Method)
        at sun.instrument.InstrumentationImpl.retransformClasses(InstrumentationImpl.java:144)
        at com.taobao.arthas.core.advisor.Enhancer.enhance(Enhancer.java:446)
        at com.taobao.arthas.core.command.monitor200.EnhancerCommand.enhance(EnhancerCommand.java:173)
        at com.taobao.arthas.core.command.monitor200.EnhancerCommand.process(EnhancerCommand.java:120)
        at com.taobao.arthas.core.shell.command.impl.AnnotatedCommandImpl.process(AnnotatedCommandImpl.java:82)
        at com.taobao.arthas.core.shell.command.impl.AnnotatedCommandImpl.access$100(AnnotatedCommandImpl.java:18)
        at com.taobao.arthas.core.shell.command.impl.AnnotatedCommandImpl$ProcessHandler.handle(AnnotatedCommandImpl.java:111)
        at com.taobao.arthas.core.shell.command.impl.AnnotatedCommandImpl$ProcessHandler.handle(AnnotatedCommandImpl.java:108)
        at com.taobao.arthas.core.shell.system.impl.ProcessImpl$CommandProcessTask.run(ProcessImpl.java:385)
        at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
        at java.util.concurrent.FutureTask.run(FutureTask.java:266)
        at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.access$201(ScheduledThreadPoolExecutor.java:180)
        at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:293)
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
        at java.lang.Thread.run(Thread.java:750)
Caused by: java.lang.ClassNotFoundException: alluxio.underfs.UfsFileStatus
        at java.net.URLClassLoader.findClass(URLClassLoader.java:387)
        at java.lang.ClassLoader.loadClass(ClassLoader.java:419)
        at com.taobao.arthas.agent.ArthasClassloader.loadClass(ArthasClassloader.java:34)
        at java.lang.ClassLoader.loadClass(ClassLoader.java:352)
        at java.lang.Class.forName0(Native Method)
        at java.lang.Class.forName(Class.java:348)
        at com.alibaba.deps.org.objectweb.asm.ClassWriter.getCommonSuperClass(ClassWriter.java:1043)
        ... 31 common frames omitted
```