### PR TITLE
feat: mcp serialization fix

### DIFF
--- a/labs/arthas-mcp-server/pom.xml
+++ b/labs/arthas-mcp-server/pom.xml
@@ -30,6 +30,13 @@
             <version>${netty.version}</version>
         </dependency>
 
+        <!-- FastJSON2 dependencies -->
+        <dependency>
+            <groupId>com.alibaba.fastjson2</groupId>
+            <artifactId>fastjson2</artifactId>
+            <version>2.0.58</version>
+        </dependency>
+
         <!-- Jackson dependencies -->
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>

--- a/labs/arthas-mcp-server/src/main/java/com/taobao/arthas/mcp/server/session/ArthasCommandContext.java
+++ b/labs/arthas-mcp-server/src/main/java/com/taobao/arthas/mcp/server/session/ArthasCommandContext.java
@@ -18,7 +18,7 @@ public class ArthasCommandContext {
 
     private final ArthasCommandSessionManager.CommandSessionBinding sessionBinding;
 
-    private static final long DEFAULT_SYNC_TIMEOUT = 10000L;
+    private static final long DEFAULT_SYNC_TIMEOUT = 30000L;
 
     public ArthasCommandContext(CommandExecutor commandExecutor) {
         this.commandExecutor = Objects.requireNonNull(commandExecutor, "commandExecutor cannot be null");

--- a/labs/arthas-mcp-server/src/main/java/com/taobao/arthas/mcp/server/tool/function/jvm300/MBeanTool.java
+++ b/labs/arthas-mcp-server/src/main/java/com/taobao/arthas/mcp/server/tool/function/jvm300/MBeanTool.java
@@ -98,22 +98,7 @@ public class MBeanTool {
             String commandStr = cmd.toString();
             logger.info("Starting mbean execution: {}", commandStr);
 
-            // 使用同步执行的情况：查看元数据 或者 不需要流式输出
-            if (Boolean.TRUE.equals(metadata) || !needStreamOutput) {
-                logger.info("Executing sync mbean command: {}", commandStr);
-                Map<String, Object> result = commandContext.executeSync(commandStr);
-                return JsonParser.toJson(result);
-            } else {
-                Map<String, Object> asyncResult = commandContext.executeAsync(commandStr);
-                logger.debug("Async execution started: {}", asyncResult);
-                
-                Map<String, Object> results = executeAndCollectResults(exchange, commandContext, execCount, interval / 10, progressToken);
-                if (results != null) {
-                    return JsonParser.toJson(createCompletedResponse("MBean execution completed successfully", results));
-                } else {
-                    return JsonParser.toJson(createErrorResponse("MBean execution failed due to timeout or error limits exceeded"));
-                }
-            }
+            return JsonParser.toJson(commandContext.executeSync(commandStr));
 
         } catch (Exception e) {
             logger.error("Error executing mbean command", e);

--- a/labs/arthas-mcp-server/src/main/java/com/taobao/arthas/mcp/server/tool/util/McpToolUtils.java
+++ b/labs/arthas-mcp-server/src/main/java/com/taobao/arthas/mcp/server/tool/util/McpToolUtils.java
@@ -135,13 +135,16 @@ public final class McpToolUtils {
 
 	private static McpSchema.CallToolResult createSuccessResult(String content) {
 		List<McpSchema.Content> contents = new ArrayList<>();
-		contents.add(new McpSchema.TextContent(content));
+		String safeContent = (content != null && !content.trim().isEmpty()) ? content : "{}";
+		contents.add(new McpSchema.TextContent(safeContent));
 		return new McpSchema.CallToolResult(contents, false);
 	}
 
 	private static McpSchema.CallToolResult createErrorResult(String errorMessage) {
 		List<McpSchema.Content> contents = new ArrayList<>();
-		contents.add(new McpSchema.TextContent(errorMessage));
+		String safeErrorMessage = (errorMessage != null && !errorMessage.trim().isEmpty()) ? 
+			errorMessage : "Unknown error occurred";
+		contents.add(new McpSchema.TextContent(safeErrorMessage));
 		return new McpSchema.CallToolResult(contents, true);
 	}
 

--- a/labs/arthas-mcp-server/src/main/java/com/taobao/arthas/mcp/server/util/McpObjectVOFilter.java
+++ b/labs/arthas-mcp-server/src/main/java/com/taobao/arthas/mcp/server/util/McpObjectVOFilter.java
@@ -1,0 +1,86 @@
+package com.taobao.arthas.mcp.server.util;
+
+import com.alibaba.fastjson2.JSON;
+import com.alibaba.fastjson2.JSONFactory;
+import com.alibaba.fastjson2.JSONWriter;
+import com.alibaba.fastjson2.filter.ValueFilter;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * mcp specific objectVO serialization filter
+ */
+public class McpObjectVOFilter implements ValueFilter {
+    
+    private static final Logger logger = LoggerFactory.getLogger(McpObjectVOFilter.class);
+    
+    @Override
+    public Object apply(Object object, String name, Object value) {
+        if (value == null) {
+            return null;
+        }
+        String className = value.getClass().getSimpleName();
+        if ("ObjectVO".equals(className)) {
+            return handleObjectVO(value);
+        }
+        
+        return value;
+    }
+
+    private Object handleObjectVO(Object objectVO) {
+        try {
+            Object innerObject = getFieldValue(objectVO, "object");
+            Integer expand = (Integer) getFieldValue(objectVO, "expand");
+            
+            if (innerObject == null) {
+                return "null";
+            }
+
+            return needExpand(expand) ? drawObjectView(innerObject) : objectToString(innerObject);
+        } catch (Exception e) {
+            logger.warn("Failed to handle ObjectVO: {}", e.getMessage());
+            return "{\"error\":\"ObjectVO serialization failed\"}";
+        }
+    }
+
+    private String drawObjectView(Object object) {
+        try {
+            JSONWriter.Context context = JSONFactory.createWriteContext();
+            context.setMaxLevel(4097);
+            context.config(JSONWriter.Feature.IgnoreErrorGetter, true);
+            context.config(JSONWriter.Feature.ReferenceDetection, true);
+            context.config(JSONWriter.Feature.IgnoreNonFieldGetter, true);
+            context.config(JSONWriter.Feature.WriteNonStringKeyAsString, true);
+            return JSON.toJSONString(object, context);
+        } catch (Exception e) {
+            logger.debug("ObjectView-style serialization failed, using toString: {}", e.getMessage());
+            return objectToString(object);
+        }
+    }
+
+    private String objectToString(Object object) {
+        if (object == null) {
+            return "null";
+        }
+        try {
+            return object.toString();
+        } catch (Exception e) {
+            return object.getClass().getSimpleName() + "@" + Integer.toHexString(object.hashCode());
+        }
+    }
+
+    private boolean needExpand(Integer expand) {
+        return expand != null && expand > 0;
+    }
+
+    private Object getFieldValue(Object obj, String fieldName) {
+        try {
+            java.lang.reflect.Field field = obj.getClass().getDeclaredField(fieldName);
+            field.setAccessible(true);
+            return field.get(obj);
+        } catch (Exception e) {
+            logger.debug("Failed to get field {} from {}: {}", fieldName, obj.getClass().getSimpleName(), e.getMessage());
+            return null;
+        }
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -147,7 +147,7 @@
             <dependency>
                 <groupId>com.alibaba.fastjson2</groupId>
                 <artifactId>fastjson2</artifactId>
-                <version>2.0.52</version>
+                <version>2.0.58</version>
             </dependency>
             <dependency>
                 <groupId>com.taobao.text</groupId>


### PR DESCRIPTION
本次PR主要针对序列化相关问题进行了全面优化和升级：

## 主要改进

1. **升级 fastjson2 版本到 2.0.58**
   - 解决了"level too large : 2049"的深度限制问题

2. **优化序列化工具类**
   - 修复了部分类缺少getter方法导致的序列化失败问题

3. **增强流式工具错误处理**
   - 添加了完善的错误信息处理机制
