### PR TITLE
fix: snapshot watch results before rendering

### DIFF
--- a/arthas-model/src/main/java/com/taobao/arthas/core/command/model/ObjectVO.java
+++ b/arthas-model/src/main/java/com/taobao/arthas/core/command/model/ObjectVO.java
@@ -12,6 +12,7 @@ package com.taobao.arthas.core.command.model;
 public class ObjectVO {
     private Object object;
     private Integer expand;
+    private String renderedValue;
 
     public ObjectVO(Object object, Integer expand) {
         this.object = object;
@@ -54,5 +55,13 @@ public class ObjectVO {
 
     public void setExpand(Integer expand) {
         this.expand = expand;
+    }
+
+    public String getRenderedValue() {
+        return renderedValue;
+    }
+
+    public void setRenderedValue(String renderedValue) {
+        this.renderedValue = renderedValue;
     }
 }

--- a/core/src/main/java/com/taobao/arthas/core/command/monitor200/WatchAdviceListener.java
+++ b/core/src/main/java/com/taobao/arthas/core/command/monitor200/WatchAdviceListener.java
@@ -10,7 +10,9 @@ import com.taobao.arthas.core.command.model.ObjectVO;
 import com.taobao.arthas.core.command.model.WatchModel;
 import com.taobao.arthas.core.shell.command.CommandProcess;
 import com.taobao.arthas.core.util.LogUtil;
+import com.taobao.arthas.core.util.StringUtils;
 import com.taobao.arthas.core.util.ThreadLocalWatch;
+import com.taobao.arthas.core.view.ObjectView;
 
 import java.time.LocalDateTime;
 
@@ -89,7 +91,7 @@ class WatchAdviceListener extends AdviceListenerAdapter {
                 WatchModel model = new WatchModel();
                 model.setTs(LocalDateTime.now());
                 model.setCost(cost);
-                model.setValue(new ObjectVO(value, command.getExpand()));
+                model.setValue(snapshot(value));
                 model.setSizeLimit(command.getSizeLimit());
                 model.setClassName(advice.getClazz().getName());
                 model.setMethodName(advice.getMethod().getName());
@@ -113,5 +115,16 @@ class WatchAdviceListener extends AdviceListenerAdapter {
                     + command.getExpress() + ", " + e.getMessage() + ", visit " + LogUtil.loggingFile()
                     + " for more details.");
         }
+    }
+
+    private ObjectVO snapshot(Object value) {
+        ObjectVO objectVO = new ObjectVO(value, command.getExpand());
+        int sizeLimit = ObjectView.normalizeMaxObjectLength(command.getSizeLimit());
+        String renderedValue = StringUtils.objectToString(
+                objectVO.needExpand() ? new ObjectView(sizeLimit, objectVO).draw() : objectVO.getObject());
+        objectVO.setRenderedValue(renderedValue);
+        // 快照完成后释放业务对象引用，避免 HTTP API 延迟消费时再次读取可变对象。
+        objectVO.setObject(null);
+        return objectVO;
     }
 }

--- a/core/src/main/java/com/taobao/arthas/core/command/view/WatchView.java
+++ b/core/src/main/java/com/taobao/arthas/core/command/view/WatchView.java
@@ -18,8 +18,11 @@ public class WatchView extends ResultView<WatchModel> {
     public void draw(CommandProcess process, WatchModel model) {
         ObjectVO objectVO = model.getValue();
         int sizeLimit = ObjectView.normalizeMaxObjectLength(model.getSizeLimit());
-        String result = StringUtils.objectToString(
-                objectVO.needExpand() ? new ObjectView(sizeLimit, objectVO).draw() : objectVO.getObject());
+        String result = objectVO.getRenderedValue();
+        if (result == null) {
+            result = StringUtils.objectToString(
+                    objectVO.needExpand() ? new ObjectView(sizeLimit, objectVO).draw() : objectVO.getObject());
+        }
 
         StringBuilder sb = new StringBuilder();
         sb.append("method=").append(model.getClassName()).append(".").append(model.getMethodName())

--- a/core/src/main/java/com/taobao/arthas/core/mcp/util/McpObjectVOFilter.java
+++ b/core/src/main/java/com/taobao/arthas/core/mcp/util/McpObjectVOFilter.java
@@ -49,6 +49,10 @@ public class McpObjectVOFilter implements ValueFilter {
 
     private Object handleObjectVO(ObjectVO objectVO) {
         try {
+            if (objectVO.getRenderedValue() != null) {
+                return objectVO.getRenderedValue();
+            }
+
             Object innerObject = objectVO.getObject();
             Integer expand = objectVO.getExpand();
             

--- a/core/src/main/java/com/taobao/arthas/core/shell/term/impl/http/api/ObjectVOFilter.java
+++ b/core/src/main/java/com/taobao/arthas/core/shell/term/impl/http/api/ObjectVOFilter.java
@@ -15,7 +15,10 @@ public class ObjectVOFilter implements ValueFilter {
     public Object apply(Object object, String name, Object value) {
         if (value instanceof ObjectVO) {
             ObjectVO vo = (ObjectVO) value;
-            String resultStr = StringUtils.objectToString(vo.needExpand() ? new ObjectView(vo).draw() : value);
+            if (vo.getRenderedValue() != null) {
+                return vo.getRenderedValue();
+            }
+            String resultStr = StringUtils.objectToString(vo.needExpand() ? new ObjectView(vo).draw() : vo.getObject());
             return resultStr;
         }
         return value;

--- a/core/src/test/java/com/taobao/arthas/core/command/monitor200/WatchAdviceListenerTest.java
+++ b/core/src/test/java/com/taobao/arthas/core/command/monitor200/WatchAdviceListenerTest.java
@@ -1,0 +1,243 @@
+package com.taobao.arthas.core.command.monitor200;
+
+import com.alibaba.fastjson2.JSON;
+import com.taobao.arthas.core.advisor.AdviceListener;
+import com.taobao.arthas.core.advisor.ArthasMethod;
+import com.taobao.arthas.core.command.model.ObjectVO;
+import com.taobao.arthas.core.command.model.ResultModel;
+import com.taobao.arthas.core.command.model.WatchModel;
+import com.taobao.arthas.core.command.view.WatchView;
+import com.taobao.arthas.core.shell.cli.CliToken;
+import com.taobao.arthas.core.shell.command.CommandProcess;
+import com.taobao.arthas.core.shell.handlers.Handler;
+import com.taobao.arthas.core.shell.session.Session;
+import com.taobao.arthas.core.shell.term.impl.http.api.ObjectVOFilter;
+import com.taobao.middleware.cli.CommandLine;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.lang.instrument.ClassFileTransformer;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+
+public class WatchAdviceListenerTest {
+
+    @Test
+    public void beforeWatchResultKeepsEntrySnapshotWhenArgumentsAreMutatedLater() throws Throwable {
+        WatchCommand command = new WatchCommand();
+        command.setBefore(true);
+        command.setExpress("params");
+        command.setExpand(2);
+
+        CapturingCommandProcess process = new CapturingCommandProcess();
+
+        WatchAdviceListener listener = new WatchAdviceListener(command, process, false);
+        MutableRequest request = new MutableRequest(62, "62*4572752.0.0.7.20220506102153");
+
+        listener.before(WatchAdviceListenerTest.class.getClassLoader(), MutableTarget.class,
+                new ArthasMethod(MutableTarget.class, "observed", "()V"), new MutableTarget(),
+                new Object[] { request, Boolean.TRUE });
+
+        request.appId = 100000;
+        request.appVersion = "4572752.0.0.7.20220506102153";
+
+        WatchModel model = (WatchModel) process.result;
+        ObjectVO value = model.getValue();
+        Assert.assertNull(value.getObject());
+
+        new WatchView().draw(process, model);
+        String terminalResult = process.output.toString();
+        Assert.assertTrue(terminalResult.contains("appId=@Integer[62]"));
+        Assert.assertTrue(terminalResult.contains("appVersion=@String[62*4572752.0.0.7.20220506102153]"));
+        Assert.assertFalse(terminalResult.contains("appId=@Integer[100000]"));
+
+        String httpResult = JSON.toJSONString(model, new ObjectVOFilter());
+
+        Assert.assertTrue(httpResult.contains("\"accessPoint\":\"AtEnter\""));
+        Assert.assertTrue(httpResult.contains("appId=@Integer[62]"));
+        Assert.assertTrue(httpResult.contains("appVersion=@String[62*4572752.0.0.7.20220506102153]"));
+        Assert.assertFalse(httpResult.contains("appId=@Integer[100000]"));
+    }
+
+    @Test
+    public void beforeWatchResultKeepsEntrySnapshotWithoutExpansion() throws Throwable {
+        WatchCommand command = new WatchCommand();
+        command.setBefore(true);
+        command.setExpress("params[0]");
+        command.setExpand(0);
+
+        CapturingCommandProcess process = new CapturingCommandProcess();
+        WatchAdviceListener listener = new WatchAdviceListener(command, process, false);
+        StringBuilder value = new StringBuilder("before");
+
+        listener.before(WatchAdviceListenerTest.class.getClassLoader(), MutableTarget.class,
+                new ArthasMethod(MutableTarget.class, "observed", "()V"), new MutableTarget(),
+                new Object[] { value, Boolean.TRUE });
+
+        value.append("-after");
+
+        ObjectVO objectVO = ((WatchModel) process.result).getValue();
+        Assert.assertNull(objectVO.getObject());
+        Assert.assertEquals("before", objectVO.getRenderedValue());
+    }
+
+    private static class MutableTarget {
+        @SuppressWarnings("unused")
+        public void observed(MutableRequest request, boolean flag) {
+        }
+    }
+
+    private static class MutableRequest {
+        private Integer appId;
+        private String appVersion;
+
+        private MutableRequest(Integer appId, String appVersion) {
+            this.appId = appId;
+            this.appVersion = appVersion;
+        }
+    }
+
+    private static class CapturingCommandProcess implements CommandProcess {
+        private final AtomicInteger times = new AtomicInteger();
+        private final StringBuilder output = new StringBuilder();
+        private ResultModel result;
+
+        @Override
+        public List<CliToken> argsTokens() {
+            return null;
+        }
+
+        @Override
+        public List<String> args() {
+            return null;
+        }
+
+        @Override
+        public CommandLine commandLine() {
+            return null;
+        }
+
+        @Override
+        public Session session() {
+            return null;
+        }
+
+        @Override
+        public boolean isForeground() {
+            return true;
+        }
+
+        @Override
+        public CommandProcess stdinHandler(Handler<String> handler) {
+            return this;
+        }
+
+        @Override
+        public CommandProcess interruptHandler(Handler<Void> handler) {
+            return this;
+        }
+
+        @Override
+        public CommandProcess suspendHandler(Handler<Void> handler) {
+            return this;
+        }
+
+        @Override
+        public CommandProcess resumeHandler(Handler<Void> handler) {
+            return this;
+        }
+
+        @Override
+        public CommandProcess endHandler(Handler<Void> handler) {
+            return this;
+        }
+
+        @Override
+        public CommandProcess write(String data) {
+            output.append(data);
+            return this;
+        }
+
+        @Override
+        public CommandProcess backgroundHandler(Handler<Void> handler) {
+            return this;
+        }
+
+        @Override
+        public CommandProcess foregroundHandler(Handler<Void> handler) {
+            return this;
+        }
+
+        @Override
+        public CommandProcess resizehandler(Handler<Void> handler) {
+            return this;
+        }
+
+        @Override
+        public void end() {
+        }
+
+        @Override
+        public void end(int status) {
+        }
+
+        @Override
+        public void end(int status, String message) {
+        }
+
+        @Override
+        public void register(AdviceListener listener, ClassFileTransformer transformer) {
+        }
+
+        @Override
+        public void unregister() {
+        }
+
+        @Override
+        public AtomicInteger times() {
+            return times;
+        }
+
+        @Override
+        public void resume() {
+        }
+
+        @Override
+        public void suspend() {
+        }
+
+        @Override
+        public void echoTips(String tips) {
+        }
+
+        @Override
+        public String cacheLocation() {
+            return null;
+        }
+
+        @Override
+        public boolean isRunning() {
+            return true;
+        }
+
+        @Override
+        public void appendResult(ResultModel result) {
+            this.result = result;
+        }
+
+        @Override
+        public String type() {
+            return "test";
+        }
+
+        @Override
+        public int width() {
+            return 80;
+        }
+
+        @Override
+        public int height() {
+            return 24;
+        }
+    }
+}

--- a/core/src/test/java/com/taobao/arthas/core/mcp/util/McpObjectVOFilterTest.java
+++ b/core/src/test/java/com/taobao/arthas/core/mcp/util/McpObjectVOFilterTest.java
@@ -1,0 +1,18 @@
+package com.taobao.arthas.core.mcp.util;
+
+import com.taobao.arthas.core.command.model.ObjectVO;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class McpObjectVOFilterTest {
+
+    @Test
+    public void shouldUseRenderedValueBeforeObjectValue() {
+        ObjectVO objectVO = new ObjectVO(null, 2);
+        objectVO.setRenderedValue("@String[snapshot]");
+
+        Object result = new McpObjectVOFilter().apply(null, "value", objectVO);
+
+        Assert.assertEquals("@String[snapshot]", result);
+    }
+}


### PR DESCRIPTION
## Summary
- render watch expression results at advice time and store the rendered snapshot on ObjectVO
- make terminal, HTTP API, and MCP ObjectVO rendering prefer the stored watch snapshot
- add regression coverage for mutable AtEnter arguments and MCP renderedValue handling

## Test Plan
- ./mvnw -ntp -pl core -am -Dtest=WatchAdviceListenerTest,McpObjectVOFilterTest -Dsurefire.failIfNoSpecifiedTests=false test
- ./mvnw -ntp -pl core -am test
- git diff --check

## Notes
- Full local reactor check passed with 263 tests, 0 failures, 0 errors, 7 skipped.