### PR TITLE
fix: upgrade netty for CVE-2026-33870

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -91,7 +91,7 @@
         <maven-invoker-plugin.version>3.0.0</maven-invoker-plugin.version>
         <project.build.outputTimestamp>2020-09-27T15:10:43Z</project.build.outputTimestamp>
         <lifecycle-mapping.version>1.0.0</lifecycle-mapping.version>
-        <netty-bom.version>4.1.130.Final</netty-bom.version>
+        <netty-bom.version>4.1.132.Final</netty-bom.version>
     </properties>
 
     <dependencyManagement>


### PR DESCRIPTION
## Summary
- Upgrade Netty BOM from 4.1.130.Final to 4.1.132.Final to address CVE-2026-33870 reported in #3170.

## Verification
- ./mvnw -pl tunnel-client,arthas-mcp-server,labs/arthas-grpc-server -am -DskipTests dependency:tree -Dincludes=io.netty:netty-codec-http,io.netty:netty-codec-http2
- ./mvnw -pl core -am -DskipTests dependency:tree -Dincludes=io.netty:netty-codec-http
- ./mvnw -pl tunnel-server -DskipTests dependency:tree -Dincludes=io.netty:netty-codec-http
- ./mvnw -pl core,tunnel-client,arthas-mcp-server,labs/arthas-grpc-server -am test -DskipITs
- ./mvnw -pl tunnel-server test -DskipITs