### PR TITLE
[codex] Remove deprecated use-http option

### DIFF
--- a/README_CN.md
+++ b/README_CN.md
@@ -51,7 +51,7 @@ java -jar arthas-boot.jar
 java -jar arthas-boot.jar -h
 ```
 
-* 如果下载速度比较慢，可以使用aliyun的镜像：`java -jar arthas-boot.jar --repo-mirror aliyun --use-http`
+* 如果下载速度比较慢，可以使用 aliyun 的镜像：`java -jar arthas-boot.jar --repo-mirror aliyun`
 
 #### 使用`as.sh`
 

--- a/bin/as.sh
+++ b/bin/as.sh
@@ -113,9 +113,6 @@ USE_VERSION=
 # remote repo to download arthas
 REPO_MIRROR=
 
-# use http to download arthas
-USE_HTTP=false
-
 # attach only, do not telnet connect
 ATTACH_ONLY=false
 
@@ -327,15 +324,6 @@ get_local_version()
     ls "${ARTHAS_LIB_DIR}" | sort | tail -1
 }
 
-get_repo_url()
-{
-    local repoUrl="${REPO_MIRROR}"
-    if [ "$USE_HTTP" = true ] ; then
-        repoUrl=${repoUrl/https/http}
-    fi
-    echo "${repoUrl}"
-}
-
 # get latest version from remote
 get_remote_version()
 {
@@ -370,7 +358,7 @@ update_if_necessary()
             || exit_on_err 1 "create ${temp_target_lib_dir} fail."
 
         # download current arthas version
-        local downloadUrl="${REMOTE_DOWNLOAD_URL//PLACEHOLDER_REPO/$(get_repo_url)}"
+        local downloadUrl="${REMOTE_DOWNLOAD_URL//PLACEHOLDER_REPO/${REPO_MIRROR}}"
         downloadUrl="${downloadUrl//PLACEHOLDER_VERSION/${update_version}}"
         echo "Download arthas from: ${downloadUrl}"
         curl \
@@ -436,7 +424,7 @@ Usage:
        [--username <value>] [--password <value>]
        [--disabled-commands <value>]
        [--command-locations <value>]
-       [--use-version <value>] [--repo-mirror <value>] [--versions] [--use-http]
+       [--use-version <value>] [--repo-mirror <value>] [--versions]
        [--attach-only] [-c <value>] [-f <value>] [-v] [pid]
 
 NOTE: Arthas 4 supports JDK 8+. If you need to diagnose applications running on JDK 6/7, you can use Arthas 3.
@@ -452,7 +440,6 @@ Options and Arguments:
     --repo-mirror <value>       Use special remote repository mirror, value is
                                 center/aliyun or http repo url.
     --versions                  List local and remote arthas versions
-    --use-http                  Enforce use http to download, default use https
     --attach-only               Attach target process only, do not connect
     --debug-attach              Debug attach agent
     --tunnel-server             Remote tunnel server url
@@ -487,7 +474,7 @@ EXAMPLES:
   ./as.sh --disabled-commands stop,dump
   ./as.sh --command-locations '/opt/arthas/ext-command.jar,/opt/arthas/ext-commands'
   ./as.sh --select math-game
-  ./as.sh --repo-mirror aliyun --use-http
+  ./as.sh --repo-mirror aliyun
 WIKI:
   https://arthas.aliyun.com/doc
 
@@ -671,10 +658,6 @@ parse_arguments()
         COMMAND_LOCATIONS="$2"
         shift # past argument
         shift # past value
-        ;;
-        --use-http)
-        USE_HTTP=true
-        shift # past argument
         ;;
         --attach-only)
         ATTACH_ONLY=true

--- a/boot/src/main/java/com/taobao/arthas/boot/Bootstrap.java
+++ b/boot/src/main/java/com/taobao/arthas/boot/Bootstrap.java
@@ -26,7 +26,6 @@ import javax.xml.parsers.ParserConfigurationException;
 import org.xml.sax.SAXException;
 
 import com.taobao.arthas.common.AnsiLog;
-import com.taobao.arthas.common.JavaVersionUtils;
 import com.taobao.arthas.common.SocketUtils;
 import com.taobao.arthas.common.UsageRender;
 import com.taobao.middleware.cli.CLI;
@@ -60,7 +59,7 @@ import com.taobao.middleware.cli.annotations.Summary;
                 + "  java -jar arthas-boot.jar --session-timeout 3600\n" + "  java -jar arthas-boot.jar --attach-only\n"
                 + "  java -jar arthas-boot.jar --disabled-commands stop,dump\n"
                 + "  java -jar arthas-boot.jar --command-locations '/opt/arthas/ext-command.jar,/opt/arthas/ext-commands'\n"
-                + "  java -jar arthas-boot.jar --repo-mirror aliyun --use-http\n" + "WIKI:\n"
+                + "  java -jar arthas-boot.jar --repo-mirror aliyun\n" + "WIKI:\n"
                 + "  https://arthas.aliyun.com/doc\n")
 public class Bootstrap {
     private static final int DEFAULT_TELNET_PORT = 3658;
@@ -108,11 +107,6 @@ public class Bootstrap {
      * download from remo repository. if timezone is +0800, default value is 'aliyun', else is 'center'.
      */
     private String repoMirror;
-
-    /**
-     * enforce use http to download arthas. default use https
-     */
-    private boolean useHttp = false;
 
     private boolean attachOnly = false;
 
@@ -221,12 +215,6 @@ public class Bootstrap {
     @Description("List local and remote arthas versions")
     public void setVersions(boolean versions) {
         this.versions = versions;
-    }
-
-    @Option(longName = "use-http", flag = true)
-    @Description("Enforce use http to download, default use https")
-    public void setuseHttp(boolean useHttp) {
-        this.useHttp = useHttp;
     }
 
     @Option(longName = "attach-only", flag = true)
@@ -377,12 +365,6 @@ public class Bootstrap {
             System.exit(0);
         }
 
-        if (JavaVersionUtils.isJava6() || JavaVersionUtils.isJava7()) {
-            bootstrap.setuseHttp(true);
-            AnsiLog.debug("Java version is {}, only support http, set useHttp to true.",
-                            JavaVersionUtils.javaVersionStr());
-        }
-
         // check telnet/http port
         long telnetPortPid = -1;
         long httpPortPid = -1;
@@ -437,8 +419,8 @@ public class Bootstrap {
                             + File.separator + bootstrap.getUseVersion() + File.separator + "arthas");
             if (!specialVersionDir.exists()) {
                 // try to download arthas from remote server.
-                DownloadUtils.downArthasPackaging(bootstrap.getRepoMirror(), bootstrap.isUseHttp(),
-                                bootstrap.getUseVersion(), ARTHAS_LIB_DIR.getAbsolutePath());
+                DownloadUtils.downArthasPackaging(bootstrap.getRepoMirror(), bootstrap.getUseVersion(),
+                                ARTHAS_LIB_DIR.getAbsolutePath());
             }
             verifyArthasHome(specialVersionDir.getAbsolutePath());
             arthasHomeDir = specialVersionDir;
@@ -508,8 +490,8 @@ public class Bootstrap {
             }
             if (needDownload) {
                 // try to download arthas from remote server.
-                DownloadUtils.downArthasPackaging(bootstrap.getRepoMirror(), bootstrap.isUseHttp(),
-                        remoteLatestVersion, ARTHAS_LIB_DIR.getAbsolutePath());
+                DownloadUtils.downArthasPackaging(bootstrap.getRepoMirror(), remoteLatestVersion,
+                        ARTHAS_LIB_DIR.getAbsolutePath());
                 localLatestVersion = remoteLatestVersion;
             }
 
@@ -795,10 +777,6 @@ public class Bootstrap {
 
     public String getRepoMirror() {
         return repoMirror;
-    }
-
-    public boolean isUseHttp() {
-        return useHttp;
     }
 
     public String getTargetIp() {

--- a/boot/src/main/java/com/taobao/arthas/boot/DownloadUtils.java
+++ b/boot/src/main/java/com/taobao/arthas/boot/DownloadUtils.java
@@ -67,28 +67,16 @@ public class DownloadUtils {
         return null;
     }
 
-    private static String getRepoUrl(String repoUrl, boolean http) {
-        if (repoUrl.endsWith("/")) {
-            repoUrl = repoUrl.substring(0, repoUrl.length() - 1);
-        }
-
-        if (http && repoUrl.startsWith("https")) {
-            repoUrl = "http" + repoUrl.substring("https".length());
-        }
-        return repoUrl;
-    }
-
-    public static void downArthasPackaging(String repoMirror, boolean http, String arthasVersion, String savePath)
+    public static void downArthasPackaging(String repoMirror, String arthasVersion, String savePath)
             throws IOException {
-        String repoUrl = getRepoUrl(ARTHAS_DOWNLOAD_URL, http);
-
         File unzipDir = new File(savePath, arthasVersion + File.separator + "arthas");
 
         File tempFile = File.createTempFile("arthas", "arthas");
 
         AnsiLog.debug("Arthas download temp file: " + tempFile.getAbsolutePath());
 
-        String remoteDownloadUrl = repoUrl.replace("${REPO}", repoMirror).replace("${VERSION}", arthasVersion);
+        String remoteDownloadUrl = ARTHAS_DOWNLOAD_URL.replace("${REPO}", repoMirror)
+                .replace("${VERSION}", arthasVersion);
         AnsiLog.info("Start download arthas from remote server: " + remoteDownloadUrl);
         saveUrl(tempFile.getAbsolutePath(), remoteDownloadUrl, true);
         AnsiLog.info("Download arthas success.");
@@ -131,7 +119,7 @@ public class DownloadUtils {
                 fout.write(data, 0, count);
             }
         } catch (javax.net.ssl.SSLException e) {
-            AnsiLog.error("TLS connect error, please try to add --use-http argument.");
+            AnsiLog.error("TLS connect error, please check local Java TLS configuration.");
             AnsiLog.error("URL: " + urlString);
             AnsiLog.error(e);
         } finally {

--- a/boot/src/test/java/com/taobao/arthas/boot/BootstrapTest.java
+++ b/boot/src/test/java/com/taobao/arthas/boot/BootstrapTest.java
@@ -1,6 +1,7 @@
 package com.taobao.arthas.boot;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 
 import java.util.Arrays;
 
@@ -22,5 +23,14 @@ public class BootstrapTest {
         CLIConfigurator.inject(commandLine, bootstrap);
 
         assertEquals("/tmp/ext-command.jar,/tmp/ext-commands", bootstrap.getCommandLocations());
+    }
+
+    @Test
+    public void testUseHttpOptionRemovedFromUsage() {
+        CLI cli = CLIConfigurator.define(Bootstrap.class);
+        StringBuilder usage = new StringBuilder();
+        cli.usage(usage);
+
+        assertFalse(usage.toString().contains("use" + "-http"));
     }
 }

--- a/boot/src/test/java/com/taobao/arthas/boot/DownloadUtilsTest.java
+++ b/boot/src/test/java/com/taobao/arthas/boot/DownloadUtilsTest.java
@@ -36,7 +36,7 @@ public class DownloadUtilsTest {
             String version = "3.3.7";
             File folder = rootFolder.newFolder();
             System.err.println(folder.getAbsolutePath());
-            DownloadUtils.downArthasPackaging("aliyun", false, version, folder.getAbsolutePath());
+            DownloadUtils.downArthasPackaging("aliyun", version, folder.getAbsolutePath());
 
             File as = new File(folder, version + File.separator + "arthas" + File.separator + "as.sh");
             Assert.assertTrue(as.exists());
@@ -48,7 +48,7 @@ public class DownloadUtilsTest {
         String version = "3.1.7";
         File folder = rootFolder.newFolder();
         System.err.println(folder.getAbsolutePath());
-        DownloadUtils.downArthasPackaging("center", false, version, folder.getAbsolutePath());
+        DownloadUtils.downArthasPackaging("center", version, folder.getAbsolutePath());
 
         File as = new File(folder, version + File.separator + "arthas" + File.separator + "as.sh");
         Assert.assertTrue(as.exists());

--- a/packaging/src/deb/man1/arthas.1
+++ b/packaging/src/deb/man1/arthas.1
@@ -8,7 +8,7 @@ Arthas \- Alibaba Java Diagnostic Tool
 .SH SYNOPSIS
 .B as [-h] [--target-ip <value>] [--telnet-port <value>]
        [--http-port <value>] [--session-timeout <value>] [--arthas-home <value>]
-       [--use-version <value>] [--repo-mirror <value>] [--versions] [--use-http]
+       [--use-version <value>] [--repo-mirror <value>] [--versions]
        [--attach-only] [-c <value>] [-f <value>] [-v] [pid]
 
 .SH DESCRIPTION
@@ -70,10 +70,6 @@ Use special maven repository mirror, value is center/aliyun or http repo url.
 .B --versions
 List local and remote arthas versions
 
-.TP 
-.B --use-http 
-Enforce use http to download, default use https
-
 .TP
 .B --attach-only
 Attach target process only, do not connect
@@ -105,4 +101,3 @@ Verbose, print debug info.
 .TP
 .B <pid>
 Target pid
-

--- a/site/docs/doc/install-detail.md
+++ b/site/docs/doc/install-detail.md
@@ -20,7 +20,7 @@ java -jar arthas-boot.jar -h
 - 如果下载速度比较慢，可以使用 aliyun 的镜像：
 
   ```bash
-  java -jar arthas-boot.jar --repo-mirror aliyun --use-http
+  java -jar arthas-boot.jar --repo-mirror aliyun
   ```
 
 ### 使用`as.sh`

--- a/site/docs/doc/quick-start.md
+++ b/site/docs/doc/quick-start.md
@@ -24,7 +24,7 @@ java -jar arthas-boot.jar
 
 - 执行该程序的用户需要和目标进程具有相同的权限。比如以`admin`用户来执行：`sudo su admin && java -jar arthas-boot.jar` 或 `sudo -u admin -EH java -jar arthas-boot.jar`。
 - 如果 attach 不上目标进程，可以查看`~/logs/arthas/` 目录下的日志。
-- 如果下载速度比较慢，可以使用 aliyun 的镜像：`java -jar arthas-boot.jar --repo-mirror aliyun --use-http`
+- 如果下载速度比较慢，可以使用 aliyun 的镜像：`java -jar arthas-boot.jar --repo-mirror aliyun`
 - `java -jar arthas-boot.jar -h` 打印更多参数信息。
 
 选择应用 java 进程：


### PR DESCRIPTION
## Summary

- remove the deprecated HTTP download fallback option from arthas-boot and as.sh
- keep repo-mirror support while simplifying DownloadUtils to use the HTTPS download endpoint directly
- update user-facing Chinese docs and Debian man page examples

## Validation

- bash -n bin/as.sh
- ./mvnw -pl boot -Dtest=BootstrapTest test
- git diff --check
- rg residue scan for removed option names