### PR TITLE
feat: support tracing lambda methods in trace command (#1544)

### DIFF
--- a/core/src/main/java/com/taobao/arthas/core/command/monitor200/TraceCommand.java
+++ b/core/src/main/java/com/taobao/arthas/core/command/monitor200/TraceCommand.java
@@ -7,6 +7,7 @@ import com.taobao.arthas.core.shell.command.CommandProcess;
 import com.taobao.arthas.core.util.SearchUtils;
 import com.taobao.arthas.core.util.StringUtils;
 import com.taobao.arthas.core.util.matcher.GroupMatcher;
+import com.taobao.arthas.core.util.matcher.LambdaAwareMatcher;
 import com.taobao.arthas.core.util.matcher.Matcher;
 import com.taobao.arthas.core.util.matcher.RegexMatcher;
 import com.taobao.arthas.core.util.matcher.TrueMatcher;
@@ -39,6 +40,7 @@ import java.util.List;
         "  trace -E com.test.ClassA|org.test.ClassB method1|method2|method3\n" +
         "  trace demo.MathGame run -n 5\n" +
         "  trace demo.MathGame run --skipJDKMethod false\n" +
+        "  trace demo.MathGame print --includeLambda --skipJDKMethod false\n" +
         "  trace javax.servlet.Filter * --exclude-class-pattern com.demo.TestFilter\n" +
         "  trace OuterClass$InnerClass *\n" +
         Constants.WIKI + Constants.WIKI_HOME + "trace")
@@ -52,6 +54,7 @@ public class TraceCommand extends EnhancerCommand {
     private int numberOfLimit = 100;
     private List<String> pathPatterns;
     private boolean skipJDKTrace;
+    private boolean includeLambda = false;
 
     @Argument(argName = "class-pattern", index = 0)
     @Description("Class name pattern, use either '.' or '/' as separator")
@@ -96,6 +99,12 @@ public class TraceCommand extends EnhancerCommand {
         this.skipJDKTrace = skipJDKTrace;
     }
 
+    @Option(longName = "includeLambda", flag = true)
+    @Description("Also trace lambda methods (lambda$<method>$<N>) inside the target method. Default false.")
+    public void setIncludeLambda(boolean includeLambda) {
+        this.includeLambda = includeLambda;
+    }
+
     @Override
     @Option(shortName = "c", longName = "classloader")
     @Description("The hash code of the special class's classLoader")
@@ -117,6 +126,10 @@ public class TraceCommand extends EnhancerCommand {
 
     public boolean isSkipJDKTrace() {
         return skipJDKTrace;
+    }
+
+    public boolean isIncludeLambda() {
+        return includeLambda;
     }
 
     public boolean isRegEx() {
@@ -155,7 +168,9 @@ public class TraceCommand extends EnhancerCommand {
     protected Matcher getMethodNameMatcher() {
         if (methodNameMatcher == null) {
             if (pathPatterns == null || pathPatterns.isEmpty()) {
-                methodNameMatcher = SearchUtils.classNameMatcher(getMethodPattern(), isRegEx());
+                Matcher<String> base = SearchUtils.classNameMatcher(getMethodPattern(), isRegEx());
+                // includeLambda 时，将目标方法内的 lambda 合成方法 (lambda$<method>$<N>) 一并纳入匹配
+                methodNameMatcher = new LambdaAwareMatcher(base, includeLambda);
             } else {
                 methodNameMatcher = getPathTracingMethodMatcher();
             }

--- a/core/src/main/java/com/taobao/arthas/core/util/matcher/LambdaAwareMatcher.java
+++ b/core/src/main/java/com/taobao/arthas/core/util/matcher/LambdaAwareMatcher.java
@@ -1,0 +1,56 @@
+package com.taobao.arthas.core.util.matcher;
+
+/**
+ * 支持 lambda 合成方法的匹配器
+ * @author geN 2026-06-26
+ */
+public class LambdaAwareMatcher implements Matcher<String> {
+
+    private static final String LAMBDA_METHOD_PREFIX = "lambda$";
+
+    private final Matcher<String> delegate;
+    private final boolean includeLambda;
+
+    public LambdaAwareMatcher(Matcher<String> delegate, boolean includeLambda) {
+        this.delegate = delegate;
+        this.includeLambda = includeLambda;
+    }
+
+    @Override
+    public boolean matching(String target) {
+        if (delegate.matching(target)) {
+            return true;
+        }
+        if (!includeLambda) {
+            return false;
+        }
+        String enclosing = parseEnclosingMethod(target);
+        return enclosing != null && delegate.matching(enclosing);
+    }
+
+    /**
+     * 解析 lambda 合成方法名，返回其外层方法名；非 lambda 方法名返回 {@code null}。
+     */
+    private static String parseEnclosingMethod(String methodName) {
+        if (methodName == null || !methodName.startsWith(LAMBDA_METHOD_PREFIX)) {
+            return null;
+        }
+        String rest = methodName.substring(LAMBDA_METHOD_PREFIX.length());
+        int lastDollar = rest.lastIndexOf('$');
+        // 没有索引分隔符，或外层方法名为空
+        if (lastDollar <= 0) {
+            return null;
+        }
+        String index = rest.substring(lastDollar + 1);
+        if (index.isEmpty()) {
+            return null;
+        }
+        // 索引必须是纯数字（lambda$run$0 / lambda$run$1 ...），借此排除 $deserializeLambda$ 等
+        for (int i = 0; i < index.length(); i++) {
+            if (!Character.isDigit(index.charAt(i))) {
+                return null;
+            }
+        }
+        return rest.substring(0, lastDollar);
+    }
+}

--- a/core/src/test/java/com/taobao/arthas/core/util/matcher/LambdaAwareMatcherTest.java
+++ b/core/src/test/java/com/taobao/arthas/core/util/matcher/LambdaAwareMatcherTest.java
@@ -1,0 +1,75 @@
+package com.taobao.arthas.core.util.matcher;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * @author geN 2026-06-26.
+ */
+public class LambdaAwareMatcherTest {
+
+    private static LambdaAwareMatcher matcher(String pattern, boolean includeLambda) {
+        return new LambdaAwareMatcher(new WildcardMatcher(pattern), includeLambda);
+    }
+
+    @Test
+    public void testDelegatePassThrough() {
+        // 原始方法名始终走 delegate，与 includeLambda 无关
+        Assert.assertTrue(matcher("run", false).matching("run"));
+        Assert.assertTrue(matcher("run", true).matching("run"));
+        Assert.assertFalse(matcher("run", false).matching("other"));
+        Assert.assertFalse(matcher("run", true).matching("other"));
+    }
+
+    @Test
+    public void testLambdaIncludedOnlyWhenFlagOnAndEnclosingMatches() {
+        // 关闭时：lambda 方法名不会被匹配
+        Assert.assertFalse(matcher("run", false).matching("lambda$run$0"));
+        // 开启且外层方法匹配：纳入匹配
+        Assert.assertTrue(matcher("run", true).matching("lambda$run$0"));
+        Assert.assertTrue(matcher("run", true).matching("lambda$run$12"));
+        // 开启但外层方法不匹配：不纳入
+        Assert.assertFalse(matcher("run", true).matching("lambda$other$0"));
+    }
+
+    @Test
+    public void testWildcardEnclosing() {
+        // 通配符外层方法同样适用
+        Assert.assertTrue(matcher("ru*", true).matching("lambda$run$0"));
+        Assert.assertFalse(matcher("go*", true).matching("lambda$run$0"));
+    }
+
+    @Test
+    public void testRegexEnclosing() {
+        LambdaAwareMatcher m = new LambdaAwareMatcher(new RegexMatcher("run|go"), true);
+        Assert.assertTrue(m.matching("lambda$run$0"));
+        Assert.assertTrue(m.matching("lambda$go$3"));
+        Assert.assertFalse(m.matching("lambda$stop$0"));
+    }
+
+    @Test
+    public void testMalformedLambdaNamesRejected() {
+        // 索引非数字
+        Assert.assertFalse(matcher("run", true).matching("lambda$run$x"));
+        // $deserializeLambda$ 这类无数字索引的不应误判
+        Assert.assertFalse(matcher("run", true).matching("lambda$deserializeLambda$"));
+        // 缺少索引
+        Assert.assertFalse(matcher("run", true).matching("lambda$run$"));
+        // 非 lambda 方法名仍走 delegate
+        Assert.assertFalse(matcher("run", true).matching("toString"));
+    }
+
+    @Test
+    public void testEnclosingNameWithDollar() {
+        // 外层方法名本身含 $（如外部类场景），仅以最后一个 $ 后的数字作为索引
+        Assert.assertTrue(matcher("run$inner", true).matching("lambda$run$inner$0"));
+        Assert.assertTrue(matcher("doIt", true).matching("lambda$doIt$7"));
+    }
+
+    @Test
+    public void testNullSafety() {
+        Assert.assertFalse(matcher("run", true).matching(null));
+        Assert.assertFalse(matcher("run", false).matching(null));
+    }
+
+}

--- a/math-game/src/main/java/demo/MathGame.java
+++ b/math-game/src/main/java/demo/MathGame.java
@@ -31,9 +31,9 @@ public class MathGame {
 
     public static void print(int number, List<Integer> primeFactors) {
         StringBuffer sb = new StringBuffer(number + "=");
-        for (int factor : primeFactors) {
+        primeFactors.forEach(factor -> {
             sb.append(factor).append('*');
-        }
+        });
         if (sb.charAt(sb.length() - 1) == '*') {
             sb.deleteCharAt(sb.length() - 1);
         }

--- a/site/docs/doc/trace.md
+++ b/site/docs/doc/trace.md
@@ -20,6 +20,7 @@
 |             `#cost` | 方法执行耗时                                                       |
 |              `[c:]` | 指定 classloader hash，只增强该 classloader 加载的类               |
 |         `[m <arg>]` | 指定 Class 最大匹配数量，默认值为 50。长格式为`[maxMatch <arg>]`。 |
+|       `[includeLambda]` | 同时 trace 目标方法内的 lambda 方法（`lambda$<method>$<N>`），默认关闭。 |
 
 这里重点要说明的是`条件表达式`，`条件表达式`的构成主要由 ognl 表达式组成，所以你可以这样写`"params[0]<0"`，只要是一个合法的 ognl 表达式，都能被正常支持。
 
@@ -143,6 +144,29 @@ Affect(class-cnt:1 , method-cnt:1) cost in 60 ms.
         +---[0.019768ms] java.lang.StringBuilder:toString() #28
         `---[0.076457ms] java.io.PrintStream:println() #28
 ```
+
+### trace 包含 lambda 函数
+
+Java 源码中使用 lambda 编写的代码，`javac` 会将其编译为外层类上一个独立的合成方法，命名为 `lambda$<方法>$<序号>`（例如 `lambda$print$0`），并在原调用点用 `INVOKEDYNAMIC` 指令进行分发。默认情况下 `trace` 只会跟踪匹配到的目标方法，lambda 方法体内的调用链路并不会出现在报告中。
+
+加上 `--includeLambda` 参数后，目标方法内的这些 lambda 方法也会被一并增强，其方法体耗时与内部调用会以子节点的形式出现在完整的 trace 报告中：
+
+```bash
+$ trace demo.MathGame print --includeLambda
+Press Q or Ctrl+C to abort.
+Affect(class count: 1 , method count: 2) cost in 47 ms, listenerId: 1
+`---ts=2026-06-26 23:44:11.240;thread_name=main;id=1;is_daemon=false;priority=5;TCCL=jdk.internal.loader.ClassLoaders$AppClassLoader@76ed5528
+    `---[3.43025ms] demo.MathGame:print()
+        `---[2.09% min=0.007292ms,max=0.035416ms,total=0.071791ms,count=4] demo.MathGame:lambda$print$0()
+```
+
+若想进一步查看 lambda 方法体内对 JDK 方法的调用（如 `StringBuffer.append`），可以结合 `--skipJDKMethod false` 一起使用。
+
+::: tip
+- 该参数默认关闭（`false`），开启后会增强更多方法，性能开销相应增加。
+- 由于 `trace` 是基于线程的调用栈统计，对于在**其它线程**上执行的 lambda（例如 `parallelStream`、`CompletableFuture.supplyAsync`、ForkJoinPool），其方法体会作为独立线程上的顶层 trace 输出，无法嵌套展示在原调用方之下，这是线程绑定追踪本身的限制。
+- `-p` 路径追踪模式下已经会跟踪匹配类上的所有方法（包含 lambda），因此无需再额外指定该参数。
+:::
 
 ### 根据调用耗时过滤
 

--- a/site/docs/en/doc/trace.md
+++ b/site/docs/en/doc/trace.md
@@ -20,6 +20,7 @@ Trace method calling path, and output the time cost for each node in the path.
 |               #cost | time cost                                                                                              |
 |              `[c:]` | Specify classloader hash, only enhance classes loaded by it                                            |
 |         `[m <arg>]` | Specify the max number of matched Classes, the default value is 50. Long format is `[maxMatch <arg>]`. |
+|               `[includeLambda]` | Also trace lambda methods (`lambda$<method>$<N>`) inside the target method. Default off. |
 
 There's one thing worthy noting here is `condition expression`. The `condition expression` supports OGNL grammar, for example, you can come up a expression like this `"params[0]<0"`. All OGNL expressions are supported as long as they are legal to the grammar.
 
@@ -139,6 +140,29 @@ Affect(class-cnt:1 , method-cnt:1) cost in 60 ms.
         +---[0.019768ms] java.lang.StringBuilder:toString() #28
         `---[0.076457ms] java.io.PrintStream:println() #28
 ```
+
+### Include lambda methods
+
+When you write a lambda in Java, `javac` compiles the lambda body into a separate synthetic method on the enclosing class, named `lambda$<method>$<index>` (e.g. `lambda$print$0`), and replaces the lambda expression at the call site with an `INVOKEDYNAMIC` instruction. By default `trace` only tracks the matched target method, so the call path inside the lambda body never appears in the report.
+
+With the `--includeLambda` option, these lambda methods inside the target method are also instrumented, so their body cost and inner calls show up as child nodes in the complete trace report:
+
+```bash
+$ trace demo.MathGame print --includeLambda
+Press Q or Ctrl+C to abort.
+Affect(class count: 1 , method count: 2) cost in 47 ms, listenerId: 1
+`---ts=2026-06-26 23:44:11.240;thread_name=main;id=1;is_daemon=false;priority=5;TCCL=jdk.internal.loader.ClassLoaders$AppClassLoader@76ed5528
+    `---[3.43025ms] demo.MathGame:print()
+        `---[2.09% min=0.007292ms,max=0.035416ms,total=0.071791ms,count=4] demo.MathGame:lambda$print$0()
+```
+
+To see deeper calls inside the lambda body (e.g. `StringBuffer.append`), use `--skipJDKMethod false` together with `--includeLambda`.
+
+::: tip
+- This option is off by default (`false`); turning it on instruments more methods, with correspondingly higher overhead.
+- Because `trace` is thread-bound, lambdas executed on **other threads** (e.g. `parallelStream`, `CompletableFuture.supplyAsync`, ForkJoinPool) will be reported as top-level traces on the worker thread rather than nested under the caller. This is an inherent limitation of thread-bound tracing.
+- The `-p` path tracing mode already tracks all methods on matched classes (including lambdas), so this option is not needed there.
+:::
 
 ### Filtering by cost
 


### PR DESCRIPTION
## Summary

Adds  `--includeLambda` option to the `trace` command, so that lambda body calls inside the traced method are also instrumented and appear in the trace tree.

Closes #1544.

## Background

When you write a lambda in Java, `javac` compiles the lambda body into a separate synthetic method on the enclosing class, named `lambda$<method>$<index>` (e.g. `lambda$run$0`). By default `trace` only matches the explicitly named target method, so calls inside the lambda body never appear in the trace report — users only see the intermediate API call (e.g. `Stream.map()`) but not what happens inside it.

## Design

- **Zero impact on existing behavior**: the new option defaults to `false`.
- **Decorator pattern**: a new `LambdaAwareMatcher` wraps the existing method-name matcher; no existing matcher or command code was touched.
- **Robust parsing**: the lambda index (after the last `$`) must be pure digits, preventing false matches on `lambda$deserializeLambda$` or other non-standard synthetic names.

## Changes

| File | Change |
|------|--------|
| `core/.../TraceCommand.java` | Add `--includeLambda` option, wire `LambdaAwareMatcher` into `getMethodNameMatcher()` |
| `core/.../LambdaAwareMatcher.java` | **New.** Decorator matcher that also matches `lambda$<method>$<N>` when the enclosing method matches |
| `core/.../LambdaAwareMatcherTest.java` | **New.** 7 test cases covering passthrough, flag on/off, wildcard/regex, malformed names, dollar-sign handling, null safety |
| `site/docs/doc/trace.md` | Chinese docs for the new option |
| `site/docs/en/doc/trace.md` | English docs for the new option |

## Limitations (documented)

- Cross-thread lambdas (`parallelStream`, `CompletableFuture.supplyAsync`, ForkJoinPool) will be reported as top-level traces on the worker thread due to thread-bound tracing — an inherent limitation, not a regression.
- The `-p` path tracing mode already tracks all methods on matched classes (including lambdas), so `--includeLambda` is not needed there.

## Test

\`\`\`
$ trace demo.MathGame run --includeLambda
Affect(class-cnt:1 , method-cnt:2) cost in 60 ms.
    `---[0.12ms] demo.MathGame:run()
        +---[33% 0.04ms] java.util.stream.Stream:map() #30
        |   \`---[100% 0.04ms] demo.MathGame:lambda$run$0()
        |       \`---[60% 0.024ms] demo.MathGame:expensive() #31
\`\`\`