### PR TITLE
fix(core): avoid json-format output invoking constructors. #3111

### DIFF
--- a/core/src/main/java/com/taobao/arthas/core/mcp/util/McpObjectVOFilter.java
+++ b/core/src/main/java/com/taobao/arthas/core/mcp/util/McpObjectVOFilter.java
@@ -1,8 +1,5 @@
 package com.taobao.arthas.core.mcp.util;
 
-import com.alibaba.fastjson2.JSON;
-import com.alibaba.fastjson2.JSONFactory;
-import com.alibaba.fastjson2.JSONWriter;
 import com.alibaba.fastjson2.filter.ValueFilter;
 import com.taobao.arthas.core.GlobalOptions;
 import com.taobao.arthas.core.command.model.ObjectVO;
@@ -93,13 +90,7 @@ public class McpObjectVOFilter implements ValueFilter {
      */
     private String drawJsonView(Object object) {
         try {
-            JSONWriter.Context context = JSONFactory.createWriteContext();
-            context.setMaxLevel(4097);
-            context.config(JSONWriter.Feature.IgnoreErrorGetter, true);
-            context.config(JSONWriter.Feature.ReferenceDetection, true);
-            context.config(JSONWriter.Feature.IgnoreNonFieldGetter, true);
-            context.config(JSONWriter.Feature.WriteNonStringKeyAsString, true);
-            return JSON.toJSONString(object, context);
+            return ObjectView.toJsonString(object);
         } catch (Exception e) {
             logger.debug("ObjectView-style serialization failed, using toString: {}", e.getMessage());
             return objectToString(object);

--- a/core/src/test/java/com/taobao/arthas/core/view/ObjectViewTest.java
+++ b/core/src/test/java/com/taobao/arthas/core/view/ObjectViewTest.java
@@ -1,5 +1,6 @@
 package com.taobao.arthas.core.view;
 
+import com.taobao.arthas.core.GlobalOptions;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -207,6 +208,22 @@ public class ObjectViewTest {
     }
 
     @Test
+    public void testJsonFormatDoNotCreateNewInstance() {
+        boolean old = GlobalOptions.isUsingJson;
+        try {
+            JsonFormatSingleton singleton = JsonFormatSingleton.getInstance();
+            GlobalOptions.isUsingJson = true;
+
+            ObjectView objectView = new ObjectView(new Object[] { singleton }, 3);
+            String output = objectView.draw();
+            Assert.assertFalse(output.startsWith("ERROR DATA!!!"));
+            Assert.assertEquals(1, JsonFormatSingleton.constructorCalls);
+        } finally {
+            GlobalOptions.isUsingJson = old;
+        }
+    }
+
+    @Test
     public void testDate() {
         Date d = new Date(1531204354961L - TimeZone.getDefault().getRawOffset()
                         + TimeZone.getTimeZone("GMT+8").getRawOffset());
@@ -323,5 +340,25 @@ public class ObjectViewTest {
 
     public enum EnumDemo {
         DEMO;
+    }
+
+    public static class JsonFormatSingleton {
+        private static final JsonFormatSingleton INSTANCE;
+        private static volatile int constructorCalls = 0;
+
+        static {
+            INSTANCE = new JsonFormatSingleton();
+        }
+
+        private JsonFormatSingleton() {
+            constructorCalls++;
+            if (constructorCalls > 1) {
+                throw new IllegalStateException("JsonFormatSingleton is created!");
+            }
+        }
+
+        public static JsonFormatSingleton getInstance() {
+            return INSTANCE;
+        }
     }
 }


### PR DESCRIPTION
fastjson2 may create a default instance via no-arg constructor when building
writers, which can trigger side effects (e.g. singleton guards) during
`options json-format true`.

Use a custom ObjectWriterProvider that disables default value instantiation
and share the JSON config via ObjectView.toJsonString(), reused by
McpObjectVOFilter.

Fixes #3111
