### PR TITLE
mvn -ntp: no transfer progress

### DIFF
--- a/.github/workflows/build-vmtool.yaml
+++ b/.github/workflows/build-vmtool.yaml
@@ -14,7 +14,7 @@ jobs:
           java-version: '8'
           distribution: 'adopt'
       - name: Build with Maven
-        run: ./mvnw package
+        run: ./mvnw -V -ntp package
       - uses: actions/upload-artifact@v3
         with:
           name: lib
@@ -30,7 +30,7 @@ jobs:
           java-version: '8'
           distribution: 'adopt'
       - name: Build with Maven
-        run: ./mvnw package
+        run: ./mvnw -V -ntp package
       - uses: actions/upload-artifact@v3
         with:
           name: lib
@@ -46,7 +46,7 @@ jobs:
           java-version: '8'
           distribution: 'adopt'
       - name: Build with Maven
-        run: ./mvnw package
+        run: ./mvnw -V -ntp package
       - uses: actions/upload-artifact@v3
         with:
           name: lib
@@ -73,7 +73,7 @@ jobs:
 
           run: |
             apt update && apt install openjdk-8-jdk g++ -y
-            ./mvnw package -pl common,arthas-vmtool
+            ./mvnw -V -ntp package -pl common,arthas-vmtool
             cp arthas-vmtool/target/libArthas* lib/
       - uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -16,7 +16,7 @@ jobs:
           java-version: '8'
           distribution: 'adopt'
       - name: Build with Maven
-        run: mvn clean package -P full
+        run: mvn -V -ntp clean package -P full
 
       - name: Release
         uses: softprops/action-gh-release@v1

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -17,7 +17,7 @@ jobs:
           distribution: 'zulu'
           cache: 'maven'
       - name: Build with Maven
-        run: mvn clean install -P full
+        run: mvn -V -ntp clean install -P full
 
   windows_build:
     runs-on: windows-2019
@@ -33,7 +33,7 @@ jobs:
           distribution: 'zulu'
           cache: 'maven'
       - name: Build with Maven
-        run: mvn clean install -P full
+        run: mvn -V -ntp clean install -P full
 
   macos_build:
     runs-on: ${{ matrix.os }}
@@ -52,4 +52,4 @@ jobs:
           distribution: 'zulu'
           cache: 'maven'
       - name: Build with Maven
-        run: mvn clean install -P full
+        run: mvn -V -ntp clean install -P full


### PR DESCRIPTION
avoid a lot of noise created by the "Progress" in build log, like

```
Downloaded from central: https://repo.maven.apache.org/maven2/org/glassfish/javax.json/1.1.4/javax.json-1.1.4.jar (129 kB at 1.8 MB/s)
Progress (1): 1.2/2.8 MB
Progress (1): 1.2/2.8 MB
Progress (1): 1.2/2.8 MB
Progress (1): 1.2/2.8 MB
Progress (1): 1.3/2.8 MB
Progress (1): 1.3/2.8 MB
...
```