### PR TITLE
fix: upgrade fastjson2 to 2.0.64

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -146,7 +146,7 @@
             <dependency>
                 <groupId>com.alibaba.fastjson2</groupId>
                 <artifactId>fastjson2</artifactId>
-                <version>2.0.58</version>
+                <version>2.0.64</version>
             </dependency>
             <dependency>
                 <groupId>com.taobao.text</groupId>


### PR DESCRIPTION
## Summary
- Upgrade `com.alibaba.fastjson2:fastjson2` from 2.0.58 to 2.0.64 in the parent `pom.xml`.
- 2.0.63 hardens AutoType deserialization and fixes parser OOM / DoS issues; 2.0.64 is the latest bugfix release.
- Child modules (`core`, `arthas-mcp-server`, `native-agent-common`) inherit the version from dependencyManagement.

Fixes #3260

## Test plan
- [ ] Confirm Maven resolves `com.alibaba.fastjson2:fastjson2:2.0.64`
- [ ] `mvn -pl core -am test` (or a local smoke of JSON output commands such as `watch` / HTTP API)
- [ ] No other modules pin a separate fastjson2 version