### PR TITLE
Respect PaginationHandler.handle() stop signal in ResultUtils.processClassNames

### DIFF
--- a/core/src/main/java/com/taobao/arthas/core/util/ResultUtils.java
+++ b/core/src/main/java/com/taobao/arthas/core/util/ResultUtils.java
@@ -23,7 +23,9 @@ public class ResultUtils {
             classNames.add(aClass.getName());
             //slice segment
             if(classNames.size() >= pageSize) {
-                handler.handle(classNames, segment++);
+                if (!handler.handle(classNames, segment++)) {
+                    return;
+                }
                 classNames = new ArrayList<String>(pageSize);
             }
         }

--- a/core/src/test/java/com/taobao/arthas/core/util/ResultUtilsTest.java
+++ b/core/src/test/java/com/taobao/arthas/core/util/ResultUtilsTest.java
@@ -1,0 +1,42 @@
+package com.taobao.arthas.core.util;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * Regression test for ResultUtils.processClassNames() ignoring the boolean return value from PaginationHandler.handle().
+ * Per the javadoc, handle() returning false should terminate processing of remaining segments.
+ */
+public class ResultUtilsTest {
+
+    @Test
+    public void testHandleReturnFalseStopsProcessing() {
+        // Create enough classes to produce 3 segments with pageSize=2
+        List<Class<?>> classes = new ArrayList<>();
+        classes.add(String.class);
+        classes.add(Integer.class);
+        classes.add(Long.class);
+        classes.add(Double.class);
+        classes.add(Boolean.class);
+
+        final AtomicInteger callCount = new AtomicInteger(0);
+
+        ResultUtils.processClassNames(classes, 2, new ResultUtils.PaginationHandler<List<String>>() {
+            @Override
+            public boolean handle(List<String> classNames, int segment) {
+                callCount.incrementAndGet();
+                // Return false on the very first call to signal "stop processing"
+                return false;
+            }
+        });
+
+        // Correct behavior: when handle() returns false, no further segments should be processed.
+        // The handler should have been called exactly once.
+        // Buggy behavior: the return value is ignored, so all 3 segments get processed (callCount = 3).
+        Assert.assertEquals("Handler should be called only once when it returns false to stop processing", 1, callCount.get());
+    }
+}


### PR DESCRIPTION
`ResultUtils.processClassNames` ignores the `boolean` returned by `PaginationHandler.handle(...)`. The handler's own Javadoc documents the contract:

```
@return  true 继续处理剩余数据， false 终止处理
```

(true = keep processing the remaining data, false = stop). Because the return value is discarded, a handler that returns `false` to stop early still receives every remaining segment.

This guards the in-loop call so that a `false` return ends processing. Adds a regression test (`ResultUtilsTest.testHandleReturnFalseStopsProcessing`) that fails before the change — the handler returning `false` is still invoked for all 3 segments (`expected:<1> but was:<3>`) — and passes after.

## AI assistance disclosure

This contribution was produced with the help of an AI pipeline. The pipeline processed a large amount of source code to surface suspected bugs, reproduced a subset of them with failing unit tests and generated candidate fixes, and prepared pull requests from the ones that held up. Each PR was then reviewed and verified by a human before being opened: the fix and test were checked by hand and the test was confirmed to fail before the change and pass after.
