### PR TITLE
fix: race condition in AdviceListenerManager causing lost listeners

### DIFF
--- a/core/src/main/java/com/taobao/arthas/core/advisor/AdviceListenerManager.java
+++ b/core/src/main/java/com/taobao/arthas/core/advisor/AdviceListenerManager.java
@@ -197,7 +197,10 @@ public class AdviceListenerManager {
 
         if (manager == null) {
             manager = new ClassLoaderAdviceListenerManager();
-            adviceListenerMap.put(classLoader, manager);
+            ClassLoaderAdviceListenerManager existing = adviceListenerMap.putIfAbsent(classLoader, manager);
+            if (existing != null) {
+                manager = existing;
+            }
         }
         manager.registerAdviceListener(className, methodName, methodDesc, listener);
     }
@@ -228,7 +231,10 @@ public class AdviceListenerManager {
 
         if (manager == null) {
             manager = new ClassLoaderAdviceListenerManager();
-            adviceListenerMap.put(classLoader, manager);
+            ClassLoaderAdviceListenerManager existing = adviceListenerMap.putIfAbsent(classLoader, manager);
+            if (existing != null) {
+                manager = existing;
+            }
         }
         manager.registerTraceAdviceListener(className, owner, methodName, methodDesc, listener);
     }
@@ -258,7 +264,10 @@ public class AdviceListenerManager {
 
         if (manager == null) {
             manager = new ClassLoaderAdviceListenerManager();
-            adviceListenerMap.put(classLoader, manager);
+            ClassLoaderAdviceListenerManager existing = adviceListenerMap.putIfAbsent(classLoader, manager);
+            if (existing != null) {
+                manager = existing;
+            }
         }
         manager.registerLineAdviceListener(className, methodName, methodDesc, lineNumber, listener);
     }


### PR DESCRIPTION
fix: race condition in AdviceListenerManager causing lost listeners

description: 
Three register methods (registerAdviceListener, registerTraceAdviceListener,
registerLineAdviceListener) used a check-then-act pattern when lazily creating
the per-ClassLoader manager:

  manager = adviceListenerMap.get(classLoader);
  if (manager == null) {
      manager = new ClassLoaderAdviceListenerManager();
      adviceListenerMap.put(classLoader, manager);  // race: overwrites
  }

If two threads concurrently see manager == null, the second put() silently
overwrites the first manager, losing all listeners registered in it. Commands
like watch/trace/stack/line would enhance classes (inject bytecode) but the
callbacks never fire since the listener is in a discarded manager.

use putIfAbsent() and fall back to the winning thread's manager