### PR TITLE
Fix off-by-one capacity guard in ThreadUnsafeFixGaStack

### DIFF
--- a/core/src/main/java/com/taobao/arthas/core/util/collection/ThreadUnsafeFixGaStack.java
+++ b/core/src/main/java/com/taobao/arthas/core/util/collection/ThreadUnsafeFixGaStack.java
@@ -22,7 +22,7 @@ public class ThreadUnsafeFixGaStack<E> implements GaStack<E> {
 
     private void checkForPush() {
         // stack is full
-        if (current == max) {
+        if (current == max - 1) {
             throw new ArrayIndexOutOfBoundsException();
         }
     }

--- a/core/src/test/java/com/taobao/arthas/core/util/collection/ThreadUnsafeFixGaStackTest.java
+++ b/core/src/test/java/com/taobao/arthas/core/util/collection/ThreadUnsafeFixGaStackTest.java
@@ -1,0 +1,88 @@
+package com.taobao.arthas.core.util.collection;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * Test for ThreadUnsafeFixGaStack capacity guard.
+ * The bug: checkForPush() checks (current == max) but should check (current == max - 1).
+ * Since current starts at -1 and is pre-incremented before array access,
+ * the guard never fires. The real AIOOBE comes from elementArray[++current].
+ * After a failed push, current is corrupted (set to max), breaking subsequent operations.
+ */
+public class ThreadUnsafeFixGaStackTest {
+
+    /**
+     * After pushing max elements and attempting one more, peek() should still
+     * return the top element (the failed push should NOT corrupt state).
+     * 
+     * With the bug: push() increments current past capacity before the JVM's
+     * array bounds check throws, corrupting current. So peek() also fails.
+     * 
+     * With the fix: checkForPush() fires BEFORE ++current, so current is
+     * unchanged and peek() works fine.
+     */
+    @Test
+    public void testPeekAfterFailedPush() {
+        ThreadUnsafeFixGaStack<String> stack = new ThreadUnsafeFixGaStack<>(3);
+        
+        // Fill the stack to capacity
+        stack.push("a");
+        stack.push("b");
+        stack.push("c");
+        
+        Assert.assertEquals("c", stack.peek());
+        
+        // Attempt push past capacity - should throw ArrayIndexOutOfBoundsException
+        try {
+            stack.push("d");
+            Assert.fail("Expected ArrayIndexOutOfBoundsException");
+        } catch (ArrayIndexOutOfBoundsException expected) {
+            // Expected - the guard (or array bounds) should reject this
+        }
+        
+        // After the failed push, peek should still work and return "c"
+        // This proves the guard fired BEFORE corrupting current
+        String top = stack.peek();
+        Assert.assertEquals("peek() should still return top element after failed push", "c", top);
+    }
+    
+    /**
+     * After pushing max elements and attempting one more, pop() should still work.
+     */
+    @Test
+    public void testPopAfterFailedPush() {
+        ThreadUnsafeFixGaStack<String> stack = new ThreadUnsafeFixGaStack<>(3);
+        
+        stack.push("a");
+        stack.push("b");
+        stack.push("c");
+        
+        // Attempt push past capacity
+        try {
+            stack.push("d");
+            Assert.fail("Expected ArrayIndexOutOfBoundsException");
+        } catch (ArrayIndexOutOfBoundsException expected) {
+        }
+        
+        // After the failed push, pop should still work
+        String top = stack.pop();
+        Assert.assertEquals("pop() should still return top element after failed push", "c", top);
+    }
+    
+    /**
+     * Verify the stack accepts exactly max elements.
+     */
+    @Test
+    public void testCapacityLimit() {
+        ThreadUnsafeFixGaStack<Integer> stack = new ThreadUnsafeFixGaStack<>(2);
+        
+        stack.push(1);
+        stack.push(2);
+        
+        Assert.assertFalse(stack.isEmpty());
+        Assert.assertEquals(2, (int) stack.pop());
+        Assert.assertEquals(1, (int) stack.pop());
+        Assert.assertTrue(stack.isEmpty());
+    }
+}


### PR DESCRIPTION
## Problem

`ThreadUnsafeFixGaStack` backs a fixed-size stack with `new Object[max]` (valid indices `0..max-1`) and pre-increments in `push()`:

```java
private void checkForPush() {
    // stack is full
    if (current == max) {            // never true for a valid sequence of pushes
        throw new ArrayIndexOutOfBoundsException();
    }
}

public void push(E e) {
    checkForPush();
    elementArray[++current] = e;     // ++current reaches max before the guard fires
}
```

Because `current` tops out at `max - 1` when the stack is full, the `current == max` guard never fires. A push past capacity instead runs `++current` to `max` and the `ArrayIndexOutOfBoundsException` comes from the array access — **after** `current` has already been advanced to `max`. The stack pointer is now corrupted, so a subsequent `peek()`/`pop()` also throws `ArrayIndexOutOfBoundsException` instead of returning the still-valid top element.

## Fix

Guard with `current == max - 1` so an over-capacity push is rejected **before** `current` is advanced, leaving the stack usable after a rejected push.

## Test

Adds `ThreadUnsafeFixGaStackTest`: after filling a stack to capacity and attempting one more push (which must throw), `peek()` and `pop()` must still return the top element. These fail on `master` (`ArrayIndexOutOfBoundsException` from `peek`/`pop`) and pass with this change.

## AI assistance disclosure

This contribution was produced with the help of an AI pipeline. The pipeline processed a large amount of source code to surface suspected bugs, reproduced a subset of them with failing unit tests and generated candidate fixes, and prepared pull requests from the ones that held up. Each PR was then reviewed and verified by a human before being opened: the fix and test were checked by hand and the test was confirmed to fail before the change and pass after.
