### PR TITLE
[codex] Add Arthas MCP version tool

### DIFF
--- a/arthas-mcp-integration-test/src/test/java/com/taobao/arthas/mcp/it/ArthasMcpJavaSdkIT.java
+++ b/arthas-mcp-integration-test/src/test/java/com/taobao/arthas/mcp/it/ArthasMcpJavaSdkIT.java
@@ -80,6 +80,7 @@ class ArthasMcpJavaSdkIT {
             "thread",
             "trace",
             "tt",
+            "version",
             "vmoption",
             "vmtool",
             "viewfile",
@@ -228,7 +229,8 @@ class ArthasMcpJavaSdkIT {
                 || "options".equals(toolName)
                 || "vmoption".equals(toolName)
                 || "classloader".equals(toolName)
-                || "perfcounter".equals(toolName)) {
+                || "perfcounter".equals(toolName)
+                || "version".equals(toolName)) {
             return args;
         }
 

--- a/arthas-mcp-integration-test/src/test/java/com/taobao/arthas/mcp/it/ArthasMcpToolsIT.java
+++ b/arthas-mcp-integration-test/src/test/java/com/taobao/arthas/mcp/it/ArthasMcpToolsIT.java
@@ -1,5 +1,6 @@
 package com.taobao.arthas.mcp.it;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.taobao.arthas.mcp.server.protocol.spec.HttpHeaders;
 import com.taobao.arthas.mcp.server.protocol.spec.McpSchema;
@@ -73,7 +74,7 @@ class ArthasMcpToolsIT {
             for (McpSchema.Tool tool : toolsResult.getTools()) {
                 toolNames.add(tool.getName());
             }
-            assertThat(toolNames).contains("jvm", "jad", "thread");
+            assertThat(toolNames).contains("jvm", "jad", "thread", "version");
             assertThat(toolNames).contains("watch", "tt");
 
             McpSchema.Tool watchTool = toolsResult.getTools().stream()
@@ -102,6 +103,16 @@ class ArthasMcpToolsIT {
             assertThat(callToolResult).isNotNull();
             assertThat(callToolResult.getIsError()).isNotEqualTo(Boolean.TRUE);
             assertThat(callToolResult.getContent()).isNotNull().isNotEmpty();
+
+            McpSchema.CallToolResult versionResult = client.callTool(sessionId, "version", Collections.emptyMap());
+            assertThat(versionResult).isNotNull();
+            assertThat(versionResult.getIsError()).isNotEqualTo(Boolean.TRUE);
+            String versionText = extractTextContent(versionResult);
+            JsonNode versionBody = OBJECT_MAPPER.readTree(versionText);
+            assertThat(versionBody.path("success").asBoolean()).isTrue();
+            JsonNode versionNode = findResultByType(versionBody.path("results"), "version");
+            assertThat(versionNode).isNotNull();
+            assertThat(versionNode.path("version").asText()).isNotBlank();
         } finally {
             if (targetJvm != null) {
                 targetJvm.destroy();
@@ -113,6 +124,30 @@ class ArthasMcpToolsIT {
                 deleteDirectoryQuietly(tempHome);
             }
         }
+    }
+
+    private static String extractTextContent(McpSchema.CallToolResult result) {
+        for (McpSchema.Content content : result.getContent()) {
+            if (content instanceof McpSchema.TextContent) {
+                String text = ((McpSchema.TextContent) content).getText();
+                if (text != null && !text.trim().isEmpty()) {
+                    return text;
+                }
+            }
+        }
+        throw new IllegalStateException("tool 返回内容中没有文本结果: " + result.getContent());
+    }
+
+    private static JsonNode findResultByType(JsonNode results, String type) {
+        if (results == null || !results.isArray()) {
+            return null;
+        }
+        for (JsonNode result : results) {
+            if (type.equals(result.path("type").asText())) {
+                return result;
+            }
+        }
+        return null;
     }
 
     private static String retry(Duration timeout, IoSupplier<String> supplier) throws Exception {

--- a/core/src/main/java/com/taobao/arthas/core/mcp/tool/function/basic1000/VersionTool.java
+++ b/core/src/main/java/com/taobao/arthas/core/mcp/tool/function/basic1000/VersionTool.java
@@ -1,0 +1,19 @@
+package com.taobao.arthas.core.mcp.tool.function.basic1000;
+
+import com.taobao.arthas.core.mcp.tool.function.AbstractArthasTool;
+import com.taobao.arthas.mcp.server.tool.ToolContext;
+import com.taobao.arthas.mcp.server.tool.annotation.Tool;
+
+/**
+ * Version MCP Tool: 查看当前 JVM 内运行的 Arthas 版本。
+ */
+public class VersionTool extends AbstractArthasTool {
+
+    @Tool(
+            name = "version",
+            description = "Version 诊断工具: 查看当前 JVM 内运行的 Arthas 版本，对应 Arthas 的 version 命令。"
+    )
+    public String version(ToolContext toolContext) {
+        return executeSync(toolContext, "version");
+    }
+}


### PR DESCRIPTION
## Summary

Add a new Arthas MCP `version` tool that wraps the existing Arthas `version` command so MCP clients can query the Arthas version running inside the target JVM.

## Changes

- Added `VersionTool` under the existing MCP basic tool package.
- Extended `ArthasMcpToolsIT` to verify `version` appears in `tools/list` and returns a nonblank `version` result through `tools/call`.

## Validation

- `./mvnw -pl core -am -DskipTests compile`
- `./mvnw -pl packaging -am -DskipTests package`
- `./mvnw -pl arthas-mcp-integration-test -Dtest=ArthasMcpToolsIT test`