### PR TITLE
interrupt时如果处于TERMINATED也应该成功

### DIFF
--- a/core/src/main/java/com/taobao/arthas/core/shell/system/impl/ProcessImpl.java
+++ b/core/src/main/java/com/taobao/arthas/core/shell/system/impl/ProcessImpl.java
@@ -140,7 +140,7 @@ public class ProcessImpl implements Process {
 
     @Override
     public boolean interrupt(final Handler<Void> completionHandler) {
-        if (processStatus == ExecStatus.RUNNING || processStatus == ExecStatus.STOPPED) {
+        if (processStatus == ExecStatus.RUNNING || processStatus == ExecStatus.STOPPED || processStatus == ExecStatus.TERMINATED) {
             final Handler<Void> handler = interruptHandler;
             try {
                 if (handler != null) {


### PR DESCRIPTION
触发条件：
HttpApiHandler的processExecRequest在job的状态是TERMINATED时会退出waitForJob，sessionManager.removeSession时会判断是否有foregroundJob， 如果存在则调用interrupt, 修改process的状态和把foregroundJob置空在另一个线程，并且是先设置状态为TERMINATED然后才会把foregroundJob置空，存在时间差