### PR TITLE
[codex] Fix MCP automatic polling timeout

### DIFF
--- a/arthas-mcp-server/src/main/java/com/taobao/arthas/mcp/server/task/ServerTaskToolHandler.java
+++ b/arthas-mcp-server/src/main/java/com/taobao/arthas/mcp/server/task/ServerTaskToolHandler.java
@@ -35,6 +35,8 @@ public class ServerTaskToolHandler extends AbstractTaskHandler<McpSchema.ServerT
 
     private static final Logger logger = LoggerFactory.getLogger(ServerTaskToolHandler.class);
 
+    private static final Duration AUTOMATIC_POLLING_GRACE = Duration.ofSeconds(10);
+
     private final ObjectMapper objectMapper;
     private final TaskManagerOptions taskOptions;
     private final Duration automaticPollingTimeout;
@@ -305,7 +307,7 @@ public class ServerTaskToolHandler extends AbstractTaskHandler<McpSchema.ServerT
                     String taskId = task.getTaskId();
                     String sessionId = extractSessionId(exchange);
 
-                    return pollTaskUntilTerminal(taskId, sessionId, task, taskTool);
+                    return pollTaskUntilTerminal(taskId, sessionId, task, taskTool, request);
                 });
     }
 
@@ -314,15 +316,17 @@ public class ServerTaskToolHandler extends AbstractTaskHandler<McpSchema.ServerT
             String taskId,
             String sessionId,
             McpSchema.Task initialTask,
-            TaskAwareToolSpecification taskTool) {
+            TaskAwareToolSpecification taskTool,
+            McpSchema.CallToolRequest request) {
         
         long pollInterval = initialTask.getPollInterval() != null 
                 ? initialTask.getPollInterval() 
                 : TaskDefaults.DEFAULT_POLL_INTERVAL_MS;
         
-        Duration timeout = this.automaticPollingTimeout != null 
-                ? this.automaticPollingTimeout 
+        Duration defaultTimeout = this.automaticPollingTimeout != null
+                ? this.automaticPollingTimeout
                 : Duration.ofMillis(TaskDefaults.DEFAULT_AUTOMATIC_POLLING_TIMEOUT_MS);
+        Duration timeout = resolveAutomaticPollingTimeout(request, defaultTimeout);
         
         CompletableFuture<List<McpSchema.Task>> watchFuture = taskStore.watchTaskUntilTerminal(
                 taskId, 
@@ -390,6 +394,45 @@ public class ServerTaskToolHandler extends AbstractTaskHandler<McpSchema.ServerT
             }
             throw new java.util.concurrent.CompletionException(cause);
         });
+    }
+
+    Duration resolveAutomaticPollingTimeout(
+            McpSchema.CallToolRequest request,
+            Duration defaultTimeout) {
+        Duration base = defaultTimeout != null
+                ? defaultTimeout
+                : Duration.ofMillis(TaskDefaults.DEFAULT_AUTOMATIC_POLLING_TIMEOUT_MS);
+        try {
+            Long timeoutSeconds = readPositiveLongArgument(request, "timeout");
+            Duration commandTimeout = timeoutSeconds != null
+                    ? Duration.ofSeconds(timeoutSeconds)
+                    : base;
+            Duration derived = commandTimeout.plus(AUTOMATIC_POLLING_GRACE);
+            return base.compareTo(derived) >= 0 ? base : derived;
+        } catch (RuntimeException e) {
+            logger.warn("Failed to resolve automatic polling timeout, fallback to default with grace", e);
+            return base.plus(AUTOMATIC_POLLING_GRACE);
+        }
+    }
+
+    private Long readPositiveLongArgument(McpSchema.CallToolRequest request, String name) {
+        if (request == null || request.getArguments() == null) {
+            return null;
+        }
+        Object value = request.getArguments().get(name);
+        if (value instanceof Number) {
+            long n = ((Number) value).longValue();
+            return n > 0 ? n : null;
+        }
+        if (value instanceof String) {
+            try {
+                long n = Long.parseLong(((String) value).trim());
+                return n > 0 ? n : null;
+            } catch (NumberFormatException ignored) {
+                return null;
+            }
+        }
+        return null;
     }
 
     private String extractSessionId(McpNettyServerExchange exchange) {

--- a/arthas-mcp-server/src/test/java/com/taobao/arthas/mcp/server/task/ServerTaskToolHandlerTest.java
+++ b/arthas-mcp-server/src/test/java/com/taobao/arthas/mcp/server/task/ServerTaskToolHandlerTest.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2024-2024 the original author or authors.
+ */
+
+package com.taobao.arthas.mcp.server.task;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.taobao.arthas.mcp.server.protocol.spec.McpSchema;
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ServerTaskToolHandlerTest {
+
+    @Test
+    void automaticPollingTimeoutShouldAddGraceWhenTimeoutArgumentIsMissing() {
+        ServerTaskToolHandler handler = newHandler(Duration.ofSeconds(30));
+
+        Duration timeout = handler.resolveAutomaticPollingTimeout(
+                new McpSchema.CallToolRequest("watch", null, null),
+                Duration.ofSeconds(30));
+
+        assertThat(timeout).isEqualTo(Duration.ofSeconds(40));
+    }
+
+    @Test
+    void automaticPollingTimeoutShouldCoverLongCommandTimeout() {
+        ServerTaskToolHandler handler = newHandler(Duration.ofSeconds(30));
+
+        Duration timeout = handler.resolveAutomaticPollingTimeout(
+                requestWithTimeout(45),
+                Duration.ofSeconds(30));
+
+        assertThat(timeout).isEqualTo(Duration.ofSeconds(55));
+    }
+
+    @Test
+    void automaticPollingTimeoutShouldNotShrinkBelowDefault() {
+        ServerTaskToolHandler handler = newHandler(Duration.ofSeconds(30));
+
+        Duration timeout = handler.resolveAutomaticPollingTimeout(
+                requestWithTimeout(5),
+                Duration.ofSeconds(30));
+
+        assertThat(timeout).isEqualTo(Duration.ofSeconds(30));
+    }
+
+    @Test
+    void automaticPollingTimeoutShouldParseNumericStringTimeout() {
+        ServerTaskToolHandler handler = newHandler(Duration.ofSeconds(30));
+
+        Duration timeout = handler.resolveAutomaticPollingTimeout(
+                requestWithTimeout("45"),
+                Duration.ofSeconds(30));
+
+        assertThat(timeout).isEqualTo(Duration.ofSeconds(55));
+    }
+
+    @Test
+    void automaticPollingTimeoutShouldFallbackWithGraceForInvalidTimeoutArguments() {
+        ServerTaskToolHandler handler = newHandler(Duration.ofSeconds(30));
+        Object[] invalidValues = new Object[] { "bad", "0", "-1", 0, -1, new Object() };
+
+        for (Object invalidValue : invalidValues) {
+            Duration timeout = handler.resolveAutomaticPollingTimeout(
+                    requestWithTimeout(invalidValue),
+                    Duration.ofSeconds(30));
+
+            assertThat(timeout).isEqualTo(Duration.ofSeconds(40));
+        }
+    }
+
+    @Test
+    void automaticPollingTimeoutShouldFallbackToTaskDefaultWhenDefaultIsNull() {
+        ServerTaskToolHandler handler = newHandler(null);
+
+        Duration timeout = handler.resolveAutomaticPollingTimeout(
+                new McpSchema.CallToolRequest("watch", null, null),
+                null);
+
+        assertThat(timeout).isEqualTo(Duration.ofMillis(TaskDefaults.DEFAULT_AUTOMATIC_POLLING_TIMEOUT_MS)
+                .plus(Duration.ofSeconds(10)));
+    }
+
+    private static ServerTaskToolHandler newHandler(Duration automaticPollingTimeout) {
+        return new ServerTaskToolHandler(
+                Collections.emptyList(),
+                null,
+                new ObjectMapper(),
+                (method, payload) -> CompletableFuture.completedFuture(null),
+                automaticPollingTimeout,
+                null);
+    }
+
+    private static McpSchema.CallToolRequest requestWithTimeout(Object timeout) {
+        Map<String, Object> arguments = new HashMap<String, Object>();
+        arguments.put("timeout", timeout);
+        return new McpSchema.CallToolRequest("watch", arguments, null);
+    }
+}

--- a/site/docs/.vuepress/theme/components/SidebarItem.vue
+++ b/site/docs/.vuepress/theme/components/SidebarItem.vue
@@ -47,7 +47,7 @@ function isActiveSidebarItem(sidebarItem, currentRoute) {
 
   if (sidebarItem.children) {
     return sidebarItem.children.some((child) =>
-      isActiveSidebarItem(child, currentRoute)
+      isActiveSidebarItem(child, currentRoute),
     );
   }
 
@@ -58,10 +58,10 @@ const hasChildren = computed(() => Boolean(item.value.children?.length));
 const usesTreeRow = computed(() => Boolean(item.value.link) && depth.value > 0);
 const isActive = computed(() => isActiveSidebarItem(item.value, route));
 const isCollapsible = computed(
-  () => Boolean(item.value.collapsible) && hasChildren.value
+  () => Boolean(item.value.collapsible) && hasChildren.value,
 );
 const isOpenDefault = computed(() =>
-  isCollapsible.value ? forceOpen.value || isActive.value : true
+  isCollapsible.value ? forceOpen.value || isActive.value : true,
 );
 const isOpen = ref(isOpenDefault.value);
 
@@ -181,7 +181,9 @@ onBeforeUnmount(() => {
   margin: 0.125rem 0.75rem;
   border-left: 0.25rem solid transparent;
   border-radius: 6px;
-  transition: background-color var(--t-color), border-color var(--t-color);
+  transition:
+    background-color var(--t-color),
+    border-color var(--t-color);
 
   &.active,
   &:hover {

--- a/site/docs/.vuepress/theme/components/SidebarItems.vue
+++ b/site/docs/.vuepress/theme/components/SidebarItems.vue
@@ -14,10 +14,10 @@ const normalizedQuery = computed(() => normalizeText(searchQuery.value.trim()));
 const isSearchActive = computed(() => normalizedQuery.value.length > 0);
 const searchPlaceholder = computed(() => (isEnglish.value ? "Search" : "搜索"));
 const clearSearchLabel = computed(() =>
-  isEnglish.value ? "Clear search" : "清除搜索"
+  isEnglish.value ? "Clear search" : "清除搜索",
 );
 const noResultsText = computed(() =>
-  isEnglish.value ? "No matches" : "没有匹配结果"
+  isEnglish.value ? "No matches" : "没有匹配结果",
 );
 
 function normalizeText(value) {
@@ -26,7 +26,7 @@ function normalizeText(value) {
 
 function sidebarItemMatches(item, query) {
   return [item.text, item.link].some((value) =>
-    normalizeText(value).includes(query)
+    normalizeText(value).includes(query),
   );
 }
 
@@ -67,7 +67,7 @@ onMounted(() => {
       if (!sidebar) return;
 
       const activeSidebarItem = document.querySelector(
-        `.sidebar a.sidebar-item[href="${route.path}${hash}"]`
+        `.sidebar a.sidebar-item[href="${route.path}${hash}"]`,
       );
       if (!activeSidebarItem) return;
 
@@ -84,7 +84,7 @@ onMounted(() => {
       ) {
         activeSidebarItem.scrollIntoView(false);
       }
-    }
+    },
   );
 });
 </script>


### PR DESCRIPTION
## Summary

- derive normal `tools/call` automatic task polling timeout from positive `arguments.timeout` plus a 10s grace window
- preserve the configured automatic polling timeout as the minimum wait
- add focused unit coverage for missing, long, short, string, invalid, and null-default timeout cases

## Root Cause

Task-aware streamable tools called through normal `tools/call` create a task and wait for it to reach a terminal state. That compatibility path used the fixed 30s automatic polling timeout, so calls like `watch` with `timeout=45` could return `Task timed out waiting for completion` before the command-level timeout produced its structured result.

## Validation

- `./mvnw -pl arthas-mcp-server -Dtest=ServerTaskToolHandlerTest test`
- `./mvnw -pl arthas-mcp-server test`
- `git diff --check`
- `./mvnw -pl arthas-mcp-integration-test -am -Dtest=com.taobao.arthas.mcp.it.ArthasMcpJavaSdkIT,com.taobao.arthas.mcp.it.task.ArthasMcpTasksIT -Dsurefire.failIfNoSpecifiedTests=false verify`