### PR TITLE
[codex] Fix MCP auth propagation for streamable tasks

### DIFF
--- a/arthas-mcp-server/src/main/java/com/taobao/arthas/mcp/server/session/ArthasCommandContext.java
+++ b/arthas-mcp-server/src/main/java/com/taobao/arthas/mcp/server/session/ArthasCommandContext.java
@@ -158,4 +158,12 @@ public class ArthasCommandContext {
             logger.debug("Set userId for session {}: {}", binding.getArthasSessionId(), userId);
         }
     }
+
+    public void setSessionAuth(Object authSubject) {
+        if (binding != null && authSubject != null) {
+            commandExecutor.setSessionAuth(binding.getArthasSessionId(), authSubject);
+            logger.debug("Set auth subject for session {}: {}",
+                    binding.getArthasSessionId(), authSubject.getClass().getSimpleName());
+        }
+    }
 }

--- a/arthas-mcp-server/src/main/java/com/taobao/arthas/mcp/server/task/DefaultCreateTaskContext.java
+++ b/arthas-mcp-server/src/main/java/com/taobao/arthas/mcp/server/task/DefaultCreateTaskContext.java
@@ -5,10 +5,12 @@
 package com.taobao.arthas.mcp.server.task;
 
 import com.taobao.arthas.mcp.server.protocol.server.McpNettyServerExchange;
+import com.taobao.arthas.mcp.server.protocol.server.McpTransportContext;
 import com.taobao.arthas.mcp.server.protocol.spec.McpSchema;
 import com.taobao.arthas.mcp.server.session.ArthasCommandContext;
 import com.taobao.arthas.mcp.server.session.ArthasCommandSessionManager;
 import com.taobao.arthas.mcp.server.session.ArthasCommandSessionManager.CommandSessionBinding;
+import com.taobao.arthas.mcp.server.util.McpAuthExtractor;
 
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Consumer;
@@ -134,7 +136,23 @@ public class DefaultCreateTaskContext implements CreateTaskContext {
             throw new IllegalStateException("SessionManager is not available");
         }
         CommandSessionBinding binding = sessionManager.createIsolatedTaskSession(taskId);
-        return new ArthasCommandContext(commandContext.getCommandExecutor(), binding);
+        ArthasCommandContext isolatedContext = new ArthasCommandContext(commandContext.getCommandExecutor(), binding);
+        Object authSubject = getTransportAuthSubject();
+        if (authSubject != null) {
+            isolatedContext.setSessionAuth(authSubject);
+        }
+        return isolatedContext;
+    }
+
+    private Object getTransportAuthSubject() {
+        if (exchange == null) {
+            return null;
+        }
+        McpTransportContext transportContext = exchange.getTransportContext();
+        if (transportContext == null) {
+            return null;
+        }
+        return transportContext.get(McpAuthExtractor.MCP_AUTH_SUBJECT_KEY);
     }
 
     @Override

--- a/arthas-mcp-server/src/test/java/com/taobao/arthas/mcp/server/session/ArthasCommandContextAuthTest.java
+++ b/arthas-mcp-server/src/test/java/com/taobao/arthas/mcp/server/session/ArthasCommandContextAuthTest.java
@@ -1,0 +1,121 @@
+package com.taobao.arthas.mcp.server.session;
+
+import com.taobao.arthas.mcp.server.CommandExecutor;
+import com.taobao.arthas.mcp.server.protocol.server.DefaultMcpTransportContext;
+import com.taobao.arthas.mcp.server.protocol.server.McpNettyServerExchange;
+import com.taobao.arthas.mcp.server.task.DefaultCreateTaskContext;
+import com.taobao.arthas.mcp.server.util.McpAuthExtractor;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+import java.util.TreeMap;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ArthasCommandContextAuthTest {
+
+    @Test
+    void setSessionAuthShouldDelegateToCommandExecutorForBoundSession() {
+        RecordingCommandExecutor commandExecutor = new RecordingCommandExecutor();
+        ArthasCommandSessionManager.CommandSessionBinding binding =
+                new ArthasCommandSessionManager.CommandSessionBinding("mcp-session", "arthas-session", "consumer");
+        ArthasCommandContext commandContext = new ArthasCommandContext(commandExecutor, binding);
+        Object authSubject = new Object();
+
+        commandContext.setSessionAuth(authSubject);
+
+        assertThat(commandExecutor.setSessionAuthCount).isEqualTo(1);
+        assertThat(commandExecutor.lastAuthSessionId).isEqualTo("arthas-session");
+        assertThat(commandExecutor.lastAuthSubject).isSameAs(authSubject);
+    }
+
+    @Test
+    void setSessionAuthShouldIgnoreTemporaryContextAndNullSubject() {
+        RecordingCommandExecutor commandExecutor = new RecordingCommandExecutor();
+        ArthasCommandContext temporaryContext = new ArthasCommandContext(commandExecutor);
+        ArthasCommandSessionManager.CommandSessionBinding binding =
+                new ArthasCommandSessionManager.CommandSessionBinding("mcp-session", "arthas-session", "consumer");
+        ArthasCommandContext boundContext = new ArthasCommandContext(commandExecutor, binding);
+
+        temporaryContext.setSessionAuth(new Object());
+        boundContext.setSessionAuth(null);
+
+        assertThat(commandExecutor.setSessionAuthCount).isZero();
+    }
+
+    @Test
+    void createIsolatedTaskSessionShouldInheritTransportAuthSubject() {
+        RecordingCommandExecutor commandExecutor = new RecordingCommandExecutor();
+        ArthasCommandSessionManager sessionManager = new ArthasCommandSessionManager(commandExecutor);
+        ArthasCommandContext parentContext = new ArthasCommandContext(commandExecutor,
+                new ArthasCommandSessionManager.CommandSessionBinding("mcp-session", "parent-session", "parent-consumer"));
+        Object authSubject = new Object();
+        DefaultMcpTransportContext transportContext = new DefaultMcpTransportContext();
+        transportContext.put(McpAuthExtractor.MCP_AUTH_SUBJECT_KEY, authSubject);
+        McpNettyServerExchange exchange = new McpNettyServerExchange(
+                "mcp-session", null, null, null, transportContext, null);
+        DefaultCreateTaskContext createTaskContext = new DefaultCreateTaskContext(
+                null, null, exchange, "mcp-session", 60000L, null, parentContext, sessionManager);
+
+        ArthasCommandContext isolatedContext = createTaskContext.createIsolatedTaskSession("task-1");
+
+        assertThat(isolatedContext.getSessionId()).isEqualTo("session-1");
+        assertThat(commandExecutor.setSessionAuthCount).isEqualTo(1);
+        assertThat(commandExecutor.lastAuthSessionId).isEqualTo("session-1");
+        assertThat(commandExecutor.lastAuthSubject).isSameAs(authSubject);
+    }
+
+    private static final class RecordingCommandExecutor implements CommandExecutor {
+        private final AtomicInteger nextSessionId = new AtomicInteger(1);
+        private int setSessionAuthCount;
+        private String lastAuthSessionId;
+        private Object lastAuthSubject;
+
+        @Override
+        public Map<String, Object> executeSync(String commandLine, long timeout, String sessionId,
+                                               Object authSubject, String userId) {
+            return new TreeMap<String, Object>();
+        }
+
+        @Override
+        public Map<String, Object> executeAsync(String commandLine, String sessionId) {
+            return new TreeMap<String, Object>();
+        }
+
+        @Override
+        public Map<String, Object> pullResults(String sessionId, String consumerId) {
+            return new TreeMap<String, Object>();
+        }
+
+        @Override
+        public Map<String, Object> interruptJob(String sessionId) {
+            return new TreeMap<String, Object>();
+        }
+
+        @Override
+        public Map<String, Object> createSession() {
+            int sessionId = nextSessionId.getAndIncrement();
+            Map<String, Object> result = new TreeMap<String, Object>();
+            result.put("sessionId", "session-" + sessionId);
+            result.put("consumerId", "consumer-" + sessionId);
+            return result;
+        }
+
+        @Override
+        public Map<String, Object> closeSession(String sessionId) {
+            return new TreeMap<String, Object>();
+        }
+
+        @Override
+        public void setSessionAuth(String sessionId, Object authSubject) {
+            this.setSessionAuthCount++;
+            this.lastAuthSessionId = sessionId;
+            this.lastAuthSubject = authSubject;
+        }
+
+        @Override
+        public void setSessionUserId(String sessionId, String userId) {
+        }
+    }
+}

--- a/core/src/main/java/com/taobao/arthas/core/mcp/tool/function/AbstractArthasTool.java
+++ b/core/src/main/java/com/taobao/arthas/core/mcp/tool/function/AbstractArthasTool.java
@@ -122,6 +122,10 @@ public abstract class AbstractArthasTool {
 
             logger.info("Starting streamable execution: {}", commandStr);
 
+            if (execContext.getAuthSubject() != null) {
+                execContext.getCommandContext().setSessionAuth(execContext.getAuthSubject());
+            }
+
             // Set userId to session before async execution for stat reporting
             if (execContext.getUserId() != null) {
                 execContext.getCommandContext().setSessionUserId(execContext.getUserId());

--- a/core/src/test/java/com/taobao/arthas/core/mcp/tool/function/AbstractArthasToolAuthTest.java
+++ b/core/src/test/java/com/taobao/arthas/core/mcp/tool/function/AbstractArthasToolAuthTest.java
@@ -1,0 +1,107 @@
+package com.taobao.arthas.core.mcp.tool.function;
+
+import com.taobao.arthas.core.mcp.util.McpAuthExtractor;
+import com.taobao.arthas.mcp.server.CommandExecutor;
+import com.taobao.arthas.mcp.server.protocol.server.DefaultMcpTransportContext;
+import com.taobao.arthas.mcp.server.session.ArthasCommandContext;
+import com.taobao.arthas.mcp.server.session.ArthasCommandSessionManager;
+import com.taobao.arthas.mcp.server.tool.ToolContext;
+import com.taobao.arthas.mcp.server.tool.ToolContextKeys;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class AbstractArthasToolAuthTest {
+
+    @Test
+    public void executeStreamableShouldApplyAuthBeforeAsyncExecution() {
+        RecordingCommandExecutor commandExecutor = new RecordingCommandExecutor();
+        ArthasCommandSessionManager.CommandSessionBinding binding =
+                new ArthasCommandSessionManager.CommandSessionBinding("mcp-session", "arthas-session", "consumer");
+        ArthasCommandContext commandContext = new ArthasCommandContext(commandExecutor, binding);
+        Object authSubject = new Object();
+        DefaultMcpTransportContext transportContext = new DefaultMcpTransportContext();
+        transportContext.put(McpAuthExtractor.MCP_AUTH_SUBJECT_KEY, authSubject);
+
+        Map<String, Object> contextMap = new HashMap<String, Object>();
+        contextMap.put(ToolContextKeys.COMMAND_CONTEXT, commandContext);
+        contextMap.put(ToolContextKeys.MCP_TRANSPORT_CONTEXT, transportContext);
+
+        new TestArthasTool().run(new ToolContext(contextMap));
+
+        assertThat(commandExecutor.events).containsExactly("setSessionAuth", "executeAsync", "pullResults", "interruptJob");
+        assertThat(commandExecutor.lastAuthSessionId).isEqualTo("arthas-session");
+        assertThat(commandExecutor.lastAuthSubject).isSameAs(authSubject);
+    }
+
+    private static final class TestArthasTool extends AbstractArthasTool {
+        private String run(ToolContext toolContext) {
+            return executeStreamable(toolContext, "watch test", 0, 1, 100, "done");
+        }
+    }
+
+    private static final class RecordingCommandExecutor implements CommandExecutor {
+        private final List<String> events = new ArrayList<String>();
+        private String lastAuthSessionId;
+        private Object lastAuthSubject;
+
+        @Override
+        public Map<String, Object> executeSync(String commandLine, long timeout, String sessionId,
+                                               Object authSubject, String userId) {
+            return new TreeMap<String, Object>();
+        }
+
+        @Override
+        public Map<String, Object> executeAsync(String commandLine, String sessionId) {
+            events.add("executeAsync");
+            Map<String, Object> result = new TreeMap<String, Object>();
+            result.put("success", true);
+            result.put("command", commandLine);
+            result.put("sessionId", sessionId);
+            return result;
+        }
+
+        @Override
+        public Map<String, Object> pullResults(String sessionId, String consumerId) {
+            events.add("pullResults");
+            Map<String, Object> result = new TreeMap<String, Object>();
+            result.put("results", Collections.emptyList());
+            result.put("jobStatus", "TERMINATED");
+            return result;
+        }
+
+        @Override
+        public Map<String, Object> interruptJob(String sessionId) {
+            events.add("interruptJob");
+            return new TreeMap<String, Object>();
+        }
+
+        @Override
+        public Map<String, Object> createSession() {
+            return new TreeMap<String, Object>();
+        }
+
+        @Override
+        public Map<String, Object> closeSession(String sessionId) {
+            return new TreeMap<String, Object>();
+        }
+
+        @Override
+        public void setSessionAuth(String sessionId, Object authSubject) {
+            events.add("setSessionAuth");
+            this.lastAuthSessionId = sessionId;
+            this.lastAuthSubject = authSubject;
+        }
+
+        @Override
+        public void setSessionUserId(String sessionId, String userId) {
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Fixes MCP Bearer Token auth propagation for streamable and task-based Arthas command execution.

## Root Cause

MCP sync tool execution passed `authSubject` into `executeSync`, and the main MCP session path applied auth to its Arthas session. Streamable tools, however, start enhanced commands through `executeAsync`, and the Task API creates an isolated Arthas session for background execution. Those paths did not consistently copy the authenticated subject into the session checked by `JobControllerImpl`, so enhanced commands such as `watch`, `trace`, `stack`, and `tt` could fail with `command not permitted`.

## Changes

- Add `ArthasCommandContext.setSessionAuth(Object)` as a session-bound counterpart to `setSessionUserId`.
- Apply the auth subject before streamable tools call async execution.
- Copy the MCP transport auth subject into Task isolated sessions when they are created.
- Add unit tests for session auth delegation, task isolated-session auth inheritance, and streamable auth-before-async ordering.

## Validation

- `./mvnw -pl arthas-mcp-server -Dtest=ArthasCommandContextAuthTest test`
- `./mvnw -pl arthas-mcp-server,core -Dtest=AbstractArthasToolAuthTest -Dsurefire.failIfNoSpecifiedTests=false -DfailIfNoTests=false test`
- `./mvnw -pl arthas-mcp-server test`
- `git diff --check`

## Notes

A broader `-am` core test was not used for final validation because it reaches `arthas-vmtool` native linking on this machine, which is blocked by an unrelated local Xcode license prerequisite.