### PR TITLE
Make tunnel-client max HTTP content length configurable (#3034)

### DIFF
--- a/common/src/main/java/com/taobao/arthas/common/ArthasConstants.java
+++ b/common/src/main/java/com/taobao/arthas/common/ArthasConstants.java
@@ -16,6 +16,35 @@ public class ArthasConstants {
 
     public static final int MAX_HTTP_CONTENT_LENGTH = 1024 * 1024 * 10;
 
+    /**
+     * System property to override the max HTTP content length used by the
+     * tunnel-client when proxying responses (e.g. JFR recording downloads)
+     * back to the tunnel-server. The value is in bytes; default is
+     * {@link #MAX_HTTP_CONTENT_LENGTH} (10 MB). See issue #3034.
+     */
+    public static final String TUNNEL_CLIENT_MAX_HTTP_CONTENT_LENGTH_PROPERTY = "arthas.tunnel.client.max-http-content-length";
+
+    /**
+     * Resolve the configured tunnel-client max HTTP content length. Falls back
+     * to {@link #MAX_HTTP_CONTENT_LENGTH} when the system property is unset,
+     * non-numeric, or non-positive.
+     */
+    public static int getTunnelClientMaxHttpContentLength() {
+        String value = System.getProperty(TUNNEL_CLIENT_MAX_HTTP_CONTENT_LENGTH_PROPERTY);
+        if (value == null || value.isEmpty()) {
+            return MAX_HTTP_CONTENT_LENGTH;
+        }
+        try {
+            int parsed = Integer.parseInt(value.trim());
+            if (parsed > 0) {
+                return parsed;
+            }
+        } catch (NumberFormatException ignore) {
+            // fall through to default
+        }
+        return MAX_HTTP_CONTENT_LENGTH;
+    }
+
     public static final String ARTHAS_OUTPUT = "arthas-output";
 
     public static final String APP_NAME = "app-name";

--- a/tunnel-client/pom.xml
+++ b/tunnel-client/pom.xml
@@ -57,6 +57,16 @@
 			<artifactId>netty-codec-http</artifactId>
 		</dependency>
 
+		<dependency>
+			<groupId>org.junit.vintage</groupId>
+			<artifactId>junit-vintage-engine</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter</artifactId>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 
 </project>

--- a/tunnel-client/src/main/java/com/alibaba/arthas/tunnel/client/ProxyClient.java
+++ b/tunnel-client/src/main/java/com/alibaba/arthas/tunnel/client/ProxyClient.java
@@ -60,7 +60,8 @@ public class ProxyClient {
                 @Override
                 protected void initChannel(LocalChannel ch) {
                     ChannelPipeline p = ch.pipeline();
-                    p.addLast(new HttpClientCodec(), new HttpObjectAggregator(ArthasConstants.MAX_HTTP_CONTENT_LENGTH),
+                    p.addLast(new HttpClientCodec(),
+                            new HttpObjectAggregator(ArthasConstants.getTunnelClientMaxHttpContentLength()),
                             new HttpProxyClientHandler(httpResponsePromise));
                 }
             });

--- a/tunnel-client/src/test/java/com/taobao/arthas/common/ArthasConstantsTest.java
+++ b/tunnel-client/src/test/java/com/taobao/arthas/common/ArthasConstantsTest.java
@@ -1,0 +1,67 @@
+package com.taobao.arthas.common;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Tests for the configurable tunnel-client max HTTP content length introduced
+ * for issue #3034 ("Unable to download JFR recordings larger than 10MB via
+ * Tunnel Server").
+ */
+public class ArthasConstantsTest {
+
+    private static final String PROPERTY = ArthasConstants.TUNNEL_CLIENT_MAX_HTTP_CONTENT_LENGTH_PROPERTY;
+
+    private String originalValue;
+
+    @Before
+    public void saveProperty() {
+        originalValue = System.getProperty(PROPERTY);
+        System.clearProperty(PROPERTY);
+    }
+
+    @After
+    public void restoreProperty() {
+        if (originalValue == null) {
+            System.clearProperty(PROPERTY);
+        } else {
+            System.setProperty(PROPERTY, originalValue);
+        }
+    }
+
+    @Test
+    public void defaultsToTenMegabytesWhenPropertyMissing() {
+        assertEquals(ArthasConstants.MAX_HTTP_CONTENT_LENGTH,
+                ArthasConstants.getTunnelClientMaxHttpContentLength());
+    }
+
+    @Test
+    public void honoursConfiguredPropertyValue() {
+        int oneHundredMb = 100 * 1024 * 1024;
+        System.setProperty(PROPERTY, Integer.toString(oneHundredMb));
+
+        assertEquals(oneHundredMb, ArthasConstants.getTunnelClientMaxHttpContentLength());
+    }
+
+    @Test
+    public void fallsBackToDefaultWhenPropertyIsNotANumber() {
+        System.setProperty(PROPERTY, "not-a-number");
+
+        assertEquals(ArthasConstants.MAX_HTTP_CONTENT_LENGTH,
+                ArthasConstants.getTunnelClientMaxHttpContentLength());
+    }
+
+    @Test
+    public void fallsBackToDefaultWhenPropertyIsNotPositive() {
+        System.setProperty(PROPERTY, "0");
+        assertEquals(ArthasConstants.MAX_HTTP_CONTENT_LENGTH,
+                ArthasConstants.getTunnelClientMaxHttpContentLength());
+
+        System.setProperty(PROPERTY, "-1");
+        assertEquals(ArthasConstants.MAX_HTTP_CONTENT_LENGTH,
+                ArthasConstants.getTunnelClientMaxHttpContentLength());
+    }
+}


### PR DESCRIPTION
## Problem

When the Arthas Web Console is connected through a tunnel-server and a user clicks **Download** on a JFR recording larger than 10 MB, the download silently fails and the browser receives a body containing the literal text `error`. The tunnel-server logs:

```
com.alibaba.arthas.deps.io.netty.handler.codec.http.TooLongHttpContentException:
    Response entity too large: DefaultHttpResponse(decodeResult: success, version: HTTP/1.1)
  at io.netty.handler.codec.http.HttpObjectAggregator.handleOversizedMessage(HttpObjectAggregator.java:275)
```

Recordings up to 10 MB download fine; anything larger is truncated to the error string.

## Root Cause

`tunnel-client/ProxyClient` configures Netty's `HttpObjectAggregator` with the shared `ArthasConstants.MAX_HTTP_CONTENT_LENGTH = 10 MB` constant. When the agent's local Arthas HTTP server emits a response exceeding 10 MB (such as a JFR file), the aggregator rejects it before the bytes can reach the tunnel-server, and the proxy falls back to its `error` payload.

## Fix

Introduce a JVM system property `arthas.tunnel.client.max-http-content-length` (in bytes) that overrides the cap used by `ProxyClient` only. The shared `MAX_HTTP_CONTENT_LENGTH` constant is left untouched, so unrelated consumers (WebSocket frame limit, `ObjectView` size limit, etc.) keep their existing semantics.

- Default remains 10 MB - existing deployments behave identically.
- Setting `-Darthas.tunnel.client.max-http-content-length=104857600` (100 MB) lets users download larger JFR recordings.
- Invalid values (non-numeric, zero, negative) fall back to the default rather than failing fast, matching the lenient parsing already used elsewhere in arthas-common.

Files touched:
- `common/src/main/java/com/taobao/arthas/common/ArthasConstants.java` - add property name + `getTunnelClientMaxHttpContentLength()` helper.
- `tunnel-client/src/main/java/com/alibaba/arthas/tunnel/client/ProxyClient.java` - call the helper instead of the hard-coded constant.
- `tunnel-client/pom.xml` - add JUnit test scope (matches `tunnel-common`).

## Tests Added

`tunnel-client/src/test/java/com/taobao/arthas/common/ArthasConstantsTest.java` covers:

- Defaults to `MAX_HTTP_CONTENT_LENGTH` when the property is unset.
- Honours a configured value (100 MB).
- Falls back to default on non-numeric input.
- Falls back to default on zero/negative input.

`mvn -pl common,tunnel-client -am clean test` passes locally (4 new tests, 0 failures).

## Impact

- Backward compatible - default behavior unchanged.
- Scoped to the tunnel-client HTTP aggregator path identified in the issue; does not alter the `MAX_HTTP_CONTENT_LENGTH` constant or the many other call sites that depend on its current value.
- Operators downloading large JFR recordings can opt in by setting the new system property on the agent JVM.

Closes #3034