### PR TITLE
fix(mcp): support -M/--sizeLimit for watch/tt

### DIFF
--- a/arthas-mcp-integration-test/src/test/java/com/taobao/arthas/mcp/it/ArthasMcpToolsIT.java
+++ b/arthas-mcp-integration-test/src/test/java/com/taobao/arthas/mcp/it/ArthasMcpToolsIT.java
@@ -74,6 +74,29 @@ class ArthasMcpToolsIT {
                 toolNames.add(tool.getName());
             }
             assertThat(toolNames).contains("jvm", "jad", "thread");
+            assertThat(toolNames).contains("watch", "tt");
+
+            McpSchema.Tool watchTool = toolsResult.getTools().stream()
+                    .filter(t -> "watch".equals(t.getName()))
+                    .findFirst()
+                    .orElse(null);
+            assertThat(watchTool).as("watch tool should exist in listTools").isNotNull();
+            assertThat(watchTool.getInputSchema()).isNotNull();
+            assertThat(watchTool.getInputSchema().getProperties()).containsKey("sizeLimit");
+            if (watchTool.getInputSchema().getRequired() != null) {
+                assertThat(watchTool.getInputSchema().getRequired()).doesNotContain("sizeLimit");
+            }
+
+            McpSchema.Tool ttTool = toolsResult.getTools().stream()
+                    .filter(t -> "tt".equals(t.getName()))
+                    .findFirst()
+                    .orElse(null);
+            assertThat(ttTool).as("tt tool should exist in listTools").isNotNull();
+            assertThat(ttTool.getInputSchema()).isNotNull();
+            assertThat(ttTool.getInputSchema().getProperties()).containsKey("sizeLimit");
+            if (ttTool.getInputSchema().getRequired() != null) {
+                assertThat(ttTool.getInputSchema().getRequired()).doesNotContain("sizeLimit");
+            }
 
             McpSchema.CallToolResult callToolResult = client.callTool(sessionId, "jvm", Collections.emptyMap());
             assertThat(callToolResult).isNotNull();

--- a/core/src/main/java/com/taobao/arthas/core/mcp/tool/function/monitor200/TimeTunnelTool.java
+++ b/core/src/main/java/com/taobao/arthas/core/mcp/tool/function/monitor200/TimeTunnelTool.java
@@ -48,6 +48,9 @@ public class TimeTunnelTool extends AbstractArthasTool {
             @ToolParam(description = "Class最大匹配数量，防止匹配到的Class数量太多导致JVM挂起，默认50", required = false)
             Integer maxMatchCount,
 
+            @ToolParam(description = "输出结果大小上限(字节)。对应 tt -M/--sizeLimit，默认 10 * 1024 * 1024", required = false)
+            Integer sizeLimit,
+
             @ToolParam(description = "命令执行超时时间，单位为秒，默认" + AbstractArthasTool.DEFAULT_TIMEOUT_SECONDS +  "秒。超时后命令自动退出（仅record操作）", required = false)
             Integer timeout,
 
@@ -61,6 +64,9 @@ public class TimeTunnelTool extends AbstractArthasTool {
         validateParameters(ttAction, classPattern, methodPattern, index, searchExpression);
 
         StringBuilder cmd = buildCommand("tt");
+        if (sizeLimit != null && sizeLimit > 0) {
+            cmd.append(" -M ").append(sizeLimit);
+        }
 
         switch (ttAction) {
             case "record":

--- a/core/src/main/java/com/taobao/arthas/core/mcp/tool/function/monitor200/WatchTool.java
+++ b/core/src/main/java/com/taobao/arthas/core/mcp/tool/function/monitor200/WatchTool.java
@@ -57,6 +57,9 @@ public class WatchTool extends AbstractArthasTool {
             @ToolParam(description = "指定输出结果的属性遍历深度，默认1，最大4", required = false)
             Integer expandLevel,
 
+            @ToolParam(description = "输出结果大小上限(字节)。对应 watch -M/--sizeLimit，默认 10 * 1024 * 1024", required = false)
+            Integer sizeLimit,
+
             @ToolParam(description = "命令执行超时时间，单位为秒，默认" + AbstractArthasTool.DEFAULT_TIMEOUT_SECONDS +  "秒。超时后命令自动退出", required = false)
             Integer timeout,
 
@@ -74,6 +77,9 @@ public class WatchTool extends AbstractArthasTool {
         cmd.append(" -n ").append(execCount);
         cmd.append(" -m ").append(maxMatch);
         cmd.append(" -x ").append(expandDepth);
+        if (sizeLimit != null && sizeLimit > 0) {
+            cmd.append(" -M ").append(sizeLimit);
+        }
 
         addFlag(cmd, "-E", regex);
 


### PR DESCRIPTION
Fixes #3144

- MCP watch tool: add optional `sizeLimit` param and pass through to `watch -M`
- MCP tt tool: add optional `sizeLimit` param and pass through to `tt -M`
- Integration test: assert `watch`/`tt` schema includes `sizeLimit` and it is optional

Tests:
- `./mvnw -pl arthas-mcp-integration-test -am verify`
