### PR TITLE
fix: send a valid WebSocket close code for missing agents

### DIFF
--- a/tunnel-server/src/main/java/com/alibaba/arthas/tunnel/server/TunnelSocketFrameHandler.java
+++ b/tunnel-server/src/main/java/com/alibaba/arthas/tunnel/server/TunnelSocketFrameHandler.java
@@ -216,7 +216,7 @@ public class TunnelSocketFrameHandler extends SimpleChannelInboundHandler<WebSoc
                 tunnelSocketCtx.close();
             }
         } else {
-            tunnelSocketCtx.channel().writeAndFlush(new CloseWebSocketFrame(2000, "Can not find arthas agent by id: "+ agentId));
+            tunnelSocketCtx.channel().writeAndFlush(new CloseWebSocketFrame(4000, "Can not find arthas agent by id: "+ agentId));
             logger.error("Can not find arthas agent by id: {}", agentId);
             throw new IllegalArgumentException("Can not find arthas agent by id: " + agentId);
         }

--- a/tunnel-server/src/test/java/com/alibaba/arthas/tunnel/server/TunnelSocketFrameHandlerTest.java
+++ b/tunnel-server/src/test/java/com/alibaba/arthas/tunnel/server/TunnelSocketFrameHandlerTest.java
@@ -1,0 +1,39 @@
+package com.alibaba.arthas.tunnel.server;
+
+import org.assertj.core.api.Assertions;
+import org.junit.Test;
+
+import io.netty.channel.embedded.EmbeddedChannel;
+import io.netty.handler.codec.http.EmptyHttpHeaders;
+import io.netty.handler.codec.http.websocketx.CloseWebSocketFrame;
+import io.netty.handler.codec.http.websocketx.WebSocketCloseStatus;
+import io.netty.handler.codec.http.websocketx.WebSocketServerProtocolHandler.HandshakeComplete;
+
+public class TunnelSocketFrameHandlerTest {
+
+    @Test
+    public void shouldSendAValidCloseFrameWhenAgentIsMissing() {
+        EmbeddedChannel channel = new EmbeddedChannel(new TunnelSocketFrameHandler(new TunnelServer()));
+        try {
+            channel.pipeline().fireUserEventTriggered(new HandshakeComplete("/ws?method=connectArthas&id=missing",
+                    EmptyHttpHeaders.INSTANCE, null));
+
+            Assertions.assertThatThrownBy(channel::checkException).isInstanceOf(IllegalArgumentException.class)
+                    .hasMessage("Can not find arthas agent by id: [missing]");
+
+            CloseWebSocketFrame closeFrame = channel.readOutbound();
+            try {
+                Assertions.assertThat(closeFrame).isNotNull();
+                Assertions.assertThat(closeFrame.statusCode()).isEqualTo(4000);
+                Assertions.assertThat(WebSocketCloseStatus.isValidStatusCode(closeFrame.statusCode())).isTrue();
+                Assertions.assertThat(closeFrame.reasonText()).isEqualTo("Can not find arthas agent by id: [missing]");
+            } finally {
+                if (closeFrame != null) {
+                    closeFrame.release();
+                }
+            }
+        } finally {
+            channel.finishAndReleaseAll();
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Send a valid private-use WebSocket close code when a tunnel client requests an unknown Arthas agent.

Related to #3187

## Motivation

TunnelSocketFrameHandler constructs a CloseWebSocketFrame with status code 2000 when the requested agent is absent. Netty rejects 2000 under RFC 6455, so the client receives an internal exception instead of the intended missing-agent close frame and error message.

## Changes

- Replace the invalid close status code 2000 with valid private-use code 4000.
- Add an EmbeddedChannel regression test for the missing-agent handshake path.

## Tests

- Docker Desktop, Maven 3.9.9 / Eclipse Temurin JDK 17: `mvn -V -ntp -pl tunnel-server -am -Dtest=TunnelSocketFrameHandlerTest -Dsurefire.failIfNoSpecifiedTests=false test` (1 test, 0 failures, 0 errors)

## Notes

This change preserves the existing missing-agent behavior. It does not register an absent agent or claim to resolve unrelated tunnel registration failures.

## Duplicate Check

Checked open pull requests for #3187 and WebSocket close-code terms. No pull request addressing this invalid close status was found.