### PR TITLE
fix(tt): avoid NPE when listing fragments

### DIFF
--- a/arthas-model/src/main/java/com/taobao/arthas/core/command/model/ObjectVO.java
+++ b/arthas-model/src/main/java/com/taobao/arthas/core/command/model/ObjectVO.java
@@ -19,6 +19,9 @@ public class ObjectVO {
     }
 
     public static ObjectVO[] array(Object[] objects, Integer expand) {
+        if (objects == null) {
+            return new ObjectVO[0];
+        }
         ObjectVO[] result = new ObjectVO[objects.length];
         for (int i = 0; i < objects.length; ++i) {
             result[i] = new ObjectVO(objects[i], expand);

--- a/core/src/main/java/com/taobao/arthas/core/command/monitor200/TimeTunnelAdviceListener.java
+++ b/core/src/main/java/com/taobao/arthas/core/command/monitor200/TimeTunnelAdviceListener.java
@@ -64,7 +64,10 @@ public class TimeTunnelAdviceListener extends AdviceListenerAdapter {
     public void afterReturning(ClassLoader loader, Class<?> clazz, ArthasMethod method, Object target, Object[] args,
                                Object returnObject) throws Throwable {
         //取出入参时的 args，因为在函数执行过程中 args可能被修改
-        args = popArgs();
+        Object[] realArgs = popArgs();
+        if (realArgs != null) {
+            args = realArgs;
+        }
         afterFinishing(Advice.newForAfterReturning(loader, clazz, method, target, args, returnObject));
     }
 
@@ -72,7 +75,10 @@ public class TimeTunnelAdviceListener extends AdviceListenerAdapter {
     public void afterThrowing(ClassLoader loader, Class<?> clazz, ArthasMethod method, Object target, Object[] args,
                               Throwable throwable) {
         //取出入参时的 args，因为在函数执行过程中 args可能被修改
-        args = popArgs();
+        Object[] realArgs = popArgs();
+        if (realArgs != null) {
+            args = realArgs;
+        }
         afterFinishing(Advice.newForAfterThrowing(loader, clazz, method, target, args, throwable));
     }
 

--- a/core/src/test/java/com/taobao/arthas/core/command/monitor200/TimeTunnelCommandTest.java
+++ b/core/src/test/java/com/taobao/arthas/core/command/monitor200/TimeTunnelCommandTest.java
@@ -1,0 +1,78 @@
+package com.taobao.arthas.core.command.monitor200;
+
+import com.taobao.arthas.core.advisor.Advice;
+import com.taobao.arthas.core.advisor.ArthasMethod;
+import com.taobao.arthas.core.command.model.ResultModel;
+import com.taobao.arthas.core.command.model.TimeFragmentVO;
+import com.taobao.arthas.core.command.model.TimeTunnelModel;
+import com.taobao.arthas.core.shell.command.CommandProcess;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
+
+import java.lang.reflect.Field;
+import java.time.LocalDateTime;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+
+public class TimeTunnelCommandTest {
+
+    public static class TestTarget {
+        public String echo(String value) {
+            return value;
+        }
+    }
+
+    @After
+    public void clearTimeTunnelState() throws Exception {
+        Field timeFragmentMapField = TimeTunnelCommand.class.getDeclaredField("timeFragmentMap");
+        timeFragmentMapField.setAccessible(true);
+        ((Map<?, ?>) timeFragmentMapField.get(null)).clear();
+
+        Field sequenceField = TimeTunnelCommand.class.getDeclaredField("sequence");
+        sequenceField.setAccessible(true);
+        ((AtomicInteger) sequenceField.get(null)).set(1000);
+    }
+
+    @Test
+    public void shouldCreateTimeFragmentVOWhenAdviceParamsIsNull() {
+        ArthasMethod method = new ArthasMethod(TestTarget.class, "echo", "(Ljava/lang/String;)Ljava/lang/String;");
+        Advice advice = Advice.newForAfterReturning(TestTarget.class.getClassLoader(), TestTarget.class, method,
+                new TestTarget(), null, "ok");
+        TimeFragment timeFragment = new TimeFragment(advice, LocalDateTime.now(), 1.0d);
+
+        TimeFragmentVO timeFragmentVO = TimeTunnelCommand.createTimeFragmentVO(1000, timeFragment, 1);
+
+        Assert.assertNotNull(timeFragmentVO);
+        Assert.assertNotNull(timeFragmentVO.getParams());
+        Assert.assertEquals(0, timeFragmentVO.getParams().length);
+    }
+
+    @Test
+    public void shouldFallbackToExitArgsWhenSnapshotIsMissing() throws Throwable {
+        TimeTunnelCommand command = new TimeTunnelCommand();
+        CommandProcess process = Mockito.mock(CommandProcess.class);
+        AtomicInteger times = new AtomicInteger();
+        Mockito.when(process.times()).thenReturn(times);
+
+        TimeTunnelAdviceListener listener = new TimeTunnelAdviceListener(command, process, false);
+        Object[] args = new Object[] { "input" };
+        listener.afterReturning(TestTarget.class.getClassLoader(), TestTarget.class,
+                new ArthasMethod(TestTarget.class, "echo", "(Ljava/lang/String;)Ljava/lang/String;"),
+                new TestTarget(), args, "ok");
+
+        ArgumentCaptor<ResultModel> resultCaptor = ArgumentCaptor.forClass(ResultModel.class);
+        Mockito.verify(process).appendResult(resultCaptor.capture());
+
+        TimeTunnelModel timeTunnelModel = (TimeTunnelModel) resultCaptor.getValue();
+        Assert.assertNotNull(timeTunnelModel.getTimeFragmentList());
+        Assert.assertEquals(1, timeTunnelModel.getTimeFragmentList().size());
+
+        TimeFragmentVO timeFragmentVO = timeTunnelModel.getTimeFragmentList().get(0);
+        Assert.assertNotNull(timeFragmentVO.getParams());
+        Assert.assertEquals(1, timeFragmentVO.getParams().length);
+        Assert.assertEquals("input", timeFragmentVO.getParams()[0].getObject());
+    }
+}


### PR DESCRIPTION
## Summary
- return an empty `ObjectVO[]` when recorded tt params are missing so `tt -l` does not throw NPE
- fall back to exit-time args when the tt enter-time snapshot is unavailable
- add regression tests for null params and missing snapshot fallback

## Testing
- mvn -pl core -am -Dtest=TimeTunnelCommandTest -Dsurefire.failIfNoSpecifiedTests=false test