### PR TITLE
fix(vmtool): accept user-friendly array className like 'Object[]'

### DIFF
--- a/core/src/main/java/com/taobao/arthas/core/command/monitor200/VmToolCommand.java
+++ b/core/src/main/java/com/taobao/arthas/core/command/monitor200/VmToolCommand.java
@@ -238,8 +238,9 @@ public class VmToolCommand extends AnnotatedCommand {
                     classLoader = ClassLoader.getSystemClassLoader();
                 }
 
+                String searchClassName = normalizeArrayClassName(className);
                 List<Class<?>> matchedClasses = new ArrayList<Class<?>>(
-                        SearchUtils.searchClassOnly(inst, className, false, hashCode));
+                        SearchUtils.searchClassOnly(inst, searchClassName, false, hashCode));
                 int matchedClassSize = matchedClasses.size();
                 if (matchedClassSize == 0) {
                     process.end(-1, "Can not find class by class name: " + className + ".");
@@ -306,6 +307,52 @@ public class VmToolCommand extends AnnotatedCommand {
             logger.error("vmtool error", e);
             process.end(1, "vmtool error: " + e.getMessage());
         }
+    }
+
+    /**
+     * 将用户友好的数组类名（例如 {@code java.lang.Object[]} 或 {@code int[][]}）
+     * 转换为 JVM 内部数组类名（例如 {@code [Ljava.lang.Object;} 或 {@code [[I}）。
+     * 非数组输入或无法识别的输入原样返回。
+     */
+    static String normalizeArrayClassName(String className) {
+        if (className == null || !className.endsWith("[]")) {
+            return className;
+        }
+        int dimensions = 0;
+        String base = className;
+        while (base.endsWith("[]")) {
+            dimensions++;
+            base = base.substring(0, base.length() - 2);
+        }
+        if (base.isEmpty()) {
+            return className;
+        }
+        String internal;
+        if ("boolean".equals(base)) {
+            internal = "Z";
+        } else if ("byte".equals(base)) {
+            internal = "B";
+        } else if ("char".equals(base)) {
+            internal = "C";
+        } else if ("short".equals(base)) {
+            internal = "S";
+        } else if ("int".equals(base)) {
+            internal = "I";
+        } else if ("long".equals(base)) {
+            internal = "J";
+        } else if ("float".equals(base)) {
+            internal = "F";
+        } else if ("double".equals(base)) {
+            internal = "D";
+        } else {
+            internal = "L" + base + ";";
+        }
+        StringBuilder sb = new StringBuilder(dimensions + internal.length());
+        for (int i = 0; i < dimensions; i++) {
+            sb.append('[');
+        }
+        sb.append(internal);
+        return sb.toString();
     }
 
     static class InstancesWrapper {

--- a/core/src/test/java/com/taobao/arthas/core/command/monitor200/VmToolCommandTest.java
+++ b/core/src/test/java/com/taobao/arthas/core/command/monitor200/VmToolCommandTest.java
@@ -1,0 +1,75 @@
+package com.taobao.arthas.core.command.monitor200;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class VmToolCommandTest {
+
+    @Test
+    public void testNormalizeArrayClassNameNull() {
+        Assert.assertNull(VmToolCommand.normalizeArrayClassName(null));
+    }
+
+    @Test
+    public void testNormalizeArrayClassNameNonArrayReturnsInput() {
+        Assert.assertEquals("java.lang.String", VmToolCommand.normalizeArrayClassName("java.lang.String"));
+        Assert.assertEquals("demo.MathGame", VmToolCommand.normalizeArrayClassName("demo.MathGame"));
+        Assert.assertEquals("", VmToolCommand.normalizeArrayClassName(""));
+    }
+
+    @Test
+    public void testNormalizeArrayClassNameObjectArray() {
+        Assert.assertEquals("[Ljava.lang.Object;",
+                VmToolCommand.normalizeArrayClassName("java.lang.Object[]"));
+    }
+
+    @Test
+    public void testNormalizeArrayClassNameStringMultiDimensional() {
+        Assert.assertEquals("[[Ljava.lang.String;",
+                VmToolCommand.normalizeArrayClassName("java.lang.String[][]"));
+        Assert.assertEquals("[[[Ljava.lang.String;",
+                VmToolCommand.normalizeArrayClassName("java.lang.String[][][]"));
+    }
+
+    @Test
+    public void testNormalizeArrayClassNamePrimitiveArrays() {
+        Assert.assertEquals("[Z", VmToolCommand.normalizeArrayClassName("boolean[]"));
+        Assert.assertEquals("[B", VmToolCommand.normalizeArrayClassName("byte[]"));
+        Assert.assertEquals("[C", VmToolCommand.normalizeArrayClassName("char[]"));
+        Assert.assertEquals("[S", VmToolCommand.normalizeArrayClassName("short[]"));
+        Assert.assertEquals("[I", VmToolCommand.normalizeArrayClassName("int[]"));
+        Assert.assertEquals("[J", VmToolCommand.normalizeArrayClassName("long[]"));
+        Assert.assertEquals("[F", VmToolCommand.normalizeArrayClassName("float[]"));
+        Assert.assertEquals("[D", VmToolCommand.normalizeArrayClassName("double[]"));
+    }
+
+    @Test
+    public void testNormalizeArrayClassNamePrimitiveMultiDimensional() {
+        Assert.assertEquals("[[I", VmToolCommand.normalizeArrayClassName("int[][]"));
+        Assert.assertEquals("[[[B", VmToolCommand.normalizeArrayClassName("byte[][][]"));
+    }
+
+    @Test
+    public void testNormalizeArrayClassNameMatchesJvmInternal() {
+        Assert.assertEquals(Object[].class.getName(),
+                VmToolCommand.normalizeArrayClassName("java.lang.Object[]"));
+        Assert.assertEquals(String[][].class.getName(),
+                VmToolCommand.normalizeArrayClassName("java.lang.String[][]"));
+        Assert.assertEquals(int[].class.getName(),
+                VmToolCommand.normalizeArrayClassName("int[]"));
+        Assert.assertEquals(long[][].class.getName(),
+                VmToolCommand.normalizeArrayClassName("long[][]"));
+    }
+
+    @Test
+    public void testNormalizeArrayClassNameJvmInternalFormatUnchanged() {
+        Assert.assertEquals("[Ljava.lang.Object;",
+                VmToolCommand.normalizeArrayClassName("[Ljava.lang.Object;"));
+        Assert.assertEquals("[I", VmToolCommand.normalizeArrayClassName("[I"));
+    }
+
+    @Test
+    public void testNormalizeArrayClassNameEmptyBaseReturnsInput() {
+        Assert.assertEquals("[]", VmToolCommand.normalizeArrayClassName("[]"));
+    }
+}

--- a/core/src/test/java/com/taobao/arthas/core/command/monitor200/VmToolCommandTest.java
+++ b/core/src/test/java/com/taobao/arthas/core/command/monitor200/VmToolCommandTest.java
@@ -71,5 +71,7 @@ public class VmToolCommandTest {
     @Test
     public void testNormalizeArrayClassNameEmptyBaseReturnsInput() {
         Assert.assertEquals("[]", VmToolCommand.normalizeArrayClassName("[]"));
+        Assert.assertEquals("[][]", VmToolCommand.normalizeArrayClassName("[][]"));
+        Assert.assertEquals("[][][]", VmToolCommand.normalizeArrayClassName("[][][]"));
     }
 }


### PR DESCRIPTION
## Problem

`vmtool --action getInstances --className java.lang.Object[]` fails with `Can not find class by class name: java.lang.Object[].`, even when `Object[]` instances exist. The same applies to `referenceAnalyze` and to primitive arrays (`int[]`, `byte[]`, etc.). Users have to know the JVM internal form — `[Ljava.lang.Object;`, `[I` — to query array classes.

## Root Cause

`VmToolCommand.process()` passes the raw user input to `SearchUtils.searchClassOnly`, which walks `Instrumentation.getAllLoadedClasses()` and compares against `Class.getName()`. For array types `Class.getName()` returns the JVM internal form (`[Ljava.lang.Object;`, `[I`, `[[Ljava.lang.String;`, …) — never `Object[]`. So the user-friendly `X[]` form can never match.

## Fix

Add `normalizeArrayClassName(String)` in `VmToolCommand` and use its output as the search key for `getInstances` / `referenceAnalyze`.

- `java.lang.Object[]` → `[Ljava.lang.Object;`
- `int[][]` → `[[I`
- `java.lang.String[][][]` → `[[[Ljava.lang.String;`
- All 8 primitives covered (`Z B C S I J F D`)
- Non-array input returned unchanged, so existing queries are unaffected
- Already-internal input (`[Ljava.lang.Object;`, `[I`) returned unchanged
- Pathological `[]` (empty base) returned unchanged to avoid producing `[L;`
- Error messages keep the user's original input for readability

## Tests Added

New `core/src/test/java/.../VmToolCommandTest.java` with 9 cases:

| Change Point | Test |
|-------------|------|
| `null` passthrough | `testNormalizeArrayClassNameNull` |
| Non-array passthrough | `testNormalizeArrayClassNameNonArrayReturnsInput` |
| Simple object array | `testNormalizeArrayClassNameObjectArray` |
| Multi-dim object array | `testNormalizeArrayClassNameStringMultiDimensional` |
| All 8 primitive arrays | `testNormalizeArrayClassNamePrimitiveArrays` |
| Multi-dim primitive arrays | `testNormalizeArrayClassNamePrimitiveMultiDimensional` |
| Output matches `Class.getName()` ground truth | `testNormalizeArrayClassNameMatchesJvmInternal` |
| JVM internal form passthrough | `testNormalizeArrayClassNameJvmInternalFormatUnchanged` |
| Empty base edge case `[]` | `testNormalizeArrayClassNameEmptyBaseReturnsInput` |

Full `mvn -pl core test` passes locally (204 tests, 0 failures, 0 errors).

## Impact

Scope is limited to `VmToolCommand` for `getInstances` and `referenceAnalyze`. Behavior for non-array classNames is byte-for-byte identical. No changes to `sc` / `watch` / `trace` / other commands.

Fixes #2816