### PR TITLE
fix(mcp-server): optimize session validation to prevent 2-second time

### DIFF
--- a/arthas-mcp-server/src/main/java/com/taobao/arthas/mcp/server/protocol/server/handler/McpHttpRequestHandler.java
+++ b/arthas-mcp-server/src/main/java/com/taobao/arthas/mcp/server/protocol/server/handler/McpHttpRequestHandler.java
@@ -4,25 +4,18 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.taobao.arthas.mcp.server.protocol.config.McpServerProperties.ServerProtocol;
 import com.taobao.arthas.mcp.server.protocol.server.McpTransportContextExtractor;
 import com.taobao.arthas.mcp.server.protocol.spec.McpError;
-import com.taobao.arthas.mcp.server.protocol.spec.McpSchema;
-import com.taobao.arthas.mcp.server.tool.ToolCallback;
 import com.taobao.arthas.mcp.server.util.Assert;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
-import io.netty.channel.ChannelHandler;
+import io.netty.channel.ChannelFutureListener;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.handler.codec.http.*;
 import io.netty.util.CharsetUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.List;
-import java.util.Map;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicBoolean;
-
-import static com.taobao.arthas.mcp.server.protocol.spec.McpSchema.*;
 
 /**
  * MCP HTTP请求处理器，分发请求到无状态或流式处理器。
@@ -146,7 +139,7 @@ public class McpHttpRequestHandler {
             response.headers().set(HttpHeaderNames.CONTENT_LENGTH, response.content().readableBytes());
             response.headers().set(HttpHeaderNames.ACCESS_CONTROL_ALLOW_ORIGIN, "*");
 
-            ctx.writeAndFlush(response);
+            ctx.writeAndFlush(response).addListener(ChannelFutureListener.CLOSE);
         } catch (Exception e) {
             logger.error("Failed to send error response: {}", e.getMessage());
             FullHttpResponse response = new DefaultFullHttpResponse(
@@ -154,7 +147,7 @@ public class McpHttpRequestHandler {
                     HttpResponseStatus.INTERNAL_SERVER_ERROR
             );
             response.headers().set(HttpHeaderNames.CONTENT_LENGTH, 0);
-            ctx.writeAndFlush(response);
+            ctx.writeAndFlush(response).addListener(ChannelFutureListener.CLOSE);
         }
     }
 

--- a/arthas-mcp-server/src/main/java/com/taobao/arthas/mcp/server/protocol/spec/McpStreamableServerSession.java
+++ b/arthas-mcp-server/src/main/java/com/taobao/arthas/mcp/server/protocol/spec/McpStreamableServerSession.java
@@ -167,7 +167,8 @@ public class McpStreamableServerSession implements McpSession {
                 logger.warn("Failed to store error response event: {}", e.getMessage());
             }
 
-            return transport.sendMessage(errorResponse, null);
+            return transport.sendMessage(errorResponse, null)
+                    .thenCompose(v -> transport.closeGracefully());
         }
         ArthasCommandContext commandContext = createCommandContext(transportContext.get(MCP_AUTH_SUBJECT_KEY));
         


### PR DESCRIPTION
## 问题描述

在使用 Cherry Studio 作为客户端连接 `arthas-mcp-server` 时，出现了严重的延迟问题：
- 每个请求（特别是 `ping` 请求）都会延迟约 2 秒
- 客户端经常收到超时错误：`notifications/cancelled` with reason "Request timed out"
- 问题在 `mcp-inspector` 中不会出现，仅在 Cherry Studio 中出现

## 根本原因

通过日志分析发现，问题出在 `ArthasCommandSessionManager.isSessionValid()` 方法中：
- 该方法使用 `commandExecutor.pullResults()` 来验证 session 是否有效
- `pullResults()` 是一个长轮询设计，当没有结果时会等待最多 2 秒（`ResultConsumerImpl.pollTimeLimit = 2000ms`）
- 对于 `ping` 等简单请求，由于没有新的命令结果，会触发完整的 2 秒等待
- 这导致每个请求都有 2 秒的延迟，Cherry Studio 的请求超时时间较短，因此频繁超时

