### PR TITLE
[codex] Add docs sidebar tree and search

### DIFF
--- a/site/docs/.vuepress/theme/components/SidebarItem.vue
+++ b/site/docs/.vuepress/theme/components/SidebarItem.vue
@@ -2,7 +2,7 @@
 import AutoLink from "@theme/AutoLink.vue";
 import DropdownTransition from "@theme/DropdownTransition.vue";
 
-import { computed, nextTick, onBeforeUnmount, ref, toRefs } from "vue";
+import { computed, nextTick, onBeforeUnmount, ref, toRefs, watch } from "vue";
 import { useRoute, useRouter } from "vue-router";
 
 const props = defineProps({
@@ -15,9 +15,14 @@ const props = defineProps({
     required: false,
     default: 0,
   },
+  forceOpen: {
+    type: Boolean,
+    required: false,
+    default: false,
+  },
 });
 
-const { item, depth } = toRefs(props);
+const { item, depth, forceOpen } = toRefs(props);
 const route = useRoute();
 const router = useRouter();
 
@@ -56,7 +61,7 @@ const isCollapsible = computed(
   () => Boolean(item.value.collapsible) && hasChildren.value
 );
 const isOpenDefault = computed(() =>
-  isCollapsible.value ? isActive.value : true
+  isCollapsible.value ? forceOpen.value || isActive.value : true
 );
 const isOpen = ref(isOpenDefault.value);
 
@@ -103,6 +108,10 @@ const unregisterRouterHook = router.afterEach(() => {
   nextTick(() => {
     isOpen.value = isOpenDefault.value;
   });
+});
+
+watch(isOpenDefault, (value) => {
+  isOpen.value = value;
 });
 
 onBeforeUnmount(() => {
@@ -157,6 +166,7 @@ onBeforeUnmount(() => {
           :key="`${depth}${child.text}${child.link}`"
           :item="child"
           :depth="depth + 1"
+          :force-open="forceOpen"
         />
       </ul>
     </DropdownTransition>

--- a/site/docs/.vuepress/theme/components/SidebarItem.vue
+++ b/site/docs/.vuepress/theme/components/SidebarItem.vue
@@ -1,0 +1,252 @@
+<script setup>
+import AutoLink from "@theme/AutoLink.vue";
+import DropdownTransition from "@theme/DropdownTransition.vue";
+
+import { computed, nextTick, onBeforeUnmount, ref, toRefs } from "vue";
+import { useRoute, useRouter } from "vue-router";
+
+const props = defineProps({
+  item: {
+    type: Object,
+    required: true,
+  },
+  depth: {
+    type: Number,
+    required: false,
+    default: 0,
+  },
+});
+
+const { item, depth } = toRefs(props);
+const route = useRoute();
+const router = useRouter();
+
+function normalizePath(path) {
+  return decodeURI(path)
+    .replace(/#.*$/, "")
+    .replace(/(index)?\.(md|html)$/, "");
+}
+
+function isActiveLink(link, currentRoute) {
+  if (currentRoute.hash === link) {
+    return true;
+  }
+
+  return normalizePath(currentRoute.path) === normalizePath(link);
+}
+
+function isActiveSidebarItem(sidebarItem, currentRoute) {
+  if (sidebarItem.link && isActiveLink(sidebarItem.link, currentRoute)) {
+    return true;
+  }
+
+  if (sidebarItem.children) {
+    return sidebarItem.children.some((child) =>
+      isActiveSidebarItem(child, currentRoute)
+    );
+  }
+
+  return false;
+}
+
+const hasChildren = computed(() => Boolean(item.value.children?.length));
+const usesTreeRow = computed(() => Boolean(item.value.link) && depth.value > 0);
+const isActive = computed(() => isActiveSidebarItem(item.value, route));
+const isCollapsible = computed(
+  () => Boolean(item.value.collapsible) && hasChildren.value
+);
+const isOpenDefault = computed(() =>
+  isCollapsible.value ? isActive.value : true
+);
+const isOpen = ref(isOpenDefault.value);
+
+const itemClass = computed(() => ({
+  "sidebar-item": true,
+  "sidebar-heading": depth.value === 0,
+  active: isActive.value,
+  collapsible: isCollapsible.value,
+}));
+
+const rowClass = computed(() => ({
+  "sidebar-tree-row": true,
+  "sidebar-tree-heading-row": depth.value === 0,
+  active: isActive.value,
+  collapsible: isCollapsible.value,
+}));
+
+const toggleLabel = computed(() => {
+  const isEnglish = route.path.startsWith("/en/");
+
+  if (isOpen.value) {
+    return `${isEnglish ? "Collapse" : "收起"} ${item.value.text}`;
+  }
+
+  return `${isEnglish ? "Expand" : "展开"} ${item.value.text}`;
+});
+
+function toggleIsOpen() {
+  if (isCollapsible.value) {
+    isOpen.value = !isOpen.value;
+  }
+}
+
+function onHeadingClick(event) {
+  if (!isCollapsible.value) {
+    return;
+  }
+
+  event.preventDefault();
+  toggleIsOpen();
+}
+
+const unregisterRouterHook = router.afterEach(() => {
+  nextTick(() => {
+    isOpen.value = isOpenDefault.value;
+  });
+});
+
+onBeforeUnmount(() => {
+  unregisterRouterHook();
+});
+</script>
+
+<template>
+  <li>
+    <div v-if="usesTreeRow" :class="rowClass">
+      <button
+        v-if="isCollapsible"
+        type="button"
+        class="sidebar-tree-toggle"
+        :aria-expanded="isOpen"
+        :aria-label="toggleLabel"
+        @click="toggleIsOpen"
+      >
+        <span
+          class="sidebar-tree-chevron"
+          :class="{ open: isOpen }"
+          aria-hidden="true"
+        />
+      </button>
+      <span v-else class="sidebar-tree-toggle-placeholder" />
+
+      <AutoLink :class="itemClass" :item="item" />
+    </div>
+
+    <AutoLink v-else-if="item.link" :class="itemClass" :item="item" />
+
+    <p
+      v-else
+      tabindex="0"
+      :class="itemClass"
+      @click="onHeadingClick"
+      @keydown.enter="onHeadingClick"
+    >
+      {{ item.text }}
+      <span
+        v-if="isCollapsible"
+        class="sidebar-tree-chevron"
+        :class="{ open: isOpen }"
+        aria-hidden="true"
+      />
+    </p>
+
+    <DropdownTransition v-if="hasChildren">
+      <ul v-show="isOpen" class="sidebar-item-children">
+        <SidebarItem
+          v-for="child in item.children"
+          :key="`${depth}${child.text}${child.link}`"
+          :item="child"
+          :depth="depth + 1"
+        />
+      </ul>
+    </DropdownTransition>
+  </li>
+</template>
+
+<style lang="scss" scoped>
+.sidebar-tree-row {
+  display: flex;
+  align-items: center;
+  min-height: 2rem;
+  margin: 0.125rem 0.75rem;
+  border-left: 0.25rem solid transparent;
+  border-radius: 6px;
+  transition: background-color var(--t-color), border-color var(--t-color);
+
+  &.active,
+  &:hover {
+    background: var(--c-bg-light);
+  }
+
+  &.active {
+    border-left-color: var(--c-text-accent);
+  }
+
+  :deep(.sidebar-item) {
+    flex: 1;
+    min-width: 0;
+    border-left: 0;
+    padding-left: 0.35rem;
+  }
+
+  :deep(.sidebar-item.active:not(p.sidebar-heading)) {
+    border-left-color: transparent;
+  }
+}
+
+.sidebar-tree-heading-row {
+  margin-right: 1rem;
+  margin-left: 1rem;
+
+  :deep(.sidebar-heading) {
+    padding-left: 0.35rem;
+  }
+}
+
+.sidebar-tree-toggle,
+.sidebar-tree-toggle-placeholder {
+  flex: 0 0 1.25rem;
+  width: 1.25rem;
+  height: 1.75rem;
+  margin-left: 0.1rem;
+}
+
+.sidebar-tree-toggle {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  appearance: none;
+  -webkit-appearance: none;
+  color: inherit;
+  font: inherit;
+  padding: 0;
+  border: 0;
+  background: transparent;
+  cursor: pointer;
+
+  &:focus-visible {
+    outline: 0;
+
+    .sidebar-tree-chevron {
+      border-color: var(--c-text-accent);
+    }
+  }
+}
+
+.sidebar-tree-toggle-placeholder {
+  display: inline-block;
+}
+
+.sidebar-tree-chevron {
+  width: 0.4rem;
+  height: 0.4rem;
+  border-right: 2px solid var(--c-text-light);
+  border-bottom: 2px solid var(--c-text-light);
+  transform: rotate(-45deg);
+  transition: transform var(--t-transform);
+
+  &.open {
+    transform: rotate(45deg);
+  }
+}
+</style>

--- a/site/docs/.vuepress/theme/components/SidebarItems.vue
+++ b/site/docs/.vuepress/theme/components/SidebarItems.vue
@@ -1,0 +1,221 @@
+<script setup>
+import SidebarItem from "@theme/SidebarItem.vue";
+
+import { computed, onMounted, ref, watch } from "vue";
+import { useRoute } from "vue-router";
+import { useSidebarItems } from "@vuepress/theme-default/client";
+
+const route = useRoute();
+const sidebarItems = useSidebarItems();
+const searchQuery = ref("");
+
+const isEnglish = computed(() => route.path.startsWith("/en/"));
+const normalizedQuery = computed(() => normalizeText(searchQuery.value.trim()));
+const isSearchActive = computed(() => normalizedQuery.value.length > 0);
+const searchPlaceholder = computed(() => (isEnglish.value ? "Search" : "搜索"));
+const clearSearchLabel = computed(() =>
+  isEnglish.value ? "Clear search" : "清除搜索"
+);
+const noResultsText = computed(() =>
+  isEnglish.value ? "No matches" : "没有匹配结果"
+);
+
+function normalizeText(value) {
+  return String(value ?? "").toLocaleLowerCase();
+}
+
+function sidebarItemMatches(item, query) {
+  return [item.text, item.link].some((value) =>
+    normalizeText(value).includes(query)
+  );
+}
+
+function filterSidebarItem(item, query) {
+  const children = (item.children ?? [])
+    .map((child) => filterSidebarItem(child, query))
+    .filter(Boolean);
+
+  if (!sidebarItemMatches(item, query) && children.length === 0) {
+    return null;
+  }
+
+  return {
+    ...item,
+    children,
+  };
+}
+
+const filteredSidebarItems = computed(() => {
+  if (!isSearchActive.value) {
+    return sidebarItems.value;
+  }
+
+  return sidebarItems.value
+    .map((item) => filterSidebarItem(item, normalizedQuery.value))
+    .filter(Boolean);
+});
+
+function clearSearch() {
+  searchQuery.value = "";
+}
+
+onMounted(() => {
+  watch(
+    () => route.hash,
+    (hash) => {
+      const sidebar = document.querySelector(".sidebar");
+      if (!sidebar) return;
+
+      const activeSidebarItem = document.querySelector(
+        `.sidebar a.sidebar-item[href="${route.path}${hash}"]`
+      );
+      if (!activeSidebarItem) return;
+
+      const { top: sidebarTop, height: sidebarHeight } =
+        sidebar.getBoundingClientRect();
+      const { top: activeSidebarItemTop, height: activeSidebarItemHeight } =
+        activeSidebarItem.getBoundingClientRect();
+
+      if (activeSidebarItemTop < sidebarTop) {
+        activeSidebarItem.scrollIntoView(true);
+      } else if (
+        activeSidebarItemTop + activeSidebarItemHeight >
+        sidebarTop + sidebarHeight
+      ) {
+        activeSidebarItem.scrollIntoView(false);
+      }
+    }
+  );
+});
+</script>
+
+<template>
+  <div v-if="sidebarItems.length" class="sidebar-search-wrapper">
+    <div class="sidebar-search" role="search">
+      <span class="sidebar-search-icon" aria-hidden="true" />
+      <input
+        v-model="searchQuery"
+        class="sidebar-search-input"
+        type="search"
+        :placeholder="searchPlaceholder"
+        :aria-label="searchPlaceholder"
+      />
+      <button
+        v-if="searchQuery"
+        type="button"
+        class="sidebar-search-clear"
+        :aria-label="clearSearchLabel"
+        @click="clearSearch"
+      >
+        ×
+      </button>
+    </div>
+  </div>
+
+  <ul v-if="filteredSidebarItems.length" class="sidebar-items">
+    <SidebarItem
+      v-for="item in filteredSidebarItems"
+      :key="`${item.text}${item.link}`"
+      :item="item"
+      :force-open="isSearchActive"
+    />
+  </ul>
+
+  <p v-else class="sidebar-search-empty">{{ noResultsText }}</p>
+</template>
+
+<style lang="scss" scoped>
+.sidebar-search-wrapper {
+  padding: 1rem 1rem 0;
+}
+
+.sidebar-search {
+  display: flex;
+  align-items: center;
+  height: 2.5rem;
+  border-radius: 8px;
+  background: var(--c-bg-light);
+  color: var(--c-text-light);
+  transition: background-color var(--t-color);
+
+  &:focus-within {
+    background: var(--c-bg-lighter);
+  }
+}
+
+.sidebar-search-icon {
+  position: relative;
+  flex: 0 0 1rem;
+  width: 1rem;
+  height: 1rem;
+  margin-left: 0.85rem;
+  border: 2px solid var(--c-text-lightest);
+  border-radius: 50%;
+
+  &::after {
+    content: "";
+    position: absolute;
+    right: -0.35rem;
+    bottom: -0.25rem;
+    width: 0.45rem;
+    height: 2px;
+    border-radius: 999px;
+    background: var(--c-text-lightest);
+    transform: rotate(45deg);
+  }
+}
+
+.sidebar-search-input {
+  flex: 1;
+  min-width: 0;
+  height: 100%;
+  padding: 0 0.65rem;
+  border: 0;
+  outline: 0;
+  background: transparent;
+  color: var(--c-text);
+  font: inherit;
+
+  &::placeholder {
+    color: var(--c-text-lightest);
+  }
+
+  &::-webkit-search-cancel-button {
+    display: none;
+  }
+}
+
+.sidebar-search-clear {
+  flex: 0 0 2rem;
+  width: 2rem;
+  height: 2rem;
+  margin-right: 0.25rem;
+  padding: 0;
+  border: 0;
+  border-radius: 50%;
+  background: transparent;
+  color: var(--c-text-light);
+  cursor: pointer;
+  font-size: 1.2rem;
+  line-height: 1;
+
+  &:hover,
+  &:focus-visible {
+    color: var(--c-text-accent);
+  }
+
+  &:focus-visible {
+    outline: 0;
+  }
+}
+
+.sidebar-items {
+  padding-top: 1rem;
+}
+
+.sidebar-search-empty {
+  margin: 1rem 1.5rem;
+  color: var(--c-text-light);
+  font-size: 0.95rem;
+}
+</style>

--- a/site/docs/.vuepress/theme/index.js
+++ b/site/docs/.vuepress/theme/index.js
@@ -20,6 +20,10 @@ export function localTheme(options) {
         __dirname,
         "components/NavbarBrand.vue",
       ),
+      "@theme/SidebarItem.vue": path.resolve(
+        __dirname,
+        "components/SidebarItem.vue",
+      ),
     },
   };
 }

--- a/site/docs/.vuepress/theme/index.js
+++ b/site/docs/.vuepress/theme/index.js
@@ -24,6 +24,10 @@ export function localTheme(options) {
         __dirname,
         "components/SidebarItem.vue",
       ),
+      "@theme/SidebarItems.vue": path.resolve(
+        __dirname,
+        "components/SidebarItems.vue",
+      ),
     },
   };
 }


### PR DESCRIPTION
## What changed

- Added a local VuePress `SidebarItem` implementation for collapsible sidebar groups with dedicated expand/collapse controls.
- Added a local `SidebarItems` implementation with a search input above the docs sidebar.
- Preserved parent links while separating text navigation from expand/collapse clicks.
- Kept sibling sidebar text aligned by reserving a consistent tree-control column.
- Filters nested sidebar items while keeping matching parent context visible and force-opening matching branches during search.

## Why

The docs sidebar already configured nested groups such as `命令列表`, `AI 相关`, and `其他特性`, but the rendered sidebar did not expose the nested document tree clearly. After adding the tree controls, ordinary sibling links and collapsible rows had different text start positions because only collapsible rows reserved space for the arrow. The search input makes large command lists easier to navigate without scrolling through every command.

## Impact

Users can now expand/collapse documentation groups from the sidebar and filter sidebar entries by typing a command or document name. Chinese and English docs use localized search placeholder, clear button label, empty state, and expand/collapse aria labels.

## Validation

- Ran `npm run docs:build` successfully; VuePress rendered 150 pages.
- Browser-tested `/doc/commands.html`:
  - `命令列表` defaults expanded and can collapse/expand.
  - `表达式核心变量`, `命令列表`, and `FAQ` align to the same text x-position.
  - Searching `mcp` shows `AI 相关 -> Arthas MCP Server` and opens that branch.
  - Searching `cat` shows `命令列表 -> cat` and opens that branch.
  - Searching a missing value shows `没有匹配结果`.
  - Clearing search restores the full sidebar.

Note: the build still reports the existing Browserslist `caniuse-lite is outdated` warning.