### PR TITLE
[codex] Add external command loading docs

### DIFF
--- a/site/docs/.vuepress/configs/sidebar/en.js
+++ b/site/docs/.vuepress/configs/sidebar/en.js
@@ -82,6 +82,7 @@ export const sidebarEN = {
             "/en/doc/arthas-properties.html",
             "/en/doc/agent.html",
             "/en/doc/spring-boot-starter.md",
+            "/en/doc/external-command.md",
             "/en/doc/http-api.md",
             "/en/doc/batch-support.md",
           ],

--- a/site/docs/.vuepress/configs/sidebar/zh.js
+++ b/site/docs/.vuepress/configs/sidebar/zh.js
@@ -82,6 +82,7 @@ export const sidebarZH = {
             "/doc/arthas-properties.html",
             "/doc/agent.html",
             "/doc/spring-boot-starter.md",
+            "/doc/external-command.md",
             "/doc/http-api.md",
             "/doc/batch-support.md",
           ],

--- a/site/docs/doc/advanced-use.md
+++ b/site/docs/doc/advanced-use.md
@@ -57,6 +57,12 @@ Arthas 支持配置项参考。
 
 - [Arthas Spring Boot Starter](spring-boot-starter.md)
 
+## 加载外部命令
+
+在 Arthas 启动时加载外部 command jar，把团队内部诊断动作扩展为新的 Arthas 命令。
+
+- [加载外部命令](external-command.md)
+
 ## HTTP API
 
 Http API 提供结构化的数据，支持更复杂的交互功能，方便自定义界面集成 arthas。

--- a/site/docs/doc/arthas-properties.md
+++ b/site/docs/doc/arthas-properties.md
@@ -68,6 +68,8 @@ arthas.commandLocations=/opt/arthas/ext-command.jar,/opt/arthas/ext-commands
 
 也可以在命令行配置： `--command-locations '/opt/arthas/ext-command.jar,/opt/arthas/ext-commands'` 。
 
+完整的外部命令开发和加载示例请参考：[加载外部命令](external-command.md)。
+
 ## 配置的优先级
 
 配置的优先级是：命令行参数 > System Env > System Properties > arthas.properties 。

--- a/site/docs/doc/commands.md
+++ b/site/docs/doc/commands.md
@@ -54,6 +54,10 @@
 
 - [options](options.md) - 查看或设置 Arthas 全局开关
 
+## 扩展命令
+
+- [加载外部命令](external-command.md) - 启动时从外部 jar 加载自定义 Arthas 命令
+
 ## 管道
 
 Arthas 支持使用管道对上述命令的结果进行进一步的处理，如`sm java.lang.String * | grep 'index'`

--- a/site/docs/doc/external-command.md
+++ b/site/docs/doc/external-command.md
@@ -1,0 +1,194 @@
+# 加载外部命令
+
+Arthas 支持在启动时加载外部 command jar，用于把团队内部常用的诊断动作封装成新的 Arthas 命令。外部命令加载后可以像内置命令一样通过 `help` 查看和执行。
+
+::: tip
+外部命令只在 Arthas 服务端启动时加载。Arthas 已经 attach 到目标 JVM 后，再把 jar 放到目录里不会自动生效，需要重新启动 Arthas 服务端。
+:::
+
+## 加载方式
+
+### 通过命令行指定
+
+`arthas-boot.jar` 支持 `--command-locations` 参数，参数值可以是 jar 文件路径，也可以是目录路径，多个路径用英文逗号分隔：
+
+```bash
+java -jar arthas-boot.jar --command-locations '/opt/arthas/ext-command.jar,/opt/arthas/ext-commands' <pid>
+```
+
+如果使用完整包里的 `as.sh`，也可以传入相同参数：
+
+```bash
+./as.sh --command-locations '/opt/arthas/ext-command.jar,/opt/arthas/ext-commands' <pid>
+```
+
+### 通过 arthas.properties 指定
+
+在 `arthas.properties` 中配置：
+
+```properties
+arthas.commandLocations=/opt/arthas/ext-command.jar,/opt/arthas/ext-commands
+```
+
+如果通过 `arthas-spring-boot-starter` 启动，Spring Boot 配置文件中推荐使用 `arthas.command-locations`：
+
+```properties
+arthas.command-locations=/opt/arthas/ext-command.jar,/opt/arthas/ext-commands
+```
+
+### 默认 commands 目录
+
+如果 `${arthas.home}/commands` 目录存在，Arthas 启动时也会自动加载该目录下的 `*.jar`：
+
+```bash
+mkdir -p ${arthas.home}/commands
+cp arthas-demo-external-command.jar ${arthas.home}/commands/
+```
+
+显式配置的 `arthas.commandLocations` 会先加载，随后再加载默认的 `${arthas.home}/commands` 目录。
+
+## 目录扫描规则
+
+- 单个路径可以指向 jar 文件，也可以指向目录。
+- 目录只扫描当前目录下的 `*.jar`，不会递归扫描子目录。
+- 同一个 jar 路径会按规范化后的绝对路径去重。
+- 如果外部命令依赖第三方 jar，可以把依赖打包进命令 jar，或把依赖 jar 一起放到被扫描的目录中。
+
+## 编写外部命令
+
+外部命令 jar 通过 Java SPI 暴露 `CommandResolver`。一个最小命令通常包含三个部分：
+
+1. 实现一个命令类，继承 `AnnotatedCommand`。
+2. 实现 `CommandResolver`，返回命令列表。
+3. 在 `META-INF/services/com.taobao.arthas.core.shell.command.CommandResolver` 中写入 `CommandResolver` 实现类名。
+
+示例命令：
+
+```java
+package demo.command;
+
+import com.taobao.arthas.core.shell.command.AnnotatedCommand;
+import com.taobao.arthas.core.shell.command.CommandProcess;
+import com.taobao.middleware.cli.annotations.Argument;
+import com.taobao.middleware.cli.annotations.Description;
+import com.taobao.middleware.cli.annotations.Name;
+import com.taobao.middleware.cli.annotations.Summary;
+
+@Name("demo-external")
+@Summary("Demo external command loaded from arthas.home/commands")
+@Description("Examples:\n"
+        + "  demo-external\n"
+        + "  demo-external Codex\n")
+public class DemoExternalCommand extends AnnotatedCommand {
+
+    private String message;
+
+    @Argument(index = 0, argName = "message", required = false)
+    @Description("message printed by the demo external command")
+    public void setMessage(String message) {
+        this.message = message;
+    }
+
+    @Override
+    public void process(CommandProcess process) {
+        String value = message;
+        if (value == null || value.trim().isEmpty()) {
+            value = "hello";
+        }
+        process.write("demo external command loaded: " + value + "\n");
+        process.end();
+    }
+}
+```
+
+示例 `CommandResolver`：
+
+```java
+package demo.command;
+
+import java.util.Collections;
+import java.util.List;
+
+import com.taobao.arthas.core.shell.command.Command;
+import com.taobao.arthas.core.shell.command.CommandResolver;
+
+public class DemoExternalCommandResolver implements CommandResolver {
+
+    @Override
+    public List<Command> commands() {
+        return Collections.singletonList(Command.create(DemoExternalCommand.class));
+    }
+}
+```
+
+SPI 文件路径：
+
+```text
+src/main/resources/META-INF/services/com.taobao.arthas.core.shell.command.CommandResolver
+```
+
+SPI 文件内容：
+
+```text
+demo.command.DemoExternalCommandResolver
+```
+
+## Maven 依赖
+
+外部命令需要依赖 Arthas 的命令接口和 CLI 注解。建议将这些依赖声明为 `provided`，避免把 Arthas 自身类重复打包进外部命令 jar：
+
+```xml
+<dependencies>
+    <dependency>
+        <groupId>com.taobao.arthas</groupId>
+        <artifactId>arthas-core</artifactId>
+        <version>${arthas.version}</version>
+        <scope>provided</scope>
+    </dependency>
+    <dependency>
+        <groupId>com.alibaba.middleware</groupId>
+        <artifactId>cli</artifactId>
+        <scope>provided</scope>
+    </dependency>
+</dependencies>
+```
+
+Arthas 仓库中提供了完整示例：[arthas-demo-external-command](https://github.com/alibaba/arthas/tree/master/arthas-demo-external-command)。
+
+## 构建和验证
+
+以示例模块为例，构建命令 jar：
+
+```bash
+./mvnw -pl arthas-demo-external-command -DskipTests package
+```
+
+将生成的 jar 放到 `${arthas.home}/commands/` 后启动 Arthas：
+
+```bash
+mkdir -p ${arthas.home}/commands
+cp arthas-demo-external-command/target/arthas-demo-external-command-*.jar ${arthas.home}/commands/
+java -jar arthas-boot.jar <pid>
+```
+
+进入 Arthas 后执行：
+
+```bash
+help demo-external
+demo-external Codex
+```
+
+预期可以看到类似输出：
+
+```text
+demo external command loaded: Codex
+```
+
+## 加载行为和冲突处理
+
+Arthas 启动时会把外部 command jar 加入 Arthas ClassLoader，然后通过 `ServiceLoader<CommandResolver>` 发现命令。命令注册时遵循下面规则：
+
+- 外部命令不能覆盖 Arthas 内置命令；如果和内置命令重名，外部命令会被跳过并记录日志。
+- 多个外部命令重名时，只保留第一个命令，后续重名命令会被跳过并记录日志。
+- `CommandResolver` 加载失败不会中断其他 resolver 的加载，错误会写入 Arthas 日志。
+- 如果没有发现有效的外部命令，Arthas 会继续按正常流程启动。

--- a/site/docs/en/doc/advanced-use.md
+++ b/site/docs/en/doc/advanced-use.md
@@ -57,6 +57,12 @@ Starting with the application.
 
 - [Arthas Spring Boot Starter](spring-boot-starter.md)
 
+## Load External Commands
+
+Load external command jars when Arthas starts and extend team-specific diagnostic actions as Arthas commands.
+
+- [Load External Commands](external-command.md)
+
 ## HTTP API
 
 The Http API provides structured data and supports more complex interactive functions, making it easier to integrate Arthas into custom interfaces.

--- a/site/docs/en/doc/arthas-properties.md
+++ b/site/docs/en/doc/arthas-properties.md
@@ -69,6 +69,8 @@ arthas.commandLocations=/opt/arthas/ext-command.jar,/opt/arthas/ext-commands
 It can also be configured on the command line:
 `--command-locations '/opt/arthas/ext-command.jar,/opt/arthas/ext-commands'`.
 
+For a complete external command development and loading example, see [Load External Commands](external-command.md).
+
 ## Configured order
 
 The order of configuration is: command line parameters > System Env > System Properties > arthas.properties.

--- a/site/docs/en/doc/commands.md
+++ b/site/docs/en/doc/commands.md
@@ -54,6 +54,10 @@
 
 - [options](options.md) - check/set Arthas global optionss
 
+## Extension commands
+
+- [Load external commands](external-command.md) - load custom Arthas commands from external jars at startup
+
 ## pipe
 
 Arthas provides `pipe` to process the result returned from commands further, e.g. `sm java.lang.String * | grep 'index'`. Commands supported in `pipe`:

--- a/site/docs/en/doc/external-command.md
+++ b/site/docs/en/doc/external-command.md
@@ -1,0 +1,194 @@
+# Load External Commands
+
+Arthas can load external command jars at startup. This is useful when you want to package team-specific diagnostic actions as Arthas commands. After an external command is loaded, you can use it like a built-in command and inspect it with `help`.
+
+::: tip
+External commands are loaded only when the Arthas server starts. If Arthas has already attached to the target JVM, copying a jar into the command directory will not take effect until the Arthas server is restarted.
+:::
+
+## Loading methods
+
+### Command line
+
+`arthas-boot.jar` supports the `--command-locations` option. Each entry can be a jar file path or a directory path, separated by commas:
+
+```bash
+java -jar arthas-boot.jar --command-locations '/opt/arthas/ext-command.jar,/opt/arthas/ext-commands' <pid>
+```
+
+If you use `as.sh` from the full distribution, you can pass the same option:
+
+```bash
+./as.sh --command-locations '/opt/arthas/ext-command.jar,/opt/arthas/ext-commands' <pid>
+```
+
+### arthas.properties
+
+Configure `arthas.commandLocations` in `arthas.properties`:
+
+```properties
+arthas.commandLocations=/opt/arthas/ext-command.jar,/opt/arthas/ext-commands
+```
+
+If you start Arthas through `arthas-spring-boot-starter`, use `arthas.command-locations` in Spring Boot configuration files:
+
+```properties
+arthas.command-locations=/opt/arthas/ext-command.jar,/opt/arthas/ext-commands
+```
+
+### Default commands directory
+
+If `${arthas.home}/commands` exists, Arthas also loads `*.jar` from that directory at startup:
+
+```bash
+mkdir -p ${arthas.home}/commands
+cp arthas-demo-external-command.jar ${arthas.home}/commands/
+```
+
+Explicit `arthas.commandLocations` are loaded first, followed by the default `${arthas.home}/commands` directory.
+
+## Directory scanning rules
+
+- Each location can point to a jar file or a directory.
+- Directory entries scan only `*.jar` files in the current directory. Subdirectories are not scanned recursively.
+- The same jar path is deduplicated by its canonical absolute path.
+- If an external command depends on third-party jars, package the dependencies into the command jar, or put those dependency jars in a scanned directory.
+
+## Writing an external command
+
+External command jars expose `CommandResolver` implementations through Java SPI. A minimal command usually has three parts:
+
+1. A command class that extends `AnnotatedCommand`.
+2. A `CommandResolver` implementation that returns the command list.
+3. A `META-INF/services/com.taobao.arthas.core.shell.command.CommandResolver` file that contains the resolver class name.
+
+Example command:
+
+```java
+package demo.command;
+
+import com.taobao.arthas.core.shell.command.AnnotatedCommand;
+import com.taobao.arthas.core.shell.command.CommandProcess;
+import com.taobao.middleware.cli.annotations.Argument;
+import com.taobao.middleware.cli.annotations.Description;
+import com.taobao.middleware.cli.annotations.Name;
+import com.taobao.middleware.cli.annotations.Summary;
+
+@Name("demo-external")
+@Summary("Demo external command loaded from arthas.home/commands")
+@Description("Examples:\n"
+        + "  demo-external\n"
+        + "  demo-external Codex\n")
+public class DemoExternalCommand extends AnnotatedCommand {
+
+    private String message;
+
+    @Argument(index = 0, argName = "message", required = false)
+    @Description("message printed by the demo external command")
+    public void setMessage(String message) {
+        this.message = message;
+    }
+
+    @Override
+    public void process(CommandProcess process) {
+        String value = message;
+        if (value == null || value.trim().isEmpty()) {
+            value = "hello";
+        }
+        process.write("demo external command loaded: " + value + "\n");
+        process.end();
+    }
+}
+```
+
+Example `CommandResolver`:
+
+```java
+package demo.command;
+
+import java.util.Collections;
+import java.util.List;
+
+import com.taobao.arthas.core.shell.command.Command;
+import com.taobao.arthas.core.shell.command.CommandResolver;
+
+public class DemoExternalCommandResolver implements CommandResolver {
+
+    @Override
+    public List<Command> commands() {
+        return Collections.singletonList(Command.create(DemoExternalCommand.class));
+    }
+}
+```
+
+SPI file path:
+
+```text
+src/main/resources/META-INF/services/com.taobao.arthas.core.shell.command.CommandResolver
+```
+
+SPI file content:
+
+```text
+demo.command.DemoExternalCommandResolver
+```
+
+## Maven dependencies
+
+External commands depend on Arthas command interfaces and CLI annotations. These dependencies should usually use `provided` scope to avoid packaging Arthas classes into the external command jar:
+
+```xml
+<dependencies>
+    <dependency>
+        <groupId>com.taobao.arthas</groupId>
+        <artifactId>arthas-core</artifactId>
+        <version>${arthas.version}</version>
+        <scope>provided</scope>
+    </dependency>
+    <dependency>
+        <groupId>com.alibaba.middleware</groupId>
+        <artifactId>cli</artifactId>
+        <scope>provided</scope>
+    </dependency>
+</dependencies>
+```
+
+The Arthas repository provides a complete example: [arthas-demo-external-command](https://github.com/alibaba/arthas/tree/master/arthas-demo-external-command).
+
+## Build and verify
+
+Use the demo module as an example:
+
+```bash
+./mvnw -pl arthas-demo-external-command -DskipTests package
+```
+
+Copy the generated jar to `${arthas.home}/commands/` and start Arthas:
+
+```bash
+mkdir -p ${arthas.home}/commands
+cp arthas-demo-external-command/target/arthas-demo-external-command-*.jar ${arthas.home}/commands/
+java -jar arthas-boot.jar <pid>
+```
+
+Run the command in Arthas:
+
+```bash
+help demo-external
+demo-external Codex
+```
+
+Expected output:
+
+```text
+demo external command loaded: Codex
+```
+
+## Loading behavior and conflicts
+
+At startup, Arthas appends external command jars to the Arthas ClassLoader and discovers commands with `ServiceLoader<CommandResolver>`. Command registration follows these rules:
+
+- External commands cannot override built-in commands. If an external command has the same name as a built-in command, it is skipped and a log is written.
+- If multiple external commands have the same name, only the first command is kept. Later duplicates are skipped and logged.
+- A broken `CommandResolver` does not stop other resolvers from loading. The error is written to the Arthas log.
+- If no valid external command is found, Arthas continues to start normally.


### PR DESCRIPTION
## Summary

- Add Chinese and English docs for loading external Arthas command jars.
- Document command loading entry points: `--command-locations`, `arthas.commandLocations`, Spring Boot relaxed binding, and `${arthas.home}/commands`.
- Link the new docs from sidebars, command indexes, advanced-use pages, and Arthas properties docs.

## Validation

- `npm run --prefix site docs:build`
- `./mvnw -pl core -Dtest=ArthasBootstrapCommandTest test`
- `git diff --cached --check`