### PR TITLE
docs: remove broken image link in arthas3.md

### DIFF
--- a/site/docs/doc/arthas3.md
+++ b/site/docs/doc/arthas3.md
@@ -105,5 +105,3 @@ ID                 NAME                                                     GROU
 #### trace 命令自动高亮显示最耗时方法调用
 
 trace 命令现在会自动显示
-
-![Untitled2](TODO /Untitled2.gif)


### PR DESCRIPTION
The image reference `![Untitled2](TODO /Untitled2.gif)` in `site/docs/doc/arthas3.md` has a literal `TODO` left in place of a real path. It's been there since the doc was first added (the original wiki import) and has never pointed to a real file, so it always renders as a broken image.

Since there's no way to recover what the actual screenshot/gif was meant to be, this just removes the broken reference rather than leaving permanently-broken markdown in the docs.