### PR TITLE
feat(mcp): add upload_file tool

### DIFF
--- a/arthas-mcp-integration-test/src/test/java/com/taobao/arthas/mcp/it/ArthasMcpJavaSdkIT.java
+++ b/arthas-mcp-integration-test/src/test/java/com/taobao/arthas/mcp/it/ArthasMcpJavaSdkIT.java
@@ -31,6 +31,7 @@ import java.nio.file.Paths;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Base64;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -52,6 +53,10 @@ class ArthasMcpJavaSdkIT {
     private static final String TARGET_CLASS_PATTERN = TargetJvmApp.class.getName();
 
     private static final String TARGET_METHOD_PATTERN = "hotMethod";
+
+    private static final String UPLOAD_FILE_NAME = "mcp-upload-it.class";
+
+    private static final String UPLOAD_FILE_CONTENT = "mcp-upload-it-content";
 
     private static final List<String> EXPECTED_TOOL_NAMES = Arrays.asList(
             "classloader",
@@ -80,6 +85,7 @@ class ArthasMcpJavaSdkIT {
             "thread",
             "trace",
             "tt",
+            "upload_file",
             "version",
             "vmoption",
             "vmtool",
@@ -184,6 +190,20 @@ class ArthasMcpJavaSdkIT {
             return;
         }
 
+        if ("upload_file".equals(toolName)) {
+            JsonNode node = OBJECT_MAPPER.readTree(body);
+            assertThat(node.path("status").asText()).isEqualTo("completed");
+            assertThat(node.path("fileName").asText()).isEqualTo(UPLOAD_FILE_NAME);
+            assertThat(node.path("reused").asBoolean()).isFalse();
+
+            Path uploadedFile = Paths.get(node.path("targetPath").asText());
+            assertThat(uploadedFile).isRegularFile();
+            assertThat(uploadedFile.getFileName().toString()).isEqualTo(UPLOAD_FILE_NAME);
+            assertThat(Files.readAllBytes(uploadedFile))
+                    .containsExactly(UPLOAD_FILE_CONTENT.getBytes(StandardCharsets.UTF_8));
+            return;
+        }
+
         if (isStreamableTool(toolName)) {
             JsonNode node = OBJECT_MAPPER.readTree(body);
             if (node != null && node.isObject()) {
@@ -265,6 +285,13 @@ class ArthasMcpJavaSdkIT {
             Files.createDirectories(outDir);
             args.put("javaFilePaths", sourceFile.toString());
             args.put("outputDir", outDir.toString());
+            return args;
+        }
+
+        if ("upload_file".equals(toolName)) {
+            args.put("fileName", UPLOAD_FILE_NAME);
+            args.put("contentBase64", Base64.getEncoder().encodeToString(
+                    UPLOAD_FILE_CONTENT.getBytes(StandardCharsets.UTF_8)));
             return args;
         }
 

--- a/core/src/main/java/com/taobao/arthas/core/mcp/tool/function/basic1000/UploadFileTool.java
+++ b/core/src/main/java/com/taobao/arthas/core/mcp/tool/function/basic1000/UploadFileTool.java
@@ -1,0 +1,455 @@
+package com.taobao.arthas.core.mcp.tool.function.basic1000;
+
+import com.taobao.arthas.core.mcp.tool.function.AbstractArthasTool;
+import com.taobao.arthas.mcp.server.protocol.spec.McpSchema;
+import com.taobao.arthas.mcp.server.tool.annotation.Tool;
+import com.taobao.arthas.mcp.server.tool.annotation.ToolParam;
+import com.taobao.arthas.mcp.server.util.JsonParser;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.ByteBuffer;
+import java.nio.channels.FileChannel;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.AtomicMoveNotSupportedException;
+import java.nio.file.DirectoryStream;
+import java.nio.file.FileAlreadyExistsException;
+import java.nio.file.Files;
+import java.nio.file.LinkOption;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.nio.file.StandardOpenOption;
+import java.nio.file.attribute.PosixFilePermission;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.Base64;
+import java.util.EnumSet;
+import java.util.LinkedHashMap;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.Semaphore;
+import java.util.regex.Pattern;
+
+/**
+ * Upload a small file to the target JVM filesystem for use by other Arthas MCP tools.
+ */
+public class UploadFileTool extends AbstractArthasTool {
+
+    static final int DEFAULT_MAX_FILE_BYTES = 1024 * 1024;
+    static final long DEFAULT_MAX_TOTAL_BYTES = 64L * 1024 * 1024;
+    static final int DEFAULT_MAX_ARTIFACTS = 64;
+
+    private static final int MAX_FILE_NAME_BYTES = 128;
+    private static final Pattern SHA_256_PATTERN = Pattern.compile("[0-9a-fA-F]{64}");
+    private static final Set<PosixFilePermission> DIRECTORY_PERMISSIONS = EnumSet.of(
+            PosixFilePermission.OWNER_READ,
+            PosixFilePermission.OWNER_WRITE,
+            PosixFilePermission.OWNER_EXECUTE);
+    private static final Set<PosixFilePermission> FILE_PERMISSIONS = EnumSet.of(
+            PosixFilePermission.OWNER_READ,
+            PosixFilePermission.OWNER_WRITE);
+
+    private final Path uploadRoot;
+    private final int maxFileBytes;
+    private final long maxTotalBytes;
+    private final int maxArtifacts;
+    private final Semaphore uploadPermit = new Semaphore(1);
+
+    public UploadFileTool() {
+        this(DefaultUploadRootHolder.UPLOAD_ROOT,
+                DEFAULT_MAX_FILE_BYTES,
+                DEFAULT_MAX_TOTAL_BYTES,
+                DEFAULT_MAX_ARTIFACTS);
+    }
+
+    UploadFileTool(Path uploadRoot, int maxFileBytes, long maxTotalBytes, int maxArtifacts) {
+        if (maxFileBytes <= 0 || maxTotalBytes < maxFileBytes || maxArtifacts <= 0) {
+            throw new IllegalArgumentException("Invalid upload limits");
+        }
+        this.uploadRoot = prepareUploadRoot(uploadRoot);
+        this.maxFileBytes = maxFileBytes;
+        this.maxTotalBytes = maxTotalBytes;
+        this.maxArtifacts = maxArtifacts;
+    }
+
+    @Tool(
+            name = "upload_file",
+            description = "上传一个小型 .class、.java 或 .jfc 文件到目标 JVM 的受控临时目录。"
+                    + "内容必须使用 RFC 4648 Base64 编码；成功后返回 targetPath，可传给 mc、redefine、"
+                    + "retransform 或 profiler。该工具只上传文件，不会自动执行文件。",
+            taskSupport = McpSchema.TaskSupportMode.FORBIDDEN
+    )
+    public String uploadFile(
+            @ToolParam(description = "文件叶子名称，仅允许字母、数字、点、下划线、连字符和 $；"
+                    + "首版支持 .class、.java、.jfc，不能包含目录。")
+            String fileName,
+
+            @ToolParam(description = "RFC 4648 标准 Base64 文件内容；解码后默认最大 1 MiB。")
+            String contentBase64,
+
+            @ToolParam(description = "可选的文件 SHA-256，64 位十六进制；提供时必须与上传内容一致。",
+                    required = false)
+            String expectedSha256
+    ) {
+        if (!uploadPermit.tryAcquire()) {
+            throw uploadError("UPLOAD_BUSY", "Another file upload is in progress");
+        }
+
+        try {
+            return upload(fileName, contentBase64, expectedSha256);
+        } finally {
+            uploadPermit.release();
+        }
+    }
+
+    private String upload(String fileName, String contentBase64, String expectedSha256) {
+        String kind = validateFileNameAndGetKind(fileName);
+        String normalizedExpectedSha256 = normalizeExpectedSha256(expectedSha256);
+        byte[] content = decodeContent(contentBase64);
+        String sha256 = sha256(content);
+
+        if (normalizedExpectedSha256 != null && !normalizedExpectedSha256.equals(sha256)) {
+            throw uploadError("CHECKSUM_MISMATCH", "The expected SHA-256 does not match the uploaded content");
+        }
+
+        ensureUploadRootIsSafe();
+        Path artifactDirectory = uploadRoot.resolve(sha256).normalize();
+        Path target = artifactDirectory.resolve(fileName).normalize();
+        if (!uploadRoot.equals(artifactDirectory.getParent()) || !artifactDirectory.equals(target.getParent())) {
+            throw uploadError("INVALID_FILE_NAME", "The file name must not contain a directory");
+        }
+
+        boolean reused;
+        if (Files.exists(artifactDirectory, LinkOption.NOFOLLOW_LINKS)) {
+            verifyArtifactDirectory(artifactDirectory);
+        }
+        if (Files.exists(target, LinkOption.NOFOLLOW_LINKS)) {
+            verifyExistingArtifact(target, sha256, content.length);
+            reused = true;
+        } else {
+            assertQuotaAvailable(content.length);
+            ensureArtifactDirectory(artifactDirectory);
+            commitAtomically(target, content, sha256);
+            reused = false;
+        }
+
+        String artifactId = "art_" + sha256((fileName + "\u0000" + sha256).getBytes(StandardCharsets.UTF_8));
+        Map<String, Object> result = new LinkedHashMap<>();
+        result.put("status", "completed");
+        result.put("stage", "final");
+        result.put("message", reused ? "Upload artifact already exists" : "Upload artifact committed");
+        result.put("artifactId", artifactId);
+        result.put("fileName", fileName);
+        result.put("kind", kind);
+        result.put("targetPath", target.toString());
+        result.put("sizeBytes", content.length);
+        result.put("sha256", sha256);
+        result.put("reused", reused);
+
+        logger.info("MCP upload committed: artifactId={}, fileName={}, sizeBytes={}, sha256={}, reused={}",
+                artifactId, fileName, content.length, sha256, reused);
+        return JsonParser.toJson(result);
+    }
+
+    private String validateFileNameAndGetKind(String fileName) {
+        if (fileName == null || fileName.isEmpty()
+                || fileName.getBytes(StandardCharsets.UTF_8).length > MAX_FILE_NAME_BYTES) {
+            throw uploadError("INVALID_FILE_NAME", "The file name is invalid");
+        }
+
+        for (int i = 0; i < fileName.length(); i++) {
+            char ch = fileName.charAt(i);
+            if (!(Character.isLetterOrDigit(ch) || ch == '.' || ch == '_' || ch == '-' || ch == '$')) {
+                throw uploadError("INVALID_FILE_NAME", "The file name contains unsupported characters");
+            }
+        }
+
+        int extensionIndex = fileName.lastIndexOf('.');
+        if (extensionIndex <= 0) {
+            throw uploadError("INVALID_FILE_NAME", "The file name must include a base name and extension");
+        }
+
+        String lowerCaseName = fileName.toLowerCase(Locale.ROOT);
+        if (lowerCaseName.endsWith(".class")) {
+            return "CLASS";
+        }
+        if (lowerCaseName.endsWith(".java")) {
+            return "JAVA_SOURCE";
+        }
+        if (lowerCaseName.endsWith(".jfc")) {
+            return "JFC";
+        }
+        throw uploadError("UNSUPPORTED_FILE_TYPE", "Only .class, .java, and .jfc files are supported");
+    }
+
+    private String normalizeExpectedSha256(String expectedSha256) {
+        if (expectedSha256 == null || expectedSha256.trim().isEmpty()) {
+            return null;
+        }
+        String normalized = expectedSha256.trim();
+        if (!SHA_256_PATTERN.matcher(normalized).matches()) {
+            throw uploadError("INVALID_CHECKSUM", "expectedSha256 must be 64 hexadecimal characters");
+        }
+        return normalized.toLowerCase(Locale.ROOT);
+    }
+
+    private byte[] decodeContent(String contentBase64) {
+        if (contentBase64 == null || contentBase64.isEmpty()) {
+            throw uploadError("INVALID_BASE64", "contentBase64 must not be empty");
+        }
+
+        long maxEncodedLength = ((maxFileBytes + 2L) / 3L) * 4L;
+        if (contentBase64.length() > maxEncodedLength) {
+            throw uploadError("FILE_TOO_LARGE", "The decoded file exceeds the configured size limit");
+        }
+
+        byte[] content;
+        try {
+            content = Base64.getDecoder().decode(contentBase64);
+        } catch (IllegalArgumentException e) {
+            throw uploadError("INVALID_BASE64", "contentBase64 is not valid RFC 4648 Base64", e);
+        }
+
+        if (content.length == 0) {
+            throw uploadError("EMPTY_FILE", "The uploaded file must not be empty");
+        }
+        if (content.length > maxFileBytes) {
+            throw uploadError("FILE_TOO_LARGE", "The decoded file exceeds the configured size limit");
+        }
+        return content;
+    }
+
+    private void assertQuotaAvailable(long incomingBytes) {
+        long totalBytes = 0;
+        int artifactCount = 0;
+
+        try (DirectoryStream<Path> stream = Files.newDirectoryStream(uploadRoot)) {
+            for (Path artifactDirectory : stream) {
+                if (Files.isSymbolicLink(artifactDirectory)) {
+                    throw uploadError("UPLOAD_ROOT_UNSAFE", "The upload directory contains a symbolic link");
+                }
+                if (!Files.isDirectory(artifactDirectory, LinkOption.NOFOLLOW_LINKS)
+                        || !SHA_256_PATTERN.matcher(artifactDirectory.getFileName().toString()).matches()) {
+                    throw uploadError("UPLOAD_ROOT_UNSAFE", "The upload directory contains an unexpected entry");
+                }
+                try (DirectoryStream<Path> artifacts = Files.newDirectoryStream(artifactDirectory)) {
+                    for (Path artifact : artifacts) {
+                        if (Files.isSymbolicLink(artifact)
+                                || !Files.isRegularFile(artifact, LinkOption.NOFOLLOW_LINKS)) {
+                            throw uploadError("UPLOAD_ROOT_UNSAFE", "The artifact directory contains an unsafe entry");
+                        }
+                        artifactCount++;
+                        totalBytes += Files.size(artifact);
+                    }
+                }
+            }
+        } catch (IOException e) {
+            throw uploadError("IO_ERROR", "Failed to inspect the upload directory", e);
+        }
+
+        if (artifactCount >= maxArtifacts || incomingBytes > maxTotalBytes - totalBytes) {
+            throw uploadError("QUOTA_EXCEEDED", "The upload directory quota has been reached");
+        }
+    }
+
+    private void commitAtomically(Path target, byte[] content, String expectedSha256) {
+        Path temp = null;
+        try {
+            temp = Files.createTempFile(target.getParent(), ".upload-", ".part");
+            setFilePermissions(temp);
+            try (FileChannel channel = FileChannel.open(temp, StandardOpenOption.WRITE,
+                    StandardOpenOption.TRUNCATE_EXISTING)) {
+                ByteBuffer buffer = ByteBuffer.wrap(content);
+                while (buffer.hasRemaining()) {
+                    channel.write(buffer);
+                }
+                channel.force(true);
+            }
+
+            try {
+                Files.move(temp, target, StandardCopyOption.ATOMIC_MOVE);
+                temp = null;
+            } catch (FileAlreadyExistsException e) {
+                verifyExistingArtifact(target, expectedSha256, content.length);
+            } catch (AtomicMoveNotSupportedException e) {
+                throw uploadError("IO_ERROR", "The upload directory does not support atomic file commits", e);
+            }
+        } catch (UploadFileException e) {
+            throw e;
+        } catch (IOException e) {
+            throw uploadError("IO_ERROR", "Failed to commit the uploaded file", e);
+        } finally {
+            if (temp != null) {
+                try {
+                    Files.deleteIfExists(temp);
+                } catch (IOException e) {
+                    logger.warn("Failed to remove temporary MCP upload file: {}", temp, e);
+                }
+            }
+        }
+    }
+
+    private void ensureArtifactDirectory(Path artifactDirectory) {
+        try {
+            try {
+                Files.createDirectory(artifactDirectory);
+                setDirectoryPermissions(artifactDirectory);
+            } catch (FileAlreadyExistsException ignored) {
+                // A previous identical upload may have created the content directory.
+            }
+            verifyArtifactDirectory(artifactDirectory);
+        } catch (UploadFileException e) {
+            throw e;
+        } catch (IOException e) {
+            throw uploadError("IO_ERROR", "Failed to prepare the artifact directory", e);
+        }
+    }
+
+    private void verifyArtifactDirectory(Path artifactDirectory) {
+        try {
+            if (Files.isSymbolicLink(artifactDirectory)
+                    || !Files.isDirectory(artifactDirectory, LinkOption.NOFOLLOW_LINKS)
+                    || !artifactDirectory.equals(artifactDirectory.toRealPath())) {
+                throw uploadError("UPLOAD_ROOT_UNSAFE", "The artifact directory is unavailable or unsafe");
+            }
+        } catch (UploadFileException e) {
+            throw e;
+        } catch (IOException e) {
+            throw uploadError("IO_ERROR", "Failed to verify the artifact directory", e);
+        }
+    }
+
+    private void verifyExistingArtifact(Path target, String expectedSha256, long expectedSize) {
+        try {
+            if (Files.isSymbolicLink(target) || !Files.isRegularFile(target, LinkOption.NOFOLLOW_LINKS)
+                    || Files.size(target) != expectedSize || !expectedSha256.equals(sha256(target))) {
+                throw uploadError("ARTIFACT_CONFLICT", "The destination already exists with different content");
+            }
+        } catch (UploadFileException e) {
+            throw e;
+        } catch (IOException e) {
+            throw uploadError("IO_ERROR", "Failed to verify the existing upload artifact", e);
+        }
+    }
+
+    private void ensureUploadRootIsSafe() {
+        try {
+            if (Files.isSymbolicLink(uploadRoot)
+                    || !Files.isDirectory(uploadRoot, LinkOption.NOFOLLOW_LINKS)
+                    || !uploadRoot.equals(uploadRoot.toRealPath())) {
+                throw uploadError("UPLOAD_ROOT_UNSAFE", "The upload directory is unavailable or unsafe");
+            }
+        } catch (UploadFileException e) {
+            throw e;
+        } catch (IOException e) {
+            throw uploadError("UPLOAD_ROOT_UNAVAILABLE", "The upload directory is unavailable", e);
+        }
+    }
+
+    private static Path prepareUploadRoot(Path root) {
+        if (root == null) {
+            throw new IllegalArgumentException("uploadRoot must not be null");
+        }
+        try {
+            Path normalized = root.toAbsolutePath().normalize();
+            if (Files.isSymbolicLink(normalized)) {
+                throw new IllegalArgumentException("uploadRoot must not be a symbolic link");
+            }
+            Files.createDirectories(normalized);
+            if (!Files.isDirectory(normalized, LinkOption.NOFOLLOW_LINKS)) {
+                throw new IllegalArgumentException("uploadRoot must be a directory");
+            }
+            Path realRoot = normalized.toRealPath();
+            setDirectoryPermissions(realRoot);
+            return realRoot;
+        } catch (IOException e) {
+            throw new IllegalStateException("Failed to prepare MCP upload directory", e);
+        }
+    }
+
+    private static Path createDefaultUploadRoot() {
+        try {
+            return Files.createTempDirectory("arthas-mcp-uploads-");
+        } catch (IOException e) {
+            throw new IllegalStateException("Failed to create MCP upload directory", e);
+        }
+    }
+
+    private static void setDirectoryPermissions(Path directory) throws IOException {
+        try {
+            Files.setPosixFilePermissions(directory, DIRECTORY_PERMISSIONS);
+        } catch (UnsupportedOperationException ignored) {
+            // POSIX permissions are not available on this filesystem.
+        }
+    }
+
+    private static void setFilePermissions(Path file) throws IOException {
+        try {
+            Files.setPosixFilePermissions(file, FILE_PERMISSIONS);
+        } catch (UnsupportedOperationException ignored) {
+            // POSIX permissions are not available on this filesystem.
+        }
+    }
+
+    private static String sha256(byte[] content) {
+        MessageDigest digest = newSha256Digest();
+        return toHex(digest.digest(content));
+    }
+
+    private static String sha256(Path path) throws IOException {
+        MessageDigest digest = newSha256Digest();
+        byte[] buffer = new byte[8192];
+        try (InputStream input = Files.newInputStream(path)) {
+            int read;
+            while ((read = input.read(buffer)) != -1) {
+                digest.update(buffer, 0, read);
+            }
+        }
+        return toHex(digest.digest());
+    }
+
+    private static MessageDigest newSha256Digest() {
+        try {
+            return MessageDigest.getInstance("SHA-256");
+        } catch (NoSuchAlgorithmException e) {
+            throw new IllegalStateException("SHA-256 is not available", e);
+        }
+    }
+
+    private static String toHex(byte[] bytes) {
+        char[] hex = new char[bytes.length * 2];
+        char[] digits = "0123456789abcdef".toCharArray();
+        for (int i = 0; i < bytes.length; i++) {
+            int value = bytes[i] & 0xff;
+            hex[i * 2] = digits[value >>> 4];
+            hex[i * 2 + 1] = digits[value & 0x0f];
+        }
+        return new String(hex);
+    }
+
+    private static UploadFileException uploadError(String code, String message) {
+        return new UploadFileException(code, message, null);
+    }
+
+    private static UploadFileException uploadError(String code, String message, Throwable cause) {
+        return new UploadFileException(code, message, cause);
+    }
+
+    static final class UploadFileException extends RuntimeException {
+        private final String code;
+
+        private UploadFileException(String code, String message, Throwable cause) {
+            super(code + ": " + message, cause);
+            this.code = code;
+        }
+
+        String getCode() {
+            return code;
+        }
+    }
+
+    private static final class DefaultUploadRootHolder {
+        private static final Path UPLOAD_ROOT = createDefaultUploadRoot();
+    }
+}

--- a/core/src/main/java/com/taobao/arthas/core/mcp/tool/function/basic1000/UploadFileTool.java
+++ b/core/src/main/java/com/taobao/arthas/core/mcp/tool/function/basic1000/UploadFileTool.java
@@ -37,8 +37,7 @@ import java.util.regex.Pattern;
 public class UploadFileTool extends AbstractArthasTool {
 
     static final int DEFAULT_MAX_FILE_BYTES = 1024 * 1024;
-    static final long DEFAULT_MAX_TOTAL_BYTES = 64L * 1024 * 1024;
-    static final int DEFAULT_MAX_ARTIFACTS = 64;
+    static final long DEFAULT_MAX_TOTAL_BYTES = 200L * 1024 * 1024;
 
     private static final int MAX_FILE_NAME_BYTES = 128;
     private static final Pattern SHA_256_PATTERN = Pattern.compile("[0-9a-fA-F]{64}");
@@ -53,24 +52,21 @@ public class UploadFileTool extends AbstractArthasTool {
     private final Path uploadRoot;
     private final int maxFileBytes;
     private final long maxTotalBytes;
-    private final int maxArtifacts;
     private final Semaphore uploadPermit = new Semaphore(1);
 
     public UploadFileTool() {
         this(DefaultUploadRootHolder.UPLOAD_ROOT,
                 DEFAULT_MAX_FILE_BYTES,
-                DEFAULT_MAX_TOTAL_BYTES,
-                DEFAULT_MAX_ARTIFACTS);
+                DEFAULT_MAX_TOTAL_BYTES);
     }
 
-    UploadFileTool(Path uploadRoot, int maxFileBytes, long maxTotalBytes, int maxArtifacts) {
-        if (maxFileBytes <= 0 || maxTotalBytes < maxFileBytes || maxArtifacts <= 0) {
+    UploadFileTool(Path uploadRoot, int maxFileBytes, long maxTotalBytes) {
+        if (maxFileBytes <= 0 || maxTotalBytes < maxFileBytes) {
             throw new IllegalArgumentException("Invalid upload limits");
         }
         this.uploadRoot = prepareUploadRoot(uploadRoot);
         this.maxFileBytes = maxFileBytes;
         this.maxTotalBytes = maxTotalBytes;
-        this.maxArtifacts = maxArtifacts;
     }
 
     @Tool(
@@ -221,7 +217,6 @@ public class UploadFileTool extends AbstractArthasTool {
 
     private void assertQuotaAvailable(long incomingBytes) {
         long totalBytes = 0;
-        int artifactCount = 0;
 
         try (DirectoryStream<Path> stream = Files.newDirectoryStream(uploadRoot)) {
             for (Path artifactDirectory : stream) {
@@ -238,7 +233,6 @@ public class UploadFileTool extends AbstractArthasTool {
                                 || !Files.isRegularFile(artifact, LinkOption.NOFOLLOW_LINKS)) {
                             throw uploadError("UPLOAD_ROOT_UNSAFE", "The artifact directory contains an unsafe entry");
                         }
-                        artifactCount++;
                         totalBytes += Files.size(artifact);
                     }
                 }
@@ -247,7 +241,7 @@ public class UploadFileTool extends AbstractArthasTool {
             throw uploadError("IO_ERROR", "Failed to inspect the upload directory", e);
         }
 
-        if (artifactCount >= maxArtifacts || incomingBytes > maxTotalBytes - totalBytes) {
+        if (incomingBytes > maxTotalBytes - totalBytes) {
             throw uploadError("QUOTA_EXCEEDED", "The upload directory quota has been reached");
         }
     }

--- a/core/src/main/java/com/taobao/arthas/core/mcp/tool/function/basic1000/UploadFileTool.java
+++ b/core/src/main/java/com/taobao/arthas/core/mcp/tool/function/basic1000/UploadFileTool.java
@@ -32,7 +32,7 @@ import java.util.concurrent.Semaphore;
 import java.util.regex.Pattern;
 
 /**
- * Upload a small file to the target JVM filesystem for use by other Arthas MCP tools.
+ * 将小文件上传到目标 JVM 文件系统，供其他 Arthas MCP 工具使用。
  */
 public class UploadFileTool extends AbstractArthasTool {
 
@@ -82,7 +82,7 @@ public class UploadFileTool extends AbstractArthasTool {
     )
     public String uploadFile(
             @ToolParam(description = "文件叶子名称，仅允许字母、数字、点、下划线、连字符和 $；"
-                    + "首版支持 .class、.java、.jfc，不能包含目录。")
+                    + "首版支持小写扩展名 .class、.java、.jfc，不能包含目录。")
             String fileName,
 
             @ToolParam(description = "RFC 4648 标准 Base64 文件内容；解码后默认最大 1 MiB。")
@@ -130,8 +130,7 @@ public class UploadFileTool extends AbstractArthasTool {
         } else {
             assertQuotaAvailable(content.length);
             ensureArtifactDirectory(artifactDirectory);
-            commitAtomically(target, content, sha256);
-            reused = false;
+            reused = commitAtomically(target, content, sha256);
         }
 
         String artifactId = "art_" + sha256((fileName + "\u0000" + sha256).getBytes(StandardCharsets.UTF_8));
@@ -170,17 +169,17 @@ public class UploadFileTool extends AbstractArthasTool {
             throw uploadError("INVALID_FILE_NAME", "The file name must include a base name and extension");
         }
 
-        String lowerCaseName = fileName.toLowerCase(Locale.ROOT);
-        if (lowerCaseName.endsWith(".class")) {
+        if (fileName.endsWith(".class")) {
             return "CLASS";
         }
-        if (lowerCaseName.endsWith(".java")) {
+        if (fileName.endsWith(".java")) {
             return "JAVA_SOURCE";
         }
-        if (lowerCaseName.endsWith(".jfc")) {
+        if (fileName.endsWith(".jfc")) {
             return "JFC";
         }
-        throw uploadError("UNSUPPORTED_FILE_TYPE", "Only .class, .java, and .jfc files are supported");
+        throw uploadError("UNSUPPORTED_FILE_TYPE",
+                "Only lowercase .class, .java, and .jfc file extensions are supported");
     }
 
     private String normalizeExpectedSha256(String expectedSha256) {
@@ -253,7 +252,7 @@ public class UploadFileTool extends AbstractArthasTool {
         }
     }
 
-    private void commitAtomically(Path target, byte[] content, String expectedSha256) {
+    private boolean commitAtomically(Path target, byte[] content, String expectedSha256) {
         Path temp = null;
         try {
             temp = Files.createTempFile(target.getParent(), ".upload-", ".part");
@@ -270,8 +269,10 @@ public class UploadFileTool extends AbstractArthasTool {
             try {
                 Files.move(temp, target, StandardCopyOption.ATOMIC_MOVE);
                 temp = null;
+                return false;
             } catch (FileAlreadyExistsException e) {
                 verifyExistingArtifact(target, expectedSha256, content.length);
+                return true;
             } catch (AtomicMoveNotSupportedException e) {
                 throw uploadError("IO_ERROR", "The upload directory does not support atomic file commits", e);
             }
@@ -296,7 +297,7 @@ public class UploadFileTool extends AbstractArthasTool {
                 Files.createDirectory(artifactDirectory);
                 setDirectoryPermissions(artifactDirectory);
             } catch (FileAlreadyExistsException ignored) {
-                // A previous identical upload may have created the content directory.
+                // 另一个相同内容的上传可能已经创建了该目录。
             }
             verifyArtifactDirectory(artifactDirectory);
         } catch (UploadFileException e) {
@@ -380,7 +381,7 @@ public class UploadFileTool extends AbstractArthasTool {
         try {
             Files.setPosixFilePermissions(directory, DIRECTORY_PERMISSIONS);
         } catch (UnsupportedOperationException ignored) {
-            // POSIX permissions are not available on this filesystem.
+            // 当前文件系统不支持 POSIX 权限。
         }
     }
 
@@ -388,7 +389,7 @@ public class UploadFileTool extends AbstractArthasTool {
         try {
             Files.setPosixFilePermissions(file, FILE_PERMISSIONS);
         } catch (UnsupportedOperationException ignored) {
-            // POSIX permissions are not available on this filesystem.
+            // 当前文件系统不支持 POSIX 权限。
         }
     }
 

--- a/core/src/test/java/com/taobao/arthas/core/mcp/tool/function/basic1000/UploadFileToolTest.java
+++ b/core/src/test/java/com/taobao/arthas/core/mcp/tool/function/basic1000/UploadFileToolTest.java
@@ -35,7 +35,7 @@ public class UploadFileToolTest {
     @Before
     public void setUp() throws Exception {
         uploadRoot = temporaryFolder.newFolder("uploads").toPath().toRealPath();
-        tool = new UploadFileTool(uploadRoot, 64, 256, 4);
+        tool = new UploadFileTool(uploadRoot, 64, 256);
     }
 
     @Test
@@ -139,7 +139,7 @@ public class UploadFileToolTest {
 
     @Test
     public void shouldRejectOversizedFile() {
-        final UploadFileTool smallTool = new UploadFileTool(uploadRoot, 3, 16, 4);
+        final UploadFileTool smallTool = new UploadFileTool(uploadRoot, 3, 16);
         final String encoded = Base64.getEncoder().encodeToString(new byte[] {1, 2, 3, 4});
 
         assertUploadError("FILE_TOO_LARGE", new UploadCall() {
@@ -168,16 +168,29 @@ public class UploadFileToolTest {
     }
 
     @Test
-    public void shouldEnforceArtifactQuota() {
-        final UploadFileTool quotaTool = new UploadFileTool(uploadRoot, 16, 16, 1);
-        quotaTool.uploadFile("One.class", Base64.getEncoder().encodeToString(new byte[] {1}), null);
+    public void shouldEnforceTotalSizeQuota() {
+        final UploadFileTool quotaTool = new UploadFileTool(uploadRoot, 16, 16);
+        quotaTool.uploadFile("One.class", Base64.getEncoder().encodeToString(new byte[8]), null);
 
         assertUploadError("QUOTA_EXCEEDED", new UploadCall() {
             @Override
             public void run() {
-                quotaTool.uploadFile("Two.class", Base64.getEncoder().encodeToString(new byte[] {2}), null);
+                quotaTool.uploadFile("Two.class", Base64.getEncoder().encodeToString(new byte[9]), null);
             }
         });
+    }
+
+    @Test
+    public void shouldNotLimitArtifactCount() {
+        for (int i = 0; i < 65; i++) {
+            tool.uploadFile("Artifact" + i + ".class",
+                    Base64.getEncoder().encodeToString(new byte[] {(byte) i}), null);
+        }
+    }
+
+    @Test
+    public void shouldUse200MiBDefaultTotalQuota() {
+        Assert.assertEquals(200L * 1024 * 1024, UploadFileTool.DEFAULT_MAX_TOTAL_BYTES);
     }
 
     @Test

--- a/core/src/test/java/com/taobao/arthas/core/mcp/tool/function/basic1000/UploadFileToolTest.java
+++ b/core/src/test/java/com/taobao/arthas/core/mcp/tool/function/basic1000/UploadFileToolTest.java
@@ -103,6 +103,21 @@ public class UploadFileToolTest {
     }
 
     @Test
+    public void shouldRejectNonLowercaseFileExtensions() {
+        final String encoded = Base64.getEncoder().encodeToString(new byte[] {1});
+        String[] invalidNames = {"Demo.CLASS", "Demo.JAVA", "profile.JFC"};
+
+        for (final String invalidName : invalidNames) {
+            assertUploadError("UNSUPPORTED_FILE_TYPE", new UploadCall() {
+                @Override
+                public void run() {
+                    tool.uploadFile(invalidName, encoded, null);
+                }
+            });
+        }
+    }
+
+    @Test
     public void shouldRejectInvalidBase64() {
         assertUploadError("INVALID_BASE64", new UploadCall() {
             @Override

--- a/core/src/test/java/com/taobao/arthas/core/mcp/tool/function/basic1000/UploadFileToolTest.java
+++ b/core/src/test/java/com/taobao/arthas/core/mcp/tool/function/basic1000/UploadFileToolTest.java
@@ -1,0 +1,257 @@
+package com.taobao.arthas.core.mcp.tool.function.basic1000;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.taobao.arthas.mcp.server.protocol.spec.McpSchema;
+import com.taobao.arthas.mcp.server.tool.DefaultToolCallbackProvider;
+import com.taobao.arthas.mcp.server.tool.ToolCallback;
+import com.taobao.arthas.mcp.server.tool.definition.ToolDefinition;
+import com.taobao.arthas.mcp.server.tool.definition.ToolDefinitions;
+import com.taobao.arthas.mcp.server.util.JsonParser;
+import org.junit.Assert;
+import org.junit.Assume;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.IOException;
+import java.lang.reflect.Method;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.security.MessageDigest;
+import java.util.Base64;
+import java.util.Map;
+import java.util.stream.Stream;
+
+public class UploadFileToolTest {
+
+    @Rule
+    public TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+    private Path uploadRoot;
+    private UploadFileTool tool;
+
+    @Before
+    public void setUp() throws Exception {
+        uploadRoot = temporaryFolder.newFolder("uploads").toPath().toRealPath();
+        tool = new UploadFileTool(uploadRoot, 64, 256, 4);
+    }
+
+    @Test
+    public void shouldUploadFileAndReturnMetadata() throws Exception {
+        byte[] content = "compiled-class-content".getBytes(StandardCharsets.UTF_8);
+        String expectedSha256 = sha256(content);
+
+        Map<String, Object> result = parse(tool.uploadFile(
+                "OrderService.class", Base64.getEncoder().encodeToString(content), expectedSha256));
+
+        Assert.assertEquals("completed", result.get("status"));
+        Assert.assertEquals("CLASS", result.get("kind"));
+        Assert.assertEquals("OrderService.class", result.get("fileName"));
+        Assert.assertEquals(expectedSha256, result.get("sha256"));
+        Assert.assertEquals(content.length, ((Number) result.get("sizeBytes")).intValue());
+        Assert.assertEquals(Boolean.FALSE, result.get("reused"));
+        Assert.assertTrue(String.valueOf(result.get("artifactId")).startsWith("art_"));
+
+        Path target = java.nio.file.Paths.get(String.valueOf(result.get("targetPath"))).toRealPath();
+        Assert.assertEquals("OrderService.class", target.getFileName().toString());
+        Assert.assertEquals(uploadRoot, target.getParent().getParent());
+        Assert.assertEquals(expectedSha256, target.getParent().getFileName().toString());
+        Assert.assertArrayEquals(content, Files.readAllBytes(target));
+    }
+
+    @Test
+    public void shouldReuseIdenticalUpload() {
+        byte[] content = "source-content".getBytes(StandardCharsets.UTF_8);
+        String encoded = Base64.getEncoder().encodeToString(content);
+
+        Map<String, Object> first = parse(tool.uploadFile("Demo.java", encoded, null));
+        Map<String, Object> second = parse(tool.uploadFile("Demo.java", encoded, null));
+
+        Assert.assertEquals(first.get("artifactId"), second.get("artifactId"));
+        Assert.assertEquals(first.get("targetPath"), second.get("targetPath"));
+        Assert.assertEquals(Boolean.FALSE, first.get("reused"));
+        Assert.assertEquals(Boolean.TRUE, second.get("reused"));
+        Assert.assertEquals("Demo.java", java.nio.file.Paths.get(
+                String.valueOf(second.get("targetPath"))).getFileName().toString());
+    }
+
+    @Test
+    public void shouldRejectUnsafeFileNames() {
+        String encoded = Base64.getEncoder().encodeToString(new byte[] {1});
+        String[] invalidNames = {"../Demo.class", "/tmp/Demo.class", "dir\\Demo.class", "Demo?.class", ".class"};
+
+        for (String invalidName : invalidNames) {
+            assertUploadError("INVALID_FILE_NAME", new UploadCall() {
+                @Override
+                public void run() {
+                    tool.uploadFile(invalidName, encoded, null);
+                }
+            });
+        }
+    }
+
+    @Test
+    public void shouldRejectUnsupportedFileType() {
+        assertUploadError("UNSUPPORTED_FILE_TYPE", new UploadCall() {
+            @Override
+            public void run() {
+                tool.uploadFile("payload.txt", Base64.getEncoder().encodeToString(new byte[] {1}), null);
+            }
+        });
+    }
+
+    @Test
+    public void shouldRejectInvalidBase64() {
+        assertUploadError("INVALID_BASE64", new UploadCall() {
+            @Override
+            public void run() {
+                tool.uploadFile("Demo.class", "%%%", null);
+            }
+        });
+    }
+
+    @Test
+    public void shouldRejectInvalidChecksum() {
+        assertUploadError("INVALID_CHECKSUM", new UploadCall() {
+            @Override
+            public void run() {
+                tool.uploadFile("Demo.class", Base64.getEncoder().encodeToString(new byte[] {1}), "not-a-sha256");
+            }
+        });
+    }
+
+    @Test
+    public void shouldRejectOversizedFile() {
+        final UploadFileTool smallTool = new UploadFileTool(uploadRoot, 3, 16, 4);
+        final String encoded = Base64.getEncoder().encodeToString(new byte[] {1, 2, 3, 4});
+
+        assertUploadError("FILE_TOO_LARGE", new UploadCall() {
+            @Override
+            public void run() {
+                smallTool.uploadFile("Demo.class", encoded, null);
+            }
+        });
+    }
+
+    @Test
+    public void shouldRejectChecksumMismatchWithoutWritingFile() throws Exception {
+        final String encoded = Base64.getEncoder().encodeToString("source".getBytes(StandardCharsets.UTF_8));
+        final String wrongSha256 = repeat('0', 64);
+
+        assertUploadError("CHECKSUM_MISMATCH", new UploadCall() {
+            @Override
+            public void run() {
+                tool.uploadFile("Demo.java", encoded, wrongSha256);
+            }
+        });
+
+        try (Stream<Path> entries = Files.list(uploadRoot)) {
+            Assert.assertEquals(0, entries.count());
+        }
+    }
+
+    @Test
+    public void shouldEnforceArtifactQuota() {
+        final UploadFileTool quotaTool = new UploadFileTool(uploadRoot, 16, 16, 1);
+        quotaTool.uploadFile("One.class", Base64.getEncoder().encodeToString(new byte[] {1}), null);
+
+        assertUploadError("QUOTA_EXCEEDED", new UploadCall() {
+            @Override
+            public void run() {
+                quotaTool.uploadFile("Two.class", Base64.getEncoder().encodeToString(new byte[] {2}), null);
+            }
+        });
+    }
+
+    @Test
+    public void shouldRejectSymlinkArtifactDirectory() throws Exception {
+        final byte[] content = "class-content".getBytes(StandardCharsets.UTF_8);
+        Path outside = temporaryFolder.newFolder("outside").toPath();
+        Path digestDirectory = uploadRoot.resolve(sha256(content));
+        try {
+            Files.createSymbolicLink(digestDirectory, outside);
+        } catch (UnsupportedOperationException e) {
+            Assume.assumeNoException("The filesystem does not support symbolic links", e);
+        } catch (IOException e) {
+            Assume.assumeNoException("Unable to create a symbolic link for this test", e);
+        }
+
+        assertUploadError("UPLOAD_ROOT_UNSAFE", new UploadCall() {
+            @Override
+            public void run() {
+                tool.uploadFile("Demo.class", Base64.getEncoder().encodeToString(content), null);
+            }
+        });
+    }
+
+    @Test
+    public void shouldExposeFlatMcpSchema() throws Exception {
+        Method method = UploadFileTool.class.getMethod(
+                "uploadFile", String.class, String.class, String.class);
+        ToolDefinition definition = ToolDefinitions.from(method);
+        McpSchema.JsonSchema schema = definition.getInputSchema();
+
+        Assert.assertEquals("upload_file", definition.getName());
+        Assert.assertEquals(McpSchema.TaskSupportMode.FORBIDDEN, definition.taskSupport());
+        Assert.assertTrue(schema.getProperties().containsKey("fileName"));
+        Assert.assertTrue(schema.getProperties().containsKey("contentBase64"));
+        Assert.assertTrue(schema.getProperties().containsKey("expectedSha256"));
+        Assert.assertTrue(schema.getRequired().contains("fileName"));
+        Assert.assertTrue(schema.getRequired().contains("contentBase64"));
+        Assert.assertFalse(schema.getRequired().contains("expectedSha256"));
+        Assert.assertEquals(Boolean.FALSE, schema.getAdditionalProperties());
+    }
+
+    @Test
+    public void shouldBeDiscoveredByToolProvider() {
+        DefaultToolCallbackProvider provider = new DefaultToolCallbackProvider();
+        provider.setToolBasePackage("com.taobao.arthas.core.mcp.tool.function.basic1000");
+
+        boolean found = false;
+        for (ToolCallback callback : provider.getToolCallbacks()) {
+            if ("upload_file".equals(callback.getToolDefinition().getName())) {
+                found = true;
+                break;
+            }
+        }
+
+        Assert.assertTrue("upload_file should be discovered by the MCP tool scanner", found);
+    }
+
+    private static void assertUploadError(String expectedCode, UploadCall call) {
+        try {
+            call.run();
+            Assert.fail("Expected upload error " + expectedCode);
+        } catch (UploadFileTool.UploadFileException e) {
+            Assert.assertEquals(expectedCode, e.getCode());
+            Assert.assertTrue(e.getMessage().startsWith(expectedCode + ":"));
+        }
+    }
+
+    private static Map<String, Object> parse(String json) {
+        return JsonParser.fromJson(json, new TypeReference<Map<String, Object>>() {});
+    }
+
+    private static String sha256(byte[] content) throws Exception {
+        byte[] digest = MessageDigest.getInstance("SHA-256").digest(content);
+        StringBuilder result = new StringBuilder(digest.length * 2);
+        for (byte value : digest) {
+            result.append(String.format("%02x", value & 0xff));
+        }
+        return result.toString();
+    }
+
+    private static String repeat(char value, int count) {
+        StringBuilder result = new StringBuilder(count);
+        for (int i = 0; i < count; i++) {
+            result.append(value);
+        }
+        return result.toString();
+    }
+
+    private interface UploadCall {
+        void run();
+    }
+}


### PR DESCRIPTION
## Summary

- add a standard MCP `upload_file` tool with `fileName`, Base64 content, and optional SHA-256 inputs
- store uploaded `.class`, `.java`, and `.jfc` files in a private, content-addressed temporary directory while preserving the original basename for `mc`
- enforce filename, file-type, Base64, size, checksum, quota, symlink, and atomic-commit checks
- return stable artifact metadata and a target-JVM `targetPath` that existing `mc`, `redefine`, `retransform`, and `profiler` tools can consume

## Why

MCP does not currently provide a dedicated client-to-server binary upload primitive. A bounded Base64 tool keeps the first version compatible with the existing Streamable and Stateless transports without adding a proprietary HTTP endpoint.

## Behavior

- decoded file limit: 1 MiB
- per-JVM upload quota: 200 MiB, with no artifact-count limit
- supported file types: lowercase `.class`, `.java`, and `.jfc`
- identical retries are idempotent
- uploads do not automatically execute or hot-update the target JVM

## Validation

- `./mvnw -pl core -am -Dtest=UploadFileToolTest -Dsurefire.failIfNoSpecifiedTests=false test`
  - 15 tests passed
- `./mvnw -pl arthas-mcp-integration-test -am -Dtest=ArthasMcpJavaSdkIT -Dsurefire.failIfNoSpecifiedTests=false verify`
  - 33 Java SDK integration tests passed, including `tools/list` coverage and a real `upload_file` call
- related MCP regression tests passed for server shutdown, auth propagation, `viewfile`, and `vmtool`

The unit test run emits the repository's existing Logback test-appender compatibility warning; it does not fail the build.