### PR TITLE
fix: close resources in NetUtils to prevent leaks

### DIFF
--- a/core/src/main/java/com/taobao/arthas/core/util/NetUtils.java
+++ b/core/src/main/java/com/taobao/arthas/core/util/NetUtils.java
@@ -76,9 +76,10 @@ public class NetUtils {
      */
     public static String simpleRequest(String url) {
         BufferedReader br = null;
+        HttpURLConnection con = null;
         try {
             URL obj = new URL(url);
-            HttpURLConnection con = (HttpURLConnection) obj.openConnection();
+            con = (HttpURLConnection) obj.openConnection();
             con.setRequestProperty("Accept", "application/json");
             int responseCode = con.getResponseCode();
 
@@ -110,6 +111,9 @@ public class NetUtils {
                     // ignore
                 }
             }
+            if (con != null) {
+                con.disconnect();
+            }
         }
     }
 
@@ -128,10 +132,12 @@ public class NetUtils {
      * @return the qos response in string format
      */
     public static Response requestViaSocket(String path) {
+        Socket s = null;
+        PrintWriter pw = null;
         BufferedReader br = null;
         try {
-            Socket s = new Socket(QOS_HOST, QOS_PORT);
-            PrintWriter pw = new PrintWriter(s.getOutputStream());
+            s = new Socket(QOS_HOST, QOS_PORT);
+            pw = new PrintWriter(s.getOutputStream());
             pw.println("GET " + path + " HTTP/1.1");
             pw.println("Host: " + QOS_HOST + ":" + QOS_PORT);
             pw.println("");
@@ -157,6 +163,16 @@ public class NetUtils {
             if (br != null) {
                 try {
                     br.close();
+                } catch (IOException e) {
+                    // ignore
+                }
+            }
+            if (pw != null) {
+                pw.close();
+            }
+            if (s != null) {
+                try {
+                    s.close();
                 } catch (IOException e) {
                     // ignore
                 }


### PR DESCRIPTION
## Summary

Fix resource leaks in `NetUtils` by ensuring proper closure of Socket, PrintWriter, and HttpURLConnection resources.

## Changes

- **`simpleRequest()`**: Add `HttpURLConnection.disconnect()` in finally block to prevent connection leaks
- **`requestViaSocket()`**: Add proper closure of Socket and PrintWriter in finally block to prevent resource leaks

## Impact

These resource leaks could lead to:
- Socket/connection exhaustion in long-running applications
- File descriptor leaks when making multiple HTTP requests
- Potential memory leaks in high-throughput scenarios

## Testing

Local environment limitations prevent full dynamic testing; relying on CI/CD automated tests for verification.

---

I apologize for any inconvenience caused by this PR. I noticed these resource leaks while reviewing the codebase and wanted to contribute fixes. Please let me know if any changes are needed.
