### PR TITLE
Return 0 from RateCounter.rate() when no values have been recorded

### DIFF
--- a/core/src/main/java/com/taobao/arthas/core/util/metrics/RateCounter.java
+++ b/core/src/main/java/com/taobao/arthas/core/util/metrics/RateCounter.java
@@ -68,6 +68,9 @@ public class RateCounter {
             sum += values.get(i);
         }
 
+        if (countLength == 0) {
+            return 0.0;
+        }
         return sum / (double) countLength;
     }
 

--- a/core/src/test/java/com/taobao/arthas/core/util/metrics/RateCounterTest.java
+++ b/core/src/test/java/com/taobao/arthas/core/util/metrics/RateCounterTest.java
@@ -1,0 +1,57 @@
+package com.taobao.arthas.core.util.metrics;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Regression test for RateCounter.rate() returning NaN when count is 0.
+ * When no values have been updated, rate() should return 0.0, not NaN.
+ */
+public class RateCounterTest {
+
+    @Test
+    public void testRateWhenNoUpdatesShouldNotBeNaN() {
+        RateCounter counter = new RateCounter();
+        double rate = counter.rate();
+        assertFalse(Double.isNaN(rate), 
+            "RateCounter.rate() should not return NaN when no values have been updated, but got: " + rate);
+        assertEquals(0.0, rate, 
+            "RateCounter.rate() should return 0.0 when no values have been updated, but got: " + rate);
+    }
+
+    @Test
+    public void testRateAfterOneUpdate() {
+        RateCounter counter = new RateCounter();
+        counter.update(100);
+        double rate = counter.rate();
+        
+        assertFalse(Double.isNaN(rate), 
+            "RateCounter.rate() should not return NaN after an update, but got: " + rate);
+        assertEquals(100.0, rate);
+    }
+
+    @Test
+    public void testRateAfterMultipleUpdates() {
+        RateCounter counter = new RateCounter();
+        counter.update(100);
+        counter.update(200);
+        counter.update(300);
+        double rate = counter.rate();
+        
+        assertFalse(Double.isNaN(rate), 
+            "RateCounter.rate() should not return NaN after updates, but got: " + rate);
+        assertEquals(200.0, rate); // (100+200+300)/3
+    }
+
+    @Test
+    public void testRateWithCustomSizeWhenNoUpdates() {
+        RateCounter counter = new RateCounter(10);
+        double rate = counter.rate();
+        
+        assertFalse(Double.isNaN(rate), 
+            "RateCounter.rate() should not return NaN when no values have been updated (size=10), but got: " + rate);
+        assertEquals(0.0, rate);
+    }
+}


### PR DESCRIPTION
`RateCounter.rate()` computes `sum / (double) countLength`. Before any value is
recorded `countLength` is `0`, so the method returns `NaN`. Callers reading the
rate of a fresh counter then propagate `NaN` (and `NaN` compares false against
every threshold).

Return `0.0` when nothing has been recorded.

## Verifying this change

The added `RateCounterTest` fails on the current `master` and passes with this change:

Before the fix (on `master`):

```
$ mvn test -Dtest=RateCounterTest -pl core
[INFO] Running com.taobao.arthas.core.util.metrics.RateCounterTest
[ERROR] Tests run: 4, Failures: 2, Errors: 0, Skipped: 0 <<< FAILURE!
org.opentest4j.AssertionFailedError: RateCounter.rate() should not return NaN when no values have been updated, but got: NaN ==> expected: <false> but was: <true>
	at com.taobao.arthas.core.util.metrics.RateCounterTest.testRateWhenNoUpdatesShouldNotBeNaN(RateCounterTest.java:18)
[INFO] BUILD FAILURE
```

After the fix:

```
$ mvn test -Dtest=RateCounterTest -pl core
[INFO] Running com.taobao.arthas.core.util.metrics.RateCounterTest
[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0
[INFO] BUILD SUCCESS
```

## AI assistance disclosure

This contribution was produced with the help of an AI pipeline. The pipeline processed a large amount of source code to surface suspected bugs, reproduced a subset of them with failing unit tests and generated candidate fixes, and prepared pull requests from the ones that held up. Each PR was then reviewed and verified by a human before being opened: the fix and test were checked by hand and the test was confirmed to fail before the change and pass after.

