### PR TITLE
[codex] Fix advice listener snapshot registration

### DIFF
--- a/core/src/main/java/com/taobao/arthas/core/advisor/AdviceListenerManager.java
+++ b/core/src/main/java/com/taobao/arthas/core/advisor/AdviceListenerManager.java
@@ -116,15 +116,7 @@ public class AdviceListenerManager {
             synchronized (this) {
                 className = className.replace('/', '.');
                 String key = key(className, methodName, methodDesc);
-
-                List<AdviceListener> listeners = map.get(key);
-                if (listeners == null) {
-                    listeners = new ArrayList<AdviceListener>();
-                    map.put(key, listeners);
-                }
-                if (!listeners.contains(listener)) {
-                    listeners.add(listener);
-                }
+                registerListener(key, listener);
             }
         }
 
@@ -142,16 +134,21 @@ public class AdviceListenerManager {
             synchronized (this) {
                 className = className.replace('/', '.');
                 String key = keyForTrace(className, owner, methodName, methodDesc);
-
-                List<AdviceListener> listeners = map.get(key);
-                if (listeners == null) {
-                    listeners = new ArrayList<AdviceListener>();
-                    map.put(key, listeners);
-                }
-                if (!listeners.contains(listener)) {
-                    listeners.add(listener);
-                }
+                registerListener(key, listener);
             }
+        }
+
+        private void registerListener(String key, AdviceListener listener) {
+            List<AdviceListener> listeners = map.get(key);
+            if (listeners != null && listeners.contains(listener)) {
+                return;
+            }
+
+            List<AdviceListener> newListeners = listeners == null
+                    ? new ArrayList<AdviceListener>()
+                    : new ArrayList<AdviceListener>(listeners);
+            newListeners.add(listener);
+            map.put(key, newListeners);
         }
 
         public List<AdviceListener> queryTraceAdviceListeners(String className, String owner, String methodName,

--- a/core/src/test/java/com/taobao/arthas/core/advisor/AdviceListenerManagerTest.java
+++ b/core/src/test/java/com/taobao/arthas/core/advisor/AdviceListenerManagerTest.java
@@ -1,0 +1,105 @@
+package com.taobao.arthas.core.advisor;
+
+import java.util.Iterator;
+import java.util.List;
+
+import org.assertj.core.api.Assertions;
+import org.junit.Test;
+
+public class AdviceListenerManagerTest {
+
+    @Test
+    public void queryAdviceListenersShouldReturnStableSnapshotWhenRegisteringAnotherListener() {
+        AdviceListenerManager.ClassLoaderAdviceListenerManager manager =
+                new AdviceListenerManager.ClassLoaderAdviceListenerManager();
+        TestAdviceListener first = new TestAdviceListener(1);
+        TestAdviceListener second = new TestAdviceListener(2);
+
+        manager.registerAdviceListener("demo.MathGame", "primeFactors", "(I)Ljava/util/List;", first);
+
+        List<AdviceListener> listeners = manager.queryAdviceListeners("demo.MathGame", "primeFactors",
+                "(I)Ljava/util/List;");
+        Iterator<AdviceListener> iterator = listeners.iterator();
+        Assertions.assertThat(iterator.next()).isSameAs(first);
+
+        manager.registerAdviceListener("demo.MathGame", "primeFactors", "(I)Ljava/util/List;", second);
+
+        Assertions.assertThatCode(new org.assertj.core.api.ThrowableAssert.ThrowingCallable() {
+            @Override
+            public void call() {
+                while (iterator.hasNext()) {
+                    iterator.next();
+                }
+            }
+        }).doesNotThrowAnyException();
+        Assertions.assertThat(listeners).containsExactly(first);
+        Assertions.assertThat(manager.queryAdviceListeners("demo.MathGame", "primeFactors", "(I)Ljava/util/List;"))
+                .containsExactly(first, second);
+    }
+
+    @Test
+    public void queryTraceAdviceListenersShouldReturnStableSnapshotWhenRegisteringAnotherListener() {
+        AdviceListenerManager.ClassLoaderAdviceListenerManager manager =
+                new AdviceListenerManager.ClassLoaderAdviceListenerManager();
+        TestAdviceListener first = new TestAdviceListener(1);
+        TestAdviceListener second = new TestAdviceListener(2);
+
+        manager.registerTraceAdviceListener("demo.MathGame", "java/lang/StringBuilder", "append",
+                "(I)Ljava/lang/StringBuilder;", first);
+
+        List<AdviceListener> listeners = manager.queryTraceAdviceListeners("demo.MathGame", "java/lang/StringBuilder",
+                "append", "(I)Ljava/lang/StringBuilder;");
+        Iterator<AdviceListener> iterator = listeners.iterator();
+        Assertions.assertThat(iterator.next()).isSameAs(first);
+
+        manager.registerTraceAdviceListener("demo.MathGame", "java/lang/StringBuilder", "append",
+                "(I)Ljava/lang/StringBuilder;", second);
+
+        Assertions.assertThatCode(new org.assertj.core.api.ThrowableAssert.ThrowingCallable() {
+            @Override
+            public void call() {
+                while (iterator.hasNext()) {
+                    iterator.next();
+                }
+            }
+        }).doesNotThrowAnyException();
+        Assertions.assertThat(listeners).containsExactly(first);
+        Assertions.assertThat(manager.queryTraceAdviceListeners("demo.MathGame", "java/lang/StringBuilder", "append",
+                "(I)Ljava/lang/StringBuilder;")).containsExactly(first, second);
+    }
+
+    private static class TestAdviceListener implements AdviceListener {
+        private final long id;
+
+        private TestAdviceListener(long id) {
+            this.id = id;
+        }
+
+        @Override
+        public long id() {
+            return id;
+        }
+
+        @Override
+        public void create() {
+        }
+
+        @Override
+        public void destroy() {
+        }
+
+        @Override
+        public void before(Class<?> clazz, String methodName, String methodDesc, Object target, Object[] args) {
+        }
+
+        @Override
+        public void afterReturning(Class<?> clazz, String methodName, String methodDesc, Object target, Object[] args,
+                Object returnObject) {
+        }
+
+        @Override
+        public void afterThrowing(Class<?> clazz, String methodName, String methodDesc, Object target, Object[] args,
+                Throwable throwable) {
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- change advice listener registration to publish a new listener-list snapshot instead of mutating the queried list in place
- cover both normal advice listener and trace advice listener registration paths
- prevent callback iteration from seeing `ConcurrentModificationException` when another client registers a listener for the same point

## Root Cause

`AdviceListenerManager` returned the internal `ArrayList` from query methods, while registration appended new listeners to the same list instance. A callback thread iterating that list could race with another client registering a listener and hit `ConcurrentModificationException`.

## Tests

- RED before fix: `./mvnw -pl core -Dtest=AdviceListenerManagerTest test` failed with `ConcurrentModificationException`
- PASS: `./mvnw -pl core -Dtest=AdviceListenerManagerTest test`
- PASS: `./mvnw -pl core -Dtest=AdviceListenerManagerTest,SpyImplTest test`
- PASS: `./mvnw -pl core test`
- PASS: `git diff --check`