### PR TITLE
[codex] Fix classloader metaspace hidden class mapping

### DIFF
--- a/core/src/main/java/com/taobao/arthas/core/command/klass100/ClassLoaderMetaspaceCommand.java
+++ b/core/src/main/java/com/taobao/arthas/core/command/klass100/ClassLoaderMetaspaceCommand.java
@@ -60,6 +60,9 @@ public class ClassLoaderMetaspaceCommand extends AnnotatedCommand {
     static final String MAPPING_EVENT_NAME = "arthas.ClassLoaderMetaspaceMapping";
     static final long DEFAULT_DURATION_MILLIS = 2500;
     static final long DEFAULT_PERIOD_MILLIS = 500;
+    private static final String DIAG_LOG_PREFIX = "[classloader-metaspace]";
+    private static final int DIAG_SAMPLE_LIMIT = 3;
+    private static final int FALLBACK_CANDIDATE_SAMPLE_LIMIT = 3;
 
     private String hashCode;
     private String classLoaderClass;
@@ -124,8 +127,11 @@ public class ClassLoaderMetaspaceCommand extends AnnotatedCommand {
         }
 
         try {
+            logger.debug("{} command start, durationMillis={}, periodMillis={}, hashFilter={}, classLoaderClassFilter={}, limit={}, verbose={}",
+                    DIAG_LOG_PREFIX, durationMillis, periodMillis, hashCode, classLoaderClass, limit, verbose);
             List<Row> rows = collect(process.session().getInstrumentation(), durationMillis, periodMillis);
             rows = sortAndLimit(rows, limit);
+            logger.debug("{} command finish, rowsAfterLimit={}", DIAG_LOG_PREFIX, rows.size());
             RowAffect affect = new RowAffect();
             affect.rCnt(rows.size());
             process.appendResult(new ClassLoaderMetaspaceModel()
@@ -147,6 +153,7 @@ public class ClassLoaderMetaspaceCommand extends AnnotatedCommand {
             throws Exception {
         Path output = Files.createTempFile("arthas-classloader-metaspace-", ".jfr");
         Recording recording = null;
+        long startNanos = System.nanoTime();
         try {
             recording = new Recording();
             recording.enable(STATS_EVENT_NAME)
@@ -155,12 +162,20 @@ public class ClassLoaderMetaspaceCommand extends AnnotatedCommand {
             recording.enable(MappingEvent.class).withoutStackTrace();
 
             recording.start();
-            emitMappings(instrumentation);
+            MappingSummary mappingSummary = emitMappings(instrumentation);
+            logMappingSummary(mappingSummary);
             waitForSample(durationMillis);
             recording.stop();
             recording.dump(output);
-            return buildRows(readRecording(output));
+            long recordingSize = safeFileSize(output);
+            RecordingData recordingData = readRecording(output);
+            logRecordingSummary(recordingData, recordingSize);
+            BuildResult buildResult = buildRows(recordingData);
+            logBuildResult(buildResult);
+            return buildResult.rows;
         } finally {
+            logger.debug("{} collection finish, costMillis={}", DIAG_LOG_PREFIX,
+                    (System.nanoTime() - startNanos) / 1000000L);
             if (recording != null) {
                 try {
                     recording.close();
@@ -189,19 +204,46 @@ public class ClassLoaderMetaspaceCommand extends AnnotatedCommand {
         }
     }
 
-    private void emitMappings(Instrumentation instrumentation) {
+    private MappingSummary emitMappings(Instrumentation instrumentation) {
         Map<ClassLoader, Class<?>> anchorClasses = new IdentityHashMap<ClassLoader, Class<?>>();
-        for (Class<?> clazz : instrumentation.getAllLoadedClasses()) {
-            if (clazz == null || clazz.isArray() || clazz.isPrimitive()) {
+        Map<ClassLoader, Long> loadedClassCountByLoader = new IdentityHashMap<ClassLoader, Long>();
+        MappingSummary summary = new MappingSummary();
+        Class<?>[] allLoadedClasses = instrumentation.getAllLoadedClasses();
+        summary.loadedClassCount = allLoadedClasses.length;
+        for (Class<?> clazz : allLoadedClasses) {
+            if (clazz == null) {
+                summary.nullClassCount++;
+                continue;
+            }
+            if (clazz.isArray()) {
+                summary.arrayClassCount++;
+            }
+            if (clazz.isPrimitive()) {
+                summary.primitiveClassCount++;
                 continue;
             }
 
             ClassLoader loader = clazz.getClassLoader();
-            if (loader == null || anchorClasses.containsKey(loader) || !matchesFilter(loader)) {
+            if (loader == null) {
+                summary.bootstrapClassCount++;
                 continue;
             }
+            // 线上 HotSpot/JFR 的 ClassLoaderStatistics 计数口径需要和 classCount + hiddenClassCount 对齐，
+            // 这里有意把数组类计入 fallback 使用的 loadedClassCount；数组类只是不适合作为 JFR anchorClass。
+            Long loadedClassCount = loadedClassCountByLoader.get(loader);
+            loadedClassCountByLoader.put(loader, loadedClassCount == null ? 1L : loadedClassCount + 1L);
+            if (clazz.isArray()) {
+                continue;
+            }
+            if (anchorClasses.containsKey(loader)) {
+                summary.duplicateLoaderClassCount++;
+                continue;
+            }
+            // Mapping 必须覆盖所有 ClassLoader。命令过滤只在输出阶段生效，否则 hash filter 会让
+            // fallback 候选集不完整，并可能把同 type/count 的其它 stats row 误映射到目标 hash。
             anchorClasses.put(loader, clazz);
         }
+        summary.candidateLoaderCount = anchorClasses.size();
 
         for (Map.Entry<ClassLoader, Class<?>> entry : anchorClasses.entrySet()) {
             ClassLoader loader = entry.getKey();
@@ -210,34 +252,46 @@ public class ClassLoaderMetaspaceCommand extends AnnotatedCommand {
             event.hash = ClassUtils.classLoaderHash(loader);
             event.type = loader.getClass().getName();
             event.loaderToString = safeToString(loader);
+            event.loadedClassCount = loadedClassCountByLoader.get(loader);
             event.commit();
+            summary.emittedMappingCount++;
         }
-    }
-
-    private boolean matchesFilter(ClassLoader loader) {
-        if (hashCode != null && !hashCode.equals(ClassUtils.classLoaderHash(loader))) {
-            return false;
-        }
-        return classLoaderClass == null || classLoaderClass.equals(loader.getClass().getName());
+        return summary;
     }
 
     private RecordingData readRecording(Path recording) throws IOException {
         Map<Long, LoaderMapping> mappingByLoaderId = new HashMap<Long, LoaderMapping>();
+        List<LoaderMapping> fallbackMappings = new ArrayList<LoaderMapping>();
+        List<String> mappingEventsWithoutLoaderSamples = new ArrayList<String>();
         Map<Long, StatsRow> latestStatsByLoaderId = new HashMap<Long, StatsRow>();
+        long mappingEventCount = 0;
+        long mappingEventWithoutLoaderCount = 0;
+        long statsEventCount = 0;
+        long duplicateStatsRowCount = 0;
         RecordingFile file = new RecordingFile(recording);
         try {
             while (file.hasMoreEvents()) {
                 RecordedEvent event = file.readEvent();
                 String eventName = event.getEventType().getName();
                 if (MAPPING_EVENT_NAME.equals(eventName)) {
+                    mappingEventCount++;
                     RecordedClass anchorClass = event.getClass("anchorClass");
                     RecordedClassLoader loader = anchorClass == null ? null : anchorClass.getClassLoader();
+                    LoaderMapping loaderMapping = LoaderMapping.from(event);
+                    fallbackMappings.add(loaderMapping);
                     if (loader != null) {
-                        mappingByLoaderId.put(loader.getId(), LoaderMapping.from(event));
+                        mappingByLoaderId.put(loader.getId(), loaderMapping);
+                    } else {
+                        mappingEventWithoutLoaderCount++;
+                        addSample(mappingEventsWithoutLoaderSamples, describeMapping(loaderMapping));
                     }
                 } else if (STATS_EVENT_NAME.equals(eventName)) {
+                    statsEventCount++;
                     StatsRow row = StatsRow.from(event);
                     StatsRow previous = latestStatsByLoaderId.get(row.loaderId);
+                    if (previous != null) {
+                        duplicateStatsRowCount++;
+                    }
                     if (previous == null || row.startTime.isAfter(previous.startTime)) {
                         latestStatsByLoaderId.put(row.loaderId, row);
                     }
@@ -246,18 +300,45 @@ public class ClassLoaderMetaspaceCommand extends AnnotatedCommand {
         } finally {
             file.close();
         }
-        return new RecordingData(mappingByLoaderId, latestStatsByLoaderId.values());
+        return new RecordingData(mappingByLoaderId, fallbackMappings, mappingEventsWithoutLoaderSamples,
+                latestStatsByLoaderId.values(), mappingEventCount, mappingEventWithoutLoaderCount, statsEventCount,
+                duplicateStatsRowCount);
     }
 
-    private List<Row> buildRows(RecordingData data) {
-        List<Row> rows = new ArrayList<Row>();
+    private BuildResult buildRows(RecordingData data) {
+        BuildResult result = new BuildResult();
         for (StatsRow stats : data.statsRows) {
             LoaderMapping mapping = data.mappingByLoaderId.get(stats.loaderId);
+            LoaderMapping parentMapping = data.mappingByLoaderId.get(stats.parentLoaderId);
+            if (mapping == null && stats.loaderId != 0) {
+                result.statsRowsWithoutMapping++;
+                FallbackDiagnostics fallbackDiagnostics = diagnoseFallbackMapping(stats, data.fallbackMappings);
+                if (fallbackDiagnostics.mapping != null) {
+                    mapping = fallbackDiagnostics.mapping;
+                    result.inferredMappingRows++;
+                    addSample(result.inferredMappingSamples,
+                            describeStatsRow(stats, mapping, parentMapping) + ", fallbackDiagnostics="
+                                    + fallbackDiagnostics);
+                } else {
+                    result.unresolvedStatsRowsWithoutMapping++;
+                    addSample(result.unresolvedStatsRowsWithoutMappingSamples,
+                            describeStatsRow(stats, mapping, parentMapping) + ", fallbackDiagnostics="
+                                    + fallbackDiagnostics);
+                }
+            }
             if (!matchesStatsRow(stats, mapping)) {
+                result.filteredRows++;
+                if (matchesParentFilter(stats, parentMapping)) {
+                    result.parentMatchedFilterRows++;
+                    addSample(result.parentMatchedFilterSamples, describeStatsRow(stats, mapping, parentMapping));
+                }
                 continue;
             }
 
-            rows.add(new Row()
+            if (mapping == null) {
+                result.outputRowsWithoutMapping++;
+            }
+            result.rows.add(new Row()
                     .setName(displayName(stats, mapping))
                     .setHash(mapping == null ? stats.hash : mapping.hash)
                     .setType(mapping == null ? stats.typeName : mapping.type)
@@ -267,7 +348,40 @@ public class ClassLoaderMetaspaceCommand extends AnnotatedCommand {
                     .setBlockSize(stats.blockSize)
                     .setHiddenBlockSize(stats.hiddenBlockSize));
         }
-        return rows;
+        return result;
+    }
+
+    static LoaderMapping findUniqueFallbackMapping(StatsRow stats, List<LoaderMapping> fallbackMappings) {
+        return diagnoseFallbackMapping(stats, fallbackMappings).mapping;
+    }
+
+    private static FallbackDiagnostics diagnoseFallbackMapping(StatsRow stats, List<LoaderMapping> fallbackMappings) {
+        LoaderMapping matched = null;
+        FallbackDiagnostics diagnostics = new FallbackDiagnostics(stats);
+        for (LoaderMapping mapping : fallbackMappings) {
+            diagnostics.totalCandidateCount++;
+            if (!mapping.matchesType(stats.typeName)) {
+                continue;
+            }
+
+            diagnostics.sameTypeCandidateCount++;
+            diagnostics.addNearestCandidate(mapping);
+            if (mapping.loadedClassCount == stats.totalClassCountForMapping()) {
+                diagnostics.exactClassCountCandidateCount++;
+                diagnostics.addExactCandidate(mapping);
+                if (matched != null) {
+                    diagnostics.ambiguous = true;
+                    diagnostics.mapping = null;
+                    continue;
+                }
+                matched = mapping;
+                diagnostics.mapping = mapping;
+            }
+        }
+        if (diagnostics.ambiguous) {
+            diagnostics.mapping = null;
+        }
+        return diagnostics;
     }
 
     private boolean matchesStatsRow(StatsRow stats, LoaderMapping mapping) {
@@ -281,6 +395,19 @@ public class ClassLoaderMetaspaceCommand extends AnnotatedCommand {
             return classLoaderClass.equals(stats.typeName);
         }
         return true;
+    }
+
+    private boolean matchesParentFilter(StatsRow stats, LoaderMapping parentMapping) {
+        if (hashCode != null) {
+            return parentMapping != null && hashCode.equals(parentMapping.hash);
+        }
+        if (classLoaderClass != null) {
+            if (parentMapping != null) {
+                return classLoaderClass.equals(parentMapping.type);
+            }
+            return classLoaderClass.equals(stats.parentTypeName);
+        }
+        return false;
     }
 
     private static String displayName(StatsRow stats, LoaderMapping mapping) {
@@ -354,6 +481,91 @@ public class ClassLoaderMetaspaceCommand extends AnnotatedCommand {
         }
     }
 
+    private void logMappingSummary(MappingSummary summary) {
+        logger.debug("{} mapping summary, loadedClasses={}, candidateLoaders={}, emittedMappings={}, bootstrapClasses={}, arrayClasses={}, primitiveClasses={}, duplicateLoaderClasses={}",
+                DIAG_LOG_PREFIX, summary.loadedClassCount, summary.candidateLoaderCount, summary.emittedMappingCount,
+                summary.bootstrapClassCount, summary.arrayClassCount, summary.primitiveClassCount,
+                summary.duplicateLoaderClassCount);
+    }
+
+    private void logRecordingSummary(RecordingData data, long recordingSize) {
+        logger.debug("{} recording summary, fileSizeBytes={}, statsEvents={}, distinctStatsRows={}, mappingEvents={}, fallbackMappings={}, mappedLoaderIds={}, mappingEventsWithoutLoader={}, duplicateStatsRows={}",
+                DIAG_LOG_PREFIX, recordingSize, data.statsEventCount, data.statsRows.size(), data.mappingEventCount,
+                data.fallbackMappings.size(), data.mappingByLoaderId.size(), data.mappingEventWithoutLoaderCount,
+                data.duplicateStatsRowCount);
+        if (data.mappingEventWithoutLoaderCount > 0) {
+            logger.debug("{} mapping events without RecordedClassLoader. These events can still be used as fallback candidates. samples={}",
+                    DIAG_LOG_PREFIX, data.mappingEventsWithoutLoaderSamples);
+        }
+    }
+
+    private void logBuildResult(BuildResult result) {
+        logger.debug("{} build summary, outputRows={}, filteredRows={}, statsRowsWithoutMapping={}, inferredMappingRows={}, unresolvedStatsRowsWithoutMapping={}, outputRowsWithoutMapping={}, parentMatchedFilterRows={}",
+                DIAG_LOG_PREFIX, result.rows.size(), result.filteredRows, result.statsRowsWithoutMapping,
+                result.inferredMappingRows, result.unresolvedStatsRowsWithoutMapping, result.outputRowsWithoutMapping,
+                result.parentMatchedFilterRows);
+        if (result.inferredMappingRows > 0) {
+            logger.debug("{} inferred Arthas hash mapping for JFR stats rows by exact type and totalClassCount. samples={}",
+                    DIAG_LOG_PREFIX, result.inferredMappingSamples);
+        }
+        if (result.unresolvedStatsRowsWithoutMapping > 0) {
+            if ((hashCode == null && classLoaderClass == null) || result.outputRowsWithoutMapping > 0) {
+                logger.warn("{} found JFR stats rows without Arthas hash mapping. hashFilter={}, classLoaderClassFilter={}, samples={}",
+                        DIAG_LOG_PREFIX, hashCode, classLoaderClass,
+                        result.unresolvedStatsRowsWithoutMappingSamples);
+            } else {
+                logger.debug("{} found JFR stats rows without Arthas hash mapping. This can be expected when filters suppress non-target mapping events. hashFilter={}, classLoaderClassFilter={}, samples={}",
+                        DIAG_LOG_PREFIX, hashCode, classLoaderClass,
+                        result.unresolvedStatsRowsWithoutMappingSamples);
+            }
+        }
+        if (result.parentMatchedFilterRows > 0) {
+            logger.warn("{} filtered JFR rows whose parentClassLoader matched the filter, but classLoader itself did not. The metaspace row belongs to the child ClassLoaderData. samples={}",
+                    DIAG_LOG_PREFIX, result.parentMatchedFilterSamples);
+        }
+    }
+
+    private static long safeFileSize(Path output) {
+        try {
+            return Files.size(output);
+        } catch (Throwable e) {
+            return -1L;
+        }
+    }
+
+    private static void addSample(List<String> samples, String sample) {
+        if (samples.size() < DIAG_SAMPLE_LIMIT) {
+            samples.add(sample);
+        }
+    }
+
+    private static String describeStatsRow(StatsRow stats, LoaderMapping mapping, LoaderMapping parentMapping) {
+        return "loaderId=" + stats.loaderId
+                + ", name=" + stats.jfrName
+                + ", type=" + stats.typeName
+                + ", parentLoaderId=" + stats.parentLoaderId
+                + ", parentName=" + stats.parentName
+                + ", parentType=" + stats.parentTypeName
+                + ", classLoaderData=" + String.format("0x%016x", stats.classLoaderData)
+                + ", classes=" + stats.classCount
+                + ", hiddenClasses=" + stats.hiddenClassCount
+                + ", totalClassesForMapping=" + stats.totalClassCountForMapping()
+                + ", chunkSize=" + stats.chunkSize
+                + ", hiddenChunkSize=" + stats.hiddenChunkSize
+                + ", blockSize=" + stats.blockSize
+                + ", hiddenBlockSize=" + stats.hiddenBlockSize
+                + ", mapping=" + describeMapping(mapping)
+                + ", parentMapping=" + describeMapping(parentMapping);
+    }
+
+    private static String describeMapping(LoaderMapping mapping) {
+        if (mapping == null) {
+            return "null";
+        }
+        return "{hash=" + mapping.hash + ", type=" + mapping.type + ", name=" + mapping.loaderToString
+                + ", loadedClassCount=" + mapping.loadedClassCount + "}";
+    }
+
     private static String safeToString(ClassLoader loader) {
         try {
             return loader == null ? "BootstrapClassLoader" : loader.toString();
@@ -370,12 +582,35 @@ public class ClassLoaderMetaspaceCommand extends AnnotatedCommand {
         }
     }
 
-    static long readHiddenBlockSize(RecordedEvent event) {
-        if (event.hasField("hiddenBlockSize")) {
-            return event.getLong("hiddenBlockSize");
+    private static long safeLong(RecordedEvent event, String fieldName) {
+        try {
+            if (event.hasField(fieldName)) {
+                return event.getLong(fieldName);
+            }
+        } catch (Throwable e) {
+            return -1L;
         }
-        if (event.hasField("anonymousBlockSize")) {
-            return event.getLong("anonymousBlockSize");
+        return -1L;
+    }
+
+    static long readHiddenClassCount(RecordedEvent event) {
+        return readLongWithFallback(event, "hiddenClassCount", "anonymousClassCount");
+    }
+
+    static long readHiddenChunkSize(RecordedEvent event) {
+        return readLongWithFallback(event, "hiddenChunkSize", "anonymousChunkSize");
+    }
+
+    static long readHiddenBlockSize(RecordedEvent event) {
+        return readLongWithFallback(event, "hiddenBlockSize", "anonymousBlockSize");
+    }
+
+    private static long readLongWithFallback(RecordedEvent event, String primaryFieldName, String fallbackFieldName) {
+        if (event.hasField(primaryFieldName)) {
+            return event.getLong(primaryFieldName);
+        }
+        if (event.hasField(fallbackFieldName)) {
+            return event.getLong(fallbackFieldName);
         }
         return 0L;
     }
@@ -387,74 +622,265 @@ public class ClassLoaderMetaspaceCommand extends AnnotatedCommand {
         return loader.getType().getName().replace('/', '.');
     }
 
-    private static class RecordingData {
-        private final Map<Long, LoaderMapping> mappingByLoaderId;
-        private final Collection<StatsRow> statsRows;
+    private static String nullableTypeName(RecordedClassLoader loader) {
+        if (loader == null || loader.getType() == null) {
+            return null;
+        }
+        return loader.getType().getName().replace('/', '.');
+    }
 
-        private RecordingData(Map<Long, LoaderMapping> mappingByLoaderId, Collection<StatsRow> statsRows) {
-            this.mappingByLoaderId = mappingByLoaderId;
-            this.statsRows = statsRows;
+    private static String classLoaderName(RecordedClassLoader loader) {
+        if (loader == null) {
+            return null;
+        }
+        try {
+            return loader.getName();
+        } catch (Throwable e) {
+            return null;
         }
     }
 
-    private static class LoaderMapping {
+    private static RecordedClassLoader recordedClassLoader(RecordedEvent event, String fieldName) {
+        try {
+            if (event.hasField(fieldName)) {
+                return event.getValue(fieldName);
+            }
+        } catch (Throwable e) {
+            return null;
+        }
+        return null;
+    }
+
+    private static class MappingSummary {
+        private long loadedClassCount;
+        private long nullClassCount;
+        private long arrayClassCount;
+        private long primitiveClassCount;
+        private long bootstrapClassCount;
+        private long duplicateLoaderClassCount;
+        private long candidateLoaderCount;
+        private long emittedMappingCount;
+    }
+
+    private static class RecordingData {
+        private final Map<Long, LoaderMapping> mappingByLoaderId;
+        private final List<LoaderMapping> fallbackMappings;
+        private final List<String> mappingEventsWithoutLoaderSamples;
+        private final Collection<StatsRow> statsRows;
+        private final long mappingEventCount;
+        private final long mappingEventWithoutLoaderCount;
+        private final long statsEventCount;
+        private final long duplicateStatsRowCount;
+
+        private RecordingData(Map<Long, LoaderMapping> mappingByLoaderId, List<LoaderMapping> fallbackMappings,
+                List<String> mappingEventsWithoutLoaderSamples, Collection<StatsRow> statsRows,
+                long mappingEventCount, long mappingEventWithoutLoaderCount, long statsEventCount,
+                long duplicateStatsRowCount) {
+            this.mappingByLoaderId = mappingByLoaderId;
+            this.fallbackMappings = fallbackMappings;
+            this.mappingEventsWithoutLoaderSamples = mappingEventsWithoutLoaderSamples;
+            this.statsRows = statsRows;
+            this.mappingEventCount = mappingEventCount;
+            this.mappingEventWithoutLoaderCount = mappingEventWithoutLoaderCount;
+            this.statsEventCount = statsEventCount;
+            this.duplicateStatsRowCount = duplicateStatsRowCount;
+        }
+    }
+
+    private static class BuildResult {
+        private final List<Row> rows = new ArrayList<Row>();
+        private long filteredRows;
+        private long statsRowsWithoutMapping;
+        private long inferredMappingRows;
+        private long unresolvedStatsRowsWithoutMapping;
+        private long outputRowsWithoutMapping;
+        private long parentMatchedFilterRows;
+        private final List<String> inferredMappingSamples = new ArrayList<String>();
+        private final List<String> unresolvedStatsRowsWithoutMappingSamples = new ArrayList<String>();
+        private final List<String> parentMatchedFilterSamples = new ArrayList<String>();
+    }
+
+    static class LoaderMapping {
         private final String hash;
         private final String type;
         private final String loaderToString;
+        private final long loadedClassCount;
 
-        private LoaderMapping(String hash, String type, String loaderToString) {
+        LoaderMapping(String hash, String type, String loaderToString, long loadedClassCount) {
             this.hash = hash;
             this.type = type;
             this.loaderToString = loaderToString;
+            this.loadedClassCount = loadedClassCount;
         }
 
         private static LoaderMapping from(RecordedEvent event) {
             return new LoaderMapping(
                     safeString(event, "hash"),
                     safeString(event, "type"),
-                    safeString(event, "loaderToString"));
+                    safeString(event, "loaderToString"),
+                    safeLong(event, "loadedClassCount"));
+        }
+
+        private boolean matchesType(String typeName) {
+            return type != null && type.equals(typeName);
+        }
+
+        private long classCountDelta(long classCount) {
+            if (loadedClassCount < 0) {
+                return Long.MAX_VALUE;
+            }
+            return Math.abs(loadedClassCount - classCount);
         }
     }
 
-    private static class StatsRow {
+    private static class FallbackDiagnostics {
+        private final String typeName;
+        private final long classCount;
+        private final long hiddenClassCount;
+        private final long totalClassCountForMapping;
+        private LoaderMapping mapping;
+        private long totalCandidateCount;
+        private long sameTypeCandidateCount;
+        private long exactClassCountCandidateCount;
+        private boolean ambiguous;
+        private final List<String> exactCandidateSamples = new ArrayList<String>();
+        private final List<LoaderMapping> nearestCandidates = new ArrayList<LoaderMapping>();
+
+        private FallbackDiagnostics(StatsRow stats) {
+            this.typeName = stats.typeName;
+            this.classCount = stats.classCount;
+            this.hiddenClassCount = stats.hiddenClassCount;
+            this.totalClassCountForMapping = stats.totalClassCountForMapping();
+        }
+
+        private void addExactCandidate(LoaderMapping mapping) {
+            addSample(exactCandidateSamples, describeFallbackCandidate(mapping));
+        }
+
+        private void addNearestCandidate(LoaderMapping mapping) {
+            int insertIndex = 0;
+            while (insertIndex < nearestCandidates.size()
+                    && compareFallbackCandidate(mapping, nearestCandidates.get(insertIndex),
+                            totalClassCountForMapping) >= 0) {
+                insertIndex++;
+            }
+            nearestCandidates.add(insertIndex, mapping);
+            if (nearestCandidates.size() > FALLBACK_CANDIDATE_SAMPLE_LIMIT) {
+                nearestCandidates.remove(nearestCandidates.size() - 1);
+            }
+        }
+
+        @Override
+        public String toString() {
+            return "{type=" + typeName
+                    + ", classCount=" + classCount
+                    + ", hiddenClassCount=" + hiddenClassCount
+                    + ", totalClassCountForMapping=" + totalClassCountForMapping
+                    + ", totalCandidateCount=" + totalCandidateCount
+                    + ", sameTypeCandidateCount=" + sameTypeCandidateCount
+                    + ", exactTotalClassCountCandidateCount=" + exactClassCountCandidateCount
+                    + ", ambiguous=" + ambiguous
+                    + ", exactCandidates=" + exactCandidateSamples
+                    + ", nearestSameTypeCandidates=" + describeFallbackCandidates(nearestCandidates,
+                            totalClassCountForMapping)
+                    + "}";
+        }
+    }
+
+    private static int compareFallbackCandidate(LoaderMapping left, LoaderMapping right, long classCount) {
+        int deltaCompare = Long.compare(left.classCountDelta(classCount), right.classCountDelta(classCount));
+        if (deltaCompare != 0) {
+            return deltaCompare;
+        }
+        int countCompare = Long.compare(left.loadedClassCount, right.loadedClassCount);
+        if (countCompare != 0) {
+            return countCompare;
+        }
+        return safeText(left.hash).compareTo(safeText(right.hash));
+    }
+
+    private static List<String> describeFallbackCandidates(List<LoaderMapping> candidates, long classCount) {
+        List<String> descriptions = new ArrayList<String>(candidates.size());
+        for (LoaderMapping candidate : candidates) {
+            descriptions.add(describeFallbackCandidate(candidate) + ", delta="
+                    + candidate.classCountDelta(classCount));
+        }
+        return descriptions;
+    }
+
+    private static String describeFallbackCandidate(LoaderMapping mapping) {
+        if (mapping == null) {
+            return "null";
+        }
+        return "{hash=" + mapping.hash + ", type=" + mapping.type + ", name=" + mapping.loaderToString
+                + ", loadedClassCount=" + mapping.loadedClassCount + "}";
+    }
+
+    private static String safeText(String value) {
+        return value == null ? "" : value;
+    }
+
+    static class StatsRow {
         private final Instant startTime;
         private final long loaderId;
+        private final long parentLoaderId;
         private final String hash;
         private final String jfrName;
         private final String typeName;
+        private final String parentName;
+        private final String parentTypeName;
         private final long classLoaderData;
         private final long classCount;
+        private final long hiddenClassCount;
         private final long chunkSize;
+        private final long hiddenChunkSize;
         private final long blockSize;
         private final long hiddenBlockSize;
 
-        private StatsRow(Instant startTime, long loaderId, String hash, String jfrName, String typeName,
-                long classLoaderData, long classCount, long chunkSize, long blockSize, long hiddenBlockSize) {
+        StatsRow(Instant startTime, long loaderId, long parentLoaderId, String hash, String jfrName,
+                String typeName, String parentName, String parentTypeName, long classLoaderData, long classCount,
+                long hiddenClassCount, long chunkSize, long hiddenChunkSize, long blockSize, long hiddenBlockSize) {
             this.startTime = startTime;
             this.loaderId = loaderId;
+            this.parentLoaderId = parentLoaderId;
             this.hash = hash;
             this.jfrName = jfrName;
             this.typeName = typeName;
+            this.parentName = parentName;
+            this.parentTypeName = parentTypeName;
             this.classLoaderData = classLoaderData;
             this.classCount = classCount;
+            this.hiddenClassCount = hiddenClassCount;
             this.chunkSize = chunkSize;
+            this.hiddenChunkSize = hiddenChunkSize;
             this.blockSize = blockSize;
             this.hiddenBlockSize = hiddenBlockSize;
         }
 
+        private long totalClassCountForMapping() {
+            return classCount + hiddenClassCount;
+        }
+
         private static StatsRow from(RecordedEvent event) {
-            RecordedClassLoader loader = event.getValue("classLoader");
+            RecordedClassLoader loader = recordedClassLoader(event, "classLoader");
+            RecordedClassLoader parentLoader = recordedClassLoader(event, "parentClassLoader");
             long loaderId = loader == null ? 0 : loader.getId();
-            String name = loader == null ? "BootstrapClassLoader" : loader.getName();
+            long parentLoaderId = parentLoader == null ? 0 : parentLoader.getId();
+            String name = loader == null ? "BootstrapClassLoader" : classLoaderName(loader);
             return new StatsRow(
                     event.getStartTime(),
                     loaderId,
+                    parentLoaderId,
                     loader == null ? "null" : null,
                     name,
                     typeName(loader),
+                    classLoaderName(parentLoader),
+                    nullableTypeName(parentLoader),
                     event.getLong("classLoaderData"),
                     event.getLong("classCount"),
+                    readHiddenClassCount(event),
                     event.getLong("chunkSize"),
+                    readHiddenChunkSize(event),
                     event.getLong("blockSize"),
                     readHiddenBlockSize(event));
         }
@@ -487,5 +913,8 @@ public class ClassLoaderMetaspaceCommand extends AnnotatedCommand {
 
         @Label("ClassLoader ToString")
         String loaderToString;
+
+        @Label("Loaded Class Count")
+        long loadedClassCount;
     }
 }

--- a/core/src/test/java/com/taobao/arthas/core/command/klass100/ClassLoaderMetaspaceCommandTest.java
+++ b/core/src/test/java/com/taobao/arthas/core/command/klass100/ClassLoaderMetaspaceCommandTest.java
@@ -10,8 +10,13 @@ import org.junit.Assert;
 import org.junit.Test;
 
 import java.io.IOException;
+import java.lang.instrument.Instrumentation;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.time.Instant;
 import java.util.Arrays;
 import java.util.List;
 
@@ -69,8 +74,84 @@ public class ClassLoaderMetaspaceCommandTest {
     }
 
     @Test
+    public void testFindUniqueFallbackMappingByTypeAndClassCount() {
+        ClassLoaderMetaspaceCommand.LoaderMapping expected = mapping("hash-a", "loader.Type", 7);
+        ClassLoaderMetaspaceCommand.LoaderMapping other = mapping("hash-b", "loader.Other", 7);
+
+        ClassLoaderMetaspaceCommand.LoaderMapping actual = ClassLoaderMetaspaceCommand.findUniqueFallbackMapping(
+                stats("loader.Type", 7), Arrays.asList(expected, other));
+
+        Assert.assertSame(expected, actual);
+    }
+
+    @Test
+    public void testFindUniqueFallbackMappingUsesHiddenClassCount() {
+        ClassLoaderMetaspaceCommand.LoaderMapping expected = mapping("hash-a", "loader.Type", 8);
+        ClassLoaderMetaspaceCommand.LoaderMapping other = mapping("hash-b", "loader.Other", 8);
+
+        ClassLoaderMetaspaceCommand.LoaderMapping actual = ClassLoaderMetaspaceCommand.findUniqueFallbackMapping(
+                stats("loader.Type", 7, 1), Arrays.asList(expected, other));
+
+        Assert.assertSame(expected, actual);
+    }
+
+    @Test
+    public void testFindUniqueFallbackMappingRejectsAmbiguousCandidates() {
+        ClassLoaderMetaspaceCommand.LoaderMapping first = mapping("hash-a", "loader.Type", 7);
+        ClassLoaderMetaspaceCommand.LoaderMapping second = mapping("hash-b", "loader.Type", 7);
+
+        ClassLoaderMetaspaceCommand.LoaderMapping actual = ClassLoaderMetaspaceCommand.findUniqueFallbackMapping(
+                stats("loader.Type", 7), Arrays.asList(first, second));
+
+        Assert.assertNull(actual);
+    }
+
+    @Test
+    public void testFindUniqueFallbackMappingRequiresExactClassCount() {
+        ClassLoaderMetaspaceCommand.LoaderMapping candidate = mapping("hash-a", "loader.Type", 8);
+
+        ClassLoaderMetaspaceCommand.LoaderMapping actual = ClassLoaderMetaspaceCommand.findUniqueFallbackMapping(
+                stats("loader.Type", 7), Arrays.asList(candidate));
+
+        Assert.assertNull(actual);
+    }
+
+    @Test
+    public void testEmitMappingsIgnoresHashFilterForGlobalFallbackCandidates() throws Exception {
+        ClassLoaderMetaspaceCommand command = new ClassLoaderMetaspaceCommand();
+        command.setHashCode("missing-hash");
+
+        Object summary = emitMappings(command, instrumentationFor(ClassLoaderMetaspaceCommandTest.class));
+
+        Assert.assertEquals(1, summaryLong(summary, "candidateLoaderCount"));
+        Assert.assertEquals(1, summaryLong(summary, "emittedMappingCount"));
+    }
+
+    @Test
     public void testReadHiddenBlockSize() throws Exception {
         Assert.assertEquals(123, ClassLoaderMetaspaceCommand.readHiddenBlockSize(recordHiddenBlockSizeEvent(123)));
+    }
+
+    @Test
+    public void testReadHiddenClassCount() throws Exception {
+        Assert.assertEquals(12, ClassLoaderMetaspaceCommand.readHiddenClassCount(recordHiddenClassCountEvent(12)));
+    }
+
+    @Test
+    public void testReadHiddenClassCountFallbackToAnonymousClassCount() throws Exception {
+        Assert.assertEquals(21,
+                ClassLoaderMetaspaceCommand.readHiddenClassCount(recordAnonymousClassCountEvent(21)));
+    }
+
+    @Test
+    public void testReadHiddenChunkSize() throws Exception {
+        Assert.assertEquals(34, ClassLoaderMetaspaceCommand.readHiddenChunkSize(recordHiddenChunkSizeEvent(34)));
+    }
+
+    @Test
+    public void testReadHiddenChunkSizeFallbackToAnonymousChunkSize() throws Exception {
+        Assert.assertEquals(43,
+                ClassLoaderMetaspaceCommand.readHiddenChunkSize(recordAnonymousChunkSizeEvent(43)));
     }
 
     @Test
@@ -86,6 +167,129 @@ public class ClassLoaderMetaspaceCommandTest {
 
     private static Row row(String name, long chunkSize, long blockSize) {
         return new Row().setName(name).setChunkSize(chunkSize).setBlockSize(blockSize);
+    }
+
+    private static ClassLoaderMetaspaceCommand.LoaderMapping mapping(String hash, String type, long loadedClassCount) {
+        return new ClassLoaderMetaspaceCommand.LoaderMapping(hash, type, type + "@" + hash, loadedClassCount);
+    }
+
+    private static ClassLoaderMetaspaceCommand.StatsRow stats(String type, long classCount) {
+        return stats(type, classCount, 0);
+    }
+
+    private static ClassLoaderMetaspaceCommand.StatsRow stats(String type, long classCount, long hiddenClassCount) {
+        return new ClassLoaderMetaspaceCommand.StatsRow(Instant.EPOCH, 1, 0, null, null, type, null, null, 0,
+                classCount, hiddenClassCount, 0, 0, 0, 0);
+    }
+
+    private static Object emitMappings(ClassLoaderMetaspaceCommand command, Instrumentation instrumentation)
+            throws Exception {
+        Method method = ClassLoaderMetaspaceCommand.class.getDeclaredMethod("emitMappings", Instrumentation.class);
+        method.setAccessible(true);
+        return method.invoke(command, instrumentation);
+    }
+
+    private static long summaryLong(Object summary, String fieldName) throws Exception {
+        Field field = summary.getClass().getDeclaredField(fieldName);
+        field.setAccessible(true);
+        return field.getLong(summary);
+    }
+
+    private static Instrumentation instrumentationFor(final Class<?>... classes) {
+        return (Instrumentation) Proxy.newProxyInstance(
+                ClassLoaderMetaspaceCommandTest.class.getClassLoader(),
+                new Class<?>[] { Instrumentation.class },
+                (proxy, method, args) -> {
+                    if ("getAllLoadedClasses".equals(method.getName())) {
+                        return classes;
+                    }
+                    Class<?> returnType = method.getReturnType();
+                    if (returnType == boolean.class) {
+                        return false;
+                    }
+                    if (returnType == long.class) {
+                        return 0L;
+                    }
+                    if (returnType == int.class) {
+                        return 0;
+                    }
+                    if (returnType == Class[].class) {
+                        return new Class<?>[0];
+                    }
+                    return null;
+                });
+    }
+
+    private static RecordedEvent recordHiddenClassCountEvent(long value) throws IOException {
+        Recording recording = new Recording();
+        Path output = Files.createTempFile("arthas-hidden-class-count-", ".jfr");
+        try {
+            recording.enable(HiddenClassCountEvent.class).withoutStackTrace();
+            recording.start();
+            HiddenClassCountEvent event = new HiddenClassCountEvent();
+            event.hiddenClassCount = value;
+            event.commit();
+            recording.stop();
+            recording.dump(output);
+            return readOnlyEvent(output);
+        } finally {
+            recording.close();
+            Files.deleteIfExists(output);
+        }
+    }
+
+    private static RecordedEvent recordHiddenChunkSizeEvent(long value) throws IOException {
+        Recording recording = new Recording();
+        Path output = Files.createTempFile("arthas-hidden-chunk-size-", ".jfr");
+        try {
+            recording.enable(HiddenChunkSizeEvent.class).withoutStackTrace();
+            recording.start();
+            HiddenChunkSizeEvent event = new HiddenChunkSizeEvent();
+            event.hiddenChunkSize = value;
+            event.commit();
+            recording.stop();
+            recording.dump(output);
+            return readOnlyEvent(output);
+        } finally {
+            recording.close();
+            Files.deleteIfExists(output);
+        }
+    }
+
+    private static RecordedEvent recordAnonymousClassCountEvent(long value) throws IOException {
+        Recording recording = new Recording();
+        Path output = Files.createTempFile("arthas-anonymous-class-count-", ".jfr");
+        try {
+            recording.enable(AnonymousClassCountEvent.class).withoutStackTrace();
+            recording.start();
+            AnonymousClassCountEvent event = new AnonymousClassCountEvent();
+            event.anonymousClassCount = value;
+            event.commit();
+            recording.stop();
+            recording.dump(output);
+            return readOnlyEvent(output);
+        } finally {
+            recording.close();
+            Files.deleteIfExists(output);
+        }
+    }
+
+    private static RecordedEvent recordAnonymousChunkSizeEvent(long value) throws IOException {
+        Recording recording = new Recording();
+        Path output = Files.createTempFile("arthas-anonymous-chunk-size-", ".jfr");
+        try {
+            recording.enable(AnonymousChunkSizeEvent.class).withoutStackTrace();
+            recording.start();
+            AnonymousChunkSizeEvent event = new AnonymousChunkSizeEvent();
+            event.anonymousChunkSize = value;
+            event.commit();
+            recording.stop();
+            recording.dump(output);
+            return readOnlyEvent(output);
+        } finally {
+            recording.close();
+            Files.deleteIfExists(output);
+        }
     }
 
     private static RecordedEvent recordHiddenBlockSizeEvent(long value) throws IOException {
@@ -155,6 +359,26 @@ public class ClassLoaderMetaspaceCommandTest {
     @Name("arthas.test.HiddenBlockSizeEvent")
     public static class HiddenBlockSizeEvent extends Event {
         long hiddenBlockSize;
+    }
+
+    @Name("arthas.test.HiddenClassCountEvent")
+    public static class HiddenClassCountEvent extends Event {
+        long hiddenClassCount;
+    }
+
+    @Name("arthas.test.HiddenChunkSizeEvent")
+    public static class HiddenChunkSizeEvent extends Event {
+        long hiddenChunkSize;
+    }
+
+    @Name("arthas.test.AnonymousClassCountEvent")
+    public static class AnonymousClassCountEvent extends Event {
+        long anonymousClassCount;
+    }
+
+    @Name("arthas.test.AnonymousChunkSizeEvent")
+    public static class AnonymousChunkSizeEvent extends Event {
+        long anonymousChunkSize;
     }
 
     @Name("arthas.test.AnonymousBlockSizeEvent")


### PR DESCRIPTION
## Summary
- keep ClassLoader metaspace fallback matching strict by comparing loader type and total class count (`classCount + hiddenClassCount`)
- include array classes in the Instrumentation-side loader count while keeping non-array classes as JFR anchor classes
- reduce default diagnostic log noise by moving success-path details to DEBUG and keeping WARN only for unresolved mappings or misleading parent-filter matches

## Root Cause
Some JFR `jdk.ClassLoaderStatistics` rows could not be joined back to Arthas ClassLoader hash/name because `RecordedClass#getClassLoader().getId()` may be missing for selected anchor classes. The fallback used `classCount` only, but HotSpot/JFR reports hidden classes separately as `hiddenClassCount`, while `Instrumentation#getAllLoadedClasses()` includes them. This made candidates like `tddl-client` differ by one class and fail the exact match.

## Validation
- `git diff --check`
- `javac -source 8 -target 8 -sourcepath core/src/main/java -cp "$(cat /tmp/arthas-core.cp)" -d /tmp/arthas-clm-compile core/src/main/java/com/taobao/arthas/core/command/klass100/ClassLoaderMetaspaceCommand.java`
- `JUnitCore com.taobao.arthas.core.command.klass100.ClassLoaderMetaspaceCommandTest com.taobao.arthas.core.command.view.ClassLoaderMetaspaceViewTest` (`OK (18 tests)`)

## Notes
Full Maven test was not rerun in this step; earlier reactor execution was blocked by an unrelated existing compile error in `AbstractArthasTool#setSessionAuth`.
