### PR TITLE
drop duplicate dependency

### DIFF
--- a/labs/cluster-management/native-agent/pom.xml
+++ b/labs/cluster-management/native-agent/pom.xml
@@ -49,13 +49,6 @@
             <version>5.8.2</version>
             <scope>test</scope>
         </dependency>
-
-        <dependency>
-            <groupId>com.taobao.arthas</groupId>
-            <artifactId>native-agent-common</artifactId>
-            <version>${project.version}</version>
-            <scope>compile</scope>
-        </dependency>
     </dependencies>
 
     <build>


### PR DESCRIPTION
fixes 1 warn when building `mvn validate`