### PR TITLE
docs: update Spring Boot starter support note

### DIFF
--- a/site/docs/en/doc/spring-boot-starter.md
+++ b/site/docs/en/doc/spring-boot-starter.md
@@ -1,7 +1,7 @@
 # Arthas Spring Boot Starter
 
 ::: tip
-Support spring boot 2
+Arthas 3.7.2 and later support both Spring Boot 2 and Spring Boot 3.
 :::
 
 Latest Version: [View](https://search.maven.org/search?q=arthas-spring-boot-starter)


### PR DESCRIPTION
## Summary

Updates the English Arthas Spring Boot Starter documentation to clarify that Arthas 3.7.2 and later support both Spring Boot 2 and Spring Boot 3.

## Changes

- Replaced the outdated English tip that said only Spring Boot 2 is supported
