### PR TITLE
Update flatten-maven-plugin to generate a flatten reduced POM

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -468,13 +468,6 @@
                         </goals>
                     </execution>
                     <execution>
-                        <id>flatten.package</id>
-                        <phase>package</phase>
-                        <goals>
-                            <goal>flatten</goal>
-                        </goals>
-                    </execution>
-                    <execution>
                         <id>flatten.clean</id>
                         <phase>clean</phase>
                         <goals>

--- a/pom.xml
+++ b/pom.xml
@@ -84,7 +84,7 @@
     </modules>
 
     <properties>
-        <revision>4.0.6-SNAPSHOT</revision>
+        <revision>4.0.5</revision>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.target>1.8</maven.compiler.target>
         <maven.compiler.source>1.8</maven.compiler.source>

--- a/pom.xml
+++ b/pom.xml
@@ -84,7 +84,7 @@
     </modules>
 
     <properties>
-        <revision>4.0.5</revision>
+        <revision>4.0.6-SNAPSHOT</revision>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.target>1.8</maven.compiler.target>
         <maven.compiler.source>1.8</maven.compiler.source>
@@ -455,7 +455,7 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>flatten-maven-plugin</artifactId>
-                <version>1.2.2</version>
+                <version>1.7.0</version>
                 <configuration>
                     <flattenMode>minimum</flattenMode>
                 </configuration>
@@ -468,7 +468,14 @@
                         </goals>
                     </execution>
                     <execution>
-                        <id>flatten-clean</id>
+                        <id>flatten.package</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>flatten</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>flatten.clean</id>
                         <phase>clean</phase>
                         <goals>
                             <goal>clean</goal>


### PR DESCRIPTION
Since  Arthas >=4.0.4, the generated POM cannot be resolved by Maven if it is imported in another project,

```xml
        <dependency>
            <groupId>com.taobao.arthas</groupId>
            <artifactId>arthas-core</artifactId>
            <version>4.0.4</version>
        </dependency>
```

The following error will be reported,

```
[ERROR] Failed to execute goal on project xxxxxxx: Could not resolve dependencies for project xxxxxxx: Failed to collect dependencies at com.taobao.arthas:arthas-core:jar:4.0.4: Failed to read artifact descriptor for com.taobao.arthas:arthas-core:jar:4.0.4: The following artifacts could not be resolved: com.taobao.arthas:arthas-all:pom:${revision} (absent): com.taobao.arthas:arthas-all:pom:${revision} was not found in https://maven.aliyun.com/repository/public during a previous attempt. This failure was cached in the local repository and resolution is not reattempted until the update interval of aliyun has elapsed or updates are forced -> [Help 1]
```

This issue may be introduced in commit https://github.com/alibaba/arthas/commit/797baf5b04f28855b1cf8205f4764aa3f89977d8, also see this discussion https://github.com/mojohaus/flatten-maven-plugin/issues/100