### PR TITLE
[codex] fix vmtool backtrace limit validation

### DIFF
--- a/arthas-vmtool/src/main/java/arthas/VmTool.java
+++ b/arthas-vmtool/src/main/java/arthas/VmTool.java
@@ -146,6 +146,9 @@ public class VmTool implements VmToolMXBean {
 
     @Override
     public String referenceAnalyze(Class<?> klass, int objectNum, int backtraceNum) {
+        if (backtraceNum < -1) {
+            throw new IllegalArgumentException("backtraceNum must be -1 or greater");
+        }
         return referenceAnalyze0(klass, objectNum, backtraceNum);
     }
 }

--- a/arthas-vmtool/src/main/native/src/heap_analyzer.c
+++ b/arthas-vmtool/src/main/native/src/heap_analyzer.c
@@ -924,6 +924,9 @@ static char *build_reference_analyze_output(heap_ctx_t *ctx, jclass klass,
   if (object_num < 0) {
     object_num = 0;
   }
+  if (backtrace_num < -1) {
+    backtrace_num = 0;
+  }
 
   if (JVMTI_CALL(ctx->jvmti, GetTag, klass, &klass_tag) != JVMTI_ERROR_NONE) {
     sb_append_cstr(&sb, "ERROR: JVMTI GetTag(klass) failed\n");

--- a/arthas-vmtool/src/test/java/arthas/VmToolTest.java
+++ b/arthas-vmtool/src/test/java/arthas/VmToolTest.java
@@ -1,6 +1,7 @@
 package arthas;
 
 import java.io.File;
+import java.lang.reflect.Constructor;
 import java.lang.ref.WeakReference;
 import java.util.ArrayList;
 import java.util.concurrent.TimeUnit;
@@ -249,5 +250,19 @@ public class VmToolTest {
         VmTool vmtool = initVmTool();
         String result = vmtool.referenceAnalyze(ByteHolder.class, 2, -1);
         Assertions.assertThat(result).contains("ByteHolder").contains("root");
+    }
+
+    @Test
+    public void testReferenceAnalyzeRejectsInvalidBacktraceNum() throws Exception {
+        Constructor<VmTool> constructor = VmTool.class.getDeclaredConstructor();
+        constructor.setAccessible(true);
+        VmTool vmtool = constructor.newInstance();
+
+        try {
+            vmtool.referenceAnalyze(ByteHolder.class, 1, Integer.MIN_VALUE);
+            Assert.fail("Expected IllegalArgumentException");
+        } catch (IllegalArgumentException e) {
+            Assertions.assertThat(e).hasMessage("backtraceNum must be -1 or greater");
+        }
     }
 }

--- a/core/src/main/java/com/taobao/arthas/core/command/monitor200/VmToolCommand.java
+++ b/core/src/main/java/com/taobao/arthas/core/command/monitor200/VmToolCommand.java
@@ -95,6 +95,7 @@ public class VmToolCommand extends AnnotatedCommand {
      * default value 2
      */
     private int backtraceNum = 2;
+    private static final String BACKTRACE_NUM_ERROR = "backtraceNum must be -1 or greater.";
 
     private String libPath;
     private static String defaultLibPath;
@@ -203,6 +204,13 @@ public class VmToolCommand extends AnnotatedCommand {
             Instrumentation inst = process.session().getInstrumentation();
 
             if (VmToolAction.getInstances.equals(action) || VmToolAction.referenceAnalyze.equals(action)) {
+                if (VmToolAction.referenceAnalyze.equals(action)) {
+                    String validateError = validateBacktraceNum(Integer.valueOf(backtraceNum));
+                    if (validateError != null) {
+                        process.end(-1, validateError);
+                        return;
+                    }
+                }
                 if (className == null) {
                     process.end(-1, "The className option cannot be empty!");
                     return;
@@ -307,6 +315,13 @@ public class VmToolCommand extends AnnotatedCommand {
             logger.error("vmtool error", e);
             process.end(1, "vmtool error: " + e.getMessage());
         }
+    }
+
+    static String validateBacktraceNum(Integer backtraceNum) {
+        if (backtraceNum != null && backtraceNum.intValue() < -1) {
+            return BACKTRACE_NUM_ERROR;
+        }
+        return null;
     }
 
     /**

--- a/core/src/test/java/com/taobao/arthas/core/command/monitor200/VmToolCommandTest.java
+++ b/core/src/test/java/com/taobao/arthas/core/command/monitor200/VmToolCommandTest.java
@@ -6,6 +6,18 @@ import org.junit.Test;
 public class VmToolCommandTest {
 
     @Test
+    public void testValidateBacktraceNum() {
+        Assert.assertNull(VmToolCommand.validateBacktraceNum(Integer.valueOf(-1)));
+        Assert.assertNull(VmToolCommand.validateBacktraceNum(Integer.valueOf(0)));
+        Assert.assertNull(VmToolCommand.validateBacktraceNum(Integer.valueOf(1)));
+        Assert.assertNull(VmToolCommand.validateBacktraceNum(null));
+        Assert.assertEquals("backtraceNum must be -1 or greater.",
+                VmToolCommand.validateBacktraceNum(Integer.valueOf(Integer.MIN_VALUE)));
+        Assert.assertEquals("backtraceNum must be -1 or greater.",
+                VmToolCommand.validateBacktraceNum(Integer.valueOf(-2)));
+    }
+
+    @Test
     public void testNormalizeArrayClassNameNull() {
         Assert.assertNull(VmToolCommand.normalizeArrayClassName(null));
     }

--- a/site/docs/doc/vmtool.md
+++ b/site/docs/doc/vmtool.md
@@ -126,6 +126,7 @@ $ vmtool --action referenceAnalyze --className java.lang.String --objectNum 5 --
 
 - 通过 `--objectNum` 参数指定展示的对象数量
 - 通过 `--backtraceNum` 参数指定回溯层数，设置为 `-1` 表示一直回溯到 root，设置为 `0` 表示不输出引用链
+- `--backtraceNum` 小于 `-1` 为非法值
 - `getInstances` 支持的 `--classLoaderClass` / `--classloader` 参数同样适用于 `referenceAnalyze`
   :::
 

--- a/site/docs/en/doc/vmtool.md
+++ b/site/docs/en/doc/vmtool.md
@@ -126,6 +126,7 @@ $ vmtool --action referenceAnalyze --className java.lang.String --objectNum 5 --
 
 - Use `--objectNum` to specify how many objects will be shown
 - Use `--backtraceNum` to specify how many steps of backtrace will be done, set `-1` to backtrace until root, set `0` to disable backtrace output
+- `--backtraceNum` values less than `-1` are invalid
 - `--classLoaderClass` and `--classloader` from `getInstances` are also applicable here
   :::
 


### PR DESCRIPTION
## Summary

Fixes #3219.

`vmtool referenceAnalyze` accepted `backtraceNum` values below `-1` and passed them through to native code. In `heap_analyzer.c`, `Integer.MIN_VALUE` then reached `backtrace_num - 1`, which is signed integer overflow.

This change:

- rejects `--backtraceNum < -1` in `VmToolCommand` before invoking JNI
- rejects invalid direct `VmTool.referenceAnalyze(...)` API calls
- keeps a native-side defensive clamp for callers that bypass Java validation
- documents the valid `--backtraceNum` range in Chinese and English docs

## Validation

- `./mvnw -pl core -Dtest=VmToolCommandTest test`
- `./mvnw -pl arthas-vmtool -Dtest=VmToolTest#testReferenceAnalyzeRejectsInvalidBacktraceNum test`
- `./mvnw -pl arthas-vmtool -Dtest=VmToolTest#testReferenceAnalyze test`
- native smoke compiled with `-ftrapv`, invoking private native `referenceAnalyze0(..., Integer.MIN_VALUE)` via reflection to confirm the native guard does not trap on signed overflow

Note: a local UBSan dylib smoke could not run on this macOS host because loading the UBSan runtime was blocked by platform code-signing policy, so `-ftrapv` was used for local overflow trapping.