### PR TITLE
feat: log cross-namespace attach success

### DIFF
--- a/core/src/main/java/com/taobao/arthas/core/Arthas.java
+++ b/core/src/main/java/com/taobao/arthas/core/Arthas.java
@@ -106,6 +106,7 @@ public class Arthas {
         boolean crossMountNamespace = inDifferentMountNamespace(targetPid);
         Path socketSymlink = null;
         if (crossMountNamespace) {
+            configure.setCrossMountNamespace(true);
             socketSymlink = exposeTargetAttachSocket(targetPid);
         }
 

--- a/core/src/main/java/com/taobao/arthas/core/config/Configure.java
+++ b/core/src/main/java/com/taobao/arthas/core/config/Configure.java
@@ -29,6 +29,11 @@ public class Configure {
     private String arthasCore;
     private String arthasAgent;
 
+    /**
+     * attach 进程和目标 JVM 是否处于不同的 mount namespace，仅用于传递内部 attach 元数据。
+     */
+    private Boolean crossMountNamespace;
+
     private String tunnelServer;
     private String agentId;
 
@@ -135,6 +140,14 @@ public class Configure {
 
     public void setArthasCore(String arthasCore) {
         this.arthasCore = arthasCore;
+    }
+
+    public boolean isCrossMountNamespace() {
+        return crossMountNamespace != null && crossMountNamespace;
+    }
+
+    public void setCrossMountNamespace(boolean crossMountNamespace) {
+        this.crossMountNamespace = crossMountNamespace;
     }
 
     public Long getSessionTimeout() {

--- a/core/src/main/java/com/taobao/arthas/core/server/ArthasBootstrap.java
+++ b/core/src/main/java/com/taobao/arthas/core/server/ArthasBootstrap.java
@@ -510,11 +510,22 @@ public class ArthasBootstrap {
             }
 
             logger().info("as-server started in {} ms", System.currentTimeMillis() - start);
+            logCrossMountNamespaceAttachSuccess(configure, arthasHome(), logger());
         } catch (Throwable e) {
             logger().error("Error during start as-server", e);
             destroy();
             throw e;
         }
+    }
+
+    static void logCrossMountNamespaceAttachSuccess(Configure configure, String arthasHome, Logger logger) {
+        if (!configure.isCrossMountNamespace()) {
+            return;
+        }
+        logger.info("event=arthas_attach status=success mode=cross-mount-namespace "
+                        + "targetPid={} arthasHome={} network={} telnet={} http={}",
+                configure.getJavaPid(), arthasHome, configure.getIp(), configure.getTelnetPort(),
+                configure.getHttpPort());
     }
 
     private CommandResolver loadExternalCommandResolver(ShellServer shellServer, BuiltinCommandPack builtinCommands)

--- a/core/src/test/java/com/taobao/arthas/core/config/ConfigureTest.java
+++ b/core/src/test/java/com/taobao/arthas/core/config/ConfigureTest.java
@@ -1,0 +1,34 @@
+package com.taobao.arthas.core.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.Test;
+
+import com.taobao.arthas.core.env.ArthasEnvironment;
+import com.taobao.arthas.core.env.MapPropertySource;
+
+public class ConfigureTest {
+
+    @Test
+    public void shouldTransmitCrossMountNamespaceMetadataThroughAgentArgs() {
+        Configure source = new Configure();
+        source.setJavaPid(123L);
+        source.setCrossMountNamespace(true);
+
+        Map<String, String> attachArgs = FeatureCodec.DEFAULT_COMMANDLINE_CODEC.toMap(source.toString());
+        Map<String, Object> targetArgs = new HashMap<String, Object>();
+        for (Map.Entry<String, String> entry : attachArgs.entrySet()) {
+            targetArgs.put("arthas." + entry.getKey(), entry.getValue());
+        }
+        ArthasEnvironment environment = new ArthasEnvironment();
+        environment.addFirst(new MapPropertySource("agentArgs", targetArgs));
+        Configure target = new Configure();
+        BinderUtils.inject(environment, target);
+
+        assertThat(target.getJavaPid()).isEqualTo(123L);
+        assertThat(target.isCrossMountNamespace()).isTrue();
+    }
+}

--- a/core/src/test/java/com/taobao/arthas/core/server/ArthasBootstrapTest.java
+++ b/core/src/test/java/com/taobao/arthas/core/server/ArthasBootstrapTest.java
@@ -10,6 +10,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
 
+import com.alibaba.arthas.deps.org.slf4j.Logger;
 import com.alibaba.bytekit.utils.ReflectionUtils;
 import com.taobao.arthas.common.JavaVersionUtils;
 import com.taobao.arthas.core.bytecode.TestHelper;
@@ -104,5 +105,32 @@ public class ArthasBootstrapTest {
         String configName = ArthasBootstrap.reslove(arthasEnvironment, ArthasBootstrap.CONFIG_NAME_PROPERTY, "arthas");
         System.clearProperty(ArthasBootstrap.CONFIG_NAME_PROPERTY);
         assertThat(configName).isEqualTo("testName");
+    }
+
+    @Test
+    public void shouldLogSuccessfulCrossMountNamespaceAttach() {
+        Configure configure = new Configure();
+        configure.setJavaPid(123L);
+        configure.setCrossMountNamespace(true);
+        configure.setIp("127.0.0.1");
+        configure.setTelnetPort(3658);
+        configure.setHttpPort(8563);
+        Logger logger = Mockito.mock(Logger.class);
+
+        ArthasBootstrap.logCrossMountNamespaceAttachSuccess(configure, "/tmp/arthas-123", logger);
+
+        Mockito.verify(logger).info("event=arthas_attach status=success mode=cross-mount-namespace "
+                        + "targetPid={} arthasHome={} network={} telnet={} http={}",
+                123L, "/tmp/arthas-123", "127.0.0.1", 3658, 8563);
+    }
+
+    @Test
+    public void shouldNotLogSuccessfulSameMountNamespaceAttach() {
+        Configure configure = new Configure();
+        Logger logger = Mockito.mock(Logger.class);
+
+        ArthasBootstrap.logCrossMountNamespaceAttachSuccess(configure, "/opt/arthas", logger);
+
+        Mockito.verifyNoInteractions(logger);
     }
 }


### PR DESCRIPTION
## Summary

- propagate the detected cross-mount-namespace attach mode through the internal agent arguments
- write a structured success event to the target JVM's `arthas.log` after the Arthas server has started
- add tests for metadata transmission and cross-namespace-only logging

## Why

Follow-up to #3247. The attach-side success output and the target-side startup log currently look the same for normal and cross-mount-namespace attaches, so users cannot confirm which path succeeded.

After this change, a successful cross-namespace startup records:

```text
event=arthas_attach status=success mode=cross-mount-namespace targetPid=... arthasHome=... network=... telnet=... http=...
```

Same-mount-namespace attaches do not emit this event.

## Validation

- `./mvnw -pl core -am -Dtest=ConfigureTest,ArthasBootstrapTest -Dsurefire.failIfNoSpecifiedTests=false test`
- `./mvnw -pl core -am test` — 300 tests, 0 failures, 0 errors, 7 skipped
- `git diff --check`
