### PR TITLE
feat: run commands during javaagent startup

### DIFF
--- a/agent/src/main/java/com/taobao/arthas/agent334/AgentBootstrap.java
+++ b/agent/src/main/java/com/taobao/arthas/agent334/AgentBootstrap.java
@@ -118,9 +118,11 @@ public class AgentBootstrap {
                 agentArgs = args;
             }
 
-            File arthasCoreJarFile = new File(arthasCoreJar);
-            if (!arthasCoreJarFile.exists()) {
-                ps.println("Can not find arthas-core jar file from args: " + arthasCoreJarFile);
+            File arthasCoreJarFile = arthasCoreJar.trim().isEmpty() ? null : new File(arthasCoreJar);
+            if (arthasCoreJarFile == null || !arthasCoreJarFile.exists()) {
+                if (arthasCoreJarFile != null) {
+                    ps.println("Can not find arthas-core jar file from args: " + arthasCoreJarFile);
+                }
                 // try to find from arthas-agent.jar directory
                 CodeSource codeSource = AgentBootstrap.class.getProtectionDomain().getCodeSource();
                 if (codeSource != null) {
@@ -136,7 +138,7 @@ public class AgentBootstrap {
                     }
                 }
             }
-            if (!arthasCoreJarFile.exists()) {
+            if (arthasCoreJarFile == null || !arthasCoreJarFile.exists()) {
                 return;
             }
 

--- a/core/src/main/java/arthas.properties
+++ b/core/src/main/java/arthas.properties
@@ -25,6 +25,9 @@ arthas.localConnectionNonAuth=true
 
 #arthas.outputPath=arthas-output
 
+# UTF-8 script with one startup command per line
+#arthas.startupScript=/opt/arthas/startup.as
+
 # MCP (Model Context Protocol) configuration
 arthas.mcpEndpoint=/mcp
 arthas.mcpProtocol=STREAMABLE

--- a/core/src/main/java/com/taobao/arthas/core/command/monitor200/EnhancerCommand.java
+++ b/core/src/main/java/com/taobao/arthas/core/command/monitor200/EnhancerCommand.java
@@ -118,6 +118,10 @@ public abstract class EnhancerCommand extends AnnotatedCommand {
         return lazy;
     }
 
+    boolean isLazy(Session session) {
+        return lazy || session != null && Boolean.TRUE.equals(session.get(Session.STARTUP_COMMAND));
+    }
+
     /**
      * 类名匹配
      *
@@ -201,6 +205,7 @@ public abstract class EnhancerCommand extends AnnotatedCommand {
         EnhancerAffect effect = null;
         int lock = session.getLock();
         try {
+            boolean lazyEnhance = isLazy(session);
             Instrumentation inst = session.getInstrumentation();
             AdviceListener listener = getAdviceListenerWithId(process);
             if (listener == null) {
@@ -216,7 +221,7 @@ public abstract class EnhancerCommand extends AnnotatedCommand {
             }
 
             Enhancer enhancer = new Enhancer(listener, listener instanceof InvokeTraceable, skipJDKTrace,
-                    getClassNameMatcher(), getClassNameExcludeMatcher(), getMethodNameMatcher(), this.lazy, this.hashCode);
+                    getClassNameMatcher(), getClassNameExcludeMatcher(), getMethodNameMatcher(), lazyEnhance, this.hashCode);
             enhancer.setLineEnhanceOptions(getLineEnhanceOptions());
             // 注册通知监听器
             process.register(listener, enhancer);
@@ -238,7 +243,7 @@ public abstract class EnhancerCommand extends AnnotatedCommand {
                 }
                 
                 // 懒加载模式：即使没有匹配的类也不立即结束，等待类加载
-                if (this.lazy) {
+                if (lazyEnhance) {
                     String lazyMsg = "Lazy mode is enabled, waiting for class to be loaded. Press Q or Ctrl+C to abort.\n"
                             + "When the target class is loaded, it will be automatically enhanced.";
                     process.write(lazyMsg + "\n");

--- a/core/src/main/java/com/taobao/arthas/core/command/startup/StartupCommandManager.java
+++ b/core/src/main/java/com/taobao/arthas/core/command/startup/StartupCommandManager.java
@@ -1,0 +1,409 @@
+package com.taobao.arthas.core.command.startup;
+
+import static com.taobao.arthas.common.ArthasConstants.SUBJECT_KEY;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import javax.security.auth.Subject;
+
+import com.alibaba.arthas.deps.org.slf4j.Logger;
+import com.alibaba.arthas.deps.org.slf4j.LoggerFactory;
+import com.alibaba.fastjson2.JSON;
+import com.alibaba.fastjson2.JSONWriter;
+import com.taobao.arthas.common.PidUtils;
+import com.taobao.arthas.core.command.CommandExecutorImpl;
+import com.taobao.arthas.core.shell.cli.CliToken;
+import com.taobao.arthas.core.shell.cli.CliTokens;
+import com.taobao.arthas.core.shell.session.Session;
+import com.taobao.arthas.core.shell.session.SessionManager;
+import com.taobao.arthas.core.shell.system.Job;
+import com.taobao.arthas.core.shell.system.JobController;
+import com.taobao.arthas.core.shell.system.JobListener;
+import com.taobao.arthas.core.shell.system.impl.InternalCommandManager;
+import com.taobao.arthas.core.shell.term.Term;
+import com.taobao.arthas.core.util.DateUtils;
+
+/**
+ * Starts commands configured for JVM startup and keeps each command in an isolated session.
+ */
+public class StartupCommandManager implements AutoCloseable {
+    static final int MAX_COMMANDS = 32;
+    static final int MAX_COMMAND_LENGTH = 8192;
+    static final long STARTUP_BARRIER_TIMEOUT_SECONDS = 30;
+
+    private static final Logger logger = LoggerFactory.getLogger(StartupCommandManager.class);
+    private static final DateTimeFormatter RUN_ID_FORMATTER = DateTimeFormatter.ofPattern("yyyyMMdd-HHmmss-SSS");
+
+    private final SessionManager sessionManager;
+    private final JobController jobController;
+    private final InternalCommandManager commandManager;
+    private final ExecutorService commandExecutor;
+    private final File outputRoot;
+    private final ConcurrentMap<String, CommandContext> activeCommands =
+                    new ConcurrentHashMap<String, CommandContext>();
+    private final List<StartupCommandResultWriter> resultWriters =
+                    Collections.synchronizedList(new ArrayList<StartupCommandResultWriter>());
+    private final AtomicBoolean started = new AtomicBoolean(false);
+    private final AtomicBoolean closed = new AtomicBoolean(false);
+
+    private volatile File runDirectory;
+
+    public StartupCommandManager(SessionManager sessionManager, JobController jobController,
+                    InternalCommandManager commandManager, ExecutorService commandExecutor, File outputRoot) {
+        this.sessionManager = sessionManager;
+        this.jobController = jobController;
+        this.commandManager = commandManager;
+        this.commandExecutor = commandExecutor;
+        this.outputRoot = outputRoot;
+    }
+
+    public void start(File scriptFile) throws IOException {
+        if (!started.compareAndSet(false, true)) {
+            throw new IllegalStateException("Startup commands have already been started");
+        }
+
+        List<String> commands = loadCommands(scriptFile.toPath());
+        if (commands.isEmpty()) {
+            logger.warn("No startup command found in script: {}", scriptFile);
+            return;
+        }
+
+        runDirectory = createRunDirectory();
+        writeManifest(scriptFile, commands);
+
+        int submitted = 0;
+        for (int i = 0; i < commands.size(); i++) {
+            if (startCommand(i + 1, commands.get(i))) {
+                submitted++;
+            }
+        }
+
+        if (submitted > 0) {
+            awaitStartupBarrier();
+        }
+        logger.info("Started {}/{} startup command(s), output directory: {}", submitted, commands.size(),
+                        runDirectory.getAbsolutePath());
+    }
+
+    static List<String> loadCommands(Path script) throws IOException {
+        if (!Files.isRegularFile(script) || !Files.isReadable(script)) {
+            throw new IOException("Startup command script is not a readable file: " + script);
+        }
+
+        List<String> commands = new ArrayList<String>();
+        try (BufferedReader reader = Files.newBufferedReader(script, StandardCharsets.UTF_8)) {
+            String line;
+            int lineNumber = 0;
+            while ((line = reader.readLine()) != null) {
+                lineNumber++;
+                if (lineNumber == 1 && line.length() > 0 && line.charAt(0) == '\uFEFF') {
+                    line = line.substring(1);
+                }
+                if (line.length() > MAX_COMMAND_LENGTH) {
+                    throw new IOException("Startup command at line " + lineNumber + " exceeds "
+                                    + MAX_COMMAND_LENGTH + " characters");
+                }
+                String command = line.trim();
+                if (command.length() == 0 || command.startsWith("#")) {
+                    continue;
+                }
+                commands.add(command);
+                if (commands.size() > MAX_COMMANDS) {
+                    throw new IOException("Startup command script contains more than " + MAX_COMMANDS + " commands");
+                }
+            }
+        }
+        return commands;
+    }
+
+    private File createRunDirectory() throws IOException {
+        String pid = PidUtils.currentPid();
+        String runId = RUN_ID_FORMATTER.format(LocalDateTime.now()) + "-"
+                        + UUID.randomUUID().toString().substring(0, 8);
+        Path pidDirectory = outputRoot.toPath().resolve("startup").resolve(pid);
+        Path currentRunDirectory = pidDirectory.resolve(runId);
+        Files.createDirectories(currentRunDirectory);
+        return currentRunDirectory.toFile();
+    }
+
+    private void writeManifest(File scriptFile, List<String> commands) throws IOException {
+        Map<String, Object> manifest = new LinkedHashMap<String, Object>();
+        manifest.put("formatVersion", 1);
+        manifest.put("pid", PidUtils.currentPid());
+        manifest.put("createdAt", DateUtils.getCurrentDateTime());
+        manifest.put("script", scriptFile.getCanonicalPath());
+        manifest.put("outputDirectory", runDirectory.getCanonicalPath());
+
+        List<Map<String, Object>> entries = new ArrayList<Map<String, Object>>(commands.size());
+        for (int i = 0; i < commands.size(); i++) {
+            Map<String, Object> entry = new LinkedHashMap<String, Object>();
+            entry.put("commandIndex", i + 1);
+            entry.put("command", commands.get(i));
+            entry.put("resultFile", resultFile(i + 1).getName());
+            entries.add(entry);
+        }
+        manifest.put("commands", entries);
+
+        byte[] json = JSON.toJSONString(manifest, JSONWriter.Feature.PrettyFormat).getBytes(StandardCharsets.UTF_8);
+        Files.write(new File(runDirectory, "manifest.json").toPath(), json, StandardOpenOption.CREATE_NEW,
+                        StandardOpenOption.WRITE);
+        Files.write(runDirectory.getParentFile().toPath().resolve("latest"),
+                        (runDirectory.getName() + System.lineSeparator()).getBytes(StandardCharsets.UTF_8),
+                        StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING, StandardOpenOption.WRITE);
+    }
+
+    private boolean startCommand(int commandIndex, String command) {
+        StartupCommandResultWriter resultWriter = null;
+        Session session = null;
+        CommandContext context = null;
+        try {
+            resultWriter = new StartupCommandResultWriter(commandIndex, command, resultFile(commandIndex));
+            resultWriters.add(resultWriter);
+            resultWriter.appendLifecycle("commandSubmitted");
+
+            session = sessionManager.createSession();
+            session.put(Session.QUIET, Boolean.TRUE);
+            session.put(Session.STARTUP_COMMAND, Boolean.TRUE);
+            session.put(SUBJECT_KEY, new Subject());
+            session.setUserId("startup");
+
+            List<CliToken> tokens = CliTokens.tokenize(command);
+            if (tokens.isEmpty()) {
+                throw new IllegalArgumentException("Startup command is empty");
+            }
+
+            context = new CommandContext(session, resultWriter);
+            StartupJobListener listener = new StartupJobListener(context);
+            Term term = new StartupTerm(session, resultWriter);
+            Job job = jobController.createJob(commandManager, tokens, session, listener, term, resultWriter);
+            context.setJob(job);
+            activeCommands.put(session.getSessionId(), context);
+            session.setForegroundJob(job);
+
+            Map<String, Object> data = new LinkedHashMap<String, Object>();
+            data.put("jobId", job.id());
+            data.put("sessionId", session.getSessionId());
+            resultWriter.appendLifecycle("commandStarted", data);
+            job.run(true);
+            return true;
+        } catch (Throwable e) {
+            logger.error("Start startup command failed: {}", command, e);
+            if (context != null) {
+                activeCommands.remove(context.session.getSessionId());
+            }
+            if (session != null) {
+                session.setForegroundJob(null);
+                sessionManager.removeSession(session.getSessionId());
+            }
+            if (resultWriter != null) {
+                Map<String, Object> data = new LinkedHashMap<String, Object>();
+                data.put("error", errorMessage(e));
+                resultWriter.appendLifecycle("commandFailed", data);
+                resultWriter.close();
+            }
+            return false;
+        }
+    }
+
+    private void awaitStartupBarrier() {
+        final CountDownLatch barrier = new CountDownLatch(1);
+        try {
+            commandExecutor.execute(new Runnable() {
+                @Override
+                public void run() {
+                    barrier.countDown();
+                }
+            });
+            boolean ready = barrier.await(STARTUP_BARRIER_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+            String event = ready ? "startupReady" : "startupTimeout";
+            for (CommandContext context : activeCommands.values()) {
+                context.resultWriter.appendLifecycle(event);
+            }
+            if (!ready) {
+                logger.warn("Startup command barrier timed out after {} seconds", STARTUP_BARRIER_TIMEOUT_SECONDS);
+            }
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            for (CommandContext context : activeCommands.values()) {
+                context.resultWriter.appendLifecycle("startupInterrupted");
+            }
+            logger.warn("Interrupted while waiting for startup commands", e);
+        } catch (Throwable e) {
+            for (CommandContext context : activeCommands.values()) {
+                Map<String, Object> data = new LinkedHashMap<String, Object>();
+                data.put("error", errorMessage(e));
+                context.resultWriter.appendLifecycle("startupBarrierFailed", data);
+            }
+            logger.warn("Submit startup command barrier failed", e);
+        }
+    }
+
+    private File resultFile(int commandIndex) {
+        return new File(runDirectory, String.format("command-%03d.jsonl", commandIndex));
+    }
+
+    public File getRunDirectory() {
+        return runDirectory;
+    }
+
+    @Override
+    public void close() {
+        if (!closed.compareAndSet(false, true)) {
+            return;
+        }
+
+        List<CommandContext> contexts = new ArrayList<CommandContext>(activeCommands.values());
+        for (CommandContext context : contexts) {
+            context.resultWriter.appendLifecycle("managerStopping");
+            try {
+                Job job = context.job;
+                if (job != null) {
+                    job.terminate();
+                }
+            } catch (Throwable e) {
+                logger.warn("Terminate startup command failed: {}", context.session.getSessionId(), e);
+                context.finish("commandFailed", errorMessage(e));
+            }
+        }
+
+        synchronized (resultWriters) {
+            for (StartupCommandResultWriter resultWriter : resultWriters) {
+                resultWriter.close();
+            }
+            long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(2);
+            for (StartupCommandResultWriter resultWriter : resultWriters) {
+                long remaining = deadline - System.nanoTime();
+                if (remaining <= 0) {
+                    break;
+                }
+                try {
+                    resultWriter.awaitClosed(remaining, TimeUnit.NANOSECONDS);
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    break;
+                }
+            }
+        }
+    }
+
+    private static String errorMessage(Throwable error) {
+        Throwable current = error;
+        while (current.getCause() != null && current.getCause() != current) {
+            current = current.getCause();
+        }
+        String message = current.getMessage();
+        return message == null ? current.toString() : message;
+    }
+
+    private class StartupJobListener implements JobListener {
+        private final CommandContext context;
+
+        private StartupJobListener(CommandContext context) {
+            this.context = context;
+        }
+
+        @Override
+        public void onForeground(Job job) {
+            context.session.setForegroundJob(job);
+        }
+
+        @Override
+        public void onBackground(Job job) {
+            context.session.setForegroundJob(job);
+        }
+
+        @Override
+        public void onTerminated(Job job) {
+            Integer exitCode = job.process().exitCode();
+            String event = exitCode != null && exitCode.intValue() == 0 ? "commandCompleted" : "commandFailed";
+            Map<String, Object> data = new LinkedHashMap<String, Object>();
+            data.put("jobId", job.id());
+            data.put("exitCode", exitCode);
+            context.finish(event, data);
+        }
+
+        @Override
+        public void onSuspend(Job job) {
+            context.resultWriter.appendLifecycle("commandSuspended");
+        }
+    }
+
+    private class CommandContext {
+        private final Session session;
+        private final StartupCommandResultWriter resultWriter;
+        private final AtomicBoolean finished = new AtomicBoolean(false);
+        private volatile Job job;
+
+        private CommandContext(Session session, StartupCommandResultWriter resultWriter) {
+            this.session = session;
+            this.resultWriter = resultWriter;
+        }
+
+        private void setJob(Job job) {
+            this.job = job;
+        }
+
+        private void finish(String event, String error) {
+            Map<String, Object> data = new LinkedHashMap<String, Object>();
+            data.put("error", error);
+            finish(event, data);
+        }
+
+        private void finish(String event, Map<String, Object> data) {
+            if (!finished.compareAndSet(false, true)) {
+                return;
+            }
+            resultWriter.appendLifecycle(event, data);
+            resultWriter.close();
+            activeCommands.remove(session.getSessionId());
+            session.setForegroundJob(null);
+            sessionManager.removeSession(session.getSessionId());
+        }
+    }
+
+    private static class StartupTerm extends CommandExecutorImpl.McpTerm {
+        private final StartupCommandResultWriter resultWriter;
+
+        private StartupTerm(Session session, StartupCommandResultWriter resultWriter) {
+            super(session);
+            this.resultWriter = resultWriter;
+        }
+
+        @Override
+        public String type() {
+            return "startup";
+        }
+
+        @Override
+        public Term write(String data) {
+            resultWriter.appendStdout(data);
+            return this;
+        }
+
+        @Override
+        public Term echo(String text) {
+            resultWriter.appendStdout(text);
+            return this;
+        }
+    }
+}

--- a/core/src/main/java/com/taobao/arthas/core/command/startup/StartupCommandResultWriter.java
+++ b/core/src/main/java/com/taobao/arthas/core/command/startup/StartupCommandResultWriter.java
@@ -1,0 +1,222 @@
+package com.taobao.arthas.core.command.startup;
+
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.StandardOpenOption;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
+
+import com.alibaba.arthas.deps.org.slf4j.Logger;
+import com.alibaba.arthas.deps.org.slf4j.LoggerFactory;
+import com.alibaba.fastjson2.JSON;
+import com.taobao.arthas.core.command.model.ResultModel;
+import com.taobao.arthas.core.distribution.ResultDistributor;
+import com.taobao.arthas.core.util.DateUtils;
+
+/**
+ * Writes one startup command's output as JSON Lines without blocking application threads on disk IO.
+ */
+class StartupCommandResultWriter implements ResultDistributor {
+    static final int DEFAULT_QUEUE_CAPACITY = 1024;
+
+    private static final Logger logger = LoggerFactory.getLogger(StartupCommandResultWriter.class);
+
+    private final int commandIndex;
+    private final String command;
+    private final File outputFile;
+    private final BlockingQueue<Event> queue;
+    private final Object queueLock = new Object();
+    private final AtomicBoolean closing = new AtomicBoolean(false);
+    private final AtomicLong droppedEvents = new AtomicLong(0);
+    private final AtomicLong sequence = new AtomicLong(0);
+    private final CountDownLatch closed = new CountDownLatch(1);
+    private final BufferedWriter writer;
+    private final Thread writerThread;
+
+    StartupCommandResultWriter(int commandIndex, String command, File outputFile) throws IOException {
+        this(commandIndex, command, outputFile, DEFAULT_QUEUE_CAPACITY);
+    }
+
+    StartupCommandResultWriter(int commandIndex, String command, File outputFile, int queueCapacity)
+                    throws IOException {
+        if (queueCapacity <= 0) {
+            throw new IllegalArgumentException("queueCapacity must be greater than 0");
+        }
+        this.commandIndex = commandIndex;
+        this.command = command;
+        this.outputFile = outputFile;
+        this.queue = new ArrayBlockingQueue<Event>(queueCapacity);
+        this.writer = Files.newBufferedWriter(outputFile.toPath(), StandardCharsets.UTF_8,
+                        StandardOpenOption.CREATE_NEW, StandardOpenOption.WRITE);
+        this.writerThread = new Thread(new Runnable() {
+            @Override
+            public void run() {
+                writeEvents();
+            }
+        }, String.format("arthas-startup-result-%03d", commandIndex));
+        this.writerThread.setDaemon(true);
+        this.writerThread.start();
+    }
+
+    @Override
+    public void appendResult(ResultModel result) {
+        if (result != null) {
+            enqueue(Event.result(result));
+        }
+    }
+
+    void appendStdout(String text) {
+        if (text != null && text.length() > 0) {
+            enqueue(Event.stdout(text));
+        }
+    }
+
+    void appendLifecycle(String event) {
+        appendLifecycle(event, null);
+    }
+
+    void appendLifecycle(String event, Map<String, Object> data) {
+        enqueue(Event.lifecycle(event, data));
+    }
+
+    private void enqueue(Event event) {
+        synchronized (queueLock) {
+            if (closing.get()) {
+                return;
+            }
+            if (!queue.offer(event)) {
+                queue.poll();
+                droppedEvents.incrementAndGet();
+                if (!queue.offer(event)) {
+                    droppedEvents.incrementAndGet();
+                }
+            }
+        }
+    }
+
+    @Override
+    public void close() {
+        synchronized (queueLock) {
+            closing.set(true);
+        }
+    }
+
+    boolean awaitClosed(long timeout, TimeUnit unit) throws InterruptedException {
+        return closed.await(timeout, unit);
+    }
+
+    private void writeEvents() {
+        try {
+            while (true) {
+                Event event = queue.poll(100, TimeUnit.MILLISECONDS);
+                writeDroppedEventsIfNecessary();
+                if (event == null) {
+                    synchronized (queueLock) {
+                        if (closing.get() && queue.isEmpty()) {
+                            break;
+                        }
+                    }
+                    continue;
+                }
+                writeEvent(event);
+            }
+            writer.flush();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        } catch (Throwable e) {
+            logger.error("Write startup command result failed: {}", outputFile, e);
+        } finally {
+            try {
+                writer.close();
+            } catch (IOException e) {
+                logger.warn("Close startup command result file failed: {}", outputFile, e);
+            }
+            closed.countDown();
+        }
+    }
+
+    private void writeDroppedEventsIfNecessary() throws IOException {
+        long count = droppedEvents.getAndSet(0);
+        if (count <= 0) {
+            return;
+        }
+        Map<String, Object> envelope = baseEnvelope(DateUtils.getCurrentDateTime(), "resultsDropped");
+        envelope.put("count", count);
+        writeJsonLine(envelope);
+    }
+
+    private void writeEvent(Event event) throws IOException {
+        Map<String, Object> envelope = baseEnvelope(event.timestamp, event.type);
+        if (event.result != null) {
+            envelope.put("resultType", event.result.getType());
+            envelope.put("result", event.result);
+        }
+        if (event.stdout != null) {
+            envelope.put("stdout", event.stdout);
+        }
+        if (event.data != null && !event.data.isEmpty()) {
+            envelope.put("data", event.data);
+        }
+        try {
+            writeJsonLine(envelope);
+        } catch (Throwable e) {
+            Map<String, Object> fallback = baseEnvelope(event.timestamp, "serializationError");
+            fallback.put("sourceEvent", event.type);
+            fallback.put("error", e.toString());
+            writeJsonLine(fallback);
+        }
+    }
+
+    private Map<String, Object> baseEnvelope(String timestamp, String event) {
+        Map<String, Object> envelope = new LinkedHashMap<String, Object>();
+        envelope.put("sequence", sequence.incrementAndGet());
+        envelope.put("timestamp", timestamp);
+        envelope.put("commandIndex", commandIndex);
+        envelope.put("command", command);
+        envelope.put("event", event);
+        return envelope;
+    }
+
+    private void writeJsonLine(Map<String, Object> value) throws IOException {
+        writer.write(JSON.toJSONString(value));
+        writer.newLine();
+        writer.flush();
+    }
+
+    private static class Event {
+        private final String timestamp;
+        private final String type;
+        private final ResultModel result;
+        private final String stdout;
+        private final Map<String, Object> data;
+
+        private Event(String timestamp, String type, ResultModel result, String stdout, Map<String, Object> data) {
+            this.timestamp = timestamp;
+            this.type = type;
+            this.result = result;
+            this.stdout = stdout;
+            this.data = data;
+        }
+
+        private static Event result(ResultModel result) {
+            return new Event(DateUtils.getCurrentDateTime(), "result", result, null, null);
+        }
+
+        private static Event stdout(String text) {
+            return new Event(DateUtils.getCurrentDateTime(), "stdout", null, text, null);
+        }
+
+        private static Event lifecycle(String type, Map<String, Object> data) {
+            return new Event(DateUtils.getCurrentDateTime(), type, null, null, data);
+        }
+    }
+}

--- a/core/src/main/java/com/taobao/arthas/core/config/Configure.java
+++ b/core/src/main/java/com/taobao/arthas/core/config/Configure.java
@@ -75,6 +75,11 @@ public class Configure {
     private String commandLocations;
 
     /**
+     * UTF-8 script containing commands to execute when Arthas starts.
+     */
+    private String startupScript;
+
+    /**
      * 本地连接不需要鉴权，即使配置了password。arthas.properties 里默认为true
      */
     private Boolean localConnectionNonAuth;
@@ -223,6 +228,14 @@ public class Configure {
 
     public void setCommandLocations(String commandLocations) {
         this.commandLocations = commandLocations;
+    }
+
+    public String getStartupScript() {
+        return startupScript;
+    }
+
+    public void setStartupScript(String startupScript) {
+        this.startupScript = startupScript;
     }
 
     public boolean isLocalConnectionNonAuth() {

--- a/core/src/main/java/com/taobao/arthas/core/server/ArthasBootstrap.java
+++ b/core/src/main/java/com/taobao/arthas/core/server/ArthasBootstrap.java
@@ -52,6 +52,7 @@ import com.taobao.arthas.core.advisor.Enhancer;
 import com.taobao.arthas.core.advisor.TransformerManager;
 import com.taobao.arthas.core.command.BuiltinCommandPack;
 import com.taobao.arthas.core.command.CommandExecutorImpl;
+import com.taobao.arthas.core.command.startup.StartupCommandManager;
 import com.taobao.arthas.core.command.view.ResultViewResolver;
 import com.taobao.arthas.core.config.BinderUtils;
 import com.taobao.arthas.core.config.Configure;
@@ -145,6 +146,7 @@ public class ArthasBootstrap {
 
     private HttpSessionManager httpSessionManager;
     private SecurityAuthenticator securityAuthenticator;
+    private StartupCommandManager startupCommandManager;
 
     private ArthasBootstrap(Instrumentation instrumentation, Map<String, String> args) throws Throwable {
         this.instrumentation = instrumentation;
@@ -829,6 +831,15 @@ public class ArthasBootstrap {
      * call reset() before destroy()
      */
     public void destroy() {
+        if (startupCommandManager != null) {
+            try {
+                startupCommandManager.close();
+            } catch (Throwable e) {
+                logger().error("stop startup commands error", e);
+            } finally {
+                startupCommandManager = null;
+            }
+        }
         if (this.arthasMcpBootstrap != null) {
             try {
                 // stop 时需要主动关闭 mcp keep-alive 调度线程，避免 stop 后残留线程导致 ArthasClassLoader 无法回收
@@ -917,9 +928,29 @@ public class ArthasBootstrap {
      */
     public synchronized static ArthasBootstrap getInstance(Instrumentation instrumentation, Map<String, String> args) throws Throwable {
         if (arthasBootstrap == null) {
-            arthasBootstrap = new ArthasBootstrap(instrumentation, args);
+            ArthasBootstrap bootstrap = new ArthasBootstrap(instrumentation, args);
+            arthasBootstrap = bootstrap;
+            bootstrap.startStartupCommands();
         }
         return arthasBootstrap;
+    }
+
+    private void startStartupCommands() {
+        String startupScript = configure.getStartupScript();
+        if (!StringUtils.hasText(startupScript)) {
+            return;
+        }
+
+        StartupCommandManager manager = new StartupCommandManager(sessionManager, shellServer.getJobController(),
+                        shellServer.getCommandManager(), executorService, outputPath);
+        startupCommandManager = manager;
+        try {
+            manager.start(new File(startupScript));
+        } catch (Throwable e) {
+            logger().error("Start startup commands failed, script: {}", startupScript, e);
+            manager.close();
+            startupCommandManager = null;
+        }
     }
 
     /**

--- a/core/src/main/java/com/taobao/arthas/core/shell/session/Session.java
+++ b/core/src/main/java/com/taobao/arthas/core/shell/session/Session.java
@@ -25,6 +25,10 @@ public interface Session {
      */
     String QUIET = "arthas-session-quiet";
     /**
+     * Marks a command submitted automatically while Arthas is starting.
+     */
+    String STARTUP_COMMAND = "arthas-session-startup-command";
+    /**
      * The tty this session related to.
      */
     String TTY = "tty";

--- a/core/src/test/java/com/taobao/arthas/core/command/monitor200/EnhancerCommandStartupLazyTest.java
+++ b/core/src/test/java/com/taobao/arthas/core/command/monitor200/EnhancerCommandStartupLazyTest.java
@@ -1,0 +1,32 @@
+package com.taobao.arthas.core.command.monitor200;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.Test;
+
+import com.taobao.arthas.core.shell.session.Session;
+import com.taobao.arthas.core.shell.session.impl.SessionImpl;
+
+public class EnhancerCommandStartupLazyTest {
+    @Test
+    public void startupSessionShouldEnableLazyModeImplicitly() {
+        WatchCommand command = new WatchCommand();
+        Session session = new SessionImpl();
+
+        assertThat(command.isLazy()).isFalse();
+        assertThat(command.isLazy(session)).isFalse();
+
+        session.put(Session.STARTUP_COMMAND, Boolean.TRUE);
+
+        assertThat(command.isLazy(session)).isTrue();
+        assertThat(command.isLazy()).isFalse();
+    }
+
+    @Test
+    public void explicitLazyShouldStillWorkForNormalSession() {
+        WatchCommand command = new WatchCommand();
+        command.setLazy(true);
+
+        assertThat(command.isLazy(new SessionImpl())).isTrue();
+    }
+}

--- a/core/src/test/java/com/taobao/arthas/core/command/startup/StartupCommandManagerTest.java
+++ b/core/src/test/java/com/taobao/arthas/core/command/startup/StartupCommandManagerTest.java
@@ -1,0 +1,136 @@
+package com.taobao.arthas.core.command.startup;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import com.alibaba.fastjson2.JSON;
+import com.alibaba.fastjson2.JSONObject;
+import com.taobao.arthas.core.shell.session.Session;
+import com.taobao.arthas.core.shell.session.SessionManager;
+import com.taobao.arthas.core.shell.session.impl.SessionImpl;
+import com.taobao.arthas.core.shell.system.Job;
+import com.taobao.arthas.core.shell.system.JobController;
+import com.taobao.arthas.core.shell.system.impl.InternalCommandManager;
+
+public class StartupCommandManagerTest {
+    @Rule
+    public TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+    @Test
+    public void loadCommandsShouldIgnoreCommentsBlankLinesAndBom() throws Exception {
+        Path script = temporaryFolder.newFile("startup.as").toPath();
+        String content = "\uFEFF# comment\n\n  watch demo.MathGame run  \n"
+                        + "  # another comment\nline --class demo.MathGame --line 42\n";
+        Files.write(script, content.getBytes(StandardCharsets.UTF_8));
+
+        assertThat(StartupCommandManager.loadCommands(script)).containsExactly(
+                        "watch demo.MathGame run",
+                        "line --class demo.MathGame --line 42");
+    }
+
+    @Test
+    public void loadCommandsShouldRejectTooManyCommands() throws Exception {
+        Path script = temporaryFolder.newFile("too-many.as").toPath();
+        StringBuilder content = new StringBuilder();
+        for (int i = 0; i <= StartupCommandManager.MAX_COMMANDS; i++) {
+            content.append("echo ").append(i).append('\n');
+        }
+        Files.write(script, content.toString().getBytes(StandardCharsets.UTF_8));
+
+        assertThatThrownBy(() -> StartupCommandManager.loadCommands(script))
+                        .isInstanceOf(IOException.class)
+                        .hasMessageContaining("more than " + StartupCommandManager.MAX_COMMANDS);
+    }
+
+    @Test
+    public void loadCommandsShouldRejectLongCommand() throws Exception {
+        Path script = temporaryFolder.newFile("too-long.as").toPath();
+        StringBuilder command = new StringBuilder();
+        for (int i = 0; i <= StartupCommandManager.MAX_COMMAND_LENGTH; i++) {
+            command.append('a');
+        }
+        Files.write(script, command.toString().getBytes(StandardCharsets.UTF_8));
+
+        assertThatThrownBy(() -> StartupCommandManager.loadCommands(script))
+                        .isInstanceOf(IOException.class)
+                        .hasMessageContaining("exceeds " + StartupCommandManager.MAX_COMMAND_LENGTH);
+    }
+
+    @Test
+    public void startShouldUseIndependentStartupSessionsForCommands() throws Exception {
+        Path script = temporaryFolder.newFile("multiple.as").toPath();
+        Files.write(script, ("echo first\necho second\n").getBytes(StandardCharsets.UTF_8));
+        File outputRoot = temporaryFolder.newFolder("output");
+
+        final List<Session> sessions = new ArrayList<Session>();
+        SessionManager sessionManager = mock(SessionManager.class);
+        when(sessionManager.createSession()).thenAnswer(invocation -> {
+            Session session = new SessionImpl();
+            session.put(Session.ID, UUID.randomUUID().toString());
+            session.put(Session.PID, 123L);
+            sessions.add(session);
+            return session;
+        });
+
+        JobController jobController = mock(JobController.class);
+        AtomicInteger jobIds = new AtomicInteger();
+        List<Job> jobs = new ArrayList<Job>();
+        when(jobController.createJob(any(), any(), any(), any(), any(), any())).thenAnswer(invocation -> {
+            Job job = mock(Job.class);
+            when(job.id()).thenReturn(jobIds.incrementAndGet());
+            when(job.run(anyBoolean())).thenReturn(job);
+            jobs.add(job);
+            return job;
+        });
+
+        ExecutorService executor = mock(ExecutorService.class);
+        doAnswer(invocation -> {
+            ((Runnable) invocation.getArgument(0)).run();
+            return null;
+        }).when(executor).execute(any(Runnable.class));
+
+        StartupCommandManager manager = new StartupCommandManager(sessionManager, jobController,
+                        mock(InternalCommandManager.class), executor, outputRoot);
+        manager.start(script.toFile());
+
+        assertThat(sessions).hasSize(2);
+        assertThat(sessions.get(0).getSessionId()).isNotEqualTo(sessions.get(1).getSessionId());
+        assertThat((Object) sessions.get(0).get(Session.STARTUP_COMMAND)).isEqualTo(Boolean.TRUE);
+        assertThat((Object) sessions.get(1).get(Session.STARTUP_COMMAND)).isEqualTo(Boolean.TRUE);
+        assertThat((Object) sessions.get(0).get(Session.QUIET)).isEqualTo(Boolean.TRUE);
+        assertThat(jobs).hasSize(2);
+        verify(jobs.get(0)).run(true);
+        verify(jobs.get(1)).run(true);
+        verify(sessionManager, times(2)).createSession();
+
+        JSONObject manifest = JSON.parseObject(new String(Files.readAllBytes(
+                        new File(manager.getRunDirectory(), "manifest.json").toPath()), StandardCharsets.UTF_8));
+        assertThat(manifest.getJSONArray("commands")).hasSize(2);
+        assertThat(manifest.getJSONArray("commands").getJSONObject(0).getString("resultFile"))
+                        .isEqualTo("command-001.jsonl");
+
+        manager.close();
+    }
+}

--- a/core/src/test/java/com/taobao/arthas/core/command/startup/StartupCommandResultWriterTest.java
+++ b/core/src/test/java/com/taobao/arthas/core/command/startup/StartupCommandResultWriterTest.java
@@ -1,0 +1,95 @@
+package com.taobao.arthas.core.command.startup;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.File;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import com.alibaba.fastjson2.JSON;
+import com.alibaba.fastjson2.JSONObject;
+import com.taobao.arthas.core.command.model.MessageModel;
+import com.taobao.arthas.core.command.model.ResultModel;
+
+public class StartupCommandResultWriterTest {
+    @Rule
+    public TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+    @Test
+    public void shouldWriteLifecycleResultAndStdoutAsJsonLines() throws Exception {
+        File output = new File(temporaryFolder.getRoot(), "command-001.jsonl");
+        StartupCommandResultWriter writer = new StartupCommandResultWriter(1, "echo hello", output);
+
+        writer.appendLifecycle("commandStarted");
+        writer.appendResult(new MessageModel("hello"));
+        writer.appendStdout("plain text\n");
+        writer.close();
+
+        assertThat(writer.awaitClosed(5, TimeUnit.SECONDS)).isTrue();
+        List<String> lines = Files.readAllLines(output.toPath(), StandardCharsets.UTF_8);
+        assertThat(lines).hasSize(3);
+
+        JSONObject lifecycle = JSON.parseObject(lines.get(0));
+        JSONObject result = JSON.parseObject(lines.get(1));
+        JSONObject stdout = JSON.parseObject(lines.get(2));
+        assertThat(lifecycle.getString("event")).isEqualTo("commandStarted");
+        assertThat(result.getString("event")).isEqualTo("result");
+        assertThat(result.getString("resultType")).isEqualTo("message");
+        assertThat(result.getJSONObject("result").getString("message")).isEqualTo("hello");
+        assertThat(stdout.getString("event")).isEqualTo("stdout");
+        assertThat(stdout.getString("stdout")).isEqualTo("plain text\n");
+        assertThat(stdout.getIntValue("commandIndex")).isEqualTo(1);
+    }
+
+    @Test
+    public void shouldRecordDroppedEventsWhenQueueOverflows() throws Exception {
+        File output = new File(temporaryFolder.getRoot(), "command-002.jsonl");
+        CountDownLatch serializationStarted = new CountDownLatch(1);
+        CountDownLatch releaseSerialization = new CountDownLatch(1);
+        StartupCommandResultWriter writer = new StartupCommandResultWriter(2, "watch demo.Test run", output, 1);
+
+        writer.appendResult(new BlockingResultModel(serializationStarted, releaseSerialization));
+        assertThat(serializationStarted.await(5, TimeUnit.SECONDS)).isTrue();
+        writer.appendStdout("first");
+        writer.appendStdout("second");
+        writer.close();
+        releaseSerialization.countDown();
+
+        assertThat(writer.awaitClosed(5, TimeUnit.SECONDS)).isTrue();
+        List<String> lines = Files.readAllLines(output.toPath(), StandardCharsets.UTF_8);
+        assertThat(lines).extracting(line -> JSON.parseObject(line).getString("event"))
+                        .contains("result", "resultsDropped");
+        JSONObject dropped = lines.stream().map(JSON::parseObject)
+                        .filter(line -> "resultsDropped".equals(line.getString("event")))
+                        .findFirst().get();
+        assertThat(dropped.getLongValue("count")).isGreaterThanOrEqualTo(1);
+    }
+
+    public static class BlockingResultModel extends ResultModel {
+        private final CountDownLatch serializationStarted;
+        private final CountDownLatch releaseSerialization;
+
+        BlockingResultModel(CountDownLatch serializationStarted, CountDownLatch releaseSerialization) {
+            this.serializationStarted = serializationStarted;
+            this.releaseSerialization = releaseSerialization;
+        }
+
+        @Override
+        public String getType() {
+            return "blocking";
+        }
+
+        public String getValue() throws InterruptedException {
+            serializationStarted.countDown();
+            releaseSerialization.await(5, TimeUnit.SECONDS);
+            return "value";
+        }
+    }
+}

--- a/core/src/test/java/com/taobao/arthas/core/config/ConfigureStartupScriptTest.java
+++ b/core/src/test/java/com/taobao/arthas/core/config/ConfigureStartupScriptTest.java
@@ -1,0 +1,25 @@
+package com.taobao.arthas.core.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Properties;
+
+import org.junit.Test;
+
+import com.taobao.arthas.core.env.ArthasEnvironment;
+import com.taobao.arthas.core.env.PropertiesPropertySource;
+
+public class ConfigureStartupScriptTest {
+    @Test
+    public void shouldBindStartupScript() {
+        Properties properties = new Properties();
+        properties.put("arthas.startupScript", "/opt/arthas/startup.as");
+        ArthasEnvironment environment = new ArthasEnvironment();
+        environment.addLast(new PropertiesPropertySource("test", properties));
+
+        Configure configure = new Configure();
+        BinderUtils.inject(environment, configure);
+
+        assertThat(configure.getStartupScript()).isEqualTo("/opt/arthas/startup.as");
+    }
+}

--- a/site/docs/doc/agent.md
+++ b/site/docs/doc/agent.md
@@ -10,4 +10,8 @@ java -javaagent:/tmp/test/arthas-agent.jar -jar math-game.jar
 
 默认的配置项在解压目录里的`arthas.properties`文件里。参考：[Arthas Properties](arthas-properties.md)
 
+如需在应用启动前自动安装 `watch`、`line` 等命令，并支持目标类尚未加载及多命令并行，
+可配置 `arthas.startupScript`。完整机制、输出目录和示例请参考：
+[Java Agent 启动命令机制设计](javaagent-startup-command.md)。
+
 Java Agent 机制参考： https://docs.oracle.com/javase/8/docs/api/java/lang/instrument/package-summary.html

--- a/site/docs/doc/arthas-properties.md
+++ b/site/docs/doc/arthas-properties.md
@@ -24,6 +24,7 @@ arthas.sessionTimeout=10800
 #arthas.tunnelServer=ws://127.0.0.1:7777/ws
 #arthas.agentId=mmmmmmyiddddd
 #arthas.commandLocations=/opt/arthas/ext-command.jar,/opt/arthas/ext-commands
+#arthas.startupScript=/opt/arthas/startup.as
 # 默认还会尝试加载 ${arthas.home}/commands 目录下的 *.jar
 ```
 
@@ -69,6 +70,19 @@ arthas.commandLocations=/opt/arthas/ext-command.jar,/opt/arthas/ext-commands
 也可以在命令行配置： `--command-locations '/opt/arthas/ext-command.jar,/opt/arthas/ext-commands'` 。
 
 完整的外部命令开发和加载示例请参考：[加载外部命令](external-command.md)。
+
+### Java Agent 启动命令
+
+通过 `arthas.startupScript` 可以在 Arthas 启动时自动执行 UTF-8 命令脚本：
+
+```properties
+arthas.startupScript=/opt/arthas/startup.as
+```
+
+脚本一行一条命令。每条命令使用独立 session/job，`watch`、`line` 等增强命令会在
+启动 session 中自动启用 lazy 模式，因此目标类尚未加载时也可以在首次加载时生效。
+结果默认保存到 `${arthas.outputPath}/startup/<pid>/<run-id>/`。详见
+[Java Agent 启动命令机制设计](javaagent-startup-command.md)。
 
 ## 配置的优先级
 

--- a/site/docs/doc/javaagent-startup-command.md
+++ b/site/docs/doc/javaagent-startup-command.md
@@ -154,7 +154,20 @@ arthas-output/startup/12345/
 示例：
 
 ```json
-{"sequence":4,"timestamp":"2026-07-23 15:30:14.201","commandIndex":2,"command":"line --class com.example.OrderService --line 128","event":"result","resultType":"line","result":{"type":"line","className":"com.example.OrderService","methodName":"createOrder","lineNumber":128}}
+{
+  "sequence": 4,
+  "timestamp": "2026-07-23 15:30:14.201",
+  "commandIndex": 2,
+  "command": "line --class com.example.OrderService --line 128",
+  "event": "result",
+  "resultType": "line",
+  "result": {
+    "type": "line",
+    "className": "com.example.OrderService",
+    "methodName": "createOrder",
+    "lineNumber": 128
+  }
+}
 ```
 
 结果分发使用每命令一个守护写线程和容量为 1024 的内存队列。业务线程只做非阻塞入队；

--- a/site/docs/doc/javaagent-startup-command.md
+++ b/site/docs/doc/javaagent-startup-command.md
@@ -1,0 +1,191 @@
+# Java Agent 启动命令机制设计
+
+日期：2026-07-23
+执行者：Codex
+
+## 背景
+
+Arthas 已经支持通过 `-javaagent` 在应用启动前加载，也已经支持增强命令的
+`--lazy` 模式。`--lazy` 会保留对应的 Transformer，在目标类首次加载时完成增强。
+
+当前缺少的是启动阶段的命令编排：没有配置入口自动提交命令；一个 Arthas session
+又只能有一个前台 job，因此不能把多个长期运行的 `watch`、`line` 命令依次放进同一
+session；启动命令也没有独立、持久、可区分的结果输出。
+
+## 目标
+
+1. JVM 使用 `-javaagent` 启动 Arthas 时，可以从脚本自动执行指定命令。
+2. `watch`、`line` 等增强命令在目标类尚未加载时自动等待，并在类首次加载时生效。
+3. 多条长期运行命令使用独立 session/job，同时存活，互不阻塞。
+4. `premain` 返回前确认启动命令已经经过 Arthas 命令执行线程，避免应用类加载与
+   Transformer 注册之间的竞态。
+5. 每条命令的结构化结果、文本输出、退出状态和丢弃统计持续写入独立文件。
+6. 启动脚本或单条命令失败不阻断业务 JVM 启动，并留下可诊断结果。
+
+## 非目标
+
+- 不新增一套命令解析器，仍使用 Arthas 的 `CliTokens` 和 `JobController`。
+- 不改变普通交互 session 的 lazy 默认值。
+- 不保证无限速写盘。结果生产速度超过磁盘消费速度时，优先保护业务线程，并显式
+  记录丢弃数量。
+- 不提供启动命令的在线增删改 API；启动后仍可使用普通 Arthas 命令管理诊断任务。
+- 首版不支持脚本续行、变量替换或 shell 控制语法。
+
+## 配置与脚本契约
+
+新增配置项：
+
+```properties
+arthas.startupScript=/opt/arthas/startup.as
+```
+
+相对路径以目标 JVM 的工作目录为基准。脚本使用 UTF-8，一行一条 Arthas 命令；空行
+和去除前导空格后以 `#` 开头的行会被忽略。首版最多加载 32 条命令，单行最多 8192
+个字符。
+
+示例：
+
+```text
+# /opt/arthas/startup.as
+watch com.example.OrderService createOrder '{params, returnObj}' -n 20
+line --class com.example.OrderService --method createOrder --line 128 --express '{params, localVarMap}' -n 20
+line --class com.example.InventoryService --line 76,81 --express '{params, localVarMap}' -n 50
+```
+
+推荐把配置写入 Arthas 目录中的 `arthas.properties`，然后正常启动：
+
+```bash
+java -javaagent:/opt/arthas/arthas-agent.jar -jar app.jar
+```
+
+也可以直接传递 agent options。由于现有 agent options 使用分号编码，完整 JVM 参数应
+整体加引号，并保留开头和结尾的分号：
+
+```bash
+java '-javaagent:/opt/arthas/arthas-agent.jar=;startupScript=/opt/arthas/startup.as;' -jar app.jar
+```
+
+## 启动时序
+
+```text
+AgentBootstrap.premain
+  -> ArthasBootstrap 初始化配置、命令注册和服务
+  -> 初始化命令执行线程与 TransformerManager
+  -> 读取 startupScript
+  -> 为每条命令创建独立 session、结果文件和 job
+  -> 把所有 job 提交到 Arthas 单线程命令执行器
+  -> 在同一执行器尾部提交 barrier 并等待
+  -> barrier 完成，premain 返回，应用 main 开始
+```
+
+job 的命令处理函数仍然按 Arthas 现有规则串行完成初始化，但 `watch`、`line` 等增强
+命令安装完 listener/Transformer 后会立即从处理函数返回，job 本身继续运行。因此
+barrier 完成时，多条长期命令已经同时处于监听状态。
+
+barrier 最多等待 30 秒。超时会写入所有尚在运行的命令结果文件并记录 Arthas 日志，
+随后允许 JVM 继续启动，避免诊断配置拖垮业务启动。
+
+## 类尚未加载时的行为
+
+启动命令 session 带有内部标记 `Session.STARTUP_COMMAND`。`EnhancerCommand` 的有效
+lazy 值为：
+
+```text
+命令显式 --lazy || 当前 session 是启动命令 session
+```
+
+因此启动脚本里的 `watch`、`line`、`trace`、`stack` 等 `EnhancerCommand` 子类默认
+具备 lazy 语义；普通终端、HTTP API 和 MCP session 的行为不变。
+
+`Enhancer` 先处理已经加载的匹配类，再注册到 `TransformerManager` 的 lazy
+Transformer 列表。后续类首次定义时，按类名、排除规则、ClassLoader 和 unsafe 规则
+重新匹配并增强。多条命令拥有独立 listener/Transformer；同一个类加载事件会依次经过
+所有匹配的 Transformer，所以多个 `line` 可以命中不同或相同的行号。
+
+## session 与 job 模型
+
+每条命令创建一个内部 session，原因是一个 session 同时只能持有一个前台 job。每个
+session：
+
+- 只运行脚本中的一条命令；
+- 标记为 quiet 和 startup command；
+- 使用独立结果分发器和输出文件；
+- 在命令结束时自动移除；
+- Arthas 停止时由启动命令管理器统一终止和关闭。
+
+启动脚本来自本机 JVM 启动配置，属于可信的进程级配置。即使 Arthas 网络入口启用了
+认证，内部启动 session 也可以执行；网络 session 的认证规则不变。`disabledCommands`
+仍然生效，因为被禁用命令不会注册到命令管理器。
+
+## 输出目录与格式
+
+复用现有 `arthas.outputPath`，默认输出到：
+
+```text
+arthas-output/startup/<pid>/<run-id>/
+```
+
+目录结构：
+
+```text
+arthas-output/startup/12345/
+├── latest
+└── 20260723-153012-123/
+    ├── manifest.json
+    ├── command-001.jsonl
+    ├── command-002.jsonl
+    └── command-003.jsonl
+```
+
+`latest` 是 UTF-8 文本文件，内容为最新 `run-id`，避免依赖不兼容 Windows 的符号链接。
+`manifest.json` 保存脚本绝对路径、PID、启动时间、命令序号、完整命令和结果文件名。
+
+每个 JSONL 事件都包含 `sequence`、`timestamp`、`commandIndex`、`command` 和 `event`。
+主要事件包括：
+
+- `commandSubmitted`：job 提交前；
+- `commandStarted`：job 已创建，包含 `jobId`；
+- `result`：原始 `ResultModel`，保留 `watch`、`line` 等结构化字段；
+- `stdout`：命令通过 `process.write` 产生的文本；
+- `startupReady`：启动 barrier 已完成；
+- `commandCompleted` / `commandFailed`：命令结束或创建失败；
+- `resultsDropped`：异步写盘队列溢出，包含从上次记录起丢弃的事件数。
+
+示例：
+
+```json
+{"sequence":4,"timestamp":"2026-07-23 15:30:14.201","commandIndex":2,"command":"line --class com.example.OrderService --line 128","event":"result","resultType":"line","result":{"type":"line","className":"com.example.OrderService","methodName":"createOrder","lineNumber":128}}
+```
+
+结果分发使用每命令一个守护写线程和容量为 1024 的内存队列。业务线程只做非阻塞入队；
+队列满时淘汰最早的待写事件并累计 `resultsDropped`，不在业务线程同步写磁盘。JSONL
+每个事件写完即 flush，使早期启动故障后仍尽可能保留完整数据。
+
+## 错误与退出策略
+
+- 脚本不存在、不可读、命令数或行长超限：不执行任何启动命令，在 Arthas 日志记录
+  错误，业务 JVM 继续启动。
+- 单条命令不存在或参数错误：只结束该命令，在对应 JSONL 写入失败/状态事件，其他
+  命令继续运行。
+- 单条结果无法 JSON 序列化：写入 `serializationError` 事件，写线程继续工作。
+- 输出目录或文件无法创建：不执行对应启动命令，避免产生无处可查的诊断任务。
+- Arthas stop/JVM shutdown：先终止启动 jobs、注销 Transformer/listener，再排空并关闭
+  结果文件。
+
+## 兼容性
+
+- 未显式传入 core JAR 路径时，agent 会把空值视为“未配置”，并从
+  `arthas-agent.jar` 同目录查找 `arthas-core.jar`，保证最简 `-javaagent` 用法可用。
+- 未配置 `arthas.startupScript` 时不创建额外 session、线程或文件，原行为不变。
+- 普通命令只有显式指定 `--lazy/-L` 才使用 lazy，原行为不变。
+- 复用 `arthas.outputPath`，不增加第二套输出根目录配置。
+- 脚本复用现有命令语法；显式 `--lazy`、`--timeout`、`-n` 等选项继续有效。
+
+## 验证计划
+
+1. 配置绑定测试：`arthas.startupScript` 能注入 `Configure`。
+2. 脚本解析测试：注释、空行、UTF-8 BOM、多命令、数量和行长限制。
+3. 输出测试：manifest、result/stdout/lifecycle JSONL、正常关闭与序列化错误。
+4. 编排测试：多条命令创建不同 session/job，单条失败不影响其他命令，barrier 可等待。
+5. lazy 测试：启动 session 自动 lazy，普通 session 保持原默认。
+6. 模块测试与编译：运行 core 相关单测并完成 Maven 编译验证。

--- a/site/docs/en/doc/agent.md
+++ b/site/docs/en/doc/agent.md
@@ -10,4 +10,8 @@ java -javaagent:/tmp/test/arthas-agent.jar -jar math-game.jar
 
 The default configuration is in the `arthas.properties` file in the decompression directory. Reference: [Arthas Properties](arthas-properties.md)
 
+Set `arthas.startupScript` to execute one or more commands automatically during startup. Each command runs in an
+independent session, and enhancer commands such as `watch` and `line` wait for matching classes that have not been
+loaded yet. Results are written under `${arthas.outputPath}/startup/<pid>/<run-id>/`.
+
 Reference: https://docs.oracle.com/javase/8/docs/api/java/lang/instrument/package-summary.html

--- a/site/docs/en/doc/arthas-properties.md
+++ b/site/docs/en/doc/arthas-properties.md
@@ -24,6 +24,7 @@ arthas.sessionTimeout=10800
 #arthas.tunnelServer=ws://127.0.0.1:7777/ws
 #arthas.agentId=mmmmmmyiddddd
 #arthas.commandLocations=/opt/arthas/ext-command.jar,/opt/arthas/ext-commands
+#arthas.startupScript=/opt/arthas/startup.as
 # Arthas will also try to load *.jar from ${arthas.home}/commands if the directory exists
 ```
 
@@ -70,6 +71,18 @@ It can also be configured on the command line:
 `--command-locations '/opt/arthas/ext-command.jar,/opt/arthas/ext-commands'`.
 
 For a complete external command development and loading example, see [Load External Commands](external-command.md).
+
+### Java Agent startup commands
+
+Set `arthas.startupScript` to a UTF-8 script containing one Arthas command per line:
+
+```properties
+arthas.startupScript=/opt/arthas/startup.as
+```
+
+Each command runs in an independent session/job. Enhancer commands such as `watch` and `line` automatically use lazy
+mode in startup sessions, so they can instrument a matching class when it is first loaded. Results are written to
+`${arthas.outputPath}/startup/<pid>/<run-id>/` by default.
 
 ## Configured order
 


### PR DESCRIPTION
## Summary

- add `arthas.startupScript` for executing UTF-8 command scripts when Arthas starts through `-javaagent`
- run every startup command in an independent session/job so multiple long-running `watch`, `line`, and other enhancer commands can coexist
- automatically enable lazy enhancement for startup sessions and wait on an executor barrier before `premain` returns
- persist a manifest and per-command JSONL event streams under `${arthas.outputPath}/startup/<pid>/<run-id>/`
- use bounded asynchronous result queues, explicit dropped-result events, fail-open startup behavior, and lifecycle cleanup
- fix blank core JAR handling so the agent reliably falls back to `arthas-core.jar` beside `arthas-agent.jar`
- document the configuration and add focused parser, orchestration, lazy-mode, configuration, and output tests

## Motivation

Starting Arthas with `-javaagent` currently initializes the server but cannot preinstall diagnostic commands. Commands submitted after application startup can miss early class loads or method calls, and one session cannot host multiple foreground long-running commands. This change adds a thin startup orchestration layer on top of the existing command, job, and transformer infrastructure.

## User impact

The feature is disabled unless `arthas.startupScript` is configured, so existing startup and interactive-session behavior is unchanged. When enabled, a script can contain one Arthas command per line; enhancer commands wait for unloaded target classes automatically, and structured results are persisted without blocking application threads on disk I/O.

Example:

```properties
arthas.startupScript=/opt/arthas/startup.as
```

```text
line --class demo.MathGame --line 51 -n 2
line --class demo.MathGame --line 57 -n 2
watch demo.MathGame primeFactors '{params, returnObj}' -n 2
```

## Validation

- `./mvnw -pl core -am test` — 291 tests, 0 failures, 7 existing skips
- `./mvnw -f agent/pom.xml -DskipTests package`
- `./mvnw -pl packaging -am -DskipTests package` — core, site, and distribution build succeeded
- manual `-javaagent` smoke test with MathGame: two `line` jobs and one `watch` job entered lazy mode before `demo.MathGame` loaded, then all produced results in separate JSONL files
