### PR TITLE
解决abortProcess的并发问题

### DIFF
--- a/core/src/main/java/com/taobao/arthas/core/advisor/AdviceListenerAdapter.java
+++ b/core/src/main/java/com/taobao/arthas/core/advisor/AdviceListenerAdapter.java
@@ -131,7 +131,9 @@ public abstract class AdviceListenerAdapter implements AdviceListener, ProcessAw
      * @return true 如果超过或者达到了上限
      */
     protected boolean isLimitExceeded(int limit, int currentTimes) {
-        return currentTimes >= limit;
+        //正常来讲，只需要判断currentTimes == limit即可，currentTimes如果是准确的（不能使用process.times().get()），
+        //那么不会出现自增时跳过limit的问题，为了应对未知的极端情况，仍旧加上currentTimes - limit > 100，以防万一
+        return limit <= 0 || currentTimes == limit || currentTimes - limit > 100;
     }
 
     /**

--- a/core/src/main/java/com/taobao/arthas/core/command/monitor200/AbstractTraceAdviceListener.java
+++ b/core/src/main/java/com/taobao/arthas/core/command/monitor200/AbstractTraceAdviceListener.java
@@ -93,13 +93,12 @@ public class AbstractTraceAdviceListener extends AdviceListenerAdapter {
                 }
                 if (conditionResult) {
                     // 满足输出条件
-                    process.times().incrementAndGet();
                     // TODO: concurrency issues for process.write
                     process.appendResult(traceEntity.getModel());
 
+                    int times = process.times().incrementAndGet();
                     // 是否到达数量限制
-                    if (isLimitExceeded(command.getNumberOfLimit(), process.times().get())) {
-                        // TODO: concurrency issue to abort process
+                    if (isLimitExceeded(command.getNumberOfLimit(), times)) {
                         abortProcess(process, command.getNumberOfLimit());
                     }
                 }

--- a/core/src/main/java/com/taobao/arthas/core/command/monitor200/StackAdviceListener.java
+++ b/core/src/main/java/com/taobao/arthas/core/command/monitor200/StackAdviceListener.java
@@ -63,8 +63,8 @@ public class StackAdviceListener extends AdviceListenerAdapter {
                 StackModel stackModel = ThreadUtil.getThreadStackModel(advice.getLoader(), Thread.currentThread());
                 stackModel.setTs(LocalDateTime.now());
                 process.appendResult(stackModel);
-                process.times().incrementAndGet();
-                if (isLimitExceeded(command.getNumberOfLimit(), process.times().get())) {
+                int times = process.times().incrementAndGet();
+                if (isLimitExceeded(command.getNumberOfLimit(), times)) {
                     abortProcess(process, command.getNumberOfLimit());
                 }
             }

--- a/core/src/main/java/com/taobao/arthas/core/command/monitor200/TimeTunnelAdviceListener.java
+++ b/core/src/main/java/com/taobao/arthas/core/command/monitor200/TimeTunnelAdviceListener.java
@@ -98,8 +98,8 @@ public class TimeTunnelAdviceListener extends AdviceListenerAdapter {
             isFirst = false;
         }
 
-        process.times().incrementAndGet();
-        if (isLimitExceeded(command.getNumberOfLimit(), process.times().get())) {
+        int times = process.times().incrementAndGet();
+        if (isLimitExceeded(command.getNumberOfLimit(), times)) {
             abortProcess(process, command.getNumberOfLimit());
         }
     }

--- a/core/src/main/java/com/taobao/arthas/core/command/monitor200/WatchAdviceListener.java
+++ b/core/src/main/java/com/taobao/arthas/core/command/monitor200/WatchAdviceListener.java
@@ -102,8 +102,8 @@ class WatchAdviceListener extends AdviceListenerAdapter {
                 }
 
                 process.appendResult(model);
-                process.times().incrementAndGet();
-                if (isLimitExceeded(command.getNumberOfLimit(), process.times().get())) {
+                int times = process.times().incrementAndGet();
+                if (isLimitExceeded(command.getNumberOfLimit(), times)) {
                     abortProcess(process, command.getNumberOfLimit());
                 }
             }

--- a/labs/arthas-grpc-web-proxy/src/main/java/com/taobao/arthas/grpcweb/grpc/service/advisor/WatchRpcAdviceListener.java
+++ b/labs/arthas-grpc-web-proxy/src/main/java/com/taobao/arthas/grpcweb/grpc/service/advisor/WatchRpcAdviceListener.java
@@ -119,8 +119,8 @@ public class WatchRpcAdviceListener extends AdviceListenerAdapter {
                     model.setAccessPoint(AccessPoint.ACCESS_AFTER_THROWING.getKey());
                 }
                 arthasStreamObserver.appendResult(model);
-                arthasStreamObserver.times().incrementAndGet();
-                if (isLimitExceeded(watchRequestModel.getNumberOfLimit(), arthasStreamObserver.times().get())) {
+                int times = arthasStreamObserver.times().incrementAndGet();
+                if (isLimitExceeded(watchRequestModel.getNumberOfLimit(), times)) {
                     String msg = "Command execution times exceed limit: " + watchRequestModel.getNumberOfLimit()
                             + ", so command will exit.\n";
                     arthasStreamObserver.end();


### PR DESCRIPTION
AbstractTraceAdviceListener的102行有一个todo，此pr解决该问题
// TODO: concurrency issue to abort process

abortProcess可能会重复执行，表现形式为重复输出“Command execution times exceed limit..."

该问题可以直接利用AtomicInteger的原子性来解决，在自增时同时获取自增后的当前值(原子操作)，并以该值作为判定依据，该值会递增且连续，那么只须判断该值是否与limit相等，便可保证有且只有一个线程调用abortProcess

原来使用AtomicInteger.get，无法保证连续（比如当前值为9，两个线程同时执行incrementAndGet，然后再同时执行get，两个线程获取到的值均为11，10这个数值便被跳过了），因而只能用大于等于来判定，从而导致并发时，可能多个线程同时满足条件
