### PR TITLE
Switch java version in release action to 17 to consider tunnel server for release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -13,8 +13,8 @@ jobs:
       - name: Setup java
         uses: actions/setup-java@v4
         with:
-          java-version: '8'
-          distribution: 'adopt'
+          java-version: '17'
+          distribution: 'temurin'
       - name: Build with Maven
         run: mvn -V -ntp clean package -P full
 


### PR DESCRIPTION
Fixes: #3190 

This bump the used Java version in release workflow to 17 to make recently updated tunnel server's requirement for an updated baseline of Java 17.
This respects other projects for their configured target Java versions.

Along with this the java distribution is switch from `adopt` to `temurin` as recommended by setup-grade action at https://github.com/actions/setup-java

