### PR TITLE
bump netty and logback version to resolve cve

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -91,7 +91,7 @@
         <maven-invoker-plugin.version>3.0.0</maven-invoker-plugin.version>
         <project.build.outputTimestamp>2020-09-27T15:10:43Z</project.build.outputTimestamp>
         <lifecycle-mapping.version>1.0.0</lifecycle-mapping.version>
-        <netty-bom.version>4.1.128.Final</netty-bom.version>
+        <netty-bom.version>4.1.130.Final</netty-bom.version>
     </properties>
 
     <dependencyManagement>
@@ -124,12 +124,12 @@
             <dependency>
                 <groupId>ch.qos.logback</groupId>
                 <artifactId>logback-classic</artifactId>
-                <version>1.2.13</version>
+                <version>1.5.25</version>
             </dependency>
             <dependency>
                 <groupId>ch.qos.logback</groupId>
                 <artifactId>logback-core</artifactId>
-                <version>1.2.13</version>
+                <version>1.5.25</version>
             </dependency>
             <dependency>
                 <groupId>com.alibaba.arthas</groupId>


### PR DESCRIPTION
Reported by trivy scan:

<img width="3726" height="735" alt="image" src="https://github.com/user-attachments/assets/ebd9b5e5-c10b-48ee-ad7f-af66cf73affa" />

# dependency update: 
netty-bom: 4.1.128.Final -> 4.1.130.Final
logback: 1.2.13 -> 1.5.25


