### PR TITLE
fix: preserve background marker in batch mode

### DIFF
--- a/client/src/main/java/com/taobao/arthas/client/TelnetConsole.java
+++ b/client/src/main/java/com/taobao/arthas/client/TelnetConsole.java
@@ -417,7 +417,11 @@ public class TelnetConsole {
                 }
             }
             // send command to server
-            outputStream.write((command + " | plaintext\n").getBytes(StandardCharsets.UTF_8));
+            String commandWithPlaintext = command.replaceFirst("\\s*&\\s*$", " | plaintext &");
+            if (commandWithPlaintext.equals(command)) {
+                commandWithPlaintext += " | plaintext";
+            }
+            outputStream.write((commandWithPlaintext + "\n").getBytes(StandardCharsets.UTF_8));
             outputStream.flush();
         }
 

--- a/client/src/test/java/com/taobao/arthas/client/TelnetConsoleBatchModeTest.java
+++ b/client/src/test/java/com/taobao/arthas/client/TelnetConsoleBatchModeTest.java
@@ -46,6 +46,31 @@ class TelnetConsoleBatchModeTest {
     }
 
     @Test
+    void batchModeShouldKeepBackgroundMarkerAfterPlaintextPipeline() throws Exception {
+        ExecutorService executorService = Executors.newSingleThreadExecutor();
+        try (ServerSocket serverSocket = new ServerSocket(0)) {
+            Future<ServerResult> serverResult = executorService.submit(() -> runPromptFirstServer(serverSocket));
+
+            int status = TelnetConsole.process(new String[] {
+                    "--quiet",
+                    "-c",
+                    "version &",
+                    "-t",
+                    "1000",
+                    "127.0.0.1",
+                    String.valueOf(serverSocket.getLocalPort())
+            });
+
+            ServerResult result = serverResult.get(2, TimeUnit.SECONDS);
+            assertThat(status).isEqualTo(TelnetConsole.STATUS_OK);
+            assertThat(result.command).contains("version | plaintext &");
+            assertThat(result.quit).isEqualTo("quit");
+        } finally {
+            executorService.shutdownNow();
+        }
+    }
+
+    @Test
     void batchModeShouldNegotiateBinaryAndSendChineseCommandAsUtf8() throws Exception {
         ExecutorService executorService = Executors.newSingleThreadExecutor();
         try (ServerSocket serverSocket = new ServerSocket(0)) {


### PR DESCRIPTION
## Summary

Keep a trailing background marker after the plaintext output pipeline generated by the Telnet batch client.

Fixes #3223

## Motivation

TelnetConsole.batchModeRun() appends `| plaintext` to every batch command. For a command ending in `&`, appending the pipeline after the marker makes `&` no longer the final token, so the server does not run the command in the background.

## Changes

- Insert `| plaintext` before a trailing background marker instead of after it.
- Add a regression test for a batch command ending in `&`.

## Tests

- Docker Desktop, Maven 3.9.9 / Eclipse Temurin JDK 17: `mvn -V -ntp -pl client -am -Dtest=TelnetConsoleBatchModeTest -Dsurefire.failIfNoSpecifiedTests=false test` (4 tests, 0 failures, 0 errors)

## Duplicate Check

Checked the first 100 open pull requests for batchModeRun, plaintext, and the Issue wording. No matching open pull request was found.