### PR TITLE
[codex] Use writer-idle websocket ping

### DIFF
--- a/core/src/main/java/com/taobao/arthas/core/shell/term/impl/http/LocalTtyServerInitializer.java
+++ b/core/src/main/java/com/taobao/arthas/core/shell/term/impl/http/LocalTtyServerInitializer.java
@@ -42,7 +42,7 @@ public class LocalTtyServerInitializer extends ChannelInitializer<LocalChannel> 
         pipeline.addLast(new HttpObjectAggregator(ArthasConstants.MAX_HTTP_CONTENT_LENGTH));
         pipeline.addLast(workerGroup, "HttpRequestHandler", new HttpRequestHandler(ArthasConstants.DEFAULT_WEBSOCKET_PATH));
         pipeline.addLast(new WebSocketServerProtocolHandler(ArthasConstants.DEFAULT_WEBSOCKET_PATH, null, false, ArthasConstants.MAX_HTTP_CONTENT_LENGTH, false, true));
-        pipeline.addLast(new IdleStateHandler(0, 0, ArthasConstants.WEBSOCKET_IDLE_SECONDS));
+        pipeline.addLast(new IdleStateHandler(0, ArthasConstants.WEBSOCKET_IDLE_SECONDS, 0));
         pipeline.addLast(new TtyWebSocketFrameHandler(group, handler));
     }
 }

--- a/core/src/main/java/com/taobao/arthas/core/shell/term/impl/http/TtyServerInitializer.java
+++ b/core/src/main/java/com/taobao/arthas/core/shell/term/impl/http/TtyServerInitializer.java
@@ -44,7 +44,7 @@ public class TtyServerInitializer extends ChannelInitializer<SocketChannel> {
     pipeline.addLast(new BasicHttpAuthenticatorHandler(httpSessionManager));
     pipeline.addLast(workerGroup, "HttpRequestHandler", new HttpRequestHandler(ArthasConstants.DEFAULT_WEBSOCKET_PATH));
     pipeline.addLast(new WebSocketServerProtocolHandler(ArthasConstants.DEFAULT_WEBSOCKET_PATH, null, false, ArthasConstants.MAX_HTTP_CONTENT_LENGTH, false, true));
-    pipeline.addLast(new IdleStateHandler(0, 0, ArthasConstants.WEBSOCKET_IDLE_SECONDS));
+    pipeline.addLast(new IdleStateHandler(0, ArthasConstants.WEBSOCKET_IDLE_SECONDS, 0));
     pipeline.addLast(new TtyWebSocketFrameHandler(group, handler));
   }
 }

--- a/core/src/main/java/com/taobao/arthas/core/shell/term/impl/httptelnet/ProtocolDetectHandler.java
+++ b/core/src/main/java/com/taobao/arthas/core/shell/term/impl/httptelnet/ProtocolDetectHandler.java
@@ -95,7 +95,7 @@ public class ProtocolDetectHandler extends ChannelInboundHandlerAdapter {
             pipeline.addLast(new BasicHttpAuthenticatorHandler(httpSessionManager));
             pipeline.addLast(workerGroup, "HttpRequestHandler", new HttpRequestHandler(ArthasConstants.DEFAULT_WEBSOCKET_PATH));
             pipeline.addLast(new WebSocketServerProtocolHandler(ArthasConstants.DEFAULT_WEBSOCKET_PATH, null, false, ArthasConstants.MAX_HTTP_CONTENT_LENGTH, false, true));
-            pipeline.addLast(new IdleStateHandler(0, 0, ArthasConstants.WEBSOCKET_IDLE_SECONDS));
+            pipeline.addLast(new IdleStateHandler(0, ArthasConstants.WEBSOCKET_IDLE_SECONDS, 0));
             pipeline.addLast(new TtyWebSocketFrameHandler(channelGroup, ttyConnectionFactory));
             ctx.fireChannelActive();
         }

--- a/core/src/test/java/com/taobao/arthas/core/shell/term/impl/http/TtyWebSocketFrameHandlerQuietTest.java
+++ b/core/src/test/java/com/taobao/arthas/core/shell/term/impl/http/TtyWebSocketFrameHandlerQuietTest.java
@@ -5,7 +5,9 @@ import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;
 import io.netty.channel.embedded.EmbeddedChannel;
 import io.netty.channel.group.DefaultChannelGroup;
+import io.netty.handler.codec.http.websocketx.PingWebSocketFrame;
 import io.netty.handler.codec.http.websocketx.TextWebSocketFrame;
+import io.netty.handler.timeout.IdleStateEvent;
 import io.netty.util.concurrent.GlobalEventExecutor;
 import org.junit.jupiter.api.Test;
 
@@ -44,6 +46,26 @@ class TtyWebSocketFrameHandlerQuietTest {
         channel.writeInbound(new TextWebSocketFrame("help"));
 
         assertThat(channel.isOpen()).isFalse();
+    }
+
+    @Test
+    void writerIdleShouldSendWebSocketPingFrame() {
+        EmbeddedChannel channel = new EmbeddedChannel(new TtyWebSocketFrameHandler(
+                new DefaultChannelGroup(GlobalEventExecutor.INSTANCE),
+                connection -> {
+                }));
+
+        channel.pipeline().fireUserEventTriggered(IdleStateEvent.WRITER_IDLE_STATE_EVENT);
+
+        PingWebSocketFrame ping = channel.readOutbound();
+        try {
+            assertThat(ping).isNotNull();
+        } finally {
+            if (ping != null) {
+                ping.release();
+            }
+            channel.finishAndReleaseAll();
+        }
     }
 
     @Test


### PR DESCRIPTION
## Summary

- Change Arthas TTY WebSocket idle handling from all-idle to writer-idle in the HTTP, local, and protocol-detect pipelines.
- Keep the existing WebSocket Ping control-frame behavior, but trigger it when the server has not written data for the idle interval.
- Add a regression test that verifies a writer-idle event emits a `PingWebSocketFrame`.

## Why

The previous all-idle configuration did not fire while clients continuously sent messages such as terminal resize events. That meant a connection with steady inbound traffic but no server output would not receive the existing server-side WebSocket ping.

With writer-idle, the server can still send ping frames when it has not produced outbound data, even if the client is actively sending resize messages.

## Validation

```bash
./mvnw -pl core -am -Dtest=TtyWebSocketFrameHandlerQuietTest -Dsurefire.failIfNoSpecifiedTests=false test
```

Result: `Tests run: 5, Failures: 0, Errors: 0`, `BUILD SUCCESS`.