### PR TITLE
test(mcp): cover last-event-id 404 guard; remove dead replay code

### DIFF
--- a/arthas-mcp-server/src/main/java/com/taobao/arthas/mcp/server/protocol/server/handler/McpStreamableHttpRequestHandler.java
+++ b/arthas-mcp-server/src/main/java/com/taobao/arthas/mcp/server/protocol/server/handler/McpStreamableHttpRequestHandler.java
@@ -197,13 +197,13 @@ public class McpStreamableHttpRequestHandler {
     }
 
     /**
-     * Handles GET requests to establish SSE connections and message replay.
+     * Handles GET requests to establish SSE listening streams.
+     * <p>
+     * Resume via {@code last-event-id} is not supported; reject immediately with 404 so
+     * clients re-initialize (#3118).
      */
     private void handleGetRequest(ChannelHandlerContext ctx, FullHttpRequest request) {
-        // TODO support last-event-id #3118
-        // MCP 客户端在 SSE 断线重连时，可能会带上 last-event-id 尝试做消息回放。
-        // Arthas MCP Server 不支持基于 last-event-id 的恢复逻辑：直接返回 404，
-        // 让客户端触发完整重置并重新走 Initialize 握手申请新的会话。
+        // Unsupported resume: reject last-event-id immediately with 404.
         if (request.headers().get(HttpHeaders.LAST_EVENT_ID) != null) {
             sendError(ctx, HttpResponseStatus.NOT_FOUND,
                     new McpError("Session not found, please re-initialize"));
@@ -259,39 +259,15 @@ public class McpStreamableHttpRequestHandler {
             NettyStreamableMcpSessionTransport sessionTransport = new NettyStreamableMcpSessionTransport(
                     sessionId, ctx);
 
-            // Check if this is a replay request
-            String lastEventId = request.headers().get(HttpHeaders.LAST_EVENT_ID);
-            if (lastEventId != null) {
-                try {
-                    // Replay messages from the last event ID
-                    try {
-                        session.replay(lastEventId).forEach(message -> {
-                            try {
-                                sessionTransport.sendMessage(message).join();
-                            } catch (Exception e) {
-                                logger.error("Failed to replay message: {}", e.getMessage());
-                                ctx.close();
-                            }
-                        });
-                    } catch (Exception e) {
-                        logger.error("Failed to replay messages: {}", e.getMessage());
-                        ctx.close();
-                    }
-                } catch (Exception e) {
-                    logger.error("Failed to replay messages: {}", e.getMessage());
-                    ctx.close();
-                }
-            } else {
-                // Establish new listening stream
-                McpStreamableServerSession.McpStreamableServerSessionStream listeningStream = session
-                        .listeningStream(sessionTransport);
+            // Establish new listening stream
+            McpStreamableServerSession.McpStreamableServerSessionStream listeningStream = session
+                    .listeningStream(sessionTransport);
 
-                // Handle channel closure
-                ctx.channel().closeFuture().addListener(future -> {
-                    logger.debug("SSE connection closed for session: {}", sessionId);
-                    listeningStream.close();
-                });
-            }
+            // Handle channel closure
+            ctx.channel().closeFuture().addListener(future -> {
+                logger.debug("SSE connection closed for session: {}", sessionId);
+                listeningStream.close();
+            });
         } catch (Exception e) {
             logger.error("Failed to handle GET request for session {}: {}", sessionId, e.getMessage());
             sendError(ctx, HttpResponseStatus.INTERNAL_SERVER_ERROR, new McpError("Internal server error"));

--- a/arthas-mcp-server/src/test/java/com/taobao/arthas/mcp/server/protocol/server/handler/McpStreamableHttpRequestHandlerTest.java
+++ b/arthas-mcp-server/src/test/java/com/taobao/arthas/mcp/server/protocol/server/handler/McpStreamableHttpRequestHandlerTest.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2024-2024 the original author or authors.
+ */
+
+package com.taobao.arthas.mcp.server.protocol.server.handler;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.taobao.arthas.mcp.server.protocol.spec.HttpHeaders;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.SimpleChannelInboundHandler;
+import io.netty.channel.embedded.EmbeddedChannel;
+import io.netty.handler.codec.http.DefaultFullHttpRequest;
+import io.netty.handler.codec.http.FullHttpRequest;
+import io.netty.handler.codec.http.FullHttpResponse;
+import io.netty.handler.codec.http.HttpHeaderNames;
+import io.netty.handler.codec.http.HttpMethod;
+import io.netty.handler.codec.http.HttpResponseStatus;
+import io.netty.handler.codec.http.HttpVersion;
+import io.netty.util.CharsetUtil;
+import io.netty.util.ReferenceCountUtil;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class McpStreamableHttpRequestHandlerTest {
+
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+    private static final String MCP_ENDPOINT = "/mcp";
+    private static final String TEXT_EVENT_STREAM = "text/event-stream";
+
+    @Test
+    void getWithLastEventIdShouldReturn404Immediately() {
+        McpStreamableHttpRequestHandler handler = newHandler();
+
+        EmbeddedChannel channel = newChannel(handler);
+        DefaultFullHttpRequest request = new DefaultFullHttpRequest(
+                HttpVersion.HTTP_1_1, HttpMethod.GET, MCP_ENDPOINT);
+        request.headers().set(HttpHeaderNames.ACCEPT, TEXT_EVENT_STREAM);
+        // Guard runs before session lookup; any session id is sufficient.
+        request.headers().set(HttpHeaders.MCP_SESSION_ID, "any-session");
+        // Cherry Studio reconnects with last-event-id after the streamable response closes.
+        request.headers().set(HttpHeaders.LAST_EVENT_ID, "event-1");
+
+        channel.writeInbound(request);
+
+        FullHttpResponse response = readOutbound(channel, FullHttpResponse.class);
+        assertThat(response.status()).isEqualTo(HttpResponseStatus.NOT_FOUND);
+        assertThat(response.content().toString(CharsetUtil.UTF_8))
+                .contains("please re-initialize");
+        ReferenceCountUtil.release(response);
+
+        // Must not leave a hanging SSE stream open for the client to time out on.
+        assertThat((Object) channel.readOutbound()).isNull();
+        assertThat(channel.isActive()).isFalse();
+        channel.finishAndReleaseAll();
+    }
+
+    @Test
+    void getWithLastEventIdIsCaseInsensitive() {
+        McpStreamableHttpRequestHandler handler = newHandler();
+
+        EmbeddedChannel channel = newChannel(handler);
+        DefaultFullHttpRequest request = new DefaultFullHttpRequest(
+                HttpVersion.HTTP_1_1, HttpMethod.GET, MCP_ENDPOINT);
+        request.headers().set(HttpHeaderNames.ACCEPT, TEXT_EVENT_STREAM);
+        request.headers().set(HttpHeaders.MCP_SESSION_ID, "any-session");
+        request.headers().set("Last-Event-ID", "event-1");
+
+        channel.writeInbound(request);
+
+        FullHttpResponse response = readOutbound(channel, FullHttpResponse.class);
+        assertThat(response.status()).isEqualTo(HttpResponseStatus.NOT_FOUND);
+        ReferenceCountUtil.release(response);
+        assertThat(channel.isActive()).isFalse();
+        channel.finishAndReleaseAll();
+    }
+
+    private static McpStreamableHttpRequestHandler newHandler() {
+        return McpStreamableHttpRequestHandler.builder()
+                .objectMapper(OBJECT_MAPPER)
+                .mcpEndpoint(MCP_ENDPOINT)
+                .build();
+    }
+
+    private static EmbeddedChannel newChannel(McpStreamableHttpRequestHandler handler) {
+        return new EmbeddedChannel(new SimpleChannelInboundHandler<FullHttpRequest>(false) {
+            @Override
+            protected void channelRead0(ChannelHandlerContext ctx, FullHttpRequest request) throws Exception {
+                handler.handle(ctx, request);
+            }
+        });
+    }
+
+    private static <T> T readOutbound(EmbeddedChannel channel, Class<T> type) {
+        Object message = channel.readOutbound();
+        assertThat(message).isInstanceOf(type);
+        return type.cast(message);
+    }
+}


### PR DESCRIPTION
## Summary

The immediate **404** when `last-event-id` is present on GET SSE requests was already fixed in `c8c585d0d` (#3118). This PR does not re-fix that behavior.

This change:
- Adds EmbeddedChannel regression tests for the existing `last-event-id` / `Last-Event-ID` guard (runs before session lookup, so tests use an arbitrary session id)
- Removes the unreachable replay branch that remained after that early reject

Relates-to #3118

## Verification

```bash
./mvnw -pl arthas-mcp-server test
```

Result: 15 tests passed (including 2 new handler tests).