### PR TITLE
fix: avoid skipping ordinary classes with $$Lambda in their names

### DIFF
--- a/core/src/main/java/com/taobao/arthas/core/util/ClassUtils.java
+++ b/core/src/main/java/com/taobao/arthas/core/util/ClassUtils.java
@@ -38,7 +38,7 @@ public class ClassUtils {
     }
 
     public static boolean isLambdaClass(Class<?> clazz) {
-        return clazz.getName().contains("$$Lambda");
+        return clazz.isSynthetic() && clazz.getName().contains("$$Lambda");
     }
 
     public static Element renderClassInfo(ClassDetailVO clazz) {

--- a/core/src/test/java/com/taobao/arthas/core/util/InstrumentationUtilsTest.java
+++ b/core/src/test/java/com/taobao/arthas/core/util/InstrumentationUtilsTest.java
@@ -1,0 +1,71 @@
+package com.taobao.arthas.core.util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.lang.instrument.ClassFileTransformer;
+import java.lang.instrument.IllegalClassFormatException;
+import java.lang.instrument.Instrumentation;
+import java.security.ProtectionDomain;
+import java.util.Collections;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.junit.Assume;
+import org.junit.Test;
+
+import net.bytebuddy.agent.ByteBuddyAgent;
+
+public class InstrumentationUtilsTest {
+
+    @Test
+    public void shouldRetransformOrdinaryClassWithLambdaInName() {
+        Instrumentation instrumentation = ByteBuddyAgent.install();
+        Assume.assumeTrue(instrumentation.isRetransformClassesSupported());
+        Assume.assumeTrue(instrumentation.isModifiableClass(Ordinary$$Lambda$1.class));
+        final AtomicReference<byte[]> captured = new AtomicReference<byte[]>();
+        ClassFileTransformer transformer = new ClassFileTransformer() {
+            @Override
+            public byte[] transform(ClassLoader loader, String className, Class<?> classBeingRedefined,
+                    ProtectionDomain protectionDomain, byte[] classfileBuffer) throws IllegalClassFormatException {
+                if (classBeingRedefined == Ordinary$$Lambda$1.class) {
+                    captured.set(classfileBuffer);
+                }
+                return null;
+            }
+        };
+
+        InstrumentationUtils.retransformClasses(instrumentation, transformer,
+                Collections.<Class<?>>singleton(Ordinary$$Lambda$1.class));
+
+        assertThat(Ordinary$$Lambda$1.class.isSynthetic()).isFalse();
+        assertThat(captured.get()).isNotNull().isNotEmpty();
+    }
+
+    @Test
+    public void shouldStillSkipGeneratedLambdaClass() {
+        Instrumentation instrumentation = ByteBuddyAgent.install();
+        Assume.assumeTrue(instrumentation.isRetransformClassesSupported());
+        Class<?> lambdaClass = ((Runnable) () -> { }).getClass();
+        final AtomicReference<Class<?>> transformed = new AtomicReference<Class<?>>();
+        ClassFileTransformer transformer = new ClassFileTransformer() {
+            @Override
+            public byte[] transform(ClassLoader loader, String className, Class<?> classBeingRedefined,
+                    ProtectionDomain protectionDomain, byte[] classfileBuffer) throws IllegalClassFormatException {
+                transformed.set(classBeingRedefined);
+                return null;
+            }
+        };
+
+        InstrumentationUtils.retransformClasses(instrumentation, transformer,
+                Collections.<Class<?>>singleton(lambdaClass));
+
+        assertThat(lambdaClass.isSynthetic()).isTrue();
+        assertThat(lambdaClass.getName()).contains("$$Lambda");
+        assertThat(transformed.get()).isNull();
+    }
+
+    static final class Ordinary$$Lambda$1 implements Runnable {
+        @Override
+        public void run() {
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- require the synthetic class flag in addition to `$$Lambda` in the binary name
- add a real `Instrumentation` regression test for an ordinary `Ordinary$$Lambda$1` class
- verify that a JVM-generated lambda is still skipped by the existing safeguard

## Background

#1512 added a conservative safeguard because retransformation of generated lambdas can break applications on JDK 8. The current classification relies only on the binary name, however, and ordinary application classes are allowed to contain `$$Lambda` in that name. As a result, such classes are skipped by bytecode capture even though they are not JVM-generated lambdas.

This change does not remove or relax the protection for real generated lambdas. It only avoids classifying a non-synthetic ordinary class as a lambda based on its name alone.

Related: #1512, [JDK-8145964](https://bugs.openjdk.org/browse/JDK-8145964)

## Testing

- JDK 17: `mvnw.cmd -pl core test` (264 tests, 0 failures, 0 errors, 7 skipped)
- JDK 8u131: `mvnw.cmd -pl core -Dtest=InstrumentationUtilsTest surefire:test` (2 tests, 0 failures, 0 errors)
