### PR TITLE
feat: enhance MCP authentication and allow configurable /mcp path

### DIFF
--- a/core/src/main/java/arthas.properties
+++ b/core/src/main/java/arthas.properties
@@ -22,3 +22,6 @@ arthas.localConnectionNonAuth=true
 #arthas.disabledCommands=stop,dump
 
 #arthas.outputPath=arthas-output
+
+# MCP (Model Context Protocol) configuration
+arthas.mcpEndpoint=/mcp

--- a/core/src/main/java/com/taobao/arthas/core/config/Configure.java
+++ b/core/src/main/java/com/taobao/arthas/core/config/Configure.java
@@ -74,6 +74,11 @@ public class Configure {
      */
     private Boolean localConnectionNonAuth;
 
+    /**
+     * MCP (Model Context Protocol) endpoint path
+     */
+    private String mcpEndpoint;
+
     public String getIp() {
         return ip;
     }
@@ -208,6 +213,14 @@ public class Configure {
 
     public void setLocalConnectionNonAuth(boolean localConnectionNonAuth) {
         this.localConnectionNonAuth = localConnectionNonAuth;
+    }
+
+    public String getMcpEndpoint() {
+        return mcpEndpoint;
+    }
+
+    public void setMcpEndpoint(String mcpEndpoint) {
+        this.mcpEndpoint = mcpEndpoint;
     }
 
     /**

--- a/core/src/main/java/com/taobao/arthas/core/server/ArthasBootstrap.java
+++ b/core/src/main/java/com/taobao/arthas/core/server/ArthasBootstrap.java
@@ -469,12 +469,15 @@ public class ArthasBootstrap {
             httpApiHandler = new HttpApiHandler(historyManager, sessionManager);
 
             // Mcp Server
-            CommandExecutor commandExecutor = new CommandExecutorImpl(sessionManager);
-            ArthasMcpBootstrap arthasMcpBootstrap = new ArthasMcpBootstrap(commandExecutor);
-            this.mcpRequestHandler = arthasMcpBootstrap.start().getMcpRequestHandler();
-
-            logger().info("as-server listening on network={};telnet={};http={};timeout={};", configure.getIp(),
-                    configure.getTelnetPort(), configure.getHttpPort(), options.getConnectionTimeout());
+            String mcpEndpoint = configure.getMcpEndpoint();
+            if (mcpEndpoint != null && !mcpEndpoint.trim().isEmpty()) {
+                logger().info("try to start mcp server, endpoint: {}.", mcpEndpoint);
+                CommandExecutor commandExecutor = new CommandExecutorImpl(sessionManager);
+                ArthasMcpBootstrap arthasMcpBootstrap = new ArthasMcpBootstrap(commandExecutor, mcpEndpoint);
+                this.mcpRequestHandler = arthasMcpBootstrap.start().getMcpRequestHandler();
+            }
+            logger().info("as-server listening on network={};telnet={};http={};timeout={};mcp={};", configure.getIp(),
+                    configure.getTelnetPort(), configure.getHttpPort(), options.getConnectionTimeout(), configure.getMcpEndpoint());
 
             // 异步回报启动次数
             if (configure.getStatUrl() != null) {
@@ -684,6 +687,10 @@ public class ArthasBootstrap {
 
     public McpHttpRequestHandler getMcpRequestHandler() {
         return mcpRequestHandler;
+    }
+
+    public boolean isMcpServerEnabled() {
+        return mcpRequestHandler != null;
     }
 
     public File getOutputPath() {

--- a/core/src/main/java/com/taobao/arthas/core/shell/term/impl/http/BasicHttpAuthenticatorHandler.java
+++ b/core/src/main/java/com/taobao/arthas/core/shell/term/impl/http/BasicHttpAuthenticatorHandler.java
@@ -196,7 +196,17 @@ public final class BasicHttpAuthenticatorHandler extends ChannelDuplexHandler {
     protected static boolean isMcpRequest(HttpRequest request) {
         try {
             String path = new java.net.URI(request.uri()).getPath();
-            return path != null && path.endsWith("/mcp");
+            if (path == null) {
+                return false;
+            }
+
+            String mcpEndpoint = ArthasBootstrap.getInstance().getConfigure().getMcpEndpoint();
+            if (mcpEndpoint == null || mcpEndpoint.trim().isEmpty()) {
+                // MCP 服务器未配置，不处理 MCP 请求
+                return false;
+            }
+            
+            return mcpEndpoint.equals(path);
         } catch (Exception e) {
             logger.debug("Failed to parse request URI: {}", request.uri(), e);
             return false;

--- a/core/src/main/java/com/taobao/arthas/core/shell/term/impl/http/BasicHttpAuthenticatorHandler.java
+++ b/core/src/main/java/com/taobao/arthas/core/shell/term/impl/http/BasicHttpAuthenticatorHandler.java
@@ -1,12 +1,5 @@
 package com.taobao.arthas.core.shell.term.impl.http;
 
-import java.nio.charset.Charset;
-import java.security.Principal;
-import java.util.List;
-import java.util.Map;
-
-import javax.security.auth.Subject;
-
 import com.alibaba.arthas.deps.org.slf4j.Logger;
 import com.alibaba.arthas.deps.org.slf4j.LoggerFactory;
 import com.taobao.arthas.common.ArthasConstants;
@@ -18,21 +11,23 @@ import com.taobao.arthas.core.server.ArthasBootstrap;
 import com.taobao.arthas.core.shell.term.impl.http.session.HttpSession;
 import com.taobao.arthas.core.shell.term.impl.http.session.HttpSessionManager;
 import com.taobao.arthas.core.util.StringUtils;
-
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.ChannelDuplexHandler;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelPromise;
 import io.netty.handler.codec.base64.Base64;
-import io.netty.handler.codec.http.DefaultHttpResponse;
-import io.netty.handler.codec.http.HttpHeaderNames;
-import io.netty.handler.codec.http.HttpRequest;
-import io.netty.handler.codec.http.HttpResponse;
-import io.netty.handler.codec.http.HttpResponseStatus;
-import io.netty.handler.codec.http.HttpVersion;
-import io.netty.handler.codec.http.QueryStringDecoder;
+import io.netty.handler.codec.http.*;
 import io.netty.util.Attribute;
+
+import javax.security.auth.Subject;
+import java.nio.charset.Charset;
+import java.security.Principal;
+import java.util.List;
+import java.util.Map;
+
+import static com.taobao.arthas.mcp.server.util.McpAuthExtractor.SUBJECT_ATTRIBUTE_KEY;
+
 
 /**
  * 
@@ -67,10 +62,9 @@ public final class BasicHttpAuthenticatorHandler extends ChannelDuplexHandler {
                 authed = true;
             }
 
+            boolean isMcpRequest = isMcpRequest(httpRequest);
             Principal principal = null;
             if (!authed) {
-                boolean isMcpRequest = isMcpRequest(httpRequest);
-                
                 if (isMcpRequest) {
                     principal = extractMcpAuthSubject(httpRequest);
                 } else {
@@ -90,13 +84,13 @@ public final class BasicHttpAuthenticatorHandler extends ChannelDuplexHandler {
                 if (session != null) {
                     session.setAttribute(ArthasConstants.SUBJECT_KEY, subject);
                 }
+                ctx.channel().attr(SUBJECT_ATTRIBUTE_KEY).set(subject);
             }
 
             if (!authed) {
                 // restricted resource, so send back 401 to require valid username/password
                 HttpResponse response = new DefaultHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.UNAUTHORIZED);
 
-                boolean isMcpRequest = isMcpRequest(httpRequest);
                 if (isMcpRequest) {
                     response.headers().add(HttpHeaderNames.WWW_AUTHENTICATE, "Bearer realm=\"arthas mcp\"")
                                        .add(HttpHeaderNames.WWW_AUTHENTICATE, "Basic realm=\"arthas mcp\"");

--- a/labs/arthas-mcp-server/src/main/java/com/taobao/arthas/mcp/server/ArthasMcpBootstrap.java
+++ b/labs/arthas-mcp-server/src/main/java/com/taobao/arthas/mcp/server/ArthasMcpBootstrap.java
@@ -13,10 +13,12 @@ public class ArthasMcpBootstrap {
     
     private ArthasMcpServer mcpServer;
     private final CommandExecutor commandExecutor;
+    private final String mcpEndpoint;
     private static ArthasMcpBootstrap instance;
 
-    public ArthasMcpBootstrap(CommandExecutor commandExecutor) {
+    public ArthasMcpBootstrap(CommandExecutor commandExecutor, String mcpEndpoint) {
         this.commandExecutor = commandExecutor;
+        this.mcpEndpoint = mcpEndpoint;
         instance = this;
     }
 
@@ -34,8 +36,8 @@ public class ArthasMcpBootstrap {
             logger.debug("Creating MCP server instance with command executor: {}", 
                     commandExecutor.getClass().getSimpleName());
             
-            // Create and start MCP server with CommandExecutor
-            mcpServer = new ArthasMcpServer(commandExecutor);
+            // Create and start MCP server with CommandExecutor and custom endpoint
+            mcpServer = new ArthasMcpServer(mcpEndpoint, commandExecutor);
             logger.debug("MCP server instance created successfully");
             
             mcpServer.start();

--- a/labs/arthas-mcp-server/src/main/java/com/taobao/arthas/mcp/server/ArthasMcpServer.java
+++ b/labs/arthas-mcp-server/src/main/java/com/taobao/arthas/mcp/server/ArthasMcpServer.java
@@ -34,8 +34,7 @@ public class ArthasMcpServer {
     private McpNettyServer streamableServer;
     private McpStatelessNettyServer statelessServer;
 
-    private final int port;
-    private final String bindAddress;
+    private final String mcpEndpoint;
 
     private final CommandExecutor commandExecutor;
 
@@ -44,14 +43,11 @@ public class ArthasMcpServer {
     private McpStreamableHttpRequestHandler streamableHandler;
 
     private McpStatelessHttpRequestHandler statelessHandler;
+
+    public static final String DEFAULT_MCP_ENDPOINT = "/mcp";
     
-    public ArthasMcpServer(CommandExecutor commandExecutor) {
-        this(8080, "localhost", commandExecutor);
-    }
-    
-    public ArthasMcpServer(int port, String bindAddress, CommandExecutor commandExecutor) {
-        this.port = port;
-        this.bindAddress = bindAddress;
+    public ArthasMcpServer(String mcpEndpoint, CommandExecutor commandExecutor) {
+        this.mcpEndpoint = mcpEndpoint != null ? mcpEndpoint : DEFAULT_MCP_ENDPOINT;
         this.commandExecutor = commandExecutor;
     }
 
@@ -63,14 +59,11 @@ public class ArthasMcpServer {
      * Start MCP server
      */
     public void start() {
-        logger.info("Starting Arthas MCP server on {}:{}", bindAddress, port);
         try {
             McpServerProperties properties = new McpServerProperties.Builder()
                     .name("arthas-mcp-server")
                     .version("1.0.0")
-                    .bindAddress(bindAddress)
-                    .port(port)
-                    .mcpEndpoint("/mcp")
+                    .mcpEndpoint(mcpEndpoint)
                     .toolChangeNotification(true)
                     .resourceChangeNotification(true)
                     .promptChangeNotification(true)
@@ -125,7 +118,6 @@ public class ArthasMcpServer {
             statelessServer = statelessServerNettySpecification.build();
             
             logger.info("Arthas MCP server started successfully");
-            logger.info("- Listening on {}:{}", bindAddress, port);
             logger.info("- MCP Endpoint: {}", properties.getMcpEndpoint());
             logger.info("- Transport modes: Streamable + Stateless");
             logger.info("- Available tools: {}", providerToolCallbacks.size());

--- a/labs/arthas-mcp-server/src/main/java/com/taobao/arthas/mcp/server/CommandExecutor.java
+++ b/labs/arthas-mcp-server/src/main/java/com/taobao/arthas/mcp/server/CommandExecutor.java
@@ -10,10 +10,14 @@ import java.util.Map;
 public interface CommandExecutor {
 
     default Map<String, Object> executeSync(String commandLine, long timeout) {
-        return executeSync(commandLine, timeout, null);
+        return executeSync(commandLine, timeout, null, null);
     }
 
-    Map<String, Object> executeSync(String commandLine, long timeout, String sessionId);
+    default Map<String, Object> executeSync(String commandLine, Object authSubject) {
+        return executeSync(commandLine, 30000L, null, authSubject);
+    }
+
+    Map<String, Object> executeSync(String commandLine, long timeout, String sessionId, Object authSubject);
 
     Map<String, Object> executeAsync(String commandLine, String sessionId);
 
@@ -24,5 +28,7 @@ public interface CommandExecutor {
     Map<String, Object> createSession();
 
     Map<String, Object> closeSession(String sessionId);
+
+    void setSessionAuth(String sessionId, Object authSubject);
 }
 

--- a/labs/arthas-mcp-server/src/main/java/com/taobao/arthas/mcp/server/protocol/config/McpServerProperties.java
+++ b/labs/arthas-mcp-server/src/main/java/com/taobao/arthas/mcp/server/protocol/config/McpServerProperties.java
@@ -29,11 +29,6 @@ public class McpServerProperties {
     private final boolean promptChangeNotification;
     private final boolean resourceSubscribe;
 
-    /**
-     * Transport layer configuration
-     */
-    private final String bindAddress;
-    private final int port;
     private final String mcpEndpoint;
 
     /**
@@ -60,8 +55,6 @@ public class McpServerProperties {
         this.resourceChangeNotification = builder.resourceChangeNotification;
         this.promptChangeNotification = builder.promptChangeNotification;
         this.resourceSubscribe = builder.resourceSubscribe;
-        this.bindAddress = builder.bindAddress;
-        this.port = builder.port;
         this.mcpEndpoint = builder.mcpEndpoint;
         this.requestTimeout = builder.requestTimeout;
         this.initializationTimeout = builder.initializationTimeout;
@@ -130,23 +123,6 @@ public class McpServerProperties {
     public boolean isResourceSubscribe() {
         return resourceSubscribe;
     }
-
-    /**
-     * Get bind address
-     * @return Bind address
-     */
-    public String getBindAddress() {
-        return bindAddress;
-    }
-
-    /**
-     * Get server port
-     * @return Server port
-     */
-    public int getPort() {
-        return port;
-    }
-
 
     /**
      * Get SSE endpoint
@@ -243,16 +219,6 @@ public class McpServerProperties {
 
         public Builder resourceSubscribe(boolean resourceSubscribe) {
             this.resourceSubscribe = resourceSubscribe;
-            return this;
-        }
-
-        public Builder bindAddress(String bindAddress) {
-            this.bindAddress = bindAddress;
-            return this;
-        }
-
-        public Builder port(int port) {
-            this.port = port;
             return this;
         }
 

--- a/labs/arthas-mcp-server/src/main/java/com/taobao/arthas/mcp/server/protocol/server/handler/McpStatelessHttpRequestHandler.java
+++ b/labs/arthas-mcp-server/src/main/java/com/taobao/arthas/mcp/server/protocol/server/handler/McpStatelessHttpRequestHandler.java
@@ -5,6 +5,7 @@
 package com.taobao.arthas.mcp.server.protocol.server.handler;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.taobao.arthas.mcp.server.util.McpAuthExtractor;
 import com.taobao.arthas.mcp.server.protocol.server.DefaultMcpTransportContext;
 import com.taobao.arthas.mcp.server.protocol.server.McpStatelessServerHandler;
 import com.taobao.arthas.mcp.server.protocol.server.McpTransportContext;
@@ -15,7 +16,6 @@ import com.taobao.arthas.mcp.server.util.Assert;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.ChannelFutureListener;
-import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.handler.codec.http.*;
 import io.netty.util.CharsetUtil;
@@ -108,6 +108,9 @@ public class McpStatelessHttpRequestHandler {
      */
     private void handlePostRequest(ChannelHandlerContext ctx, FullHttpRequest request) {
         McpTransportContext transportContext = this.contextExtractor.extract(request, new DefaultMcpTransportContext());
+
+        Object authSubject = McpAuthExtractor.extractAuthSubjectFromContext(ctx);
+        transportContext.put(McpAuthExtractor.MCP_AUTH_SUBJECT_KEY, authSubject);
 
         String accept = request.headers().get(ACCEPT);
         if (accept == null || !(accept.contains(APPLICATION_JSON) && accept.contains(TEXT_EVENT_STREAM))) {

--- a/labs/arthas-mcp-server/src/main/java/com/taobao/arthas/mcp/server/protocol/server/handler/McpStreamableHttpRequestHandler.java
+++ b/labs/arthas-mcp-server/src/main/java/com/taobao/arthas/mcp/server/protocol/server/handler/McpStreamableHttpRequestHandler.java
@@ -6,6 +6,7 @@ package com.taobao.arthas.mcp.server.protocol.server.handler;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.taobao.arthas.mcp.server.util.McpAuthExtractor;
 import com.taobao.arthas.mcp.server.protocol.server.DefaultMcpTransportContext;
 import com.taobao.arthas.mcp.server.protocol.server.McpTransportContext;
 import com.taobao.arthas.mcp.server.protocol.server.McpTransportContextExtractor;
@@ -16,7 +17,6 @@ import com.taobao.arthas.mcp.server.util.KeepAliveScheduler;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.Channel;
-import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.handler.codec.http.*;
 import io.netty.util.CharsetUtil;
@@ -32,6 +32,8 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.locks.ReentrantLock;
+
+import static com.taobao.arthas.mcp.server.util.McpAuthExtractor.MCP_AUTH_SUBJECT_KEY;
 
 /**
  * Server-side implementation of the Model Context Protocol (MCP) streamable transport
@@ -225,6 +227,9 @@ public class McpStreamableHttpRequestHandler {
 
         McpTransportContext transportContext = this.contextExtractor.extract(request, new DefaultMcpTransportContext());
 
+        Object authSubject = McpAuthExtractor.extractAuthSubjectFromContext(ctx);
+        transportContext.put(McpAuthExtractor.MCP_AUTH_SUBJECT_KEY, authSubject);
+
         try {
             // Set up SSE response headers
             HttpResponse response = new DefaultHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.OK);
@@ -293,6 +298,9 @@ public class McpStreamableHttpRequestHandler {
         }
 
         McpTransportContext transportContext = this.contextExtractor.extract(request, new DefaultMcpTransportContext());
+
+        Object authSubject = McpAuthExtractor.extractAuthSubjectFromContext(ctx);
+        transportContext.put(MCP_AUTH_SUBJECT_KEY, authSubject);
 
         try {
             ByteBuf content = request.content();

--- a/labs/arthas-mcp-server/src/main/java/com/taobao/arthas/mcp/server/protocol/server/transport/NettyStatelessServerTransport.java
+++ b/labs/arthas-mcp-server/src/main/java/com/taobao/arthas/mcp/server/protocol/server/transport/NettyStatelessServerTransport.java
@@ -14,6 +14,8 @@ import io.netty.handler.codec.http.FullHttpRequest;
 
 import java.util.concurrent.CompletableFuture;
 
+import static com.taobao.arthas.mcp.server.ArthasMcpServer.DEFAULT_MCP_ENDPOINT;
+
 /**
  * Server-side implementation of the Model Context Protocol (MCP) stateless transport
  * layer using HTTP through Netty. This implementation provides a bridge between 
@@ -81,7 +83,7 @@ public class NettyStatelessServerTransport implements McpStatelessServerTranspor
     public static class Builder {
 
         private ObjectMapper objectMapper;
-        private String mcpEndpoint = "/mcp";
+        private String mcpEndpoint = DEFAULT_MCP_ENDPOINT;
         private McpTransportContextExtractor<FullHttpRequest> contextExtractor = (serverRequest, context) -> context;
 
         public Builder objectMapper(ObjectMapper objectMapper) {

--- a/labs/arthas-mcp-server/src/main/java/com/taobao/arthas/mcp/server/protocol/server/transport/NettyStreamableServerTransportProvider.java
+++ b/labs/arthas-mcp-server/src/main/java/com/taobao/arthas/mcp/server/protocol/server/transport/NettyStreamableServerTransportProvider.java
@@ -15,6 +15,8 @@ import io.netty.handler.codec.http.FullHttpRequest;
 import java.time.Duration;
 import java.util.concurrent.CompletableFuture;
 
+import static com.taobao.arthas.mcp.server.ArthasMcpServer.DEFAULT_MCP_ENDPOINT;
+
 /**
  * Server-side implementation of the Model Context Protocol (MCP) streamable transport
  * layer using HTTP with Server-Sent Events (SSE) through Netty. This implementation
@@ -98,7 +100,7 @@ public class NettyStreamableServerTransportProvider implements McpStreamableServ
     public static class Builder {
 
         private ObjectMapper objectMapper;
-        private String mcpEndpoint = "/mcp";
+        private String mcpEndpoint = DEFAULT_MCP_ENDPOINT;
         private boolean disallowDelete = false;
         private McpTransportContextExtractor<FullHttpRequest> contextExtractor = (serverRequest, context) -> context;
         private Duration keepAliveInterval;

--- a/labs/arthas-mcp-server/src/main/java/com/taobao/arthas/mcp/server/session/ArthasCommandContext.java
+++ b/labs/arthas-mcp-server/src/main/java/com/taobao/arthas/mcp/server/session/ArthasCommandContext.java
@@ -48,10 +48,8 @@ public class ArthasCommandContext {
     public Map<String, Object> executeSync(String commandLine, long timeout) {
         return commandExecutor.executeSync(commandLine, timeout);
     }
-
-    public Map<String, Object> executeSyncWithSession(String commandLine, long timeout) {
-        requireSessionSupport();
-        return commandExecutor.executeSync(commandLine, timeout, sessionBinding.getArthasSessionId());
+    public Map<String, Object> executeSync(String commandStr, Object authSubject) {
+        return commandExecutor.executeSync(commandStr, DEFAULT_SYNC_TIMEOUT, null, authSubject);
     }
 
     public Map<String, Object> executeAsync(String commandLine) {

--- a/labs/arthas-mcp-server/src/main/java/com/taobao/arthas/mcp/server/tool/function/jvm300/GetStaticTool.java
+++ b/labs/arthas-mcp-server/src/main/java/com/taobao/arthas/mcp/server/tool/function/jvm300/GetStaticTool.java
@@ -1,11 +1,14 @@
 package com.taobao.arthas.mcp.server.tool.function.jvm300;
 
+import com.taobao.arthas.mcp.server.protocol.server.McpTransportContext;
 import com.taobao.arthas.mcp.server.session.ArthasCommandContext;
 import com.taobao.arthas.mcp.server.tool.ToolContext;
 import com.taobao.arthas.mcp.server.tool.annotation.Tool;
 import com.taobao.arthas.mcp.server.tool.annotation.ToolParam;
 import com.taobao.arthas.mcp.server.util.JsonParser;
 
+import static com.taobao.arthas.mcp.server.util.McpAuthExtractor.MCP_AUTH_SUBJECT_KEY;
+import static com.taobao.arthas.mcp.server.tool.util.McpToolUtils.MCP_TRANSPORT_CONTEXT;
 import static com.taobao.arthas.mcp.server.tool.util.McpToolUtils.TOOL_CONTEXT_COMMAND_CONTEXT_KEY;
 
 public class GetStaticTool {
@@ -34,6 +37,8 @@ public class GetStaticTool {
             ToolContext toolContext
     ) {
         ArthasCommandContext commandContext = (ArthasCommandContext) toolContext.getContext().get(TOOL_CONTEXT_COMMAND_CONTEXT_KEY);
+        McpTransportContext mcpTransportContext = (McpTransportContext) toolContext.getContext().get(MCP_TRANSPORT_CONTEXT);
+        Object authSubject = mcpTransportContext.get(MCP_AUTH_SUBJECT_KEY);
         StringBuilder cmd = new StringBuilder("getstatic");
 
         if (classLoaderHash != null && !classLoaderHash.trim().isEmpty()) {
@@ -50,6 +55,6 @@ public class GetStaticTool {
         }
 
         String commandStr = cmd.toString();
-        return JsonParser.toJson(commandContext.executeSync(commandStr));
+        return JsonParser.toJson(commandContext.executeSync(commandStr, authSubject));
     }
 }

--- a/labs/arthas-mcp-server/src/main/java/com/taobao/arthas/mcp/server/tool/function/jvm300/HeapdumpTool.java
+++ b/labs/arthas-mcp-server/src/main/java/com/taobao/arthas/mcp/server/tool/function/jvm300/HeapdumpTool.java
@@ -1,5 +1,6 @@
 package com.taobao.arthas.mcp.server.tool.function.jvm300;
 
+import com.taobao.arthas.mcp.server.protocol.server.McpTransportContext;
 import com.taobao.arthas.mcp.server.session.ArthasCommandContext;
 import com.taobao.arthas.mcp.server.tool.ToolContext;
 import com.taobao.arthas.mcp.server.tool.annotation.Tool;
@@ -14,6 +15,8 @@ import java.nio.file.Paths;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 
+import static com.taobao.arthas.mcp.server.util.McpAuthExtractor.MCP_AUTH_SUBJECT_KEY;
+import static com.taobao.arthas.mcp.server.tool.util.McpToolUtils.MCP_TRANSPORT_CONTEXT;
 import static com.taobao.arthas.mcp.server.tool.util.McpToolUtils.TOOL_CONTEXT_COMMAND_CONTEXT_KEY;
 
 public class HeapdumpTool {
@@ -42,6 +45,8 @@ public class HeapdumpTool {
             ToolContext toolContext
     ) throws IOException {
         ArthasCommandContext commandContext = (ArthasCommandContext) toolContext.getContext().get(TOOL_CONTEXT_COMMAND_CONTEXT_KEY);
+        McpTransportContext mcpTransportContext = (McpTransportContext) toolContext.getContext().get(MCP_TRANSPORT_CONTEXT);
+        Object authSubject = mcpTransportContext.get(MCP_AUTH_SUBJECT_KEY);
 
         String finalFilePath;
 
@@ -65,6 +70,6 @@ public class HeapdumpTool {
         cmd.append(" ").append(finalFilePath);
 
         String commandStr = cmd.toString();
-        return JsonParser.toJson(commandContext.executeSync(commandStr));
+        return JsonParser.toJson(commandContext.executeSync(commandStr, authSubject));
     }
 }

--- a/labs/arthas-mcp-server/src/main/java/com/taobao/arthas/mcp/server/tool/function/jvm300/JvmTool.java
+++ b/labs/arthas-mcp-server/src/main/java/com/taobao/arthas/mcp/server/tool/function/jvm300/JvmTool.java
@@ -1,10 +1,13 @@
 package com.taobao.arthas.mcp.server.tool.function.jvm300;
 
+import com.taobao.arthas.mcp.server.protocol.server.McpTransportContext;
 import com.taobao.arthas.mcp.server.session.ArthasCommandContext;
 import com.taobao.arthas.mcp.server.tool.ToolContext;
 import com.taobao.arthas.mcp.server.tool.annotation.Tool;
 import com.taobao.arthas.mcp.server.util.JsonParser;
 
+import static com.taobao.arthas.mcp.server.util.McpAuthExtractor.MCP_AUTH_SUBJECT_KEY;
+import static com.taobao.arthas.mcp.server.tool.util.McpToolUtils.MCP_TRANSPORT_CONTEXT;
 import static com.taobao.arthas.mcp.server.tool.util.McpToolUtils.TOOL_CONTEXT_COMMAND_CONTEXT_KEY;
 
 public class JvmTool {
@@ -15,7 +18,9 @@ public class JvmTool {
     )
     public String jvm(ToolContext toolContext) {
         ArthasCommandContext commandContext = (ArthasCommandContext) toolContext.getContext().get(TOOL_CONTEXT_COMMAND_CONTEXT_KEY);
+        McpTransportContext mcpTransportContext = (McpTransportContext) toolContext.getContext().get(MCP_TRANSPORT_CONTEXT);
+        Object authSubject = mcpTransportContext.get(MCP_AUTH_SUBJECT_KEY);
         String commandStr = "jvm";
-        return JsonParser.toJson(commandContext.executeSync(commandStr));
+        return JsonParser.toJson(commandContext.executeSync(commandStr, authSubject));
     }
 }

--- a/labs/arthas-mcp-server/src/main/java/com/taobao/arthas/mcp/server/tool/function/jvm300/MemoryTool.java
+++ b/labs/arthas-mcp-server/src/main/java/com/taobao/arthas/mcp/server/tool/function/jvm300/MemoryTool.java
@@ -1,10 +1,13 @@
 package com.taobao.arthas.mcp.server.tool.function.jvm300;
 
+import com.taobao.arthas.mcp.server.protocol.server.McpTransportContext;
 import com.taobao.arthas.mcp.server.session.ArthasCommandContext;
 import com.taobao.arthas.mcp.server.tool.ToolContext;
 import com.taobao.arthas.mcp.server.tool.annotation.Tool;
 import com.taobao.arthas.mcp.server.util.JsonParser;
 
+import static com.taobao.arthas.mcp.server.util.McpAuthExtractor.MCP_AUTH_SUBJECT_KEY;
+import static com.taobao.arthas.mcp.server.tool.util.McpToolUtils.MCP_TRANSPORT_CONTEXT;
 import static com.taobao.arthas.mcp.server.tool.util.McpToolUtils.TOOL_CONTEXT_COMMAND_CONTEXT_KEY;
 
 public class MemoryTool {
@@ -15,7 +18,9 @@ public class MemoryTool {
     )
     public String memory(ToolContext toolContext) {
         ArthasCommandContext commandContext = (ArthasCommandContext) toolContext.getContext().get(TOOL_CONTEXT_COMMAND_CONTEXT_KEY);
+        McpTransportContext mcpTransportContext = (McpTransportContext) toolContext.getContext().get(MCP_TRANSPORT_CONTEXT);
+        Object authSubject = mcpTransportContext.get(MCP_AUTH_SUBJECT_KEY);
         String commandStr = "memory";
-        return JsonParser.toJson(commandContext.executeSync(commandStr));
+        return JsonParser.toJson(commandContext.executeSync(commandStr, authSubject));
     }
 }

--- a/labs/arthas-mcp-server/src/main/java/com/taobao/arthas/mcp/server/tool/function/jvm300/OgnlTool.java
+++ b/labs/arthas-mcp-server/src/main/java/com/taobao/arthas/mcp/server/tool/function/jvm300/OgnlTool.java
@@ -1,11 +1,14 @@
 package com.taobao.arthas.mcp.server.tool.function.jvm300;
 
+import com.taobao.arthas.mcp.server.protocol.server.McpTransportContext;
 import com.taobao.arthas.mcp.server.session.ArthasCommandContext;
 import com.taobao.arthas.mcp.server.tool.ToolContext;
 import com.taobao.arthas.mcp.server.tool.annotation.Tool;
 import com.taobao.arthas.mcp.server.tool.annotation.ToolParam;
 import com.taobao.arthas.mcp.server.util.JsonParser;
 
+import static com.taobao.arthas.mcp.server.util.McpAuthExtractor.MCP_AUTH_SUBJECT_KEY;
+import static com.taobao.arthas.mcp.server.tool.util.McpToolUtils.MCP_TRANSPORT_CONTEXT;
 import static com.taobao.arthas.mcp.server.tool.util.McpToolUtils.TOOL_CONTEXT_COMMAND_CONTEXT_KEY;
 
 public class OgnlTool {
@@ -30,6 +33,8 @@ public class OgnlTool {
             ToolContext toolContext
     ) {
         ArthasCommandContext commandContext = (ArthasCommandContext) toolContext.getContext().get(TOOL_CONTEXT_COMMAND_CONTEXT_KEY);
+        McpTransportContext mcpTransportContext = (McpTransportContext) toolContext.getContext().get(MCP_TRANSPORT_CONTEXT);
+        Object authSubject = mcpTransportContext.get(MCP_AUTH_SUBJECT_KEY);
         StringBuilder cmd = new StringBuilder("ognl");
 
         if (classLoaderHash != null && !classLoaderHash.trim().isEmpty()) {
@@ -44,6 +49,6 @@ public class OgnlTool {
         cmd.append(" ").append(expression.trim());
 
         String commandStr = cmd.toString();
-        return JsonParser.toJson(commandContext.executeSync(commandStr));
+        return JsonParser.toJson(commandContext.executeSync(commandStr, authSubject));
     }
 }

--- a/labs/arthas-mcp-server/src/main/java/com/taobao/arthas/mcp/server/tool/function/jvm300/PerfCounterTool.java
+++ b/labs/arthas-mcp-server/src/main/java/com/taobao/arthas/mcp/server/tool/function/jvm300/PerfCounterTool.java
@@ -1,11 +1,14 @@
 package com.taobao.arthas.mcp.server.tool.function.jvm300;
 
+import com.taobao.arthas.mcp.server.protocol.server.McpTransportContext;
 import com.taobao.arthas.mcp.server.session.ArthasCommandContext;
 import com.taobao.arthas.mcp.server.tool.ToolContext;
 import com.taobao.arthas.mcp.server.tool.annotation.Tool;
 import com.taobao.arthas.mcp.server.tool.annotation.ToolParam;
 import com.taobao.arthas.mcp.server.util.JsonParser;
 
+import static com.taobao.arthas.mcp.server.util.McpAuthExtractor.MCP_AUTH_SUBJECT_KEY;
+import static com.taobao.arthas.mcp.server.tool.util.McpToolUtils.MCP_TRANSPORT_CONTEXT;
 import static com.taobao.arthas.mcp.server.tool.util.McpToolUtils.TOOL_CONTEXT_COMMAND_CONTEXT_KEY;
 
 public class PerfCounterTool {
@@ -20,11 +23,13 @@ public class PerfCounterTool {
             ToolContext toolContext
     ) {
         ArthasCommandContext commandContext = (ArthasCommandContext) toolContext.getContext().get(TOOL_CONTEXT_COMMAND_CONTEXT_KEY);
+        McpTransportContext mcpTransportContext = (McpTransportContext) toolContext.getContext().get(MCP_TRANSPORT_CONTEXT);
+        Object authSubject = mcpTransportContext.get(MCP_AUTH_SUBJECT_KEY);
         StringBuilder cmd = new StringBuilder("perfcounter");
         if (Boolean.TRUE.equals(detailed)) {
             cmd.append(" -d");
         }
         String commandStr = cmd.toString();
-        return JsonParser.toJson(commandContext.executeSync(commandStr));
+        return JsonParser.toJson(commandContext.executeSync(commandStr, authSubject));
     }
 }

--- a/labs/arthas-mcp-server/src/main/java/com/taobao/arthas/mcp/server/tool/function/jvm300/SysEnvTool.java
+++ b/labs/arthas-mcp-server/src/main/java/com/taobao/arthas/mcp/server/tool/function/jvm300/SysEnvTool.java
@@ -1,11 +1,14 @@
 package com.taobao.arthas.mcp.server.tool.function.jvm300;
 
+import com.taobao.arthas.mcp.server.protocol.server.McpTransportContext;
 import com.taobao.arthas.mcp.server.session.ArthasCommandContext;
 import com.taobao.arthas.mcp.server.tool.ToolContext;
 import com.taobao.arthas.mcp.server.tool.annotation.Tool;
 import com.taobao.arthas.mcp.server.tool.annotation.ToolParam;
 import com.taobao.arthas.mcp.server.util.JsonParser;
 
+import static com.taobao.arthas.mcp.server.util.McpAuthExtractor.MCP_AUTH_SUBJECT_KEY;
+import static com.taobao.arthas.mcp.server.tool.util.McpToolUtils.MCP_TRANSPORT_CONTEXT;
 import static com.taobao.arthas.mcp.server.tool.util.McpToolUtils.TOOL_CONTEXT_COMMAND_CONTEXT_KEY;
 
 public class SysEnvTool {
@@ -20,11 +23,13 @@ public class SysEnvTool {
             ToolContext toolContext
     ) {
         ArthasCommandContext commandContext = (ArthasCommandContext) toolContext.getContext().get(TOOL_CONTEXT_COMMAND_CONTEXT_KEY);
+        McpTransportContext mcpTransportContext = (McpTransportContext) toolContext.getContext().get(MCP_TRANSPORT_CONTEXT);
+        Object authSubject = mcpTransportContext.get(MCP_AUTH_SUBJECT_KEY);
         StringBuilder cmd = new StringBuilder("sysenv");
         if (envName != null && !envName.trim().isEmpty()) {
             cmd.append(" ").append(envName.trim());
         }
         String commandStr = cmd.toString();
-        return JsonParser.toJson(commandContext.executeSync(commandStr));
+        return JsonParser.toJson(commandContext.executeSync(commandStr, authSubject));
     }
 }

--- a/labs/arthas-mcp-server/src/main/java/com/taobao/arthas/mcp/server/tool/function/jvm300/SysPropTool.java
+++ b/labs/arthas-mcp-server/src/main/java/com/taobao/arthas/mcp/server/tool/function/jvm300/SysPropTool.java
@@ -1,11 +1,14 @@
 package com.taobao.arthas.mcp.server.tool.function.jvm300;
 
+import com.taobao.arthas.mcp.server.protocol.server.McpTransportContext;
 import com.taobao.arthas.mcp.server.session.ArthasCommandContext;
 import com.taobao.arthas.mcp.server.tool.ToolContext;
 import com.taobao.arthas.mcp.server.tool.annotation.Tool;
 import com.taobao.arthas.mcp.server.tool.annotation.ToolParam;
 import com.taobao.arthas.mcp.server.util.JsonParser;
 
+import static com.taobao.arthas.mcp.server.util.McpAuthExtractor.MCP_AUTH_SUBJECT_KEY;
+import static com.taobao.arthas.mcp.server.tool.util.McpToolUtils.MCP_TRANSPORT_CONTEXT;
 import static com.taobao.arthas.mcp.server.tool.util.McpToolUtils.TOOL_CONTEXT_COMMAND_CONTEXT_KEY;
 
 public class SysPropTool {
@@ -24,6 +27,8 @@ public class SysPropTool {
             ToolContext toolContext
     ) {
         ArthasCommandContext commandContext = (ArthasCommandContext) toolContext.getContext().get(TOOL_CONTEXT_COMMAND_CONTEXT_KEY);
+        McpTransportContext mcpTransportContext = (McpTransportContext) toolContext.getContext().get(MCP_TRANSPORT_CONTEXT);
+        Object authSubject = mcpTransportContext.get(MCP_AUTH_SUBJECT_KEY);
         StringBuilder cmd = new StringBuilder("sysprop");
         if (propertyName != null && !propertyName.trim().isEmpty()) {
             cmd.append(" ").append(propertyName.trim());
@@ -32,6 +37,6 @@ public class SysPropTool {
             }
         }
         String commandStr = cmd.toString();
-        return JsonParser.toJson(commandContext.executeSync(commandStr));
+        return JsonParser.toJson(commandContext.executeSync(commandStr, authSubject));
     }
 }

--- a/labs/arthas-mcp-server/src/main/java/com/taobao/arthas/mcp/server/tool/function/jvm300/ThreadTool.java
+++ b/labs/arthas-mcp-server/src/main/java/com/taobao/arthas/mcp/server/tool/function/jvm300/ThreadTool.java
@@ -1,5 +1,6 @@
 package com.taobao.arthas.mcp.server.tool.function.jvm300;
 
+import com.taobao.arthas.mcp.server.protocol.server.McpTransportContext;
 import com.taobao.arthas.mcp.server.session.ArthasCommandContext;
 import com.taobao.arthas.mcp.server.tool.ToolContext;
 import com.taobao.arthas.mcp.server.tool.annotation.Tool;
@@ -8,8 +9,7 @@ import com.taobao.arthas.mcp.server.util.JsonParser;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.Map;
-
+import static com.taobao.arthas.mcp.server.util.McpAuthExtractor.MCP_AUTH_SUBJECT_KEY;
 import static com.taobao.arthas.mcp.server.tool.util.McpToolUtils.*;
 
 public class ThreadTool {
@@ -44,6 +44,8 @@ public class ThreadTool {
             ToolContext toolContext
     ) {
         ArthasCommandContext commandContext = (ArthasCommandContext) toolContext.getContext().get(TOOL_CONTEXT_COMMAND_CONTEXT_KEY);
+        McpTransportContext mcpTransportContext = (McpTransportContext) toolContext.getContext().get(MCP_TRANSPORT_CONTEXT);
+        Object authSubject = mcpTransportContext.get(MCP_AUTH_SUBJECT_KEY);
 
         StringBuilder cmd = new StringBuilder("thread");
 
@@ -63,6 +65,6 @@ public class ThreadTool {
         String commandStr = cmd.toString();
         logger.info("Executing thread command: {}", commandStr);
 
-        return JsonParser.toJson(commandContext.executeSync(commandStr));
+        return JsonParser.toJson(commandContext.executeSync(commandStr, authSubject));
     }
 }

--- a/labs/arthas-mcp-server/src/main/java/com/taobao/arthas/mcp/server/tool/function/jvm300/VMOptionTool.java
+++ b/labs/arthas-mcp-server/src/main/java/com/taobao/arthas/mcp/server/tool/function/jvm300/VMOptionTool.java
@@ -1,11 +1,14 @@
 package com.taobao.arthas.mcp.server.tool.function.jvm300;
 
+import com.taobao.arthas.mcp.server.protocol.server.McpTransportContext;
 import com.taobao.arthas.mcp.server.session.ArthasCommandContext;
 import com.taobao.arthas.mcp.server.tool.ToolContext;
 import com.taobao.arthas.mcp.server.tool.annotation.Tool;
 import com.taobao.arthas.mcp.server.tool.annotation.ToolParam;
 import com.taobao.arthas.mcp.server.util.JsonParser;
 
+import static com.taobao.arthas.mcp.server.util.McpAuthExtractor.MCP_AUTH_SUBJECT_KEY;
+import static com.taobao.arthas.mcp.server.tool.util.McpToolUtils.MCP_TRANSPORT_CONTEXT;
 import static com.taobao.arthas.mcp.server.tool.util.McpToolUtils.TOOL_CONTEXT_COMMAND_CONTEXT_KEY;
 
 public class VMOptionTool {
@@ -24,6 +27,8 @@ public class VMOptionTool {
             ToolContext toolContext
     ) {
         ArthasCommandContext commandContext = (ArthasCommandContext) toolContext.getContext().get(TOOL_CONTEXT_COMMAND_CONTEXT_KEY);
+        McpTransportContext mcpTransportContext = (McpTransportContext) toolContext.getContext().get(MCP_TRANSPORT_CONTEXT);
+        Object authSubject = mcpTransportContext.get(MCP_AUTH_SUBJECT_KEY);
         StringBuilder cmd = new StringBuilder("vmoption");
         if (key != null && !key.trim().isEmpty()) {
             cmd.append(" ").append(key.trim());
@@ -32,6 +37,6 @@ public class VMOptionTool {
             }
         }
         String commandStr = cmd.toString();
-        return JsonParser.toJson(commandContext.executeSync(commandStr));
+        return JsonParser.toJson(commandContext.executeSync(commandStr, authSubject));
     }
 }

--- a/labs/arthas-mcp-server/src/main/java/com/taobao/arthas/mcp/server/tool/function/jvm300/VMToolTool.java
+++ b/labs/arthas-mcp-server/src/main/java/com/taobao/arthas/mcp/server/tool/function/jvm300/VMToolTool.java
@@ -1,11 +1,14 @@
 package com.taobao.arthas.mcp.server.tool.function.jvm300;
 
+import com.taobao.arthas.mcp.server.protocol.server.McpTransportContext;
 import com.taobao.arthas.mcp.server.session.ArthasCommandContext;
 import com.taobao.arthas.mcp.server.tool.ToolContext;
 import com.taobao.arthas.mcp.server.tool.annotation.Tool;
 import com.taobao.arthas.mcp.server.tool.annotation.ToolParam;
 import com.taobao.arthas.mcp.server.util.JsonParser;
 
+import static com.taobao.arthas.mcp.server.util.McpAuthExtractor.MCP_AUTH_SUBJECT_KEY;
+import static com.taobao.arthas.mcp.server.tool.util.McpToolUtils.MCP_TRANSPORT_CONTEXT;
 import static com.taobao.arthas.mcp.server.tool.util.McpToolUtils.TOOL_CONTEXT_COMMAND_CONTEXT_KEY;
 
 public class VMToolTool {
@@ -46,6 +49,8 @@ public class VMToolTool {
             ToolContext toolContext
     ) {
         ArthasCommandContext commandContext = (ArthasCommandContext) toolContext.getContext().get(TOOL_CONTEXT_COMMAND_CONTEXT_KEY);
+        McpTransportContext mcpTransportContext = (McpTransportContext) toolContext.getContext().get(MCP_TRANSPORT_CONTEXT);
+        Object authSubject = mcpTransportContext.get(MCP_AUTH_SUBJECT_KEY);
         StringBuilder cmd = new StringBuilder("vmtool");
         if (action == null || action.trim().isEmpty()) {
             throw new IllegalArgumentException("vmtool: action 参数不能为空");
@@ -83,7 +88,7 @@ public class VMToolTool {
         }
 
         String commandStr = cmd.toString();
-        return JsonParser.toJson(commandContext.executeSync(commandStr));
+        return JsonParser.toJson(commandContext.executeSync(commandStr, authSubject));
     }
 
 

--- a/labs/arthas-mcp-server/src/main/java/com/taobao/arthas/mcp/server/tool/function/klass100/ClassLoaderTool.java
+++ b/labs/arthas-mcp-server/src/main/java/com/taobao/arthas/mcp/server/tool/function/klass100/ClassLoaderTool.java
@@ -1,11 +1,14 @@
 package com.taobao.arthas.mcp.server.tool.function.klass100;
 
+import com.taobao.arthas.mcp.server.protocol.server.McpTransportContext;
 import com.taobao.arthas.mcp.server.session.ArthasCommandContext;
 import com.taobao.arthas.mcp.server.tool.ToolContext;
 import com.taobao.arthas.mcp.server.tool.annotation.Tool;
 import com.taobao.arthas.mcp.server.tool.annotation.ToolParam;
 import com.taobao.arthas.mcp.server.util.JsonParser;
 
+import static com.taobao.arthas.mcp.server.util.McpAuthExtractor.MCP_AUTH_SUBJECT_KEY;
+import static com.taobao.arthas.mcp.server.tool.util.McpToolUtils.MCP_TRANSPORT_CONTEXT;
 import static com.taobao.arthas.mcp.server.tool.util.McpToolUtils.TOOL_CONTEXT_COMMAND_CONTEXT_KEY;
 
 public class ClassLoaderTool {
@@ -75,6 +78,8 @@ public class ClassLoaderTool {
             cmd.append(" --load ").append(loadClass.trim());
         }
 
-        return JsonParser.toJson(commandContext.executeSync(cmd.toString()));
+        McpTransportContext mcpTransportContext = (McpTransportContext) toolContext.getContext().get(MCP_TRANSPORT_CONTEXT);
+        Object authSubject = mcpTransportContext.get(MCP_AUTH_SUBJECT_KEY);
+        return JsonParser.toJson(commandContext.executeSync(cmd.toString(), authSubject));
     }
 }

--- a/labs/arthas-mcp-server/src/main/java/com/taobao/arthas/mcp/server/tool/function/klass100/DumpClassTool.java
+++ b/labs/arthas-mcp-server/src/main/java/com/taobao/arthas/mcp/server/tool/function/klass100/DumpClassTool.java
@@ -1,13 +1,14 @@
 package com.taobao.arthas.mcp.server.tool.function.klass100;
 
+import com.taobao.arthas.mcp.server.protocol.server.McpTransportContext;
 import com.taobao.arthas.mcp.server.session.ArthasCommandContext;
 import com.taobao.arthas.mcp.server.tool.ToolContext;
 import com.taobao.arthas.mcp.server.tool.annotation.Tool;
 import com.taobao.arthas.mcp.server.tool.annotation.ToolParam;
 import com.taobao.arthas.mcp.server.util.JsonParser;
 
-import java.nio.file.Paths;
-
+import static com.taobao.arthas.mcp.server.util.McpAuthExtractor.MCP_AUTH_SUBJECT_KEY;
+import static com.taobao.arthas.mcp.server.tool.util.McpToolUtils.MCP_TRANSPORT_CONTEXT;
 import static com.taobao.arthas.mcp.server.tool.util.McpToolUtils.TOOL_CONTEXT_COMMAND_CONTEXT_KEY;
 
 public class DumpClassTool {
@@ -41,6 +42,8 @@ public class DumpClassTool {
 
             ToolContext toolContext) {
         ArthasCommandContext commandContext = (ArthasCommandContext) toolContext.getContext().get(TOOL_CONTEXT_COMMAND_CONTEXT_KEY);
+        McpTransportContext mcpTransportContext = (McpTransportContext) toolContext.getContext().get(MCP_TRANSPORT_CONTEXT);
+        Object authSubject = mcpTransportContext.get(MCP_AUTH_SUBJECT_KEY);
         StringBuilder cmd = new StringBuilder("dump");
 
         cmd.append(" ").append(classPattern);
@@ -63,6 +66,6 @@ public class DumpClassTool {
             cmd.append(" --limit ").append(limit);
         }
 
-        return JsonParser.toJson(commandContext.executeSync(cmd.toString()));
+        return JsonParser.toJson(commandContext.executeSync(cmd.toString(), authSubject));
     }
 }

--- a/labs/arthas-mcp-server/src/main/java/com/taobao/arthas/mcp/server/tool/function/klass100/JadTool.java
+++ b/labs/arthas-mcp-server/src/main/java/com/taobao/arthas/mcp/server/tool/function/klass100/JadTool.java
@@ -1,11 +1,14 @@
 package com.taobao.arthas.mcp.server.tool.function.klass100;
 
+import com.taobao.arthas.mcp.server.protocol.server.McpTransportContext;
 import com.taobao.arthas.mcp.server.session.ArthasCommandContext;
 import com.taobao.arthas.mcp.server.tool.ToolContext;
 import com.taobao.arthas.mcp.server.tool.annotation.Tool;
 import com.taobao.arthas.mcp.server.tool.annotation.ToolParam;
 import com.taobao.arthas.mcp.server.util.JsonParser;
 
+import static com.taobao.arthas.mcp.server.util.McpAuthExtractor.MCP_AUTH_SUBJECT_KEY;
+import static com.taobao.arthas.mcp.server.tool.util.McpToolUtils.MCP_TRANSPORT_CONTEXT;
 import static com.taobao.arthas.mcp.server.tool.util.McpToolUtils.TOOL_CONTEXT_COMMAND_CONTEXT_KEY;
 
 public class JadTool {
@@ -38,6 +41,8 @@ public class JadTool {
 
             ToolContext toolContext) {
         ArthasCommandContext commandContext = (ArthasCommandContext) toolContext.getContext().get(TOOL_CONTEXT_COMMAND_CONTEXT_KEY);
+        McpTransportContext mcpTransportContext = (McpTransportContext) toolContext.getContext().get(MCP_TRANSPORT_CONTEXT);
+        Object authSubject = mcpTransportContext.get(MCP_AUTH_SUBJECT_KEY);
 
         StringBuilder cmd = new StringBuilder("jad");
 
@@ -65,6 +70,6 @@ public class JadTool {
             cmd.append(" -d ").append(dumpDirectory.trim());
         }
 
-        return JsonParser.toJson(commandContext.executeSync(cmd.toString()));
+        return JsonParser.toJson(commandContext.executeSync(cmd.toString(), authSubject));
     }
 }

--- a/labs/arthas-mcp-server/src/main/java/com/taobao/arthas/mcp/server/tool/function/klass100/MemoryCompilerTool.java
+++ b/labs/arthas-mcp-server/src/main/java/com/taobao/arthas/mcp/server/tool/function/klass100/MemoryCompilerTool.java
@@ -1,5 +1,6 @@
 package com.taobao.arthas.mcp.server.tool.function.klass100;
 
+import com.taobao.arthas.mcp.server.protocol.server.McpTransportContext;
 import com.taobao.arthas.mcp.server.session.ArthasCommandContext;
 import com.taobao.arthas.mcp.server.tool.ToolContext;
 import com.taobao.arthas.mcp.server.tool.annotation.Tool;
@@ -8,6 +9,8 @@ import com.taobao.arthas.mcp.server.util.JsonParser;
 
 import java.nio.file.Paths;
 
+import static com.taobao.arthas.mcp.server.util.McpAuthExtractor.MCP_AUTH_SUBJECT_KEY;
+import static com.taobao.arthas.mcp.server.tool.util.McpToolUtils.MCP_TRANSPORT_CONTEXT;
 import static com.taobao.arthas.mcp.server.tool.util.McpToolUtils.TOOL_CONTEXT_COMMAND_CONTEXT_KEY;
 
 public class MemoryCompilerTool {
@@ -50,6 +53,8 @@ public class MemoryCompilerTool {
             cmd.append(" -d ").append(DEFAULT_DUMP_DIR);
         }
 
-        return JsonParser.toJson(commandContext.executeSync(cmd.toString()));
+        McpTransportContext mcpTransportContext = (McpTransportContext) toolContext.getContext().get(MCP_TRANSPORT_CONTEXT);
+        Object authSubject = mcpTransportContext.get(MCP_AUTH_SUBJECT_KEY);
+        return JsonParser.toJson(commandContext.executeSync(cmd.toString(), authSubject));
     }
 }

--- a/labs/arthas-mcp-server/src/main/java/com/taobao/arthas/mcp/server/tool/function/klass100/RedefineTool.java
+++ b/labs/arthas-mcp-server/src/main/java/com/taobao/arthas/mcp/server/tool/function/klass100/RedefineTool.java
@@ -1,11 +1,14 @@
 package com.taobao.arthas.mcp.server.tool.function.klass100;
 
+import com.taobao.arthas.mcp.server.protocol.server.McpTransportContext;
 import com.taobao.arthas.mcp.server.session.ArthasCommandContext;
 import com.taobao.arthas.mcp.server.tool.ToolContext;
 import com.taobao.arthas.mcp.server.tool.annotation.Tool;
 import com.taobao.arthas.mcp.server.tool.annotation.ToolParam;
 import com.taobao.arthas.mcp.server.util.JsonParser;
 
+import static com.taobao.arthas.mcp.server.util.McpAuthExtractor.MCP_AUTH_SUBJECT_KEY;
+import static com.taobao.arthas.mcp.server.tool.util.McpToolUtils.MCP_TRANSPORT_CONTEXT;
 import static com.taobao.arthas.mcp.server.tool.util.McpToolUtils.TOOL_CONTEXT_COMMAND_CONTEXT_KEY;
 
 public class RedefineTool {
@@ -37,6 +40,8 @@ public class RedefineTool {
             cmd.append(" --classLoaderClass ").append(classLoaderClass.trim());
         }
 
-        return JsonParser.toJson(commandContext.executeSync(cmd.toString()));
+        McpTransportContext mcpTransportContext = (McpTransportContext) toolContext.getContext().get(MCP_TRANSPORT_CONTEXT);
+        Object authSubject = mcpTransportContext.get(MCP_AUTH_SUBJECT_KEY);
+        return JsonParser.toJson(commandContext.executeSync(cmd.toString(), authSubject));
     }
 }

--- a/labs/arthas-mcp-server/src/main/java/com/taobao/arthas/mcp/server/tool/function/klass100/RetransformTool.java
+++ b/labs/arthas-mcp-server/src/main/java/com/taobao/arthas/mcp/server/tool/function/klass100/RetransformTool.java
@@ -1,11 +1,14 @@
 package com.taobao.arthas.mcp.server.tool.function.klass100;
 
+import com.taobao.arthas.mcp.server.protocol.server.McpTransportContext;
 import com.taobao.arthas.mcp.server.session.ArthasCommandContext;
 import com.taobao.arthas.mcp.server.tool.ToolContext;
 import com.taobao.arthas.mcp.server.tool.annotation.Tool;
 import com.taobao.arthas.mcp.server.tool.annotation.ToolParam;
 import com.taobao.arthas.mcp.server.util.JsonParser;
 
+import static com.taobao.arthas.mcp.server.util.McpAuthExtractor.MCP_AUTH_SUBJECT_KEY;
+import static com.taobao.arthas.mcp.server.tool.util.McpToolUtils.MCP_TRANSPORT_CONTEXT;
 import static com.taobao.arthas.mcp.server.tool.util.McpToolUtils.TOOL_CONTEXT_COMMAND_CONTEXT_KEY;
 
 public class RetransformTool {
@@ -37,6 +40,8 @@ public class RetransformTool {
             cmd.append(" --classLoaderClass ").append(classLoaderClass.trim());
         }
 
-        return JsonParser.toJson(commandContext.executeSync(cmd.toString()));
+        McpTransportContext mcpTransportContext = (McpTransportContext) toolContext.getContext().get(MCP_TRANSPORT_CONTEXT);
+        Object authSubject = mcpTransportContext.get(MCP_AUTH_SUBJECT_KEY);
+        return JsonParser.toJson(commandContext.executeSync(cmd.toString(), authSubject));
     }
 }

--- a/labs/arthas-mcp-server/src/main/java/com/taobao/arthas/mcp/server/tool/function/klass100/SearchClassTool.java
+++ b/labs/arthas-mcp-server/src/main/java/com/taobao/arthas/mcp/server/tool/function/klass100/SearchClassTool.java
@@ -1,11 +1,14 @@
 package com.taobao.arthas.mcp.server.tool.function.klass100;
 
+import com.taobao.arthas.mcp.server.protocol.server.McpTransportContext;
 import com.taobao.arthas.mcp.server.session.ArthasCommandContext;
 import com.taobao.arthas.mcp.server.tool.ToolContext;
 import com.taobao.arthas.mcp.server.tool.annotation.Tool;
 import com.taobao.arthas.mcp.server.tool.annotation.ToolParam;
 import com.taobao.arthas.mcp.server.util.JsonParser;
 
+import static com.taobao.arthas.mcp.server.util.McpAuthExtractor.MCP_AUTH_SUBJECT_KEY;
+import static com.taobao.arthas.mcp.server.tool.util.McpToolUtils.MCP_TRANSPORT_CONTEXT;
 import static com.taobao.arthas.mcp.server.tool.util.McpToolUtils.TOOL_CONTEXT_COMMAND_CONTEXT_KEY;
 
 public class SearchClassTool {
@@ -18,7 +21,9 @@ public class SearchClassTool {
             @ToolParam(description = "要查询的类名，支持全限定名") String className,
             ToolContext toolContext) {
         ArthasCommandContext commandContext = (ArthasCommandContext) toolContext.getContext().get(TOOL_CONTEXT_COMMAND_CONTEXT_KEY);
-        return JsonParser.toJson(commandContext.executeSync("sc -d " + className));
+        McpTransportContext mcpTransportContext = (McpTransportContext) toolContext.getContext().get(MCP_TRANSPORT_CONTEXT);
+        Object authSubject = mcpTransportContext.get(MCP_AUTH_SUBJECT_KEY);
+        return JsonParser.toJson(commandContext.executeSync("sc -d " + className, authSubject));
     }
 
 

--- a/labs/arthas-mcp-server/src/main/java/com/taobao/arthas/mcp/server/tool/function/klass100/SearchMethodTool.java
+++ b/labs/arthas-mcp-server/src/main/java/com/taobao/arthas/mcp/server/tool/function/klass100/SearchMethodTool.java
@@ -1,11 +1,14 @@
 package com.taobao.arthas.mcp.server.tool.function.klass100;
 
+import com.taobao.arthas.mcp.server.protocol.server.McpTransportContext;
 import com.taobao.arthas.mcp.server.session.ArthasCommandContext;
 import com.taobao.arthas.mcp.server.tool.ToolContext;
 import com.taobao.arthas.mcp.server.tool.annotation.Tool;
 import com.taobao.arthas.mcp.server.tool.annotation.ToolParam;
 import com.taobao.arthas.mcp.server.util.JsonParser;
 
+import static com.taobao.arthas.mcp.server.util.McpAuthExtractor.MCP_AUTH_SUBJECT_KEY;
+import static com.taobao.arthas.mcp.server.tool.util.McpToolUtils.MCP_TRANSPORT_CONTEXT;
 import static com.taobao.arthas.mcp.server.tool.util.McpToolUtils.TOOL_CONTEXT_COMMAND_CONTEXT_KEY;
 
 public class SearchMethodTool {
@@ -18,7 +21,9 @@ public class SearchMethodTool {
             @ToolParam(description = "要查询的类名，支持全限定名") String className,
             ToolContext toolContext) {
         ArthasCommandContext commandContext = (ArthasCommandContext) toolContext.getContext().get(TOOL_CONTEXT_COMMAND_CONTEXT_KEY);
-        return JsonParser.toJson(commandContext.executeSync("sm " + className));
+        McpTransportContext mcpTransportContext = (McpTransportContext) toolContext.getContext().get(MCP_TRANSPORT_CONTEXT);
+        Object authSubject = mcpTransportContext.get(MCP_AUTH_SUBJECT_KEY);
+        return JsonParser.toJson(commandContext.executeSync("sm " + className, authSubject));
     }
 
 }

--- a/labs/arthas-mcp-server/src/main/java/com/taobao/arthas/mcp/server/util/McpAuthExtractor.java
+++ b/labs/arthas-mcp-server/src/main/java/com/taobao/arthas/mcp/server/util/McpAuthExtractor.java
@@ -1,0 +1,46 @@
+package com.taobao.arthas.mcp.server.util;
+
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.util.AttributeKey;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * MCP认证信息提取工具
+ *
+ * @author Yeaury
+ */
+public class McpAuthExtractor {
+
+    private static final Logger logger = LoggerFactory.getLogger(McpAuthExtractor.class);
+
+    public static final String MCP_AUTH_SUBJECT_KEY = "mcp.auth.subject";
+
+    public static final AttributeKey<Object> SUBJECT_ATTRIBUTE_KEY =
+            AttributeKey.valueOf("arthas.auth.subject");
+
+    /**
+     * 从ChannelHandlerContext中提取认证主体
+     *
+     * @param ctx Netty ChannelHandlerContext
+     * @return 认证主体对象，如果未认证则返回null
+     */
+    public static Object extractAuthSubjectFromContext(ChannelHandlerContext ctx) {
+        if (ctx == null || ctx.channel() == null) {
+            return null;
+        }
+
+        try {
+            Object subject = ctx.channel().attr(SUBJECT_ATTRIBUTE_KEY).get();
+            if (subject != null) {
+                logger.debug("Extracted auth subject from channel context: {}", subject.getClass().getSimpleName());
+                return subject;
+            }
+        } catch (Exception e) {
+            logger.debug("Failed to extract auth subject from context: {}", e.getMessage());
+        }
+
+        return null;
+    }
+
+}


### PR DESCRIPTION
## 主要改动

1. **实现 MCP 模块完整认证传递链路**

   * 在 `BasicHttpAuthenticatorHandler` 中新增 `Subject` 到 `Channel AttributeKey` 的存储。
   * 修复 MCP 工具调用时报 `"try to use 'auth' command to authenticates"` 错误。

2. **新增配置项：支持自定义 MCP path**

   * 配置文件中可指定 `mcp server path`（默认值为 `/mcp`）。
   * 若未指定 `mcp path`，默认不开启 MCP server。

