### PR TITLE
drop duplicate dependencies

### DIFF
--- a/labs/arthas-grpc-server/pom.xml
+++ b/labs/arthas-grpc-server/pom.xml
@@ -110,15 +110,7 @@
         </dependency>
         <dependency>
             <groupId>ch.qos.logback</groupId>
-            <artifactId>logback-classic</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>ch.qos.logback</groupId>
             <artifactId>logback-core</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-api</artifactId>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
fixes 2 warn when building `mvn validate`

```
[WARNING] Some problems were encountered while building the effective model for com.taobao.arthas:arthas-grpc-server:jar:4.0.5
[WARNING] 'dependencies.dependency.(groupId:artifactId:type:classifier)' must be unique: ch.qos.logback:logback-classic:jar -> version 1.5.0 vs (?) @ com.taobao.arthas:arthas-grpc-server:${revision}, /home/dev/labs/arthas-grpc-server/pom.xml, line 111, column 21
[WARNING] 'dependencies.dependency.(groupId:artifactId:type:classifier)' must be unique: org.slf4j:slf4j-api:jar -> version 2.0.12 vs (?) @ com.taobao.arthas:arthas-grpc-server:${revision},/home/dev/labs/arthas-grpc-server/pom.xml, line 119, column 21
```