### PR TITLE
docs: fix -t example in tt.md

### DIFF
--- a/site/docs/doc/tt.md
+++ b/site/docs/doc/tt.md
@@ -55,7 +55,7 @@ Affect(class count:1 , method count:1) cost in 130 ms, listenerId: 1.
 - 命令参数解析
   - `-t`
 
-    tt 命令有很多个主参数，`-t` 就是其中之一。这个参数的表明希望记录下类 `*Test` 的 `print` 方法的每次执行情况。
+    tt 命令有很多个主参数，`-t` 就是其中之一。这个参数的表明希望记录下类 `demo.MathGame` 的 `primeFactors` 方法的每次执行情况。
 
   - `-n 3`
 


### PR DESCRIPTION
in commit https://github.com/alibaba/arthas/commit/a59838289093042171ea17e438d0fd65dd255846#diff-c8bdf702280ca2c4e6dd74c6f54701e08db55042a31edb010c1dce6851aeca26 

this commit has updated example from `tt -t -n 3 *Test print` to `tt -t demo.MathGame primeFactors`. But forgot to update the comment in Chinese docs. The English version is OK.
