### PR TITLE
fix bug of enum obj

### DIFF
--- a/core/src/main/java/com/taobao/arthas/core/view/ObjectView.java
+++ b/core/src/main/java/com/taobao/arthas/core/view/ObjectView.java
@@ -587,7 +587,7 @@ public class ObjectView implements View {
                 appendStringBuilder(buf, format("@%s[%s]", className, new SimpleDateFormat("yyyy-MM-dd HH:mm:ss,SSS").format(obj)));
             }
 
-            else if (object instanceof Enum<?>) {
+            else if (obj instanceof Enum<?>) {
                 appendStringBuilder(buf, format("@%s[%s]", className, obj));
             }
 

--- a/core/src/test/java/com/taobao/arthas/core/view/ObjectViewTest.java
+++ b/core/src/test/java/com/taobao/arthas/core/view/ObjectViewTest.java
@@ -190,6 +190,23 @@ public class ObjectViewTest {
     }
 
     @Test
+    public void testEnum() {
+        EnumDemo t = EnumDemo.DEMO;
+        ObjectView objectView = new ObjectView(t, 3);
+        Assert.assertEquals("@EnumDemo[DEMO]", objectView.draw());
+    }
+
+    @Test
+    public void testEnumList() {
+        EnumDemo t = EnumDemo.DEMO;
+        ObjectView objectView = new ObjectView(new Object[] {t}, 3);
+        String expected = "@Object[][\n" +
+            "    @EnumDemo[DEMO],\n" +
+            "]";
+        Assert.assertEquals(expected, objectView.draw());
+    }
+
+    @Test
     public void testDate() {
         Date d = new Date(1531204354961L - TimeZone.getDefault().getRawOffset()
                         + TimeZone.getTimeZone("GMT+8").getRawOffset());
@@ -302,5 +319,9 @@ public class ObjectViewTest {
         public void setJ(String j) {
             this.j = j;
         }
+    }
+
+    public enum EnumDemo {
+        DEMO;
     }
 }


### PR DESCRIPTION
使用了错误的类型判断，所以导致 enum 枚举走了不该走的逻辑。

在 jdk 高版本 的场景下，会有问题。

ts=2025-07-17 15:58:47.327; [cost=0.03725ms] result=ERROR DATA!!! object class: class java.util.ArrayList, exception class: class java.lang.reflect.InaccessibleObjectException, exception message: Unable to make field private final java.lang.String java.lang.Enum.name accessible: module java.base does not "opens java.lang" to unnamed module @3d3762e1

这里会遍历 enum 的多个字段，会有访问性问题。
<img width="521" height="32" alt="Clipboard_Screenshot_1752739474" src="https://github.com/user-attachments/assets/a338b409-69f8-4683-83bd-4cf36f0f4035" />
